### PR TITLE
chore: register apn device token Data

### DIFF
--- a/Sources/MessagingPushAPN/MessagingPush+APN.swift
+++ b/Sources/MessagingPushAPN/MessagingPush+APN.swift
@@ -3,6 +3,12 @@ import CioTracking
 import Foundation
 
 public protocol MessagingPushAPNInstance: AutoMockable {
+    // sourcery:Name=registerAPNDeviceToken
+    func registerDeviceToken(
+        apnDeviceToken: Data,
+        onComplete: @escaping (Result<Void, CustomerIOError>) -> Void
+    )
+
     // sourcery:Name=didRegisterForRemoteNotifications
     func application(
         _ application: Any,
@@ -22,12 +28,17 @@ public protocol MessagingPushAPNInstance: AutoMockable {
  MessagingPush extension to support APN push notification messaging.
   */
 public extension MessagingPush {
+    func registerDeviceToken(apnDeviceToken: Data, onComplete: @escaping (Result<Void, CustomerIOError>) -> Void) {
+        let deviceToken = String(apnDeviceToken: apnDeviceToken)
+        return registerDeviceToken(deviceToken, onComplete: onComplete)
+    }
+
     func application(
         _ application: Any,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data,
         onComplete: @escaping (Result<Void, CustomerIOError>) -> Void
     ) {
-        registerDeviceToken(String(apnDeviceToken: deviceToken), onComplete: onComplete)
+        registerDeviceToken(apnDeviceToken: deviceToken, onComplete: onComplete)
     }
 
     func application(

--- a/Sources/MessagingPushAPN/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingPushAPN/autogenerated/AutoMockable.generated.swift
@@ -89,6 +89,40 @@ public class MessagingPushAPNInstanceMock: MessagingPushAPNInstance {
     /// If *any* interactions done on mock. `true` if any method or property getter/setter called.
     public var mockCalled: Bool = false //
 
+    // MARK: - registerDeviceToken
+
+    /// Number of times the function was called.
+    public private(set) var registerAPNDeviceTokenCallsCount = 0
+    /// `true` if the function was ever called.
+    public var registerAPNDeviceTokenCalled: Bool {
+        registerAPNDeviceTokenCallsCount > 0
+    }
+
+    /// The arguments from the *last* time the function was called.
+    public private(set) var registerAPNDeviceTokenReceivedArguments: (apnDeviceToken: Data,
+                                                                      onComplete: (Result<Void, CustomerIOError>)
+                                                                          -> Void)?
+    /// Arguments from *all* of the times that the function was called.
+    public private(set) var registerAPNDeviceTokenReceivedInvocations: [(apnDeviceToken: Data,
+                                                                         onComplete: (Result<Void, CustomerIOError>)
+                                                                             -> Void)] = []
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     */
+    public var registerAPNDeviceTokenClosure: ((Data, (Result<Void, CustomerIOError>) -> Void) -> Void)?
+
+    /// Mocked function for `registerDeviceToken(apnDeviceToken: Data, onComplete: @escaping (Result<Void, CustomerIOError>) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func registerDeviceToken(
+        apnDeviceToken: Data,
+        onComplete: @escaping (Result<Void, CustomerIOError>) -> Void
+    ) {
+        mockCalled = true
+        registerAPNDeviceTokenCallsCount += 1
+        registerAPNDeviceTokenReceivedArguments = (apnDeviceToken: apnDeviceToken, onComplete: onComplete)
+        registerAPNDeviceTokenReceivedInvocations.append((apnDeviceToken: apnDeviceToken, onComplete: onComplete))
+        registerAPNDeviceTokenClosure?(apnDeviceToken, onComplete)
+    }
+
     // MARK: - application
 
     /// Number of times the function was called.


### PR DESCRIPTION
Adds an overload to the `registerDeviceToken` func on the `MessagingPushAPN` class for those who want to call it directly instead of using our wrapper