### PR TITLE
fix: add siteid to logs help with multi-workspace

### DIFF
--- a/Sources/Tracking/Store/SiteId.swift
+++ b/Sources/Tracking/Store/SiteId.swift
@@ -1,3 +1,9 @@
 import Foundation
 
 public typealias SiteId = String
+
+public extension SiteId {
+    var abbreviatedSiteId: String {
+        self[0 ..< 5]
+    }
+}

--- a/Sources/Tracking/Util/Log.swift
+++ b/Sources/Tracking/Util/Log.swift
@@ -49,13 +49,15 @@ public class ConsoleLogger: Logger {
     private let logSubsystem = "io.customer.sdk"
     private let logCategory = "CIO"
 
+    private let siteId: SiteId
     private let sdkConfigStore: SdkConfigStore
 
     private var minLogLevel: CioLogLevel {
         sdkConfigStore.config.logLevel
     }
 
-    init(sdkConfigStore: SdkConfigStore) {
+    init(siteId: SiteId, sdkConfigStore: SdkConfigStore) {
+        self.siteId = siteId
         self.sdkConfigStore = sdkConfigStore
     }
 
@@ -65,12 +67,15 @@ public class ConsoleLogger: Logger {
     private func printMessage(_ message: String, _ level: OSLogType) {
         if !minLogLevel.shouldLog(level) { return }
 
+        let logsPrefix = "(siteid:\(siteId.abbreviatedSiteId))"
+        let messageToPrint = "\(logsPrefix) \(message)"
+
         if #available(iOS 14, *) {
             let logger = os.Logger(subsystem: self.logSubsystem, category: self.logCategory)
-            logger.log(level: level, "\(message, privacy: .public)")
+            logger.log(level: level, "\(messageToPrint, privacy: .public)")
         } else {
             let logger = OSLog(subsystem: logSubsystem, category: logCategory)
-            os_log("%{public}@", log: logger, type: level, message)
+            os_log("%{public}@", log: logger, type: level, messageToPrint)
         }
     }
 

--- a/Sources/Tracking/Util/Log.swift
+++ b/Sources/Tracking/Util/Log.swift
@@ -67,8 +67,7 @@ public class ConsoleLogger: Logger {
     private func printMessage(_ message: String, _ level: OSLogType) {
         if !minLogLevel.shouldLog(level) { return }
 
-        let logsPrefix = "(siteid:\(siteId.abbreviatedSiteId))"
-        let messageToPrint = "\(logsPrefix) \(message)"
+        let messageToPrint = "(siteid:\(siteId.abbreviatedSiteId)) \(message)"
 
         if #available(iOS 14, *) {
             let logger = os.Logger(subsystem: self.logSubsystem, category: self.logCategory)

--- a/Sources/Tracking/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/Tracking/autogenerated/AutoDependencyInjection.generated.swift
@@ -373,7 +373,7 @@ public class DITracking {
     }
 
     private var newLogger: Logger {
-        ConsoleLogger(sdkConfigStore: sdkConfigStore)
+        ConsoleLogger(siteId: siteId, sdkConfigStore: sdkConfigStore)
     }
 
     // HttpRetryPolicy


### PR DESCRIPTION
When the SDK is used with multiple CIO Workspaces (such as in the Remote Habits app), the SDK logs are difficult to understand. When an event happens, it's hard to see if the event is being recorded for workspace A or workspace B. 

This change adds to the logs the siteId that the event happens for to make debugging issues easier. 