### PR TITLE
fix: locale uses preferred language

### DIFF
--- a/Sources/Tracking/Util/DeviceInfo.swift
+++ b/Sources/Tracking/Util/DeviceInfo.swift
@@ -66,12 +66,22 @@ public class CIODeviceInfo: DeviceInfo {
         SdkVersion.version
     }
 
+    // Requirements:
+    // 1. Use - instead of _
+    // 2. We prefer to get the OS language that the user has set. First try to return that. If that does not succeed
+    // we default to the language set for the host app. The language returned for that will only return languagues
+    // that the app supports. If OS set to "es" but app does not support Spanish, then "es" will not be returned.
     public var deviceLocale: String {
-        guard let preferredIdentifier = Locale.preferredLanguages.first else {
-            return Locale.current.identifier
+        if let osSetLanguage = Locale.preferredLanguages.first {
+            let locale = Locale(identifier: osSetLanguage)
+
+            if let languageCode = locale.languageCode,
+               let regionCode = locale.regionCode {
+                return "\(languageCode)-\(regionCode)"
+            }
         }
 
-        return preferredIdentifier.replacingOccurrences(of: "_", with: "-")
+        return Locale.current.identifier.replacingOccurrences(of: "_", with: "-")
     }
 
     public func isPushSubscribed(completion: @escaping (Bool) -> Void) {

--- a/Sources/Tracking/Util/DeviceInfo.swift
+++ b/Sources/Tracking/Util/DeviceInfo.swift
@@ -67,7 +67,11 @@ public class CIODeviceInfo: DeviceInfo {
     }
 
     public var deviceLocale: String {
-        Locale.current.identifier.replacingOccurrences(of: "_", with: "-")
+        guard let preferredIdentifier = Locale.preferredLanguages.first else {
+            return Locale.current.identifier
+        }
+
+        return preferredIdentifier.replacingOccurrences(of: "_", with: "-")
     }
 
     public func isPushSubscribed(completion: @escaping (Bool) -> Void) {


### PR DESCRIPTION
Currently, the device locale that the SDK obtains is the current locale of the host app. This has limitations on it because if the user's device is set to Spanish but the host app does not support Spanish, the device locale that the SDK receives is not Spanish. 

We want to improve our SDK's code in regards to obtaining the device locale. We would prefer is we get the locale of the device even if the host app does not support it. That's what this PR is doing. 

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request. A bot will *squash and merge* the pull request for you after the label is added. 