### PR TITLE
fix: opened push metrics being sent to API again

### DIFF
--- a/Sources/MessagingPush/MessagingPushImplementation.swift
+++ b/Sources/MessagingPush/MessagingPushImplementation.swift
@@ -94,7 +94,7 @@ internal class MessagingPushImplementation: MessagingPushInstance {
         logger.debug("delivery id \(deliveryID) device token \(deviceToken)")
 
         _ = backgroundQueue.addTask(type: QueueTaskType.trackPushMetric.rawValue,
-                                    data: MetricRequest(deliveryID: deliveryID, event: event, deviceToken: deviceToken,
+                                    data: MetricRequest(deliveryId: deliveryID, event: event, deviceToken: deviceToken,
                                                         timestamp: Date()))
     }
 }

--- a/Sources/MessagingPush/Service/Request/MetricRequest.swift
+++ b/Sources/MessagingPush/Service/Request/MetricRequest.swift
@@ -8,15 +8,21 @@ public enum Metric: String, Codable {
 
 // https://customer.io/docs/api/#operation/pushMetrics
 internal struct MetricRequest: Codable {
-    let deliveryID: String
+    let deliveryId: String
     let event: Metric
     let deviceToken: String
     let timestamp: Date
 
     enum CodingKeys: String, CodingKey {
-        case deliveryID = "delivery_id"
+        case deliveryId
         case event
-        case deviceToken = "device_id"
+        case deviceToken = "deviceId"
         case timestamp
+    }
+}
+
+internal extension MetricRequest {
+    static var random: MetricRequest {
+        MetricRequest(deliveryId: String.random, event: .opened, deviceToken: String.random, timestamp: Date())
     }
 }

--- a/Sources/Tracking/Util/JsonAdapter.swift
+++ b/Sources/Tracking/Util/JsonAdapter.swift
@@ -47,6 +47,7 @@ public class JsonAdapter {
             let seconds = Int(date.timeIntervalSince1970)
             try container.encode(seconds)
         }
+        encoder.outputFormatting = .sortedKeys
         return encoder
     }
 

--- a/Tests/MessagingPush/MessagingPushImplementationTest.swift
+++ b/Tests/MessagingPush/MessagingPushImplementationTest.swift
@@ -115,7 +115,7 @@ class MessagingPushImplementationTest: UnitTest {
         XCTAssertEqual(queueMock.addTaskCallsCount, 1)
         XCTAssertEqual(queueMock.addTaskReceivedArguments?.type, QueueTaskType.trackPushMetric.rawValue)
         let actualQueueTaskData = queueMock.addTaskReceivedArguments!.data.value as! MetricRequest
-        XCTAssertEqual(actualQueueTaskData.deliveryID, givenDeliveryId)
+        XCTAssertEqual(actualQueueTaskData.deliveryId, givenDeliveryId)
         XCTAssertEqual(actualQueueTaskData.event, givenEvent)
         XCTAssertEqual(actualQueueTaskData.deviceToken, givenDeviceToken)
     }

--- a/Tests/MessagingPush/Service/Request/MetricRequestTest.swift
+++ b/Tests/MessagingPush/Service/Request/MetricRequestTest.swift
@@ -1,0 +1,35 @@
+@testable import CioMessagingPush
+@testable import CioTracking
+import Foundation
+import SharedTests
+import XCTest
+
+class MetricRequestTest: UnitTest {
+    func test_expectSuccessful_decode_encode() {
+        let metric = MetricRequest.random
+
+        guard let jsonData = jsonAdapter.toJson(metric, encoder: nil) else {
+            return XCTFail()
+        }
+
+        guard let _: MetricRequest = jsonAdapter.fromJson(jsonData) else {
+            return XCTFail()
+        }
+    }
+
+    func test_expectJsonStringApiRequires() {
+        let given = MetricRequest(deliveryId: "123", event: .opened, deviceToken: "234",
+                                  timestamp: Date(timeIntervalSince1970: 1642018466))
+        let expectedJson = """
+        {"delivery_id":"123","device_id":"234","event":"opened","timestamp":1642018466}
+        """
+
+        guard let jsonData = jsonAdapter.toJson(given, encoder: nil), let actualJson = jsonData.string else {
+            return XCTFail()
+        }
+
+        print(actualJson)
+
+        XCTAssertEqual(expectedJson, actualJson)
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/customerio/customerio-ios/issues/110
