### PR TITLE
ci: update SDK version during deployment

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -22,5 +22,6 @@ jobs:
             @semantic-release/changelog@5
             @semantic-release/git@9
             @semantic-release/github@7
+            @semantic-release/exec@5
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_PUSH_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -8,6 +8,9 @@
     "plugins": [
         "@semantic-release/commit-analyzer",
         "@semantic-release/release-notes-generator",        
+        ["@semantic-release/exec", {
+            "verifyReleaseCmd": "./update_version.sh ${nextRelease.version} Sources/Tracking/Version.swift"
+        }],
         ["@semantic-release/changelog",{
             "changelogFile": "CHANGELOG.md"
         }],

--- a/update_version.sh
+++ b/update_version.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Script that updates the Swift file in the SDK that contains the semantic version of the SDK. 
+# 
+# Use script: ./update_version.sh 0.1.1 Sources/Common/Version.swift
+
+set -e 
+
+NEW_VERSION="$1"
+SWIFT_SOURCE_FILE="$2"
+
+# Given line: `    static let version: String = "0.1.1"` 
+# Regex string will match the line of the file that we can then substitute. 
+LINE_PATTERN="let version: String = \"\(.*\)\""
+
+echo "Updating file: $SWIFT_SOURCE_FILE to new version: $NEW_VERSION"
+
+# -i overwrites file 
+# "s/" means substitute given pattern with given string. 
+# 
+sed -i "s/$LINE_PATTERN/let version: String = \"$NEW_VERSION\"/" $SWIFT_SOURCE_FILE
+
+echo "Done! New version: "
+
+# print the line (/p) that is matched in the file to show the change. 
+sed -n "/$LINE_PATTERN/p" $SWIFT_SOURCE_FILE


### PR DESCRIPTION
The version of the SDK is in the swift source code so it can be used in the SDK. 

Since we automate deployments, we need to automate changing the SDK version, too. 