### PR TITLE
feat: save all siteids registered with SDK

### DIFF
--- a/Sources/Tracking/Store/SdkCredentialsStore.swift
+++ b/Sources/Tracking/Store/SdkCredentialsStore.swift
@@ -47,5 +47,24 @@ internal class CIOSdkCredentialsStore: SdkCredentialsStore {
     func save(siteId: String, credentials: SdkCredentials) {
         keyValueStorage.setString(siteId: siteId, value: credentials.apiKey, forKey: .apiKey)
         keyValueStorage.setString(siteId: siteId, value: credentials.region.rawValue, forKey: .regionCode)
+
+        appendSiteId(siteId)
+    }
+
+    /**
+     Save all of the site ids given to the SDK. We are storing this because we may need to iterate all of the
+     site ids in the future so let's capture them now so we have them.
+     */
+    internal func appendSiteId(_ siteId: String) {
+        let existingSiteIds = keyValueStorage.string(siteId: keyValueStorage.sharedSiteId, forKey: .allSiteIds) ?? ""
+
+        // Must convert String.Substring to String which is why we map()
+        var allSiteIds = Set(existingSiteIds.split(separator: ",").map { String($0) })
+
+        allSiteIds.insert(siteId)
+
+        let newSiteIds = allSiteIds.joined(separator: ",")
+
+        keyValueStorage.setString(siteId: keyValueStorage.sharedSiteId, value: newSiteIds, forKey: .allSiteIds)
     }
 }

--- a/Sources/Tracking/Util/KeyValueStorageKey.swift
+++ b/Sources/Tracking/Util/KeyValueStorageKey.swift
@@ -8,4 +8,5 @@ public enum KeyValueStorageKey: String {
     case apiKey
     case regionCode
     case identifiedProfileId
+    case allSiteIds
 }

--- a/Tests/Shared/XCTestCaseExtensions.swift
+++ b/Tests/Shared/XCTestCaseExtensions.swift
@@ -18,4 +18,16 @@ public extension XCTestCase {
     func getEnvironmentVariable(_ key: String) -> String? {
         ProcessInfo.processInfo.environment[key]
     }
+
+    func XCTAssertEqualEither<T: Equatable>(_ expected: [T], actual: T, file: StaticString = #file,
+                                            line: UInt = #line)
+    {
+        let matches = expected.contains { value in
+            value == actual
+        }
+
+        if !matches {
+            XCTFail("\(actual) does not equal any of: \(expected)", file: file, line: line)
+        }
+    }
 }


### PR DESCRIPTION
What if there is a scenario when we need to iterate all of the site ids ever registered with the SDK? Up until this PR, you can't. We use site ids as the keys to getting a key/value storage store. If we ever need to iterate all of the key/value stores, for example, then we need to have all of those site ids persisted.

Potential use cases of needing this:

* Migrations to data stored in key/value storage.
* When a background queue is added to the SDK, the background queues may be separated by the site ids. It's important that we send all of that data for all site ids up to the API so we need to know all of the site ids registered with the SDK to sync all of the data for all sites.
﻿
