### PR TITLE
fix: add sdkwrapperconfig to rich push SDK config

### DIFF
--- a/Sources/Common/Store/SdkConfig.swift
+++ b/Sources/Common/Store/SdkConfig.swift
@@ -108,6 +108,12 @@ public struct NotificationServiceExtensionSdkConfig {
     public var logLevel: CioLogLevel
     /// See `SdkConfig.autoTrackDeviceAttributes`
     public var autoTrackDeviceAttributes: Bool
+    // property is used internally so disable swiftlint rule
+    /**
+     Used internally at Customer.io to override some information in the SDK when the SDK is being used
+     as a wrapper/bridge such as with ReactNative.
+     */
+    public var _sdkWrapperConfig: SdkWrapperConfig? // swiftlint:disable:this identifier_name
 
     // Used to create new instance when the SDK is initialized.
     // Then, each property can be modified by the user.
@@ -134,6 +140,7 @@ public struct NotificationServiceExtensionSdkConfig {
         sdkConfig.autoTrackPushEvents = autoTrackPushEvents
         sdkConfig.logLevel = logLevel
         sdkConfig.autoTrackDeviceAttributes = autoTrackDeviceAttributes
+        sdkConfig._sdkWrapperConfig = _sdkWrapperConfig
 
         // Default to running tasks added to the BQ immediately.
         // Since a Notification Service Extension is only in memory for a small amount of time,


### PR DESCRIPTION
Forgot this SDK config option in our `2.0.0-alpha.1` release. We might need it for wrappers such as RN. 

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request. A bot will *squash and merge* the pull request for you after the label is added. 