### PR TITLE
fix: send attributes in all caps to API

### DIFF
--- a/Sources/MessagingPush/MessagingPushImplementation.swift
+++ b/Sources/MessagingPush/MessagingPushImplementation.swift
@@ -97,7 +97,7 @@ internal class MessagingPushImplementation: MessagingPushInstance {
                                                                    lastUsed: self.dateUtil.now,
                                                                    attributes: encodableBody))
 
-            guard let jsonBodyString = self.jsonAdapter.toJsonString(requestBody, encoder: nil) else {
+            guard let jsonBodyString = self.jsonAdapter.toJsonString(requestBody) else {
                 return
             }
             let queueTaskData = RegisterPushNotificationQueueTaskData(profileIdentifier: identifier,

--- a/Sources/Tracking/CustomerIOImplementation.swift
+++ b/Sources/Tracking/CustomerIOImplementation.swift
@@ -80,7 +80,7 @@ public class CustomerIOImplementation: CustomerIOInstance {
             guard let existingProfileIdentifier = profileStore.identifier else {
                 return
             }
-            identify(identifier: existingProfileIdentifier, body: StringAnyEncodable(newValue))
+            identify(identifier: existingProfileIdentifier, body: newValue)
         }
     }
 
@@ -117,7 +117,8 @@ public class CustomerIOImplementation: CustomerIOInstance {
             }
         }
 
-        let jsonBodyString = jsonAdapter.toJsonString(body, encoder: nil)
+        // Custom attributes so do not modify keys in JSON string
+        let jsonBodyString = jsonAdapter.toJsonString(body, convertKeysToSnakecase: false)
         logger.debug("identify profile attributes \(jsonBodyString ?? "none")")
 
         let queueTaskData = IdentifyProfileQueueTaskData(identifier: identifier,
@@ -217,7 +218,7 @@ extension CustomerIOImplementation {
         let data: AnyEncodable = (data == nil) ? AnyEncodable(EmptyRequestBody()) : AnyEncodable(data)
 
         let requestBody = TrackRequestBody(type: type, name: name, data: data, timestamp: Date())
-        guard let jsonBodyString = jsonAdapter.toJsonString(requestBody, encoder: nil) else {
+        guard let jsonBodyString = jsonAdapter.toJsonString(requestBody) else {
             logger.error("attributes provided for \(eventTypeDescription) \(name) failed to JSON encode.")
             return
         }

--- a/Sources/Tracking/Util/JsonAdapter.swift
+++ b/Sources/Tracking/Util/JsonAdapter.swift
@@ -151,7 +151,8 @@ public class JsonAdapter {
         return nil
     }
 
-    // default values for parameters are designed for creating JSON strings to send to our API. they are to meet the requirements of our API.
+    // default values for parameters are designed for creating JSON strings to send to our API.
+    // They are to meet the requirements of our API.
     public func toJsonString<T: Encodable>(_ obj: T,
                                            convertKeysToSnakecase: Bool = true,
                                            nilIfEmpty: Bool = true) -> String? {

--- a/Sources/Tracking/Util/JsonAdapter.swift
+++ b/Sources/Tracking/Util/JsonAdapter.swift
@@ -151,9 +151,12 @@ public class JsonAdapter {
         return nil
     }
 
-    public func toJsonString<T: Encodable>(_ obj: T, encoder override: JSONEncoder? = nil,
+    // default values for parameters are designed for creating JSON strings to send to our API. they are to meet the requirements of our API.
+    public func toJsonString<T: Encodable>(_ obj: T,
+                                           convertKeysToSnakecase: Bool = true,
                                            nilIfEmpty: Bool = true) -> String? {
-        guard let data = toJson(obj, encoder: override ?? encoder) else { return nil }
+        guard let data = toJson(obj, encoder: getEncoder(convertKeysToSnakecase: convertKeysToSnakecase))
+        else { return nil }
 
         let jsonString = data.string
 
@@ -165,5 +168,17 @@ public class JsonAdapter {
         }
 
         return jsonString
+    }
+
+    // modify the default encoder to change it's behavior for certain use cases.
+    private func getEncoder(convertKeysToSnakecase: Bool) -> JSONEncoder {
+        let modifiedEncoder = encoder
+        if convertKeysToSnakecase {
+            modifiedEncoder.keyEncodingStrategy = .convertToSnakeCase
+        } else {
+            modifiedEncoder.keyEncodingStrategy = .useDefaultKeys
+        }
+
+        return modifiedEncoder
     }
 }


### PR DESCRIPTION
Fix to production SDK to fix bug where custom attributes with keys in all caps gets sent to API with snackcase. Example: send "CITY" to the SDK and SDK converts this key to "c_ity". 

This PR is simply the bug fix itself. It does not include tests. I created [another PR](https://github.com/customerio/customerio-ios/pull/169) that is meant to get merged into `develop` that includes all of the tests for this PR. I tried to add the tests to this PR but there was a bit of complexity because of many utility classes created in `develop` that's not in `main`. 

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request. A bot will *squash and merge* the pull request for you after the label is added. 