### PR TITLE
fix: image not shown in push notification using fcm

### DIFF
--- a/Sources/MessagingPush/RichPush/MessagingPush+RichPush.swift
+++ b/Sources/MessagingPush/RichPush/MessagingPush+RichPush.swift
@@ -48,55 +48,67 @@ extension MessagingPushImplementation {
         _ request: UNNotificationRequest,
         withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
     ) -> Bool {
-        logger.info("did recieve notification request. Checking if message was a rich push sent from Customer.io...")
+        logger.info("did recieve notification request. Checking if message was a push sent from Customer.io...")
         logger.debug("notification request: \(request.content.userInfo)")
 
-        if sdkConfig.autoTrackPushEvents,
-           let deliveryID: String = request.content.userInfo["CIO-Delivery-ID"] as? String,
-           let deviceToken: String = request.content.userInfo["CIO-Delivery-Token"] as? String {
+        guard let deliveryID: String = request.content.userInfo["CIO-Delivery-ID"] as? String,
+              let deviceToken: String = request.content.userInfo["CIO-Delivery-Token"] as? String
+        else {
+            logger.info("the notification was not sent by Customer.io. Ignoring notification request.")
+            return false
+        }
+
+        logger.info("push was sent from Customer.io. Processing the request...")
+
+        if sdkConfig.autoTrackPushEvents {
             logger.info("automatically tracking push metric: delivered")
             logger.debug("parsed deliveryId \(deliveryID), deviceToken: \(deviceToken)")
 
             trackMetric(deliveryID: deliveryID, event: .delivered, deviceToken: deviceToken)
         }
 
-        guard let pushContent = CustomerIOParsedPushPayload.parse(
+        if let richPushContent = CustomerIOParsedPushPayload.parse(
             notificationContent: request.content,
             jsonAdapter: jsonAdapter
-        )
-        else {
-            // push does not contain a CIO rich payload, so end early
-            logger.info("the notification was not sent by Customer.io. Ignoring notification request.")
-            return false
-        }
+        ) {
+            logger
+                .info("""
+                Parsing notification request to display rich content such as images, deep links, etc.
+                """)
+            logger.debug("push content: \(richPushContent)")
 
-        logger
-            .info("""
-            the notification was sent by Customer.io.
-            Parsing notification request to display rich content such as images, deep links, etc.
-            """)
-        logger.debug("push content: \(pushContent)")
+            RichPushRequestHandler.shared.startRequest(
+                request,
+                content: richPushContent,
+                siteId: siteId
+            ) { notificationContent in
+                self.logger.debug("rich push was composed \(notificationContent).")
 
-        RichPushRequestHandler.shared.startRequest(
-            request,
-            content: pushContent,
-            siteId: siteId
-        ) { notificationContent in
-            self.logger.debug("rich push was composed \(notificationContent).")
-
-            self.logger
-                .debug(
-                    "running all background queue tasks and waiting until complete to prevent OS from killing notification service extension before all HTTP requests have been performed"
-                )
-            self.backgroundQueue.run {
-                self.logger.debug("all background queue tasks done running.")
-                self.logger.info("Customer.io rich push processing is done!")
-
-                contentHandler(notificationContent)
+                self.finishTasksThenReturn(contentHandler: contentHandler, notificationContent: notificationContent)
             }
+        } else {
+            logger.info("the push was a simple push, not a rich push. Processing is complete.")
+
+            finishTasksThenReturn(contentHandler: contentHandler, notificationContent: request.content)
         }
 
         return true
+    }
+
+    private func finishTasksThenReturn(
+        contentHandler: @escaping (UNNotificationContent) -> Void,
+        notificationContent: UNNotificationContent
+    ) {
+        logger
+            .debug(
+                "running all background queue tasks and waiting until complete to prevent OS from killing notification service extension before all HTTP requests have been performed"
+            )
+        backgroundQueue.run {
+            self.logger.debug("all background queue tasks done running.")
+            self.logger.info("Customer.io push processing is done!")
+
+            contentHandler(notificationContent)
+        }
     }
 
     /**

--- a/Sources/MessagingPushAPN/MessagingPushAPN.swift
+++ b/Sources/MessagingPushAPN/MessagingPushAPN.swift
@@ -51,7 +51,7 @@ public protocol MessagingPushAPNInstance: AutoMockable {
 public class MessagingPushAPN: MessagingPushAPNInstance {
     internal static let shared = MessagingPushAPN()
 
-    internal var messagingPush: MessagingPush {
+    internal var messagingPush: MessagingPushInstance {
         MessagingPush.shared
     }
 

--- a/Sources/MessagingPushFCM/MessagingPushFCM.swift
+++ b/Sources/MessagingPushFCM/MessagingPushFCM.swift
@@ -49,7 +49,7 @@ public protocol MessagingPushFCMInstance: AutoMockable {
 public class MessagingPushFCM: MessagingPushFCMInstance {
     internal static let shared = MessagingPushFCM()
 
-    internal var messagingPush: MessagingPush {
+    internal var messagingPush: MessagingPushInstance {
         MessagingPush.shared
     }
 
@@ -90,7 +90,7 @@ public class MessagingPushFCM: MessagingPushFCMInstance {
         _ request: UNNotificationRequest,
         withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
     ) -> Bool {
-        (messagingPush as MessagingPushInstance).didReceive(request, withContentHandler: contentHandler)
+        messagingPush.didReceive(request, withContentHandler: contentHandler)
     }
 
     /**

--- a/Sources/MessagingPushFCM/MessagingPushFCM.swift
+++ b/Sources/MessagingPushFCM/MessagingPushFCM.swift
@@ -90,7 +90,7 @@ public class MessagingPushFCM: MessagingPushFCMInstance {
         _ request: UNNotificationRequest,
         withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
     ) -> Bool {
-        messagingPush.didReceive(request, withContentHandler: contentHandler)
+        (messagingPush as MessagingPushInstance).didReceive(request, withContentHandler: contentHandler)
     }
 
     /**


### PR DESCRIPTION
Customers using FCM were not able to see the image on push notification despite using the initializer workaround being suggested. This PR has a fix for that (tested and confirmed by a customer). 

closes [#help (Chirag) images not showing (RN SDK + FCM + ObjC) #waiting-for-customer-reply](https://github.com/customerio/issues/issues/8640)

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request. A bot will *squash and merge* the pull request for you after the label is added. 