### PR TITLE
fix: change property name from push_subscribed to push_enabled

### DIFF
--- a/Sources/MessagingPush/util/DeviceAttributesProvider.swift
+++ b/Sources/MessagingPush/util/DeviceAttributesProvider.swift
@@ -33,7 +33,7 @@ internal class SdkDeviceAttributesProvider: DeviceAttributesProvider {
             deviceAttributes["device_os"] = deviceOs
         }
         deviceInfo.isPushSubscribed { isSubscribed in
-            deviceAttributes["push_subscribed"] = String(isSubscribed)
+            deviceAttributes["push_enabled"] = String(isSubscribed)
 
             onComplete(deviceAttributes)
         }

--- a/Tests/MessagingPush/util/DeviceAttributesProviderTest.swift
+++ b/Tests/MessagingPush/util/DeviceAttributesProviderTest.swift
@@ -49,7 +49,7 @@ class DeviceAttributesProviderTest: UnitTest {
             "cio_sdk_version": givenSdkVersion,
             "app_version": givenAppVersion,
             "device_locale": givenDeviceLocale,
-            "push_subscribed": "true"
+            "push_enabled": "true"
         ]
         deviceInfoMock.underlyingSdkVersion = givenSdkVersion
         deviceInfoMock.underlyingCustomerAppVersion = givenAppVersion


### PR DESCRIPTION
This fix is related to [PR #143](https://github.com/customerio/customerio-ios/pull/143) and [this](https://github.com/customerio/issues/issues/6510) ticket. 

minor fix to change property name (from list of default device attributes) from `push_subscribed` to `push_enabled` 

<img width="1171" alt="Screenshot 2022-03-22 at 10 07 59 PM" src="https://user-images.githubusercontent.com/91549653/159530280-8c7e3c3d-a549-419c-a107-856c8d8ab9d2.png">

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [x] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request. A bot will *squash and merge* the pull request for you after the label is added. 