### PR TITLE
ci: update to mac11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,11 @@ jobs:
     strategy:
       matrix:
         # 12.4 = swift 5.3
-        # 12.5 = swift 5.4 (not available because macos-11 is private preview, only on github)
+        # 12.5 = swift 5.4
+        # 13.0 = swift 5.5
         # Thanks: https://swiftly.dev/swift-versions and https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#xcode
-        xcode: ["12.4"]
-    runs-on: macos-10.15
+        xcode: ["12.4", "12.5", "13.0"]
+    runs-on: macos-11
     name: XCode macOS tests (xcode ${{ matrix.xcode }})
     # skip if '[skip ci]' exists in commit message 
     if: ${{ !contains(format('{0} {1}', github.event.head_commit.message, github.event.pull_request.title), '[skip ci]') }}


### PR DESCRIPTION
GitHub made mac11 out of private beta! 

Now we can run tests on XCode 13 which is swift 5.5. Ubuntu 20 is still on swift 5.4 (understandable, 5.5 beta) so we don't test swift 5.5 on the Linux environment yet. 