### PR TITLE
fix: consolidate all apple platforms under ios

### DIFF
--- a/Sources/MessagingPush/MessagingPushImplementation.swift
+++ b/Sources/MessagingPush/MessagingPushImplementation.swift
@@ -82,7 +82,7 @@ internal class MessagingPushImplementation: MessagingPushInstance {
         // OS name might not be available if running on non-apple product. We currently only support iOS for the SDK
         // and iOS should always be non-nil. Though, we are consolidating all Apple platforms under iOS but this check is
         // required to prevent SDK execution for unsupported OS.
-        guard let _ = deviceInfo.osName else {
+        if deviceInfo.osName == nil {
             logger.info("SDK being executed from unsupported OS. Ignoring request to register push token.")
             return
         }

--- a/Sources/MessagingPush/MessagingPushImplementation.swift
+++ b/Sources/MessagingPush/MessagingPushImplementation.swift
@@ -80,12 +80,14 @@ internal class MessagingPushImplementation: MessagingPushInstance {
             return
         }
         // OS name might not be available if running on non-apple product. We currently only support iOS for the SDK
-        // and iOS should always be non-nil.
-        guard let deviceOsName = deviceInfo.osName else {
+        // and iOS should always be non-nil. Though, we are consolidating all Apple platforms under iOS but this check is
+        // required to prevent SDK execution for unsupported OS.
+        guard let _ = deviceInfo.osName else {
             logger.info("SDK being executed from unsupported OS. Ignoring request to register push token.")
             return
         }
-
+        // Consolidate all Apple platforms under iOS
+        let deviceOsName = "iOS"
         deviceAttributesProvider.getDefaultDeviceAttributes { defaultDeviceAttributes in
             let deviceAttributes = defaultDeviceAttributes.mergeWith(customAttributes)
 


### PR DESCRIPTION
[Slack conversation](https://customerio.slack.com/archives/C01QYDKD0SU/p1661158061399669)

**Issue**
Customers registering their device from iPad were not getting listed under devices because the expected platforms are `iOS/Android`.

**Fix**
Consolidating all Apple platforms under `iOS` 

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request. A bot will *squash and merge* the pull request for you after the label is added. 