### PR TITLE
fix: added expo and flutter values in source enum

### DIFF
--- a/Sources/Common/Type/SDKWrapperConfig.swift
+++ b/Sources/Common/Type/SDKWrapperConfig.swift
@@ -13,6 +13,8 @@ public struct SdkWrapperConfig {
     /// to expand this to include more Sources besides ones that we use internally.
     public enum Source: String {
         case reactNative = "ReactNative"
+        case expo = "Expo"
+        case flutter = "Flutter"
     }
     public init(source: Source, version: String) {
         self.source = source


### PR DESCRIPTION
### Note that this branch will merge into main, creating a new version on production on merge.

**Added enum values for Expo and Flutter (so that we don't have to make a update for flutter, the next SDK in queue)**


Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request. A bot will *squash and merge* the pull request for you after the label is added. 