### PR TITLE
fix: image not shown in rich push notification

### DIFF
--- a/Sources/MessagingPushAPN/MessagingPushAPN.swift
+++ b/Sources/MessagingPushAPN/MessagingPushAPN.swift
@@ -49,9 +49,8 @@ public protocol MessagingPushAPNInstance: AutoMockable {
 }
 
 public class MessagingPushAPN: MessagingPushAPNInstance {
-    internal let messagingPush: MessagingPush
     internal let customerIO: CustomerIOInstance!
-
+    internal let messagingPush: MessagingPush
     public init(customerIO: CustomerIOInstance) {
         self.customerIO = customerIO
         self.messagingPush = MessagingPush(customerIO: customerIO)
@@ -89,7 +88,7 @@ public class MessagingPushAPN: MessagingPushAPNInstance {
         _ request: UNNotificationRequest,
         withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
     ) -> Bool {
-        messagingPush.didReceive(request, withContentHandler: contentHandler)
+        (messagingPush as MessagingPushInstance).didReceive(request, withContentHandler: contentHandler)
     }
 
     /**
@@ -97,7 +96,7 @@ public class MessagingPushAPN: MessagingPushAPNInstance {
      Stop all network requests and modifying and show the push for what it looks like now.
      */
     public func serviceExtensionTimeWillExpire() {
-        messagingPush.serviceExtensionTimeWillExpire()
+        (messagingPush as MessagingPushInstance).serviceExtensionTimeWillExpire()
     }
 
     @available(iOSApplicationExtension, unavailable)


### PR DESCRIPTION
[Slack conversation](https://customerio.slack.com/archives/C03F7C5KQ4C/p1661347252603109?thread_ts=1661188398.751329&cid=C03F7C5KQ4C)

**Issue :**
Rich push notification was not showing image in the notification.

**Fix:**
The function was pointing to wrong instance which caused recursive calls & hence failed to show image in the push.

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [x] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request. A bot will *squash and merge* the pull request for you after the label is added. 