### PR TITLE
ci: add customeriocommon podspec to cocoapod deployment

### DIFF
--- a/.github/workflows/deploy-cocoapods.yml
+++ b/.github/workflows/deploy-cocoapods.yml
@@ -30,7 +30,9 @@ jobs:
         with:
           ref: ${{ github.event.inputs.tagBranchOrCommitToPush }}
       - name: Install cocoapods 
-        run: gem install cocoapods 
+        run: gem install cocoapods
+      - name: Push CustomerIOCommon
+        run: ./scripts/push-cocoapod.sh CustomerIOCommon.podspec
       - name: Push CustomerIOTracking
         run: ./scripts/push-cocoapod.sh CustomerIOTracking.podspec
       - name: Push CustomerIOMessagingPush 


### PR DESCRIPTION
### Problem
Deployment to Cocoapods failed because the module CustomerIOTracking depends on CustomerIOCommon and this module is missing in the deployment workflow. Because CustomerIOTracking could not be published, subsequent podspecs dependent on it also could not get deployed. 

Here is the error screenshot for reference.
 <img width="1333" alt="Screenshot 2022-08-08 at 5 18 32 PM" src="https://user-images.githubusercontent.com/91549653/183428092-576c037e-6901-4abb-a08e-aa49469095f9.png">

### Fix:
Updated workflow and added CustomerIOCommon podspec. Note that the series of podspecs to be run is important. Because CustomerIOTracking depends on CustomerIOCommon, this is why CustomerIOCommon is added to the start of push list followed by other podspecs.

### Steps to get PR merged
Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [x] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request. A bot will *squash and merge* the pull request for you after the label is added. 