### PR TITLE
fix: convert APN device token to string

### DIFF
--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -62,7 +62,7 @@ public class MessagingPush: MessagingPushInstance {
      */
     public func registerDeviceToken(_ deviceToken: Data,
                                     onComplete: @escaping (Result<Void, CustomerIOError>) -> Void) {
-        let device = Device(token: String(decoding: deviceToken, as: UTF8.self), lastUsed: Date())
+        let device = Device(token: String(apnDeviceToken: deviceToken), lastUsed: Date())
         guard let bodyData = jsonAdapter.toJson(RegisterDeviceRequest(device: device)) else {
             return onComplete(.failure(.http(.noRequestMade(nil))))
         }

--- a/Sources/Tracking/Extensions/StringExtensions.swift
+++ b/Sources/Tracking/Extensions/StringExtensions.swift
@@ -1,6 +1,12 @@
 import Foundation
 
-internal extension String {
+public extension String {
+    init(apnDeviceToken: Data) {
+        /// Convert `Data` to `String` for APN device token.
+        /// [Reference](https://nshipster.com/apns-device-tokens/)
+        self = apnDeviceToken.map { String(format: "%02x", $0) }.joined()
+    }
+
     var data: Data! {
         data(using: .utf8)
     }


### PR DESCRIPTION
The current way of converting the APN device token to string does not work. This fixes that. 