### PR TITLE
ci: copy deployed commits into develop after main deployments

### DIFF
--- a/.github/workflows/deploy-git-tag.yml
+++ b/.github/workflows/deploy-git-tag.yml
@@ -26,3 +26,10 @@ jobs:
         env:
           # Needs to push git commits to repo. Needs write access. 
           GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_BOT_TOKEN }}
+          
+      - name: Copy commits into develop after main deployment 
+        uses: levibostian/action-sync-branches@v1
+        with:
+          behind: develop
+          ahead: main 
+          githubToken: ${{ secrets.WRITE_ACCESS_BOT_TOKEN }}


### PR DESCRIPTION
Part of [`git-flow`](https://nvie.com/posts/a-successful-git-branching-model/) is that once you make a production deployment, you merge those commits back into your `develop` branch. I forgot to add this step to [my previous git-flow PR](https://github.com/customerio/customerio-ios/pull/133). This PR adds this task in where commits added to `main` will be merged into `develop` after a production deployment. 

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [x] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [x] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [x] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request. A bot will *squash and merge* the pull request for you after the label is added. 