### PR TITLE
ci: prevent false positives pushing cocoapods script

### DIFF
--- a/.github/FAIL_COCOAPODS_DEPLOY_ISSUE_TEMPLATE.md
+++ b/.github/FAIL_COCOAPODS_DEPLOY_ISSUE_TEMPLATE.md
@@ -1,0 +1,7 @@
+---
+title: Failure deploying Cocoapods
+---
+
+🤖 Automated message from deployment bot 🤖
+
+Tried to deploy {{ env.RELEASE_VERSION }} to Cocoapods. Deployment encountered a failure. See GitHub Actions logs to fix the issue and retry. 

--- a/.github/workflows/deploy-cocoapods.yml
+++ b/.github/workflows/deploy-cocoapods.yml
@@ -41,3 +41,12 @@ jobs:
         run: ./scripts/push-cocoapod.sh CustomerIOMessagingPushFCM.podspec
       - name: Push CustomerIO
         run: ./scripts/push-cocoapod.sh CustomerIO.podspec
+
+      - name: Create GitHub issue if fail to deploy 
+        uses: JasonEtco/create-an-issue@v2
+        if: ${{ failure() }} 
+        with: 
+          filename: .github/FAIL_COCOAPODS_DEPLOY_ISSUE_TEMPLATE.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.READ_ONLY_BOT_TOKEN }}
+          RELEASE_VERSION: ${{ github.event.release.tag_name }}

--- a/.github/workflows/deploy-cocoapods.yml
+++ b/.github/workflows/deploy-cocoapods.yml
@@ -1,8 +1,17 @@
 name: Deploy SDK to Cocoapods
+
 # Deploy cocoapods after a git tag made. Cocoapods uses tags to deploy. 
+# We also allow manually running this workflow in case a deploy failed for a given git tag and 
+# we want to retry it. 
 on:
   release:
     types: [published]
+  workflow_dispatch: 
+    inputs:
+      tagToPush:
+        description: 'Type name of existing git tag to retry pushing cocoapods for (example: 1.0.3)'
+        required: true
+        type: string 
 
 env:
   COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
@@ -13,6 +22,13 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Checkout existing tag if manually running CI task  
+        uses: actions/checkout@v2
+        # If input is not given, that probably means this CI task was run automatically by a new 
+        # git tag being pushed. Skip this step and try to deploy pods for new tag. 
+        if: ${{ github.event.inputs.tagToPush != '' }}
+        with:
+          ref: ${{ github.event.inputs.tagToPush }}
       - name: Install cocoapods 
         run: gem install cocoapods 
       - name: Push CustomerIOTracking 

--- a/scripts/push-cocoapod.sh
+++ b/scripts/push-cocoapod.sh
@@ -22,6 +22,7 @@
 set -e 
 
 PODSPEC="$1"
+NUMBER_RETRIES=60
 
 if ! [[ -f "$PODSPEC" ]]; then
     echo "File $PODSPEC does not exist. Please check the pod name."
@@ -29,9 +30,14 @@ fi
 
 echo "Pushing podspec: $PODSPEC."
 
-for i in {1..50}; do 
+for i in $(seq 1 $NUMBER_RETRIES); do 
     echo "Push attempt $i..."
     pod repo update;
     pod trunk push "$PODSPEC" --allow-warnings && break || sleep 30; 
     echo "Failed to push. Sleeping, then will try again."
+
+    if [ $i -eq $NUMBER_RETRIES ]; then 
+        echo "Hit retry limit. Failed to push the pod $PODSPEC. Exiting script with failure status."
+        exit 1
+    fi 
 done

--- a/scripts/push-cocoapod.sh
+++ b/scripts/push-cocoapod.sh
@@ -29,7 +29,7 @@ fi
 
 echo "Pushing podspec: $PODSPEC."
 
-for i in {1..30}; do 
+for i in {1..50}; do 
     echo "Push attempt $i..."
     pod repo update;
     pod trunk push "$PODSPEC" --allow-warnings && break || sleep 30; 


### PR DESCRIPTION
Right now, if the CI is pushing to cocoapods and the retry limit is reached, the script will gracefully shut down and report that the cocoapod pushed successfully. 

This PR makes the script fail if the max retry limit reached. 

This PR was made because the latest push to cocoapods hit it's retry limit but I didn't catch it because the CI's status is saying the script ran successfully. https://github.com/customerio/customerio-ios/actions/runs/1785461160

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [x] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [x] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [x] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request. A bot will *squash and merge* the pull request for you after the label is added. 
- [x] Retry pushing tag `1.0.1` on github actions. A couple of the pods failed to push. Now that we can manually run tasks after this PR is merged, retry `1.0.1`. 