### PR TITLE
fix: 1.2.8 initialize in-app with debug logs no longer crashes SDK

### DIFF
--- a/Tests/MessagingInApp/MessagingInAppIntegrationTest.swift
+++ b/Tests/MessagingInApp/MessagingInAppIntegrationTest.swift
@@ -1,0 +1,21 @@
+@testable import CioTracking
+@testable import CioMessagingInApp
+@testable import Common
+import Foundation
+import SharedTests
+import XCTest
+
+class MessagingInAppIntegrationTests: IntegrationTest {
+    
+    // Reproduce bug: https://github.com/customerio/customerio-ios/issues/242
+    func test_initialize_enableDebugLogs_() {
+        CustomerIO.resetSharedInstance()
+        
+        CustomerIO.initialize(siteId: testSiteId, apiKey: .random)
+        CustomerIO.config {
+            $0.logLevel = .debug
+        }
+        
+        MessagingInApp.shared.initialize(organizationId: .random)
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/customerio/customerio-ios/issues/242

v1.2.8 has a bug where the diGraph instance isn't populated (when it should) in `CustomerIO` class. 

This PR refactors the `CustomerIO` class to populate the diGraph when the SDK is being initialized. 