### PR TITLE
fix: call callback on main thread APN tokens

### DIFF
--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -80,14 +80,16 @@ public class MessagingPush: MessagingPushInstance {
 
         httpClient
             .request(httpRequestParameters) { [weak self] result in
-                guard let self = self else { return }
+                DispatchQueue.main.async { [weak self] in
+                    guard let self = self else { return }
 
-                switch result {
-                case .success:
-                    self.deviceToken = deviceToken
-                    onComplete(Result.success(()))
-                case .failure(let error):
-                    onComplete(Result.failure(.http(error)))
+                    switch result {
+                    case .success:
+                        self.deviceToken = deviceToken
+                        onComplete(Result.success(()))
+                    case .failure(let error):
+                        onComplete(Result.failure(.http(error)))
+                    }
                 }
             }
     }
@@ -117,14 +119,16 @@ public class MessagingPush: MessagingPushInstance {
 
         httpClient
             .request(httpRequestParameters) { [weak self] result in
-                guard let self = self else { return }
+                DispatchQueue.main.async { [weak self] in
+                    guard let self = self else { return }
 
-                switch result {
-                case .success:
-                    self.deviceToken = nil
-                    onComplete(Result.success(()))
-                case .failure(let error):
-                    onComplete(Result.failure(.http(error)))
+                    switch result {
+                    case .success:
+                        self.deviceToken = nil
+                        onComplete(Result.success(()))
+                    case .failure(let error):
+                        onComplete(Result.failure(.http(error)))
+                    }
                 }
             }
     }

--- a/Tests/MessagingPush/MessagingPushTest.swift
+++ b/Tests/MessagingPush/MessagingPushTest.swift
@@ -84,14 +84,10 @@ class MessagingPushTest: UnitTest {
             expect.fulfill()
         }
 
-        guard let storedToken = push.deviceToken else {
-            return XCTFail()
-        }
-
-        XCTAssertEqual(storedToken, actualToken)
-
         waitForExpectations()
 
+        guard let storedToken = push.deviceToken else { return XCTFail() }
+        XCTAssertEqual(storedToken, actualToken)
         XCTAssertTrue(httpClientMock.requestCalled)
     }
 
@@ -167,10 +163,9 @@ class MessagingPushTest: UnitTest {
             expect.fulfill()
         }
 
-        XCTAssertNil(push.deviceToken)
-
         waitForExpectations()
 
+        XCTAssertNil(push.deviceToken)
         XCTAssertTrue(httpClientMock.requestCalled)
     }
 

--- a/Tests/Tracking/VersionTest.swift
+++ b/Tests/Tracking/VersionTest.swift
@@ -5,7 +5,7 @@ import XCTest
 
 class VersionTest: XCTestCase {
     func test_versionValidSemanticVersion() {
-        // regex: https://regexr.com/63gj6
-        XCTAssertTrue(SdkVersion.version.matches(regex: #"(\d+)\.(\d+)\.(\d+)(-alpha|-beta)*"#))
+        // regex: https://regexr.com/65mpt
+        XCTAssertTrue(SdkVersion.version.matches(regex: #"(\d+)\.(\d+)\.(\d+)(-alpha|-beta)*(\.\d)*"#))
     }
 }


### PR DESCRIPTION
To be consistent with identifying a profile function, call the callback function on the main thread for APN token functions. 