### PR TITLE
ci: disable production deployments

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -1,7 +1,7 @@
 name: Deploy SDK 
 on:
   push:
-    branches: [main, beta, alpha]
+    branches: [beta, alpha]
 
 jobs:
   deploy-sdk:


### PR DESCRIPTION
While we are only in alpha and beta, disable production deployments so we don't make a mistake and deploy to it﻿
