### PR TITLE
feat: enable gist routing for automatic screenviews

### DIFF
--- a/Sources/Tracking/CustomerIO.swift
+++ b/Sources/Tracking/CustomerIO.swift
@@ -402,7 +402,7 @@ public class CustomerIO: CustomerIOInstance {
         data: RequestBody
     ) {
         getActiveWorkspaceInstances().forEach { _ in
-            implementation?.automaticScreenView(name: name, data: data)
+            implementation?.screen(name: name, data: data)
         }
     }
 } // swiftlint:disable:this file_length

--- a/Sources/Tracking/CustomerIOImplementation.swift
+++ b/Sources/Tracking/CustomerIOImplementation.swift
@@ -180,35 +180,36 @@ internal class CustomerIOImplementation: CustomerIOInstance {
         name: String,
         data: RequestBody?
     ) {
-        trackEvent(type: .event, name: name, data: data)
+        _ = trackEvent(type: .event, name: name, data: data)
     }
 
     public func track(name: String, data: [String: Any]) {
         track(name: name, data: StringAnyEncodable(data))
     }
 
-    // Meant to be called for manually tracked screen
     public func screen(name: String, data: [String: Any]) {
         screen(name: name, data: StringAnyEncodable(data))
     }
 
-    // Meant to be called for manually tracked screen
     public func screen<RequestBody: Encodable>(
         name: String,
         data: RequestBody
     ) {
-        trackEvent(type: .screen, name: name, data: data)
-    }
+        let eventWasTracked = trackEvent(type: .screen, name: name, data: data)
 
-    internal func automaticScreenView<RequestBody: Encodable>(name: String, data: RequestBody?) {
-        trackEvent(type: .screen, name: name, data: data)
+        if eventWasTracked {
+            hooks.screenViewHooks.forEach { hook in
+                hook.screenViewed(name: name)
+            }
+        }
     }
 }
 
 extension CustomerIOImplementation {
+    // returns if an event was tracked. If no event was tracked (request was ignored), false will be returned.
     private func trackEvent<RequestBody: Encodable>(type: EventType,
                                                     name: String,
-                                                    data: RequestBody?) {
+                                                    data: RequestBody?) -> Bool {
         let eventTypeDescription = (type == .screen) ? "track screen view event" : "track event"
 
         logger.info("\(eventTypeDescription) \(name)")
@@ -217,7 +218,7 @@ extension CustomerIOImplementation {
             // XXX: when we have anonymous profiles in SDK,
             // we can decide to not ignore events when a profile is not logged yet.
             logger.info("ignoring \(eventTypeDescription) \(name) because no profile currently identified")
-            return
+            return false
         }
 
         // JSON encoding with `data = nil` returns `"data":null`.
@@ -227,7 +228,7 @@ extension CustomerIOImplementation {
         let requestBody = TrackRequestBody(type: type, name: name, data: data, timestamp: Date())
         guard let jsonBodyString = jsonAdapter.toJsonString(requestBody) else {
             logger.error("attributes provided for \(eventTypeDescription) \(name) failed to JSON encode.")
-            return
+            return false
         }
         logger.debug("\(eventTypeDescription) attributes \(jsonBodyString)")
 
@@ -241,10 +242,6 @@ extension CustomerIOImplementation {
                                         .identifiedProfile(identifier: currentlyIdentifiedProfileIdentifier)
                                     ])
 
-        if type == .screen {
-            hooks.screenViewHooks.forEach { hook in
-                hook.screenViewed(name: name)
-            }
-        }
+        return true
     }
 }

--- a/Sources/Tracking/CustomerIOImplementation.swift
+++ b/Sources/Tracking/CustomerIOImplementation.swift
@@ -197,11 +197,6 @@ internal class CustomerIOImplementation: CustomerIOInstance {
         name: String,
         data: RequestBody
     ) {
-        // call hooks for manual screen view events at this time. Automatic screen view tracking is not the most stable.
-        hooks.screenViewHooks.forEach { hook in
-            hook.screenViewed(name: name)
-        }
-
         trackEvent(type: .screen, name: name, data: data)
     }
 
@@ -245,5 +240,11 @@ extension CustomerIOImplementation {
                                     blockingGroups: [
                                         .identifiedProfile(identifier: currentlyIdentifiedProfileIdentifier)
                                     ])
+
+        if type == .screen {
+            hooks.screenViewHooks.forEach { hook in
+                hook.screenViewed(name: name)
+            }
+        }
     }
 }

--- a/Tests/Tracking/CustomerIOImplementationTest.swift
+++ b/Tests/Tracking/CustomerIOImplementationTest.swift
@@ -214,15 +214,16 @@ class CustomerIOImplementationTest: UnitTest {
 
     // MARK: screen
 
-    func test_screen_givenNoProfileIdentified_expectIgnoreRequest() {
+    func test_screen_givenNoProfileIdentified_expectIgnoreRequest_expectDoNotCallHooks() {
         profileStoreMock.identifier = nil
 
         customerIO.screen(name: String.random)
 
         XCTAssertFalse(backgroundQueueMock.addTaskCalled)
+        XCTAssertFalse(hooksMock.mockCalled)
     }
 
-    func test_screen_expectAddTaskToQueue_expectCorrectDataAddedToQueue() {
+    func test_screen_expectAddTaskToQueue_expectCorrectDataAddedToQueue_expectCallHooks() {
         let givenIdentifier = String.random
         let givenData = ["first_name": "Dana"]
         profileStoreMock.identifier = givenIdentifier
@@ -238,5 +239,7 @@ class CustomerIOImplementationTest: UnitTest {
 
         XCTAssertEqual(actualQueueTaskData?.identifier, givenIdentifier)
         XCTAssertTrue(actualQueueTaskData!.attributesJsonString.contains(jsonAdapter.toJsonString(givenData)!))
+        XCTAssertTrue(hooksMock.screenViewHooksCalled)
+        XCTAssertEqual(hooksMock.screenViewHooksGetCallsCount, 1)
     }
 }


### PR DESCRIPTION
This PR enables Gist SDK in-app routing with automatic screen view tracking.  SDK was setup for only manually recorded screen views. Now that the iOS SDK has more stable automatic screenview reporting, we can enable routing for both manual and automatic screenview tracking. 

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request. A bot will *squash and merge* the pull request for you after the label is added. 