### PR TITLE
fix: opened push metrics

### DIFF
--- a/Sources/MessagingPush/MessagingPush+NotificationCenter.swift
+++ b/Sources/MessagingPush/MessagingPush+NotificationCenter.swift
@@ -17,10 +17,10 @@ public extension MessagingPush {
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
-    ) -> Bool {
+    ) {
         guard let siteId = customerIO.siteId else {
             completionHandler()
-            return false
+            return
         }
 
         let diGraph = DITracking.getInstance(siteId: siteId)
@@ -41,7 +41,7 @@ public extension MessagingPush {
                                                   jsonAdapter: jsonAdapter)
         else {
             // push does not contain a CIO rich payload, so end early
-            return false
+            return
         }
 
         switch response.actionIdentifier {
@@ -60,12 +60,10 @@ public extension MessagingPush {
 
                 completionHandler()
 
-                return true
+                return
             }
         default: break
         }
-
-        return false
     }
 
     func trackMetric(

--- a/Sources/MessagingPush/MessagingPush+NotificationCenter.swift
+++ b/Sources/MessagingPush/MessagingPush+NotificationCenter.swift
@@ -17,10 +17,10 @@ public extension MessagingPush {
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
-    ) {
+    ) -> Bool {
         guard let siteId = customerIO.siteId else {
             completionHandler()
-            return
+            return false
         }
 
         let diGraph = DITracking.getInstance(siteId: siteId)
@@ -41,7 +41,7 @@ public extension MessagingPush {
                                                   jsonAdapter: jsonAdapter)
         else {
             // push does not contain a CIO rich payload, so end early
-            return
+            return false
         }
 
         switch response.actionIdentifier {
@@ -60,10 +60,12 @@ public extension MessagingPush {
 
                 completionHandler()
 
-                return
+                return true
             }
         default: break
         }
+
+        return false
     }
 
     func trackMetric(

--- a/Sources/MessagingPush/Service/Request/MetricRequest.swift
+++ b/Sources/MessagingPush/Service/Request/MetricRequest.swift
@@ -16,7 +16,7 @@ internal struct MetricRequest: Codable {
     enum CodingKeys: String, CodingKey {
         case deliveryID = "delivery_id"
         case event
-        case deviceToken = "token"
+        case deviceToken = "device_id"
         case timestamp
     }
 }

--- a/Sources/Tracking/Extensions/JsonExtensions.swift
+++ b/Sources/Tracking/Extensions/JsonExtensions.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension JSONEncoder {
+    var secondsSince1970NoDecimal: DateEncodingStrategy {
+        .custom { date, encoder in
+            var container = encoder.singleValueContainer()
+            let seconds = Int(date.timeIntervalSince1970)
+            try container.encode(seconds)
+        }
+    }
+}

--- a/Sources/Tracking/Service/HttpEndpoint.swift
+++ b/Sources/Tracking/Service/HttpEndpoint.swift
@@ -10,11 +10,12 @@ public enum HttpEndpoint {
 
     var path: String {
         switch self {
-        case .findAccountRegion: return "/accounts/region"
-        case .identifyCustomer(let identifier): return "/customers/\(identifier)"
-        case .registerDevice(let identifier): return "/customers/\(identifier)/devices"
-        case .deleteDevice(let identifier, let deviceToken): return "/customers/\(identifier)/devices/\(deviceToken)"
-        case .trackCustomerEvent(let identifier): return "/customers/\(identifier)/events"
+        case .findAccountRegion: return "/api/v1/accounts/region"
+        case .identifyCustomer(let identifier): return "/api/v1/customers/\(identifier)"
+        case .registerDevice(let identifier): return "/api/v1/customers/\(identifier)/devices"
+        case .deleteDevice(let identifier,
+                           let deviceToken): return "/api/v1/customers/\(identifier)/devices/\(deviceToken)"
+        case .trackCustomerEvent(let identifier): return "/api/v1/customers/\(identifier)/events"
         case .pushMetrics: return "/push/events"
         }
     }

--- a/Sources/Tracking/Store/SdkCredentials.swift
+++ b/Sources/Tracking/Store/SdkCredentials.swift
@@ -15,8 +15,8 @@ public enum Region: String, Equatable {
 
     internal var productionTrackingUrl: String {
         switch self {
-        case .US: return "https://track.customer.io/api/v1"
-        case .EU: return "https://track-eu.customer.io/api/v1"
+        case .US: return "https://track.customer.io"
+        case .EU: return "https://track-eu.customer.io"
         }
     }
 }

--- a/Sources/Tracking/Util/JsonAdapter.swift
+++ b/Sources/Tracking/Util/JsonAdapter.swift
@@ -38,7 +38,14 @@ public class JsonAdapter {
     var encoder: JSONEncoder {
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
-        encoder.dateEncodingStrategy = .secondsSince1970
+        // We are using custom date encoding because if there are milliseconds in Date object,
+        // the default `secondsSince1970` will give a unix time with a decimal. The
+        // Customer.io API does not accept timestamps with a decimal value unix time.
+        encoder.dateEncodingStrategy = .custom { date, encoder in
+            var container = encoder.singleValueContainer()
+            let seconds = Int(date.timeIntervalSince1970)
+            try container.encode(seconds)
+        }
         return encoder
     }
 

--- a/Tests/Tracking/Service/HttpEndpointTest.swift
+++ b/Tests/Tracking/Service/HttpEndpointTest.swift
@@ -28,8 +28,8 @@ class HttpEndpointTest: UnitTest {
     }
 
     func test_getUrlString_givenBaseUrlTrailingSlash_expectValidBaseUrl() {
-        let expected = "https://customer.io/api/accounts/region"
-        setHttpBaseUrls(trackingApi: "https://customer.io/api/")
+        let expected = "https://customer.io/api/v1/accounts/region"
+        setHttpBaseUrls(trackingApi: "https://customer.io/")
 
         let actual = defaultEndpoint.getUrlString(baseUrls: httpBaseUrls)
 
@@ -37,8 +37,8 @@ class HttpEndpointTest: UnitTest {
     }
 
     func test_getUrlString_givenBaseUrlNoTrailingSlash_expectValueBaseUrl() {
-        let expected = "https://customer.io/api/accounts/region"
-        setHttpBaseUrls(trackingApi: "https://customer.io/api")
+        let expected = "https://customer.io/api/v1/accounts/region"
+        setHttpBaseUrls(trackingApi: "https://customer.io")
 
         let actual = defaultEndpoint.getUrlString(baseUrls: httpBaseUrls)
 

--- a/Tests/Tracking/Util/JsonAdapterTest.swift
+++ b/Tests/Tracking/Util/JsonAdapterTest.swift
@@ -10,7 +10,7 @@ class JsonAdapterTest: UnitTest {
      Value got from getting the current epoch time (seconds since 1970)
      https://www.epochconverter.com/
      */
-    private let givenSecondsSince1970: TimeInterval = 1629743524
+    private let givenSecondsSince1970: TimeInterval = 1629743524.100
 
     func test_snakeCase_givenObjectInCamelCase_expectJsonStringSnakeCase() {
         let given = TestCase(barDate: Date(timeIntervalSince1970: givenSecondsSince1970))
@@ -22,7 +22,7 @@ class JsonAdapterTest: UnitTest {
     }
 
     func test_snakeCase_givenStringInSnakeCase_expectObjectInCamelCase() {
-        let givenString = #"{"bar_date":1629743524}"#
+        let givenString = #"{"bar_date":1629743524.100}"#
         let expected = TestCase(barDate: Date(timeIntervalSince1970: givenSecondsSince1970))
 
         let actual: TestCase = jsonAdapter.fromJson(givenString.data)!


### PR DESCRIPTION
- push events tracking url path
- prevent messagingpush not being garbage collected
- brought back returning bool handled
- fix push metrics request body
- fix jsonadapter remove decimal unix time
- fix opened push metric tracking
