### PR TITLE
fix: improve user-agent with more detail

### DIFF
--- a/Sources/Tracking/DeviceInfo.swift
+++ b/Sources/Tracking/DeviceInfo.swift
@@ -1,4 +1,5 @@
 import Foundation
+#if canImport(UIKit)
 import UIKit
 
 internal enum DeviceInfo {

--- a/Sources/Tracking/DeviceInfo.swift
+++ b/Sources/Tracking/DeviceInfo.swift
@@ -3,10 +3,13 @@ import Foundation
 import UIKit
 
 internal enum DeviceInfo {
+    /// Device's model on which SDK is running eg. iPhone12,3
     static let deviceInfo: String = UIDevice.deviceModelCode
-    static let phoneName : String = Bundle.main.infoDictionary?["CFBundleName"] as! String
+    /// Operating system and version of OS of the Device
     static let osInfo : String = "\(UIDevice().systemName) \(UIDevice().systemVersion)"
+    /// Name of customer's application using the SDK
     static let customerAppName : String = Bundle.main.infoDictionary?["CFBundleName"] as? String ?? ""
+    /// Version of the customer's application using the SDK
     static let customerAppVersion : String = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
 }
 #endif

--- a/Sources/Tracking/DeviceInfo.swift
+++ b/Sources/Tracking/DeviceInfo.swift
@@ -9,3 +9,4 @@ internal enum DeviceInfo {
     static let customerAppName : String = Bundle.main.infoDictionary?["CFBundleName"] as? String ?? ""
     static let customerAppVersion : String = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
 }
+#endif

--- a/Sources/Tracking/DeviceInfo.swift
+++ b/Sources/Tracking/DeviceInfo.swift
@@ -1,0 +1,10 @@
+import Foundation
+import UIKit
+
+internal enum DeviceInfo {
+    static let deviceInfo: String = UIDevice.deviceModelCode
+    static let phoneName : String = Bundle.main.infoDictionary?["CFBundleName"] as! String
+    static let osInfo : String = "\(UIDevice().systemName) \(UIDevice().systemVersion)"
+    static let customerAppName : String = Bundle.main.infoDictionary?["CFBundleName"] as? String ?? ""
+    static let customerAppVersion : String = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+}

--- a/Sources/Tracking/Extensions/DeviceExtension.swift
+++ b/Sources/Tracking/Extensions/DeviceExtension.swift
@@ -1,0 +1,18 @@
+import Foundation
+import UIKit
+
+public extension UIDevice {
+
+    static let deviceModelCode : String = {
+            
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        let machineMirror = Mirror(reflecting: systemInfo.machine)
+        let identifier = machineMirror.children.reduce("") { identifier, element in
+            guard let value = element.value as? Int8, value != 0 else { return identifier }
+            return identifier + String(UnicodeScalar(UInt8(value)))
+        }
+        return identifier
+    }()
+    
+}

--- a/Sources/Tracking/Extensions/DeviceExtension.swift
+++ b/Sources/Tracking/Extensions/DeviceExtension.swift
@@ -2,6 +2,18 @@ import Foundation
 #if canImport(UIKit)
 import UIKit
 
+
+/**
+ Extend `UIDevice` to get user's device information such as
+ device's model. If running on Simulator `deviceModelCode`
+ will return values like`x86_64` but when running on a device, this function
+ returns exact device model for example, `iPhone12,3`
+ 
+ Use case :
+ To get model detail, simply use
+ 
+ let deviceModelInfo = UIDevice.deviceModelCode
+ */
 public extension UIDevice {
 
     static let deviceModelCode : String = {

--- a/Sources/Tracking/Extensions/DeviceExtension.swift
+++ b/Sources/Tracking/Extensions/DeviceExtension.swift
@@ -1,4 +1,5 @@
 import Foundation
+#if canImport(UIKit)
 import UIKit
 
 public extension UIDevice {
@@ -14,5 +15,5 @@ public extension UIDevice {
         }
         return identifier
     }()
-    
 }
+#endif

--- a/Sources/Tracking/Service/HttpClient.swift
+++ b/Sources/Tracking/Service/HttpClient.swift
@@ -132,10 +132,11 @@ extension CIOHttpClient {
     static func getUserAgent() -> String {
         var userAgent = "Customer.io iOS Client/"
         userAgent += SdkVersion.version
+        #if canImport(UIKit)
         userAgent += " (\(DeviceInfo.deviceInfo); \(DeviceInfo.osInfo))"
         userAgent += " \(DeviceInfo.customerAppName)/"
         userAgent += DeviceInfo.customerAppVersion
-        
+        #endif
         return userAgent
     }
 }

--- a/Sources/Tracking/Service/HttpClient.swift
+++ b/Sources/Tracking/Service/HttpClient.swift
@@ -111,12 +111,13 @@ extension CIOHttpClient {
         let urlSessionConfig = URLSessionConfiguration.ephemeral
         let basicAuthHeaderString = "Basic \(getBasicAuthHeaderString(siteId: siteId, apiKey: apiKey))"
 
+        
         urlSessionConfig.allowsCellularAccess = true
         urlSessionConfig.timeoutIntervalForResource = 30
         urlSessionConfig.timeoutIntervalForRequest = 60
         urlSessionConfig.httpAdditionalHeaders = ["Content-Type": "application/json; charset=utf-8",
                                                   "Authorization": basicAuthHeaderString,
-                                                  "User-Agent": "CustomerIO-SDK-iOS/\(SdkVersion.version)"]
+                                                  "User-Agent": getUserAgent()]
 
         return URLSession(configuration: urlSessionConfig, delegate: nil, delegateQueue: nil)
     }
@@ -126,5 +127,15 @@ extension CIOHttpClient {
         let encodedRawHeader = rawHeader.data(using: .utf8)!
 
         return encodedRawHeader.base64EncodedString(options: NSData.Base64EncodingOptions(rawValue: 0))
+    }
+    
+    static func getUserAgent() -> String {
+        var userAgent = "Customer.io iOS Client/"
+        userAgent += SdkVersion.version
+        userAgent += " (\(DeviceInfo.deviceInfo); \(DeviceInfo.osInfo))"
+        userAgent += " \(DeviceInfo.customerAppName)/"
+        userAgent += DeviceInfo.customerAppVersion
+        
+        return userAgent
     }
 }

