### PR TITLE
fix: some classes not found in tracking module

### DIFF
--- a/Sources/Tracking/Type/Aliases.swift
+++ b/Sources/Tracking/Type/Aliases.swift
@@ -1,0 +1,12 @@
+import Common
+import Foundation
+
+/*
+ Contains public aliases to expose public structures from the 'Common' module
+ to the 'Tracking' module. The goal is that customers do not need to import
+ the 'Common' module in their code. But, some data structures need to exist
+ in 'Common' as they are used in the 'Common' code.
+ */
+
+public typealias Region = Common.Region
+public typealias CioLogLevel = Common.CioLogLevel


### PR DESCRIPTION
While developing remote habits, I experienced a moment where some classes could not be imported from the SDK. These classes exist in the `Common` module which we do not suggest customers `import` in their source code. The solution is to make these classes `public` and visible in one of the SDKs (probably the `Tracking` one). 

This PR fixes the issue by exporting the classes from the `Tracking` module. This fixed the issue with remote habits where now importing the Tracking module in the remote habits source code can now find these classes. I prefer to have the `Common` module be written in a more generic form where it does not contain classes the other SDKs require, but it would take a bigger refactor to be able to make these classes exported in this PR to no longer be needed in the `Common` module. 

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request. A bot will *squash and merge* the pull request for you after the label is added. 