### PR TITLE
fix: sdk not able to compile in ios app

### DIFF
--- a/Sources/Tracking/CustomerIO.swift
+++ b/Sources/Tracking/CustomerIO.swift
@@ -163,9 +163,14 @@ public class CustomerIO: CustomerIOInstance {
             siteId: siteId,
             apiKey: apiKey,
             region: region,
-            isFromiOSApplicationExtension: false,
             config: newSdkConfig
         )
+
+        if newSdkConfig.autoTrackScreenViews {
+            // Setting up screen view tracking is not available for rich push (Notification Service Extension).
+            // Only call this code when not possibly being called from a NSE.
+            Self.shared.setupAutoScreenviewTracking()
+        }
     }
 
     /**
@@ -190,7 +195,6 @@ public class CustomerIO: CustomerIOInstance {
             siteId: siteId,
             apiKey: apiKey,
             region: region,
-            isFromiOSApplicationExtension: true,
             config: newSdkConfig.toSdkConfig()
         )
     }
@@ -201,19 +205,12 @@ public class CustomerIO: CustomerIOInstance {
         siteId: String,
         apiKey: String,
         region: Region,
-        isFromiOSApplicationExtension: Bool,
         config: SdkConfig
     ) {
         let newDiGraph = DIGraph(siteId: siteId, apiKey: apiKey, sdkConfig: config)
 
         Self.shared.diGraph = newDiGraph
         Self.shared.implementation = CustomerIOImplementation(siteId: siteId, diGraph: newDiGraph)
-
-        if !isFromiOSApplicationExtension, config.autoTrackScreenViews {
-            // Setting up screen view tracking is not available for rich push (Notification Service Extension).
-            // Only call this code when not possibly being called from a NSE.
-            Self.shared.setupAutoScreenviewTracking()
-        }
 
         Self.shared.postInitialize(siteId: siteId, diGraph: newDiGraph)
     }


### PR DESCRIPTION
I found this bug while updating our sample apps with `2.0.0-alpha.1`. 

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request. A bot will *squash and merge* the pull request for you after the label is added. 