### PR TITLE
fix: rename singletons instance to shared

### DIFF
--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -6,7 +6,7 @@ import Foundation
  So, performing an HTTP request to the API with a device token goes here.
   */
 open class MessagingPush {
-    public private(set) static var instance = MessagingPush(customerIO: CustomerIO.instance)
+    @Atomic public private(set) static var shared = MessagingPush(customerIO: CustomerIO.shared)
 
     public let customerIO: CustomerIO!
     private let httpClient: HttpClient

--- a/Sources/Tracking/CustomerIO.swift
+++ b/Sources/Tracking/CustomerIO.swift
@@ -86,7 +86,7 @@ public class CustomerIO: CustomerIOInstance {
 
      Note: Don't forget to call `CustomerIO.initialize()` before using this!
      */
-    @Atomic public private(set) static var instance = CustomerIO()
+    @Atomic public private(set) static var shared = CustomerIO()
 
     @Atomic public var sdkConfig: SdkConfig
     @Atomic public var credentials: SdkCredentials?
@@ -140,7 +140,7 @@ public class CustomerIO: CustomerIOInstance {
      Note: It's recommended to delete app data before doing this to prevent loading persisted credentials
      */
     internal static func resetSharedInstance() {
-        Self.instance = CustomerIO()
+        Self.shared = CustomerIO()
     }
 
     /**
@@ -181,7 +181,7 @@ public class CustomerIO: CustomerIOInstance {
      automated tests, dependency injection, or sending data to multiple Workspaces.
      */
     public init(siteId: String, apiKey: String, region: Region = Region.US) {
-        self.sdkConfig = Self.instance.sdkConfig
+        self.sdkConfig = Self.shared.sdkConfig
 
         setCredentials(siteId: siteId, apiKey: apiKey, region: region)
     }
@@ -191,9 +191,9 @@ public class CustomerIO: CustomerIOInstance {
      Call this function when your app launches, before using `CustomerIO.instance`.
      */
     public static func initialize(siteId: String, apiKey: String, region: Region = Region.US) {
-        Self.instance.setCredentials(siteId: siteId, apiKey: apiKey, region: region)
+        Self.shared.setCredentials(siteId: siteId, apiKey: apiKey, region: region)
 
-        Self.instance.credentialsStore.sharedInstanceSiteId = siteId
+        Self.shared.credentialsStore.sharedInstanceSiteId = siteId
     }
 
     /**
@@ -228,7 +228,7 @@ public class CustomerIO: CustomerIOInstance {
      ```
      */
     public static func config(_ handler: (inout SdkConfig) -> Void) {
-        instance.config(handler)
+        shared.config(handler)
     }
 
     /**

--- a/Sources/Tracking/Tracking.swift
+++ b/Sources/Tracking/Tracking.swift
@@ -18,7 +18,7 @@ public protocol TrackingInstance: AutoMockable {}
  */
 public class Tracking: TrackingInstance {
     /// Singleton shared instance of `Tracking`. Use this if you use the singeton instance of the `CustomerIO` class.
-    public private(set) static var instance = Tracking(customerIO: CustomerIO.instance)
+    @Atomic public private(set) static var shared = Tracking(customerIO: CustomerIO.shared)
 
     private let customerIO: CustomerIO!
 

--- a/Tests/Tracking/CustomerIOTest.swift
+++ b/Tests/Tracking/CustomerIOTest.swift
@@ -20,7 +20,7 @@ class CustomerIOTest: UnitTest {
     // MARK: credentials
 
     func test_sharedInstance_givenNotInitialized_expectNotLoadCredentialsOnInit() {
-        XCTAssertNil(CustomerIO.instance.credentials)
+        XCTAssertNil(CustomerIO.shared.credentials)
     }
 
     func test_sharedInstance_givenInitializeBefore_expectLoadCredentialsOnInit() {
@@ -44,16 +44,16 @@ class CustomerIOTest: UnitTest {
         let givenSiteIdSharedInstance = String.random
         let givenSiteIdNewInstance = String.random
 
-        CustomerIO.instance.setCredentials(siteId: givenSiteIdSharedInstance, apiKey: String.random, region: Region.US)
+        CustomerIO.shared.setCredentials(siteId: givenSiteIdSharedInstance, apiKey: String.random, region: Region.US)
         let newInstance = CustomerIO(siteId: givenSiteIdNewInstance, apiKey: String.random, region: Region.EU)
 
-        XCTAssertNotNil(CustomerIO.instance.credentials)
+        XCTAssertNotNil(CustomerIO.shared.credentials)
         XCTAssertNotNil(newInstance.credentials)
 
-        XCTAssertEqual(CustomerIO.instance.credentials?.siteId, givenSiteIdSharedInstance)
+        XCTAssertEqual(CustomerIO.shared.credentials?.siteId, givenSiteIdSharedInstance)
         XCTAssertEqual(newInstance.credentials?.siteId, givenSiteIdNewInstance)
 
-        XCTAssertNotEqual(CustomerIO.instance.credentials?.apiKey, newInstance.credentials?.apiKey)
+        XCTAssertNotEqual(CustomerIO.shared.credentials?.apiKey, newInstance.credentials?.apiKey)
     }
 
     func test_newInstance_expectInitializedInstance() {
@@ -82,20 +82,20 @@ class CustomerIOTest: UnitTest {
     func test_config_expectNotNilOnInit() {
         let instance = CustomerIO(siteId: String.random, apiKey: String.random, region: Region.US)
 
-        XCTAssertNotNil(CustomerIO.instance.sdkConfig)
+        XCTAssertNotNil(CustomerIO.shared.sdkConfig)
         XCTAssertNotNil(instance.sdkConfig)
     }
 
     func test_config_sharedInstance_givenModifyConfig_expectSetConfigOnInstance() {
         let givenTrackingApiUrl = String.random
 
-        XCTAssertNotEqual(CustomerIO.instance.sdkConfig.trackingApiUrl, givenTrackingApiUrl)
+        XCTAssertNotEqual(CustomerIO.shared.sdkConfig.trackingApiUrl, givenTrackingApiUrl)
 
         CustomerIO.config {
             $0.trackingApiUrl = givenTrackingApiUrl
         }
 
-        XCTAssertEqual(CustomerIO.instance.sdkConfig.trackingApiUrl, givenTrackingApiUrl)
+        XCTAssertEqual(CustomerIO.shared.sdkConfig.trackingApiUrl, givenTrackingApiUrl)
     }
 
     func test_config_expectSharedInstanceConfigStartingValueForModifyingConfig() {


### PR DESCRIPTION
Using `shared` is the common naming in the community + Apple's SDKs for singletons. ﻿
