### PR TITLE
fix: logs now show up in mac console app

### DIFF
--- a/Sources/Tracking/Util/Log.swift
+++ b/Sources/Tracking/Util/Log.swift
@@ -2,9 +2,6 @@ import Foundation
 #if canImport(os)
 import os.log
 #endif
-#if canImport(OSLog)
-import OSLog
-#endif
 
 /// mockable logger + abstract that allows you to log to multiple places if you wish
 public protocol Logger: AutoMockable {
@@ -27,17 +24,17 @@ public class ConsoleLogger: Logger {
     private let logSubsystem = "io.customer.sdk"
     private let logCategory = "CIO"
 
+    #if canImport(os)
     // Unified logging for Swift. https://www.avanderlee.com/workflow/oslog-unified-logging/
     // This means we can view logs in xcode console + Console app.
     private func printMessage(_ message: String, _ level: OSLogType) {
-        #if canImport(os)
-        newOsLog(message, level)
-        #elseif canImport(OSLog)
-        oldOsLog(message, level)
-        #endif
-
-        // At this time, Linux cannot use `os.log` or `OSLog`. Instead, use: https://github.com/apple/swift-log/
-        // As we don't officially support Linux at this time, no need to add a dependency to the project.
+        if #available(iOS 14, *) {
+            let logger = os.Logger(subsystem: self.logSubsystem, category: self.logCategory)
+            logger.info("\(message, privacy: .public)")
+        } else {
+            let logger = OSLog(subsystem: logSubsystem, category: logCategory)
+            os_log("%{public}@", log: logger, type: .info, message)
+        }
     }
 
     public func debug(_ message: String) {
@@ -51,24 +48,12 @@ public class ConsoleLogger: Logger {
     public func error(_ message: String) {
         printMessage(message, .error)
     }
-}
-
-extension ConsoleLogger {
-    private func newOsLog(_ message: String, _ level: OSLogType) {
-        #if canImport(os)
-        if #available(iOS 14, *) {
-            let logger = os.Logger(subsystem: self.logSubsystem, category: self.logCategory)
-            logger.info("\(message, privacy: .public)")
-        } else {
-            oldOsLog(message, level)
-        }
-        #endif
-    }
-
-    private func oldOsLog(_ message: String, _ level: OSLogType) {
-        #if canImport(OSLog)
-        let logger = OSLog(subsystem: logSubsystem, category: logCategory)
-        os_log("%{public}@", log: logger, type: .info, message)
-        #endif
-    }
+    #else
+    // At this time, Linux cannot use `os.log` or `OSLog`. Instead, use: https://github.com/apple/swift-log/
+    // As we don't officially support Linux at this time, no need to add a dependency to the project.
+    // therefore, we are not logging if can't import os.log
+    public func debug(_ message: String) {}
+    public func info(_ message: String) {}
+    public func error(_ message: String) {}
+    #endif
 }

--- a/Sources/Tracking/Util/Log.swift
+++ b/Sources/Tracking/Util/Log.swift
@@ -1,34 +1,49 @@
 import Foundation
+import os.log
+import OSLog
 
-public protocol Logger {
-    func verbose(_ message: String)
+/// mockable logger + abstract that allows you to log to multiple places if you wish
+public protocol Logger: AutoMockable {
+    /// the noisey log level. Feel free to spam this log level with any
+    /// information about the SDK that would be useful for debugging the SDK.
     func debug(_ message: String)
+    /// Not noisy log messages. Good for general information such as
+    /// when the background queue begins and ends running but use `debug`
+    /// for the status of each background queue task running.
     func info(_ message: String)
-    func warning(_ message: String)
+    /// the SDK is in an unstable state that you want to notify
+    /// the customer or our development team about.
     func error(_ message: String)
 }
 
+// log messages to console.
 // sourcery: InjectRegister = "Logger"
 public class ConsoleLogger: Logger {
-    private let prefix = "[Cio]"
+    // allows filtering in Console mac app
+    private let logSubsystem = "io.customer.sdk"
+    private let logCategory = "CIO"
 
-    public func verbose(_ message: String) {
-        print("\(prefix) Verbose: \(message)")
+    // Unified logging for Swift. https://www.avanderlee.com/workflow/oslog-unified-logging/
+    // This means we can view logs in xcode console + Console app.
+    private func printMessage(_ message: String, _ level: OSLogType) {
+        if #available(iOS 14, *) {
+            let logger = os.Logger(subsystem: self.logSubsystem, category: self.logCategory)
+            logger.info("\(message, privacy: .public)")
+        } else {
+            let logger = OSLog(subsystem: logSubsystem, category: logCategory)
+            os_log("%{public}@", log: logger, type: .info, message)
+        }
     }
 
     public func debug(_ message: String) {
-        print("\(prefix) Debug: \(message)")
+        printMessage(message, .debug)
     }
 
     public func info(_ message: String) {
-        print("\(prefix) Info: \(message)")
-    }
-
-    public func warning(_ message: String) {
-        print("\(prefix) Warning: \(message)")
+        printMessage(message, .info)
     }
 
     public func error(_ message: String) {
-        print("\(prefix) Error: \(message)")
+        printMessage(message, .error)
     }
 }

--- a/Sources/Tracking/Util/Log.swift
+++ b/Sources/Tracking/Util/Log.swift
@@ -2,7 +2,9 @@ import Foundation
 #if canImport(os)
 import os.log
 #endif
+#if canImport(OSLog)
 import OSLog
+#endif
 
 /// mockable logger + abstract that allows you to log to multiple places if you wish
 public protocol Logger: AutoMockable {
@@ -30,9 +32,12 @@ public class ConsoleLogger: Logger {
     private func printMessage(_ message: String, _ level: OSLogType) {
         #if canImport(os)
         newOsLog(message, level)
-        #else
+        #elseif canImport(OSLog)
         oldOsLog(message, level)
         #endif
+
+        // At this time, Linux cannot use `os.log` or `OSLog`. Instead, use: https://github.com/apple/swift-log/
+        // As we don't officially support Linux at this time, no need to add a dependency to the project.
     }
 
     public func debug(_ message: String) {
@@ -50,16 +55,20 @@ public class ConsoleLogger: Logger {
 
 extension ConsoleLogger {
     private func newOsLog(_ message: String, _ level: OSLogType) {
+        #if canImport(os)
         if #available(iOS 14, *) {
             let logger = os.Logger(subsystem: self.logSubsystem, category: self.logCategory)
             logger.info("\(message, privacy: .public)")
         } else {
             oldOsLog(message, level)
         }
+        #endif
     }
 
     private func oldOsLog(_ message: String, _ level: OSLogType) {
+        #if canImport(OSLog)
         let logger = OSLog(subsystem: logSubsystem, category: logCategory)
         os_log("%{public}@", log: logger, type: .info, message)
+        #endif
     }
 }


### PR DESCRIPTION
To better improve the QA experience of the team, log messages now show up in the macOS Console app instead of just the Xcode console. This allows the team to be able to view logs for pre-built versions of the app and not just builds built in Xcode. 