### PR TITLE
fix: fix compile time errors notification service extensions

### DIFF
--- a/Sources/Common/Extensions/UIApplicationExtensions.swift
+++ b/Sources/Common/Extensions/UIApplicationExtensions.swift
@@ -3,7 +3,7 @@ import Foundation
 import UIKit
 
 public extension UIApplication {
-    @available(iOSApplicationExtension, unavailable)
+    @available(iOSApplicationExtension, unavailable) // since some extension functions may be able to run in iOS app extensions, only disable for this 1 function
     func open(url: URL) {
         open(url, options: [:]) { _ in }
     }

--- a/Sources/Common/Extensions/UIApplicationExtensions.swift
+++ b/Sources/Common/Extensions/UIApplicationExtensions.swift
@@ -3,6 +3,7 @@ import Foundation
 import UIKit
 
 public extension UIApplication {
+    @available(iOSApplicationExtension, unavailable)
     func open(url: URL) {
         open(url, options: [:]) { _ in }
     }

--- a/Sources/Tracking/CustomerIOImplementation+ScreenViews.swift
+++ b/Sources/Tracking/CustomerIOImplementation+ScreenViews.swift
@@ -2,7 +2,7 @@ import Foundation
 #if canImport(UIKit)
 import UIKit
 
-@available(iOSApplicationExtension, unavailable)
+@available(iOSApplicationExtension, unavailable) // screen view tracking is not available for notification service extension. disable all functions having to deal with screen view tracking feature. 
 extension CustomerIOImplementation {
     func setupAutoScreenviewTracking() {
         swizzle(
@@ -24,7 +24,7 @@ extension CustomerIOImplementation {
     }
 }
 
-@available(iOSApplicationExtension, unavailable)
+@available(iOSApplicationExtension, unavailable) // screen view tracking is not available for notification service extension. disable all functions having to deal with screen view tracking feature. 
 internal extension UIViewController {
     var defaultScreenViewBody: ScreenViewData {
         ScreenViewData()

--- a/Sources/Tracking/CustomerIOImplementation+ScreenViews.swift
+++ b/Sources/Tracking/CustomerIOImplementation+ScreenViews.swift
@@ -2,6 +2,7 @@ import Foundation
 #if canImport(UIKit)
 import UIKit
 
+@available(iOSApplicationExtension, unavailable)
 extension CustomerIOImplementation {
     func setupAutoScreenviewTracking() {
         swizzle(
@@ -23,6 +24,7 @@ extension CustomerIOImplementation {
     }
 }
 
+@available(iOSApplicationExtension, unavailable)
 internal extension UIViewController {
     var defaultScreenViewBody: ScreenViewData {
         ScreenViewData()


### PR DESCRIPTION
Fixes: https://secure.helpscout.net/conversation/2063138194/182158
Xcode gives compile-time errors unless certain annotations are added to the code. This bug has been fixed in the past, but was not tested in the configuration that the customer is using (cocoapods with FCM). 

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request. A bot will *squash and merge* the pull request for you after the label is added. 