### PR TITLE
fix: remove apn device token profile request body

### DIFF
--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -112,7 +112,8 @@ public class MessagingPush: MessagingPushInstance {
         }
 
         let httpRequestParameters =
-            HttpRequestParams(endpoint: .deleteDevice(identifier: identifier, deviceToken: deviceToken),
+            HttpRequestParams(endpoint: .deleteDevice(identifier: identifier,
+                                                      deviceToken: String(apnDeviceToken: deviceToken)),
                               headers: nil, body: bodyData)
 
         httpClient

--- a/Sources/Tracking/Service/HttpEndpoint.swift
+++ b/Sources/Tracking/Service/HttpEndpoint.swift
@@ -4,7 +4,7 @@ public enum HttpEndpoint {
     case findAccountRegion
     case identifyCustomer(identifier: String)
     case registerDevice(identifier: String)
-    case deleteDevice(identifier: String, deviceToken: Data)
+    case deleteDevice(identifier: String, deviceToken: String)
 
     var path: String {
         switch self {

--- a/Tests/Tracking/VersionTest.swift
+++ b/Tests/Tracking/VersionTest.swift
@@ -5,7 +5,7 @@ import XCTest
 
 class VersionTest: XCTestCase {
     func test_versionValidSemanticVersion() {
-        // regex: https://regexr.com/63gj6
-        XCTAssertTrue(SdkVersion.version.matches(regex: #"(\d+)\.(\d+)\.(\d+)(-alpha|-beta)*"#))
+        // regex: https://regexr.com/65mpt
+        XCTAssertTrue(SdkVersion.version.matches(regex: #"(\d+)\.(\d+)\.(\d+)(-alpha|-beta)*(\.\d)*"#))
     }
 }


### PR DESCRIPTION
Deleting a device token was not working where the request body was not readable by the API. 