### PR TITLE
fix: create valid JSON request body when sending nil as track events data

### DIFF
--- a/Sources/Tracking/CustomerIO.swift
+++ b/Sources/Tracking/CustomerIO.swift
@@ -116,6 +116,11 @@ public class CustomerIO: CustomerIOInstance {
         }
     }
 
+    // Constructor for testing.
+    internal init(implementation: CustomerIOImplementation) {
+        self.implementation = implementation
+    }
+
     /**
      Make testing the singleton `instance` possible.
      Note: It's recommended to delete app data before doing this to prevent loading persisted credentials
@@ -277,7 +282,7 @@ public class CustomerIO: CustomerIOInstance {
      */
     public func track<RequestBody: Encodable>(
         name: String,
-        data: RequestBody
+        data: RequestBody?
     ) {
         // XXX: notify developer if SDK not initialized yet
 

--- a/Tests/Tracking/CustomerIOImplementationTest.swift
+++ b/Tests/Tracking/CustomerIOImplementationTest.swift
@@ -4,7 +4,11 @@ import SharedTests
 import XCTest
 
 class CustomerIOImplementationTest: UnitTest {
-    private var customerIO: CustomerIOImplementation!
+    private var implementation: CustomerIOImplementation!
+    // When calling CustomerIOInstance functions in the test functions, use this `CustomerIO` instance.
+    // This is a workaround until this code base contains implementation tests. There have been bugs
+    // that have gone undiscovered in the code when `CustomerIO` passes a request to `CustomerIOImplementation`.
+    private var customerIO: CustomerIO!
 
     private var backgroundQueueMock = QueueMock()
     private var profileStoreMock = ProfileStoreMock()
@@ -20,7 +24,8 @@ class CustomerIOImplementationTest: UnitTest {
 
         hooksMock.underlyingProfileIdentifyHooks = [profileIdentifyHookMock]
 
-        customerIO = CustomerIOImplementation(siteId: diGraph.siteId)
+        implementation = CustomerIOImplementation(siteId: diGraph.siteId)
+        customerIO = CustomerIO(implementation: implementation)
     }
 
     // MARK: config


### PR DESCRIPTION
Customer is reporting issue is still happening: https://github.com/customerio/customerio-ios/issues/134#issuecomment-1031532870 where tracking events is generating `data:null` JSON request bodies. 

A [previous bug fix](https://github.com/customerio/customerio-ios/commit/04c5211ac83592e7191d7313a61e37cea8be38fa) was created to combat this issue with a test case to reproduce the error. However, the test resulted in a false positive because the test function only tested calling `CustomerIOImplementation.track()` and not calling `CustomerIO.track()`. When changing the test function to call `CustomerIO.track()` the bug was able to be reproduced and show that it still exists. 

