### PR TITLE
fix: make sdkwrapperconfig accessible

### DIFF
--- a/Sources/Common/Type/SDKWrapperConfig.swift
+++ b/Sources/Common/Type/SDKWrapperConfig.swift
@@ -3,15 +3,15 @@ import Foundation
 /// Metadata about a SDK wrapper/bridge made to use this Customer.io SDK.
 public struct SdkWrapperConfig {
     /// What is the technology used for this wrapper?
-    let source: Source
+    public let source: Source
     /// What version of your wrapper is installed?
-    let version: String
+    public let version: String
 
     /// All of the official SDK wrappers that we create around this SDK.
     /// At this time, we do not recommend to customers to build their own
     /// bridge/wrapper around our native mobile SDKs so there is no need
     /// to expand this to include more Sources besides ones that we use internally.
-    enum Source: String {
+    public enum Source: String {
         case reactNative = "ReactNative"
     }
 }

--- a/Sources/Common/Type/SDKWrapperConfig.swift
+++ b/Sources/Common/Type/SDKWrapperConfig.swift
@@ -14,4 +14,9 @@ public struct SdkWrapperConfig {
     public enum Source: String {
         case reactNative = "ReactNative"
     }
+    
+    public init(source: Source, version: String) {
+        self.source = source
+        self.version = version
+    }
 }

--- a/Sources/Common/Type/SDKWrapperConfig.swift
+++ b/Sources/Common/Type/SDKWrapperConfig.swift
@@ -14,7 +14,6 @@ public struct SdkWrapperConfig {
     public enum Source: String {
         case reactNative = "ReactNative"
     }
-    
     public init(source: Source, version: String) {
         self.source = source
         self.version = version


### PR DESCRIPTION
SdkWrapperConfig is inaccessible right now to modules outside it's scope such as using it in react native package. The fix is to make SdkWrapperConfig accessible.


Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request. A bot will *squash and merge* the pull request for you after the label is added. 