### PR TITLE
refactor!: remove FCM dependency from cocoapods

### DIFF
--- a/CustomerIOMessagingPushFCM.podspec
+++ b/CustomerIOMessagingPushFCM.podspec
@@ -20,6 +20,5 @@ Pod::Spec.new do |spec|
   spec.source_files  = "Sources/MessagingPushFCM/**/*"
   spec.module_name = "CioMessagingPushFCM" # the `import X` name when using SDK in Swift files 
   
-  spec.dependency "CustomerIOMessagingPush", "= #{spec.version.to_s}"
-  spec.dependency "FirebaseMessaging", '~> 8.10.0'
+  spec.dependency "CustomerIOMessagingPush", "= #{spec.version.to_s}"  
 end


### PR DESCRIPTION
Breaking change introduced: 
* Customers impacted: React Native customers using FCM. That's because if they follow our docs as they appear today, we do not tell customers to install Firebase dependencies on their own with cocoapods. So, by RN customers upgrading the iOS SDK to include this change, they will need to install the firebase SDK themselves. 

~~Needs to be tested:~~ [done](https://github.com/customerio/customerio-ios/pull/210#issuecomment-1305794706)
* Create new iOS app that uses cocoapods
* Install [this PR](https://github.com/customerio/customerio-ios/issues/203#issuecomment-1303787347)
* Integrate FCM
* Run app and see if receive a rich push

This PR fixes [this customer reported issue](https://github.com/customerio/customerio-ios/issues/203). Our original action item was to update the Firebase dependency in our iOS SDK. However, after evaluation, I determined that our code doesn't not actually reference anything from Firebase at this time. Our SPM config files do not contain any Firebase dependency items at all. So, I removed the dependency to fix this customer issue. 

Maybe the Firebase dependency was originally added for react native? If so, I assume that the react native can declare FCM as a dependency in itself instead of inheriting the FCM dependency from the CIO iOS SDK. 