--- a/Sources/Tracking/Service/HttpClient.swift
+++ b/Sources/Tracking/Service/HttpClient.swift
@@ -129,6 +129,16 @@ extension CIOHttpClient {
         return encodedRawHeader.base64EncodedString(options: NSData.Base64EncodingOptions(rawValue: 0))
     }
     
+    /**
+     * getUserAgent - To get `user-agent` header value. This value depends on SDK version
+     * and device detail such as OS version, device model, customer's app name etc
+     *
+     * In case, UIKit is available then this function returns value in following format :
+     * `Customer.io iOS Client/1.0.0-alpha.16 (iPhone 11 Pro; iOS 14.5) User App/1.0`
+     *
+     * Otherwise will return
+     * `Customer.io iOS Client/1.0.0-alpha.16`
+     */
     static func getUserAgent() -> String {
         var userAgent = "Customer.io iOS Client/"
         userAgent += SdkVersion.version

--- a/Tests/Tracking/Service/HttpClientTest.swift
+++ b/Tests/Tracking/Service/HttpClientTest.swift
@@ -167,4 +167,20 @@ class HttpClientTest: UnitTest {
 
         XCTAssertEqual(actual, expected)
     }
+    
+    func testGetUserAgent() {
+        let userAgentValue = CIOHttpClient.getUserAgent()
+        
+        var expectedUserAgent = "Customer.io iOS Client/\(SdkVersion.version)"
+        
+        #if canImport(UIKit)
+        let deviceModel = UIDevice.deviceModelCode
+        let appName = Bundle.main.infoDictionary?["CFBundleName"] as? String ?? ""
+        let osInfo = "\(UIDevice().systemName) \(UIDevice().systemVersion)"
+        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+        expectedUserAgent += " (\(deviceModel); \(osInfo)) \(appName)/\(appVersion)"
+        #endif
+        
+        XCTAssertEqual(userAgentValue, expectedUserAgent)
+    }
 }


### PR DESCRIPTION
[Issue 6245](https://github.com/customerio/issues/issues/6245) 

This PR contains : 

### Adding user-agent value in request header ### 

- Add value of user-agent in header which can be easily parsed by the backend
- Format followed : `Customer.io iOS Client/1.0.0-alpha.16 (x86_64; iOS 14.5) User App/1.0`
- In case UIKit is unavailable : `Customer.io iOS Client/1.0.0-alpha.16`


Manual testing done on :
- [x] Simulator
- [ ] Physical Device