### PR TITLE
fix: async running BQ operations in loop

### DIFF
--- a/Sources/Common/Background Queue/QueueRunRequest.swift
+++ b/Sources/Common/Background Queue/QueueRunRequest.swift
@@ -12,6 +12,7 @@ public class CioQueueRunRequest: QueueRunRequest {
     private let requestManager: QueueRequestManager
     private let logger: Logger
     private let queryRunner: QueueQueryRunner
+    private let threadUtil: ThreadUtil
 
     private let shortTaskId: (String) -> String = { $0[0 ..< 5] }
 
@@ -20,13 +21,15 @@ public class CioQueueRunRequest: QueueRunRequest {
         storage: QueueStorage,
         requestManager: QueueRequestManager,
         logger: Logger,
-        queryRunner: QueueQueryRunner
+        queryRunner: QueueQueryRunner,
+        threadUtil: ThreadUtil
     ) {
         self.runner = runner
         self.storage = storage
         self.requestManager = requestManager
         self.logger = logger
         self.queryRunner = queryRunner
+        self.threadUtil = threadUtil
     }
 
     public func start(onComplete: @escaping () -> Void) {
@@ -38,7 +41,9 @@ public class CioQueueRunRequest: QueueRunRequest {
     }
 
     private func startNewRequestRun() {
-        runTasks()
+        threadUtil.runBackground {
+            self.runTasks()
+        }
     }
 
     // Disable swiftlint because function at this time isn't too complex to need to make it smaller.

--- a/Sources/Common/Background Queue/QueueRunRequest.swift
+++ b/Sources/Common/Background Queue/QueueRunRequest.swift
@@ -45,10 +45,11 @@ public class CioQueueRunRequest: QueueRunRequest {
     // Many of the lines of this function are logging related.
     // swiftlint:disable:next function_body_length
     internal func runTasks() {
+        // Variables that power the logic of the queue run loop
         var lastRanTask: QueueTaskMetadata?
         var lastFailedTask: QueueTaskMetadata?
         var continueRunnning = true
-        let whileLoopWait = DispatchGroup()
+        let whileLoopWait = DispatchGroup() // make async operations perform synchronously in while loop
 
         // call when you're done with task
         func updateWhileLoopLogicVariables(didTaskFail: Bool, taskJustExecuted: QueueTaskMetadata) {
@@ -65,6 +66,7 @@ public class CioQueueRunRequest: QueueRunRequest {
             return requestManager.requestComplete()
         }
 
+        // The queue runs a continuous loop until it has determined that it has reached the end of the queue and has processed all the tasks that it can at this time.
         while continueRunnning {
             // get the inventory before running each task. If a task was added to the queue while the last task was being
             // executed, we can assert that new task will execute during this run.
@@ -150,6 +152,7 @@ public class CioQueueRunRequest: QueueRunRequest {
                 whileLoopWait.leave()
             }
 
+            // wait to end the while loop until the async operation has completed.
             whileLoopWait.wait()
         }
     }

--- a/Sources/Common/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/Common/autogenerated/AutoDependencyInjection.generated.swift
@@ -148,18 +148,7 @@ extension DIGraph {
     }
 
     private var newHttpClient: HttpClient {
-        CIOHttpClient(
-            siteId: siteId,
-            apiKey: apiKey,
-            sdkConfig: sdkConfig,
-            jsonAdapter: jsonAdapter,
-            httpRequestRunner: httpRequestRunner,
-            globalDataStore: globalDataStore,
-            logger: logger,
-            timer: simpleTimer,
-            retryPolicy: httpRetryPolicy,
-            userAgentUtil: userAgentUtil
-        )
+        CIOHttpClient(siteId: siteId, apiKey: apiKey, sdkConfig: sdkConfig, jsonAdapter: jsonAdapter, httpRequestRunner: httpRequestRunner, globalDataStore: globalDataStore, logger: logger, timer: simpleTimer, retryPolicy: httpRetryPolicy, userAgentUtil: userAgentUtil)
     }
 
     // GlobalDataStore
@@ -183,8 +172,7 @@ extension DIGraph {
     }
 
     public var sharedHooksManager: HooksManager {
-        // Use a DispatchQueue to make singleton thread safe. You must create unique dispatchqueues instead of using 1
-        // shared one or you will get a crash when trying
+        // Use a DispatchQueue to make singleton thread safe. You must create unique dispatchqueues instead of using 1 shared one or you will get a crash when trying
         // to call DispatchQueue.sync{} while already inside another DispatchQueue.sync{} call.
         DispatchQueue(label: "DIGraph_HooksManager_singleton_access").sync {
             if let overridenDep = self.overrides[String(describing: HooksManager.self)] {
@@ -222,16 +210,7 @@ extension DIGraph {
     }
 
     private var newQueue: Queue {
-        CioQueue(
-            siteId: siteId,
-            storage: queueStorage,
-            runRequest: queueRunRequest,
-            jsonAdapter: jsonAdapter,
-            logger: logger,
-            sdkConfig: sdkConfig,
-            queueTimer: singleScheduleTimer,
-            dateUtil: dateUtil
-        )
+        CioQueue(siteId: siteId, storage: queueStorage, runRequest: queueRunRequest, jsonAdapter: jsonAdapter, logger: logger, sdkConfig: sdkConfig, queueTimer: singleScheduleTimer, dateUtil: dateUtil)
     }
 
     // QueueQueryRunner
@@ -255,15 +234,13 @@ extension DIGraph {
     }
 
     public var sharedQueueRequestManager: QueueRequestManager {
-        // Use a DispatchQueue to make singleton thread safe. You must create unique dispatchqueues instead of using 1
-        // shared one or you will get a crash when trying
+        // Use a DispatchQueue to make singleton thread safe. You must create unique dispatchqueues instead of using 1 shared one or you will get a crash when trying
         // to call DispatchQueue.sync{} while already inside another DispatchQueue.sync{} call.
         DispatchQueue(label: "DIGraph_QueueRequestManager_singleton_access").sync {
             if let overridenDep = self.overrides[String(describing: QueueRequestManager.self)] {
                 return overridenDep as! QueueRequestManager
             }
-            let existingSingletonInstance = self
-                .singletons[String(describing: QueueRequestManager.self)] as? QueueRequestManager
+            let existingSingletonInstance = self.singletons[String(describing: QueueRequestManager.self)] as? QueueRequestManager
             let instance = existingSingletonInstance ?? _get_queueRequestManager()
             self.singletons[String(describing: QueueRequestManager.self)] = instance
             return instance
@@ -283,13 +260,7 @@ extension DIGraph {
     }
 
     private var newQueueRunRequest: QueueRunRequest {
-        CioQueueRunRequest(
-            runner: queueRunner,
-            storage: queueStorage,
-            requestManager: queueRequestManager,
-            logger: logger,
-            queryRunner: queueQueryRunner
-        )
+        CioQueueRunRequest(runner: queueRunner, storage: queueStorage, requestManager: queueRequestManager, logger: logger, queryRunner: queueQueryRunner)
     }
 
     // QueueRunner
@@ -301,14 +272,7 @@ extension DIGraph {
     }
 
     private var newQueueRunner: QueueRunner {
-        CioQueueRunner(
-            siteId: siteId,
-            jsonAdapter: jsonAdapter,
-            logger: logger,
-            httpClient: httpClient,
-            hooksManager: hooksManager,
-            sdkConfig: sdkConfig
-        )
+        CioQueueRunner(siteId: siteId, jsonAdapter: jsonAdapter, logger: logger, httpClient: httpClient, hooksManager: hooksManager, sdkConfig: sdkConfig)
     }
 
     // SimpleTimer
@@ -332,15 +296,13 @@ extension DIGraph {
     }
 
     internal var sharedSingleScheduleTimer: SingleScheduleTimer {
-        // Use a DispatchQueue to make singleton thread safe. You must create unique dispatchqueues instead of using 1
-        // shared one or you will get a crash when trying
+        // Use a DispatchQueue to make singleton thread safe. You must create unique dispatchqueues instead of using 1 shared one or you will get a crash when trying
         // to call DispatchQueue.sync{} while already inside another DispatchQueue.sync{} call.
         DispatchQueue(label: "DIGraph_SingleScheduleTimer_singleton_access").sync {
             if let overridenDep = self.overrides[String(describing: SingleScheduleTimer.self)] {
                 return overridenDep as! SingleScheduleTimer
             }
-            let existingSingletonInstance = self
-                .singletons[String(describing: SingleScheduleTimer.self)] as? SingleScheduleTimer
+            let existingSingletonInstance = self.singletons[String(describing: SingleScheduleTimer.self)] as? SingleScheduleTimer
             let instance = existingSingletonInstance ?? _get_singleScheduleTimer()
             self.singletons[String(describing: SingleScheduleTimer.self)] = instance
             return instance
@@ -420,15 +382,7 @@ extension DIGraph {
     }
 
     private var newQueueStorage: QueueStorage {
-        FileManagerQueueStorage(
-            siteId: siteId,
-            fileStorage: fileStorage,
-            jsonAdapter: jsonAdapter,
-            lockManager: lockManager,
-            sdkConfig: sdkConfig,
-            logger: logger,
-            dateUtil: dateUtil
-        )
+        FileManagerQueueStorage(siteId: siteId, fileStorage: fileStorage, jsonAdapter: jsonAdapter, lockManager: lockManager, sdkConfig: sdkConfig, logger: logger, dateUtil: dateUtil)
     }
 
     // JsonAdapter
@@ -452,8 +406,7 @@ extension DIGraph {
     }
 
     public var sharedLockManager: LockManager {
-        // Use a DispatchQueue to make singleton thread safe. You must create unique dispatchqueues instead of using 1
-        // shared one or you will get a crash when trying
+        // Use a DispatchQueue to make singleton thread safe. You must create unique dispatchqueues instead of using 1 shared one or you will get a crash when trying
         // to call DispatchQueue.sync{} while already inside another DispatchQueue.sync{} call.
         DispatchQueue(label: "DIGraph_LockManager_singleton_access").sync {
             if let overridenDep = self.overrides[String(describing: LockManager.self)] {

--- a/Sources/Common/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/Common/autogenerated/AutoDependencyInjection.generated.swift
@@ -260,7 +260,7 @@ extension DIGraph {
     }
 
     private var newQueueRunRequest: QueueRunRequest {
-        CioQueueRunRequest(runner: queueRunner, storage: queueStorage, requestManager: queueRequestManager, logger: logger, queryRunner: queueQueryRunner)
+        CioQueueRunRequest(runner: queueRunner, storage: queueStorage, requestManager: queueRequestManager, logger: logger, queryRunner: queueQueryRunner, threadUtil: threadUtil)
     }
 
     // QueueRunner

--- a/Sources/Common/autogenerated/AutoLenses.generated.swift
+++ b/Sources/Common/autogenerated/AutoLenses.generated.swift
@@ -109,113 +109,53 @@ extension QueueTaskMetadata {
     static let taskPersistedIdLens = Lens<QueueTaskMetadata, String>(
         get: { $0.taskPersistedId },
         set: { taskPersistedId, existing in
-            QueueTaskMetadata(
-                taskPersistedId: taskPersistedId,
-                taskType: existing.taskType,
-                groupStart: existing.groupStart,
-                groupMember: existing.groupMember,
-                createdAt: existing.createdAt
-            )
+            QueueTaskMetadata(taskPersistedId: taskPersistedId, taskType: existing.taskType, groupStart: existing.groupStart, groupMember: existing.groupMember, createdAt: existing.createdAt)
         }
     )
     static let taskTypeLens = Lens<QueueTaskMetadata, String>(
         get: { $0.taskType },
         set: { taskType, existing in
-            QueueTaskMetadata(
-                taskPersistedId: existing.taskPersistedId,
-                taskType: taskType,
-                groupStart: existing.groupStart,
-                groupMember: existing.groupMember,
-                createdAt: existing.createdAt
-            )
+            QueueTaskMetadata(taskPersistedId: existing.taskPersistedId, taskType: taskType, groupStart: existing.groupStart, groupMember: existing.groupMember, createdAt: existing.createdAt)
         }
     )
     static let groupStartLens = Lens<QueueTaskMetadata, String?>(
         get: { $0.groupStart },
         set: { groupStart, existing in
-            QueueTaskMetadata(
-                taskPersistedId: existing.taskPersistedId,
-                taskType: existing.taskType,
-                groupStart: groupStart,
-                groupMember: existing.groupMember,
-                createdAt: existing.createdAt
-            )
+            QueueTaskMetadata(taskPersistedId: existing.taskPersistedId, taskType: existing.taskType, groupStart: groupStart, groupMember: existing.groupMember, createdAt: existing.createdAt)
         }
     )
     static let groupMemberLens = Lens<QueueTaskMetadata, [String]?>(
         get: { $0.groupMember },
         set: { groupMember, existing in
-            QueueTaskMetadata(
-                taskPersistedId: existing.taskPersistedId,
-                taskType: existing.taskType,
-                groupStart: existing.groupStart,
-                groupMember: groupMember,
-                createdAt: existing.createdAt
-            )
+            QueueTaskMetadata(taskPersistedId: existing.taskPersistedId, taskType: existing.taskType, groupStart: existing.groupStart, groupMember: groupMember, createdAt: existing.createdAt)
         }
     )
     static let createdAtLens = Lens<QueueTaskMetadata, Date>(
         get: { $0.createdAt },
         set: { createdAt, existing in
-            QueueTaskMetadata(
-                taskPersistedId: existing.taskPersistedId,
-                taskType: existing.taskType,
-                groupStart: existing.groupStart,
-                groupMember: existing.groupMember,
-                createdAt: createdAt
-            )
+            QueueTaskMetadata(taskPersistedId: existing.taskPersistedId, taskType: existing.taskType, groupStart: existing.groupStart, groupMember: existing.groupMember, createdAt: createdAt)
         }
     )
 
     // Convenient set functions to edit a property of the immutable object
     func taskPersistedIdSet(_ taskPersistedId: String) -> QueueTaskMetadata {
-        QueueTaskMetadata(
-            taskPersistedId: taskPersistedId,
-            taskType: taskType,
-            groupStart: groupStart,
-            groupMember: groupMember,
-            createdAt: createdAt
-        )
+        QueueTaskMetadata(taskPersistedId: taskPersistedId, taskType: taskType, groupStart: groupStart, groupMember: groupMember, createdAt: createdAt)
     }
 
     func taskTypeSet(_ taskType: String) -> QueueTaskMetadata {
-        QueueTaskMetadata(
-            taskPersistedId: taskPersistedId,
-            taskType: taskType,
-            groupStart: groupStart,
-            groupMember: groupMember,
-            createdAt: createdAt
-        )
+        QueueTaskMetadata(taskPersistedId: taskPersistedId, taskType: taskType, groupStart: groupStart, groupMember: groupMember, createdAt: createdAt)
     }
 
     func groupStartSet(_ groupStart: String?) -> QueueTaskMetadata {
-        QueueTaskMetadata(
-            taskPersistedId: taskPersistedId,
-            taskType: taskType,
-            groupStart: groupStart,
-            groupMember: groupMember,
-            createdAt: createdAt
-        )
+        QueueTaskMetadata(taskPersistedId: taskPersistedId, taskType: taskType, groupStart: groupStart, groupMember: groupMember, createdAt: createdAt)
     }
 
     func groupMemberSet(_ groupMember: [String]?) -> QueueTaskMetadata {
-        QueueTaskMetadata(
-            taskPersistedId: taskPersistedId,
-            taskType: taskType,
-            groupStart: groupStart,
-            groupMember: groupMember,
-            createdAt: createdAt
-        )
+        QueueTaskMetadata(taskPersistedId: taskPersistedId, taskType: taskType, groupStart: groupStart, groupMember: groupMember, createdAt: createdAt)
     }
 
     func createdAtSet(_ createdAt: Date) -> QueueTaskMetadata {
-        QueueTaskMetadata(
-            taskPersistedId: taskPersistedId,
-            taskType: taskType,
-            groupStart: groupStart,
-            groupMember: groupMember,
-            createdAt: createdAt
-        )
+        QueueTaskMetadata(taskPersistedId: taskPersistedId, taskType: taskType, groupStart: groupStart, groupMember: groupMember, createdAt: createdAt)
     }
 }
 

--- a/Sources/Common/autogenerated/AutoMockable.generated.swift
+++ b/Sources/Common/autogenerated/AutoMockable.generated.swift
@@ -463,10 +463,9 @@ public class DeviceInfoMock: DeviceInfo, Mock {
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    public var isPushSubscribedClosure: (((Bool) -> Void) -> Void)?
+    public var isPushSubscribedClosure: ((@escaping (Bool) -> Void) -> Void)?
 
-    /// Mocked function for `isPushSubscribed(completion: @escaping (Bool) -> Void)`. Your opportunity to return a
-    /// mocked value and check result of mock in test code.
+    /// Mocked function for `isPushSubscribed(completion: @escaping (Bool) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func isPushSubscribed(completion: @escaping (Bool) -> Void) {
         mockCalled = true
         isPushSubscribedCallsCount += 1
@@ -589,8 +588,7 @@ public class FileStorageMock: FileStorage, Mock {
      */
     public var saveClosure: ((FileType, Data, String?) -> Bool)?
 
-    /// Mocked function for `save(type: FileType, contents: Data, fileId: String?)`. Your opportunity to return a mocked
-    /// value and check result of mock in test code.
+    /// Mocked function for `save(type: FileType, contents: Data, fileId: String?)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func save(type: FileType, contents: Data, fileId: String?) -> Bool {
         mockCalled = true
         saveCallsCount += 1
@@ -621,8 +619,7 @@ public class FileStorageMock: FileStorage, Mock {
      */
     public var getClosure: ((FileType, String?) -> Data?)?
 
-    /// Mocked function for `get(type: FileType, fileId: String?)`. Your opportunity to return a mocked value and check
-    /// result of mock in test code.
+    /// Mocked function for `get(type: FileType, fileId: String?)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func get(type: FileType, fileId: String?) -> Data? {
         mockCalled = true
         getCallsCount += 1
@@ -653,8 +650,7 @@ public class FileStorageMock: FileStorage, Mock {
      */
     public var deleteClosure: ((FileType, String) -> Bool)?
 
-    /// Mocked function for `delete(type: FileType, fileId: String)`. Your opportunity to return a mocked value and
-    /// check result of mock in test code.
+    /// Mocked function for `delete(type: FileType, fileId: String)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func delete(type: FileType, fileId: String) -> Bool {
         mockCalled = true
         deleteCallsCount += 1
@@ -777,8 +773,7 @@ public class GlobalDataStoreMock: GlobalDataStore, Mock {
      */
     public var deleteAllClosure: (() -> Void)?
 
-    /// Mocked function for `deleteAll()`. Your opportunity to return a mocked value and check result of mock in test
-    /// code.
+    /// Mocked function for `deleteAll()`. Your opportunity to return a mocked value and check result of mock in test code.
     public func deleteAll() {
         mockCalled = true
         deleteAllCallsCount += 1
@@ -941,8 +936,7 @@ public class HooksManagerMock: HooksManager, Mock {
      */
     public var addClosure: ((HookModule, ModuleHookProvider) -> Void)?
 
-    /// Mocked function for `add(key: HookModule, provider: ModuleHookProvider)`. Your opportunity to return a mocked
-    /// value and check result of mock in test code.
+    /// Mocked function for `add(key: HookModule, provider: ModuleHookProvider)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func add(key: HookModule, provider: ModuleHookProvider) {
         mockCalled = true
         addCallsCount += 1
@@ -995,22 +989,15 @@ public class HttpClientMock: HttpClient, Mock {
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var requestReceivedArguments: (
-        params: HttpRequestParams,
-        onComplete: (Result<Data, HttpRequestError>) -> Void
-    )?
+    public private(set) var requestReceivedArguments: (params: HttpRequestParams, onComplete: (Result<Data, HttpRequestError>) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var requestReceivedInvocations: [(
-        params: HttpRequestParams,
-        onComplete: (Result<Data, HttpRequestError>) -> Void
-    )] = []
+    public private(set) var requestReceivedInvocations: [(params: HttpRequestParams, onComplete: (Result<Data, HttpRequestError>) -> Void)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    public var requestClosure: ((HttpRequestParams, (Result<Data, HttpRequestError>) -> Void) -> Void)?
+    public var requestClosure: ((HttpRequestParams, @escaping (Result<Data, HttpRequestError>) -> Void) -> Void)?
 
-    /// Mocked function for `request(_ params: HttpRequestParams, onComplete: @escaping (Result<Data, HttpRequestError>)
-    /// -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
+    /// Mocked function for `request(_ params: HttpRequestParams, onComplete: @escaping (Result<Data, HttpRequestError>) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func request(_ params: HttpRequestParams, onComplete: @escaping (Result<Data, HttpRequestError>) -> Void) {
         mockCalled = true
         requestCallsCount += 1
@@ -1029,24 +1016,15 @@ public class HttpClientMock: HttpClient, Mock {
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var downloadFileReceivedArguments: (
-        url: URL,
-        fileType: DownloadFileType,
-        onComplete: (URL?) -> Void
-    )?
+    public private(set) var downloadFileReceivedArguments: (url: URL, fileType: DownloadFileType, onComplete: (URL?) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var downloadFileReceivedInvocations: [(
-        url: URL,
-        fileType: DownloadFileType,
-        onComplete: (URL?) -> Void
-    )] = []
+    public private(set) var downloadFileReceivedInvocations: [(url: URL, fileType: DownloadFileType, onComplete: (URL?) -> Void)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    public var downloadFileClosure: ((URL, DownloadFileType, (URL?) -> Void) -> Void)?
+    public var downloadFileClosure: ((URL, DownloadFileType, @escaping (URL?) -> Void) -> Void)?
 
-    /// Mocked function for `downloadFile(url: URL, fileType: DownloadFileType, onComplete: @escaping (URL?) -> Void)`.
-    /// Your opportunity to return a mocked value and check result of mock in test code.
+    /// Mocked function for `downloadFile(url: URL, fileType: DownloadFileType, onComplete: @escaping (URL?) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func downloadFile(url: URL, fileType: DownloadFileType, onComplete: @escaping (URL?) -> Void) {
         mockCalled = true
         downloadFileCallsCount += 1
@@ -1073,8 +1051,7 @@ public class HttpClientMock: HttpClient, Mock {
      */
     public var cancelClosure: ((Bool) -> Void)?
 
-    /// Mocked function for `cancel(finishTasks: Bool)`. Your opportunity to return a mocked value and check result of
-    /// mock in test code.
+    /// Mocked function for `cancel(finishTasks: Bool)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func cancel(finishTasks: Bool) {
         mockCalled = true
         cancelCallsCount += 1
@@ -1122,30 +1099,16 @@ internal class HttpRequestRunnerMock: HttpRequestRunner, Mock {
     }
 
     /// The arguments from the *last* time the function was called.
-    internal private(set) var requestReceivedArguments: (
-        params: HttpRequestParams,
-        session: URLSession,
-        onComplete: (Data?, HTTPURLResponse?, Error?) -> Void
-    )?
+    internal private(set) var requestReceivedArguments: (params: HttpRequestParams, session: URLSession, onComplete: (Data?, HTTPURLResponse?, Error?) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    internal private(set) var requestReceivedInvocations: [(
-        params: HttpRequestParams,
-        session: URLSession,
-        onComplete: (Data?, HTTPURLResponse?, Error?) -> Void
-    )] = []
+    internal private(set) var requestReceivedInvocations: [(params: HttpRequestParams, session: URLSession, onComplete: (Data?, HTTPURLResponse?, Error?) -> Void)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    internal var requestClosure: ((HttpRequestParams, URLSession, (Data?, HTTPURLResponse?, Error?) -> Void) -> Void)?
+    internal var requestClosure: ((HttpRequestParams, URLSession, @escaping (Data?, HTTPURLResponse?, Error?) -> Void) -> Void)?
 
-    /// Mocked function for `request(params: HttpRequestParams, session: URLSession, onComplete: @escaping (Data?,
-    /// HTTPURLResponse?, Error?) -> Void)`. Your opportunity to return a mocked value and check result of mock in test
-    /// code.
-    internal func request(
-        params: HttpRequestParams,
-        session: URLSession,
-        onComplete: @escaping (Data?, HTTPURLResponse?, Error?) -> Void
-    ) {
+    /// Mocked function for `request(params: HttpRequestParams, session: URLSession, onComplete: @escaping (Data?, HTTPURLResponse?, Error?) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
+    internal func request(params: HttpRequestParams, session: URLSession, onComplete: @escaping (Data?, HTTPURLResponse?, Error?) -> Void) {
         mockCalled = true
         requestCallsCount += 1
         requestReceivedArguments = (params: params, session: session, onComplete: onComplete)
@@ -1163,32 +1126,16 @@ internal class HttpRequestRunnerMock: HttpRequestRunner, Mock {
     }
 
     /// The arguments from the *last* time the function was called.
-    internal private(set) var downloadFileReceivedArguments: (
-        url: URL,
-        fileType: DownloadFileType,
-        session: URLSession,
-        onComplete: (URL?) -> Void
-    )?
+    internal private(set) var downloadFileReceivedArguments: (url: URL, fileType: DownloadFileType, session: URLSession, onComplete: (URL?) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    internal private(set) var downloadFileReceivedInvocations: [(
-        url: URL,
-        fileType: DownloadFileType,
-        session: URLSession,
-        onComplete: (URL?) -> Void
-    )] = []
+    internal private(set) var downloadFileReceivedInvocations: [(url: URL, fileType: DownloadFileType, session: URLSession, onComplete: (URL?) -> Void)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    internal var downloadFileClosure: ((URL, DownloadFileType, URLSession, (URL?) -> Void) -> Void)?
+    internal var downloadFileClosure: ((URL, DownloadFileType, URLSession, @escaping (URL?) -> Void) -> Void)?
 
-    /// Mocked function for `downloadFile(url: URL, fileType: DownloadFileType, session: URLSession, onComplete:
-    /// @escaping (URL?) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
-    internal func downloadFile(
-        url: URL,
-        fileType: DownloadFileType,
-        session: URLSession,
-        onComplete: @escaping (URL?) -> Void
-    ) {
+    /// Mocked function for `downloadFile(url: URL, fileType: DownloadFileType, session: URLSession, onComplete: @escaping (URL?) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
+    internal func downloadFile(url: URL, fileType: DownloadFileType, session: URLSession, onComplete: @escaping (URL?) -> Void) {
         mockCalled = true
         downloadFileCallsCount += 1
         downloadFileReceivedArguments = (url: url, fileType: fileType, session: session, onComplete: onComplete)
@@ -1306,8 +1253,7 @@ public class LoggerMock: Logger, Mock {
      */
     public var debugClosure: ((String) -> Void)?
 
-    /// Mocked function for `debug(_ message: String)`. Your opportunity to return a mocked value and check result of
-    /// mock in test code.
+    /// Mocked function for `debug(_ message: String)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func debug(_ message: String) {
         mockCalled = true
         debugCallsCount += 1
@@ -1334,8 +1280,7 @@ public class LoggerMock: Logger, Mock {
      */
     public var infoClosure: ((String) -> Void)?
 
-    /// Mocked function for `info(_ message: String)`. Your opportunity to return a mocked value and check result of
-    /// mock in test code.
+    /// Mocked function for `info(_ message: String)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func info(_ message: String) {
         mockCalled = true
         infoCallsCount += 1
@@ -1362,8 +1307,7 @@ public class LoggerMock: Logger, Mock {
      */
     public var errorClosure: ((String) -> Void)?
 
-    /// Mocked function for `error(_ message: String)`. Your opportunity to return a mocked value and check result of
-    /// mock in test code.
+    /// Mocked function for `error(_ message: String)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func error(_ message: String) {
         mockCalled = true
         errorCallsCount += 1
@@ -1552,28 +1496,20 @@ public class ProfileIdentifyHookMock: ProfileIdentifyHook, Mock {
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var beforeIdentifiedProfileChangeReceivedArguments: (
-        oldIdentifier: String,
-        newIdentifier: String
-    )?
+    public private(set) var beforeIdentifiedProfileChangeReceivedArguments: (oldIdentifier: String, newIdentifier: String)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var beforeIdentifiedProfileChangeReceivedInvocations: [(
-        oldIdentifier: String,
-        newIdentifier: String
-    )] = []
+    public private(set) var beforeIdentifiedProfileChangeReceivedInvocations: [(oldIdentifier: String, newIdentifier: String)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
     public var beforeIdentifiedProfileChangeClosure: ((String, String) -> Void)?
 
-    /// Mocked function for `beforeIdentifiedProfileChange(oldIdentifier: String, newIdentifier: String)`. Your
-    /// opportunity to return a mocked value and check result of mock in test code.
+    /// Mocked function for `beforeIdentifiedProfileChange(oldIdentifier: String, newIdentifier: String)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func beforeIdentifiedProfileChange(oldIdentifier: String, newIdentifier: String) {
         mockCalled = true
         beforeIdentifiedProfileChangeCallsCount += 1
         beforeIdentifiedProfileChangeReceivedArguments = (oldIdentifier: oldIdentifier, newIdentifier: newIdentifier)
-        beforeIdentifiedProfileChangeReceivedInvocations
-            .append((oldIdentifier: oldIdentifier, newIdentifier: newIdentifier))
+        beforeIdentifiedProfileChangeReceivedInvocations.append((oldIdentifier: oldIdentifier, newIdentifier: newIdentifier))
         beforeIdentifiedProfileChangeClosure?(oldIdentifier, newIdentifier)
     }
 
@@ -1595,8 +1531,7 @@ public class ProfileIdentifyHookMock: ProfileIdentifyHook, Mock {
      */
     public var profileIdentifiedClosure: ((String) -> Void)?
 
-    /// Mocked function for `profileIdentified(identifier: String)`. Your opportunity to return a mocked value and check
-    /// result of mock in test code.
+    /// Mocked function for `profileIdentified(identifier: String)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func profileIdentified(identifier: String) {
         mockCalled = true
         profileIdentifiedCallsCount += 1
@@ -1623,8 +1558,7 @@ public class ProfileIdentifyHookMock: ProfileIdentifyHook, Mock {
      */
     public var beforeProfileStoppedBeingIdentifiedClosure: ((String) -> Void)?
 
-    /// Mocked function for `beforeProfileStoppedBeingIdentified(oldIdentifier: String)`. Your opportunity to return a
-    /// mocked value and check result of mock in test code.
+    /// Mocked function for `beforeProfileStoppedBeingIdentified(oldIdentifier: String)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func beforeProfileStoppedBeingIdentified(oldIdentifier: String) {
         mockCalled = true
         beforeProfileStoppedBeingIdentifiedCallsCount += 1
@@ -1740,8 +1674,7 @@ public class QueueMock: Queue, Mock {
     /// The arguments from the *last* time the function was called.
     public private(set) var addTrackInAppDeliveryTaskReceivedArguments: (deliveryId: String, event: InAppMetric)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var addTrackInAppDeliveryTaskReceivedInvocations: [(deliveryId: String, event: InAppMetric)] =
-        []
+    public private(set) var addTrackInAppDeliveryTaskReceivedInvocations: [(deliveryId: String, event: InAppMetric)] = []
     /// Value to return from the mocked function.
     public var addTrackInAppDeliveryTaskReturnValue: ModifyQueueResult!
     /**
@@ -1751,8 +1684,7 @@ public class QueueMock: Queue, Mock {
      */
     public var addTrackInAppDeliveryTaskClosure: ((String, InAppMetric) -> ModifyQueueResult)?
 
-    /// Mocked function for `addTrackInAppDeliveryTask(deliveryId: String, event: InAppMetric)`. Your opportunity to
-    /// return a mocked value and check result of mock in test code.
+    /// Mocked function for `addTrackInAppDeliveryTask(deliveryId: String, event: InAppMetric)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func addTrackInAppDeliveryTask(deliveryId: String, event: InAppMetric) -> ModifyQueueResult {
         mockCalled = true
         addTrackInAppDeliveryTaskCallsCount += 1
@@ -1771,19 +1703,9 @@ public class QueueMock: Queue, Mock {
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var addTaskReceivedArguments: (
-        type: String,
-        data: AnyEncodable,
-        groupStart: QueueTaskGroup?,
-        blockingGroups: [QueueTaskGroup]?
-    )?
+    public private(set) var addTaskReceivedArguments: (type: String, data: AnyEncodable, groupStart: QueueTaskGroup?, blockingGroups: [QueueTaskGroup]?)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var addTaskReceivedInvocations: [(
-        type: String,
-        data: AnyEncodable,
-        groupStart: QueueTaskGroup?,
-        blockingGroups: [QueueTaskGroup]?
-    )] = []
+    public private(set) var addTaskReceivedInvocations: [(type: String, data: AnyEncodable, groupStart: QueueTaskGroup?, blockingGroups: [QueueTaskGroup]?)] = []
     /// Value to return from the mocked function.
     public var addTaskReturnValue: ModifyQueueResult!
     /**
@@ -1793,25 +1715,12 @@ public class QueueMock: Queue, Mock {
      */
     public var addTaskClosure: ((String, AnyEncodable, QueueTaskGroup?, [QueueTaskGroup]?) -> ModifyQueueResult)?
 
-    /// Mocked function for `addTask<TaskData: Codable>(type: String, data: TaskData, groupStart: QueueTaskGroup?,
-    /// blockingGroups: [QueueTaskGroup]?)`. Your opportunity to return a mocked value and check result of mock in test
-    /// code.
-    public func addTask<TaskData: Codable>(
-        type: String,
-        data: TaskData,
-        groupStart: QueueTaskGroup?,
-        blockingGroups: [QueueTaskGroup]?
-    ) -> ModifyQueueResult {
+    /// Mocked function for `addTask<TaskData: Codable>(type: String, data: TaskData, groupStart: QueueTaskGroup?, blockingGroups: [QueueTaskGroup]?)`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func addTask<TaskData: Codable>(type: String, data: TaskData, groupStart: QueueTaskGroup?, blockingGroups: [QueueTaskGroup]?) -> ModifyQueueResult {
         mockCalled = true
         addTaskCallsCount += 1
-        addTaskReceivedArguments = (
-            type: type,
-            data: AnyEncodable(data),
-            groupStart: groupStart,
-            blockingGroups: blockingGroups
-        )
-        addTaskReceivedInvocations
-            .append((type: type, data: AnyEncodable(data), groupStart: groupStart, blockingGroups: blockingGroups))
+        addTaskReceivedArguments = (type: type, data: AnyEncodable(data), groupStart: groupStart, blockingGroups: blockingGroups)
+        addTaskReceivedInvocations.append((type: type, data: AnyEncodable(data), groupStart: groupStart, blockingGroups: blockingGroups))
         return addTaskClosure.map { $0(type, AnyEncodable(data), groupStart, blockingGroups) } ?? addTaskReturnValue
     }
 
@@ -1831,10 +1740,9 @@ public class QueueMock: Queue, Mock {
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    public var runClosure: ((() -> Void) -> Void)?
+    public var runClosure: ((@escaping () -> Void) -> Void)?
 
-    /// Mocked function for `run(onComplete: @escaping () -> Void)`. Your opportunity to return a mocked value and check
-    /// result of mock in test code.
+    /// Mocked function for `run(onComplete: @escaping () -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func run(onComplete: @escaping () -> Void) {
         mockCalled = true
         runCallsCount += 1
@@ -1857,8 +1765,7 @@ public class QueueMock: Queue, Mock {
      */
     public var deleteExpiredTasksClosure: (() -> Void)?
 
-    /// Mocked function for `deleteExpiredTasks()`. Your opportunity to return a mocked value and check result of mock
-    /// in test code.
+    /// Mocked function for `deleteExpiredTasks()`. Your opportunity to return a mocked value and check result of mock in test code.
     public func deleteExpiredTasks() {
         mockCalled = true
         deleteExpiredTasksCallsCount += 1
@@ -1902,17 +1809,9 @@ internal class QueueQueryRunnerMock: QueueQueryRunner, Mock {
     }
 
     /// The arguments from the *last* time the function was called.
-    internal private(set) var getNextTaskReceivedArguments: (
-        queue: [QueueTaskMetadata],
-        lastRanTask: QueueTaskMetadata?,
-        lastFailedTask: QueueTaskMetadata?
-    )?
+    internal private(set) var getNextTaskReceivedArguments: (queue: [QueueTaskMetadata], lastRanTask: QueueTaskMetadata?, lastFailedTask: QueueTaskMetadata?)?
     /// Arguments from *all* of the times that the function was called.
-    internal private(set) var getNextTaskReceivedInvocations: [(
-        queue: [QueueTaskMetadata],
-        lastRanTask: QueueTaskMetadata?,
-        lastFailedTask: QueueTaskMetadata?
-    )] = []
+    internal private(set) var getNextTaskReceivedInvocations: [(queue: [QueueTaskMetadata], lastRanTask: QueueTaskMetadata?, lastFailedTask: QueueTaskMetadata?)] = []
     /// Value to return from the mocked function.
     internal var getNextTaskReturnValue: QueueTaskMetadata?
     /**
@@ -1920,18 +1819,10 @@ internal class QueueQueryRunnerMock: QueueQueryRunner, Mock {
      The closure has first priority to return a value for the mocked function. If the closure returns `nil`,
      then the mock will attempt to return the value for `getNextTaskReturnValue`
      */
-    internal var getNextTaskClosure: (
-        ([QueueTaskMetadata], QueueTaskMetadata?, QueueTaskMetadata?)
-            -> QueueTaskMetadata?
-    )?
+    internal var getNextTaskClosure: (([QueueTaskMetadata], QueueTaskMetadata?, QueueTaskMetadata?) -> QueueTaskMetadata?)?
 
-    /// Mocked function for `getNextTask(_ queue: [QueueTaskMetadata], lastRanTask: QueueTaskMetadata?, lastFailedTask:
-    /// QueueTaskMetadata?)`. Your opportunity to return a mocked value and check result of mock in test code.
-    internal func getNextTask(
-        _ queue: [QueueTaskMetadata],
-        lastRanTask: QueueTaskMetadata?,
-        lastFailedTask: QueueTaskMetadata?
-    ) -> QueueTaskMetadata? {
+    /// Mocked function for `getNextTask(_ queue: [QueueTaskMetadata], lastRanTask: QueueTaskMetadata?, lastFailedTask: QueueTaskMetadata?)`. Your opportunity to return a mocked value and check result of mock in test code.
+    internal func getNextTask(_ queue: [QueueTaskMetadata], lastRanTask: QueueTaskMetadata?, lastFailedTask: QueueTaskMetadata?) -> QueueTaskMetadata? {
         mockCalled = true
         getNextTaskCallsCount += 1
         getNextTaskReceivedArguments = (queue: queue, lastRanTask: lastRanTask, lastFailedTask: lastFailedTask)
@@ -2001,8 +1892,7 @@ public class QueueRequestManagerMock: QueueRequestManager, Mock {
      */
     public var requestCompleteClosure: (() -> Void)?
 
-    /// Mocked function for `requestComplete()`. Your opportunity to return a mocked value and check result of mock in
-    /// test code.
+    /// Mocked function for `requestComplete()`. Your opportunity to return a mocked value and check result of mock in test code.
     public func requestComplete() {
         mockCalled = true
         requestCompleteCallsCount += 1
@@ -2029,10 +1919,9 @@ public class QueueRequestManagerMock: QueueRequestManager, Mock {
      The closure has first priority to return a value for the mocked function. If the closure returns `nil`,
      then the mock will attempt to return the value for `startRequestReturnValue`
      */
-    public var startRequestClosure: ((() -> Void) -> Bool)?
+    public var startRequestClosure: ((@escaping () -> Void) -> Bool)?
 
-    /// Mocked function for `startRequest(onComplete: @escaping () -> Void)`. Your opportunity to return a mocked value
-    /// and check result of mock in test code.
+    /// Mocked function for `startRequest(onComplete: @escaping () -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func startRequest(onComplete: @escaping () -> Void) -> Bool {
         mockCalled = true
         startRequestCallsCount += 1
@@ -2081,10 +1970,9 @@ public class QueueRunRequestMock: QueueRunRequest, Mock {
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    public var startClosure: ((() -> Void) -> Void)?
+    public var startClosure: ((@escaping () -> Void) -> Void)?
 
-    /// Mocked function for `start(onComplete: @escaping () -> Void)`. Your opportunity to return a mocked value and
-    /// check result of mock in test code.
+    /// Mocked function for `start(onComplete: @escaping () -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func start(onComplete: @escaping () -> Void) {
         mockCalled = true
         startCallsCount += 1
@@ -2127,22 +2015,15 @@ public class QueueRunnerMock: QueueRunner, Mock {
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var runTaskReceivedArguments: (
-        task: QueueTask,
-        onComplete: (Result<Void, HttpRequestError>) -> Void
-    )?
+    public private(set) var runTaskReceivedArguments: (task: QueueTask, onComplete: (Result<Void, HttpRequestError>) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var runTaskReceivedInvocations: [(
-        task: QueueTask,
-        onComplete: (Result<Void, HttpRequestError>) -> Void
-    )] = []
+    public private(set) var runTaskReceivedInvocations: [(task: QueueTask, onComplete: (Result<Void, HttpRequestError>) -> Void)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
     public var runTaskClosure: ((QueueTask, @escaping (Result<Void, HttpRequestError>) -> Void) -> Void)?
 
-    /// Mocked function for `runTask(_ task: QueueTask, onComplete: @escaping (Result<Void, HttpRequestError>) ->
-    /// Void)`. Your opportunity to return a mocked value and check result of mock in test code.
+    /// Mocked function for `runTask(_ task: QueueTask, onComplete: @escaping (Result<Void, HttpRequestError>) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func runTask(_ task: QueueTask, onComplete: @escaping (Result<Void, HttpRequestError>) -> Void) {
         mockCalled = true
         runTaskCallsCount += 1
@@ -2185,15 +2066,9 @@ public class QueueRunnerHookMock: QueueRunnerHook, Mock {
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var runTaskReceivedArguments: (
-        task: QueueTask,
-        onComplete: (Result<Void, HttpRequestError>) -> Void
-    )?
+    public private(set) var runTaskReceivedArguments: (task: QueueTask, onComplete: (Result<Void, HttpRequestError>) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var runTaskReceivedInvocations: [(
-        task: QueueTask,
-        onComplete: (Result<Void, HttpRequestError>) -> Void
-    )] = []
+    public private(set) var runTaskReceivedInvocations: [(task: QueueTask, onComplete: (Result<Void, HttpRequestError>) -> Void)] = []
     /// Value to return from the mocked function.
     public var runTaskReturnValue: Bool!
     /**
@@ -2201,10 +2076,9 @@ public class QueueRunnerHookMock: QueueRunnerHook, Mock {
      The closure has first priority to return a value for the mocked function. If the closure returns `nil`,
      then the mock will attempt to return the value for `runTaskReturnValue`
      */
-    public var runTaskClosure: ((QueueTask, (Result<Void, HttpRequestError>) -> Void) -> Bool)?
+    public var runTaskClosure: ((QueueTask, @escaping (Result<Void, HttpRequestError>) -> Void) -> Bool)?
 
-    /// Mocked function for `runTask(_ task: QueueTask, onComplete: @escaping (Result<Void, HttpRequestError>) ->
-    /// Void)`. Your opportunity to return a mocked value and check result of mock in test code.
+    /// Mocked function for `runTask(_ task: QueueTask, onComplete: @escaping (Result<Void, HttpRequestError>) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func runTask(_ task: QueueTask, onComplete: @escaping (Result<Void, HttpRequestError>) -> Void) -> Bool {
         mockCalled = true
         runTaskCallsCount += 1
@@ -2281,8 +2155,7 @@ public class QueueStorageMock: QueueStorage, Mock {
      */
     public var getInventoryClosure: (() -> [QueueTaskMetadata])?
 
-    /// Mocked function for `getInventory()`. Your opportunity to return a mocked value and check result of mock in test
-    /// code.
+    /// Mocked function for `getInventory()`. Your opportunity to return a mocked value and check result of mock in test code.
     public func getInventory() -> [QueueTaskMetadata] {
         mockCalled = true
         getInventoryCallsCount += 1
@@ -2311,8 +2184,7 @@ public class QueueStorageMock: QueueStorage, Mock {
      */
     public var saveInventoryClosure: (([QueueTaskMetadata]) -> Bool)?
 
-    /// Mocked function for `saveInventory(_ inventory: [QueueTaskMetadata])`. Your opportunity to return a mocked value
-    /// and check result of mock in test code.
+    /// Mocked function for `saveInventory(_ inventory: [QueueTaskMetadata])`. Your opportunity to return a mocked value and check result of mock in test code.
     public func saveInventory(_ inventory: [QueueTaskMetadata]) -> Bool {
         mockCalled = true
         saveInventoryCallsCount += 1
@@ -2331,19 +2203,9 @@ public class QueueStorageMock: QueueStorage, Mock {
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var createReceivedArguments: (
-        type: String,
-        data: Data,
-        groupStart: QueueTaskGroup?,
-        blockingGroups: [QueueTaskGroup]?
-    )?
+    public private(set) var createReceivedArguments: (type: String, data: Data, groupStart: QueueTaskGroup?, blockingGroups: [QueueTaskGroup]?)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var createReceivedInvocations: [(
-        type: String,
-        data: Data,
-        groupStart: QueueTaskGroup?,
-        blockingGroups: [QueueTaskGroup]?
-    )] = []
+    public private(set) var createReceivedInvocations: [(type: String, data: Data, groupStart: QueueTaskGroup?, blockingGroups: [QueueTaskGroup]?)] = []
     /// Value to return from the mocked function.
     public var createReturnValue: CreateQueueStorageTaskResult!
     /**
@@ -2353,19 +2215,12 @@ public class QueueStorageMock: QueueStorage, Mock {
      */
     public var createClosure: ((String, Data, QueueTaskGroup?, [QueueTaskGroup]?) -> CreateQueueStorageTaskResult)?
 
-    /// Mocked function for `create(type: String, data: Data, groupStart: QueueTaskGroup?, blockingGroups:
-    /// [QueueTaskGroup]?)`. Your opportunity to return a mocked value and check result of mock in test code.
-    public func create(
-        type: String,
-        data: Data,
-        groupStart: QueueTaskGroup?,
-        blockingGroups: [QueueTaskGroup]?
-    ) -> CreateQueueStorageTaskResult {
+    /// Mocked function for `create(type: String, data: Data, groupStart: QueueTaskGroup?, blockingGroups: [QueueTaskGroup]?)`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func create(type: String, data: Data, groupStart: QueueTaskGroup?, blockingGroups: [QueueTaskGroup]?) -> CreateQueueStorageTaskResult {
         mockCalled = true
         createCallsCount += 1
         createReceivedArguments = (type: type, data: data, groupStart: groupStart, blockingGroups: blockingGroups)
-        createReceivedInvocations
-            .append((type: type, data: data, groupStart: groupStart, blockingGroups: blockingGroups))
+        createReceivedInvocations.append((type: type, data: data, groupStart: groupStart, blockingGroups: blockingGroups))
         return createClosure.map { $0(type, data, groupStart, blockingGroups) } ?? createReturnValue
     }
 
@@ -2391,8 +2246,7 @@ public class QueueStorageMock: QueueStorage, Mock {
      */
     public var updateClosure: ((String, QueueTaskRunResults) -> Bool)?
 
-    /// Mocked function for `update(storageId: String, runResults: QueueTaskRunResults)`. Your opportunity to return a
-    /// mocked value and check result of mock in test code.
+    /// Mocked function for `update(storageId: String, runResults: QueueTaskRunResults)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func update(storageId: String, runResults: QueueTaskRunResults) -> Bool {
         mockCalled = true
         updateCallsCount += 1
@@ -2423,8 +2277,7 @@ public class QueueStorageMock: QueueStorage, Mock {
      */
     public var getClosure: ((String) -> QueueTask?)?
 
-    /// Mocked function for `get(storageId: String)`. Your opportunity to return a mocked value and check result of mock
-    /// in test code.
+    /// Mocked function for `get(storageId: String)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func get(storageId: String) -> QueueTask? {
         mockCalled = true
         getCallsCount += 1
@@ -2455,8 +2308,7 @@ public class QueueStorageMock: QueueStorage, Mock {
      */
     public var deleteClosure: ((String) -> Bool)?
 
-    /// Mocked function for `delete(storageId: String)`. Your opportunity to return a mocked value and check result of
-    /// mock in test code.
+    /// Mocked function for `delete(storageId: String)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func delete(storageId: String) -> Bool {
         mockCalled = true
         deleteCallsCount += 1
@@ -2483,8 +2335,7 @@ public class QueueStorageMock: QueueStorage, Mock {
      */
     public var deleteExpiredClosure: (() -> [QueueTaskMetadata])?
 
-    /// Mocked function for `deleteExpired()`. Your opportunity to return a mocked value and check result of mock in
-    /// test code.
+    /// Mocked function for `deleteExpired()`. Your opportunity to return a mocked value and check result of mock in test code.
     public func deleteExpired() -> [QueueTaskMetadata] {
         mockCalled = true
         deleteExpiredCallsCount += 1
@@ -2533,8 +2384,7 @@ public class ScreenTrackingHookMock: ScreenTrackingHook, Mock {
      */
     public var screenViewedClosure: ((String) -> Void)?
 
-    /// Mocked function for `screenViewed(name: String)`. Your opportunity to return a mocked value and check result of
-    /// mock in test code.
+    /// Mocked function for `screenViewed(name: String)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func screenViewed(name: String) {
         mockCalled = true
         screenViewedCallsCount += 1
@@ -2591,10 +2441,9 @@ internal class SimpleTimerMock: SimpleTimer, Mock {
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    internal var scheduleAndCancelPreviousClosure: ((Seconds, () -> Void) -> Void)?
+    internal var scheduleAndCancelPreviousClosure: ((Seconds, @escaping () -> Void) -> Void)?
 
-    /// Mocked function for `scheduleAndCancelPrevious(seconds: Seconds, block: @escaping () -> Void)`. Your opportunity
-    /// to return a mocked value and check result of mock in test code.
+    /// Mocked function for `scheduleAndCancelPrevious(seconds: Seconds, block: @escaping () -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
     internal func scheduleAndCancelPrevious(seconds: Seconds, block: @escaping () -> Void) {
         mockCalled = true
         scheduleAndCancelPreviousCallsCount += 1
@@ -2623,10 +2472,9 @@ internal class SimpleTimerMock: SimpleTimer, Mock {
      The closure has first priority to return a value for the mocked function. If the closure returns `nil`,
      then the mock will attempt to return the value for `scheduleIfNotAlreadyReturnValue`
      */
-    internal var scheduleIfNotAlreadyClosure: ((Seconds, () -> Void) -> Bool)?
+    internal var scheduleIfNotAlreadyClosure: ((Seconds, @escaping () -> Void) -> Bool)?
 
-    /// Mocked function for `scheduleIfNotAlready(seconds: Seconds, block: @escaping () -> Void)`. Your opportunity to
-    /// return a mocked value and check result of mock in test code.
+    /// Mocked function for `scheduleIfNotAlready(seconds: Seconds, block: @escaping () -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
     internal func scheduleIfNotAlready(seconds: Seconds, block: @escaping () -> Void) -> Bool {
         mockCalled = true
         scheduleIfNotAlreadyCallsCount += 1
@@ -2703,10 +2551,9 @@ internal class SingleScheduleTimerMock: SingleScheduleTimer, Mock {
      The closure has first priority to return a value for the mocked function. If the closure returns `nil`,
      then the mock will attempt to return the value for `scheduleIfNotAlreadyReturnValue`
      */
-    internal var scheduleIfNotAlreadyClosure: ((Seconds, () -> Void) -> Bool)?
+    internal var scheduleIfNotAlreadyClosure: ((Seconds, @escaping () -> Void) -> Bool)?
 
-    /// Mocked function for `scheduleIfNotAlready(seconds: Seconds, block: @escaping () -> Void)`. Your opportunity to
-    /// return a mocked value and check result of mock in test code.
+    /// Mocked function for `scheduleIfNotAlready(seconds: Seconds, block: @escaping () -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
     internal func scheduleIfNotAlready(seconds: Seconds, block: @escaping () -> Void) -> Bool {
         mockCalled = true
         scheduleIfNotAlreadyCallsCount += 1
@@ -2776,8 +2623,7 @@ public class UserAgentUtilMock: UserAgentUtil, Mock {
      */
     public var getUserAgentHeaderValueClosure: (() -> String)?
 
-    /// Mocked function for `getUserAgentHeaderValue()`. Your opportunity to return a mocked value and check result of
-    /// mock in test code.
+    /// Mocked function for `getUserAgentHeaderValue()`. Your opportunity to return a mocked value and check result of mock in test code.
     public func getUserAgentHeaderValue() -> String {
         mockCalled = true
         getUserAgentHeaderValueCallsCount += 1

--- a/Sources/Common/autogenerated/AutoMockable.generated.swift
+++ b/Sources/Common/autogenerated/AutoMockable.generated.swift
@@ -2139,7 +2139,7 @@ public class QueueRunnerMock: QueueRunner, Mock {
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    public var runTaskClosure: ((QueueTask, (Result<Void, HttpRequestError>) -> Void) -> Void)?
+    public var runTaskClosure: ((QueueTask, @escaping (Result<Void, HttpRequestError>) -> Void) -> Void)?
 
     /// Mocked function for `runTask(_ task: QueueTask, onComplete: @escaping (Result<Void, HttpRequestError>) ->
     /// Void)`. Your opportunity to return a mocked value and check result of mock in test code.

--- a/Sources/MessagingInApp/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingInApp/autogenerated/AutoMockable.generated.swift
@@ -136,8 +136,7 @@ internal class InAppProviderMock: InAppProvider, Mock {
      */
     internal var initializeClosure: ((String, GistDelegate) -> Void)?
 
-    /// Mocked function for `initialize(organizationId: String, delegate: GistDelegate)`. Your opportunity to return a
-    /// mocked value and check result of mock in test code.
+    /// Mocked function for `initialize(organizationId: String, delegate: GistDelegate)`. Your opportunity to return a mocked value and check result of mock in test code.
     internal func initialize(organizationId: String, delegate: GistDelegate) {
         mockCalled = true
         initializeCallsCount += 1
@@ -164,8 +163,7 @@ internal class InAppProviderMock: InAppProvider, Mock {
      */
     internal var setProfileIdentifierClosure: ((String) -> Void)?
 
-    /// Mocked function for `setProfileIdentifier(_ id: String)`. Your opportunity to return a mocked value and check
-    /// result of mock in test code.
+    /// Mocked function for `setProfileIdentifier(_ id: String)`. Your opportunity to return a mocked value and check result of mock in test code.
     internal func setProfileIdentifier(_ id: String) {
         mockCalled = true
         setProfileIdentifierCallsCount += 1
@@ -188,8 +186,7 @@ internal class InAppProviderMock: InAppProvider, Mock {
      */
     internal var clearIdentifyClosure: (() -> Void)?
 
-    /// Mocked function for `clearIdentify()`. Your opportunity to return a mocked value and check result of mock in
-    /// test code.
+    /// Mocked function for `clearIdentify()`. Your opportunity to return a mocked value and check result of mock in test code.
     internal func clearIdentify() {
         mockCalled = true
         clearIdentifyCallsCount += 1
@@ -214,8 +211,7 @@ internal class InAppProviderMock: InAppProvider, Mock {
      */
     internal var setRouteClosure: ((String) -> Void)?
 
-    /// Mocked function for `setRoute(_ route: String)`. Your opportunity to return a mocked value and check result of
-    /// mock in test code.
+    /// Mocked function for `setRoute(_ route: String)`. Your opportunity to return a mocked value and check result of mock in test code.
     internal func setRoute(_ route: String) {
         mockCalled = true
         setRouteCallsCount += 1
@@ -266,8 +262,7 @@ public class MessagingInAppInstanceMock: MessagingInAppInstance, Mock {
      */
     public var initializeClosure: ((String) -> Void)?
 
-    /// Mocked function for `initialize(organizationId: String)`. Your opportunity to return a mocked value and check
-    /// result of mock in test code.
+    /// Mocked function for `initialize(organizationId: String)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func initialize(organizationId: String) {
         mockCalled = true
         initializeCallsCount += 1

--- a/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
@@ -156,8 +156,7 @@ public class MessagingPushInstanceMock: MessagingPushInstance, Mock {
      */
     public var registerDeviceTokenClosure: ((String) -> Void)?
 
-    /// Mocked function for `registerDeviceToken(_ deviceToken: String)`. Your opportunity to return a mocked value and
-    /// check result of mock in test code.
+    /// Mocked function for `registerDeviceToken(_ deviceToken: String)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func registerDeviceToken(_ deviceToken: String) {
         mockCalled = true
         registerDeviceTokenCallsCount += 1
@@ -180,8 +179,7 @@ public class MessagingPushInstanceMock: MessagingPushInstance, Mock {
      */
     public var deleteDeviceTokenClosure: (() -> Void)?
 
-    /// Mocked function for `deleteDeviceToken()`. Your opportunity to return a mocked value and check result of mock in
-    /// test code.
+    /// Mocked function for `deleteDeviceToken()`. Your opportunity to return a mocked value and check result of mock in test code.
     public func deleteDeviceToken() {
         mockCalled = true
         deleteDeviceTokenCallsCount += 1
@@ -200,15 +198,13 @@ public class MessagingPushInstanceMock: MessagingPushInstance, Mock {
     /// The arguments from the *last* time the function was called.
     public private(set) var trackMetricReceivedArguments: (deliveryID: String, event: Metric, deviceToken: String)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var trackMetricReceivedInvocations: [(deliveryID: String, event: Metric, deviceToken: String)] =
-        []
+    public private(set) var trackMetricReceivedInvocations: [(deliveryID: String, event: Metric, deviceToken: String)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
     public var trackMetricClosure: ((String, Metric, String) -> Void)?
 
-    /// Mocked function for `trackMetric(deliveryID: String, event: Metric, deviceToken: String)`. Your opportunity to
-    /// return a mocked value and check result of mock in test code.
+    /// Mocked function for `trackMetric(deliveryID: String, event: Metric, deviceToken: String)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func trackMetric(deliveryID: String, event: Metric, deviceToken: String) {
         mockCalled = true
         trackMetricCallsCount += 1
@@ -228,15 +224,9 @@ public class MessagingPushInstanceMock: MessagingPushInstance, Mock {
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var didReceiveNotificationRequestReceivedArguments: (
-        request: UNNotificationRequest,
-        contentHandler: (UNNotificationContent) -> Void
-    )?
+    public private(set) var didReceiveNotificationRequestReceivedArguments: (request: UNNotificationRequest, contentHandler: (UNNotificationContent) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var didReceiveNotificationRequestReceivedInvocations: [(
-        request: UNNotificationRequest,
-        contentHandler: (UNNotificationContent) -> Void
-    )] = []
+    public private(set) var didReceiveNotificationRequestReceivedInvocations: [(request: UNNotificationRequest, contentHandler: (UNNotificationContent) -> Void)] = []
     /// Value to return from the mocked function.
     public var didReceiveNotificationRequestReturnValue: Bool!
     /**
@@ -244,22 +234,16 @@ public class MessagingPushInstanceMock: MessagingPushInstance, Mock {
      The closure has first priority to return a value for the mocked function. If the closure returns `nil`,
      then the mock will attempt to return the value for `didReceiveNotificationRequestReturnValue`
      */
-    public var didReceiveNotificationRequestClosure: ((UNNotificationRequest, (UNNotificationContent) -> Void) -> Bool)?
+    public var didReceiveNotificationRequestClosure: ((UNNotificationRequest, @escaping (UNNotificationContent) -> Void) -> Bool)?
 
-    /// Mocked function for `didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping
-    /// (UNNotificationContent) -> Void)`. Your opportunity to return a mocked value and check result of mock in test
-    /// code.
+    /// Mocked function for `didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
     @discardableResult
-    public func didReceive(
-        _ request: UNNotificationRequest,
-        withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
-    ) -> Bool {
+    public func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) -> Bool {
         mockCalled = true
         didReceiveNotificationRequestCallsCount += 1
         didReceiveNotificationRequestReceivedArguments = (request: request, contentHandler: contentHandler)
         didReceiveNotificationRequestReceivedInvocations.append((request: request, contentHandler: contentHandler))
-        return didReceiveNotificationRequestClosure
-            .map { $0(request, contentHandler) } ?? didReceiveNotificationRequestReturnValue
+        return didReceiveNotificationRequestClosure.map { $0(request, contentHandler) } ?? didReceiveNotificationRequestReturnValue
     }
     #endif
 
@@ -278,8 +262,7 @@ public class MessagingPushInstanceMock: MessagingPushInstance, Mock {
      */
     public var serviceExtensionTimeWillExpireClosure: (() -> Void)?
 
-    /// Mocked function for `serviceExtensionTimeWillExpire()`. Your opportunity to return a mocked value and check
-    /// result of mock in test code.
+    /// Mocked function for `serviceExtensionTimeWillExpire()`. Your opportunity to return a mocked value and check result of mock in test code.
     public func serviceExtensionTimeWillExpire() {
         mockCalled = true
         serviceExtensionTimeWillExpireCallsCount += 1
@@ -298,17 +281,9 @@ public class MessagingPushInstanceMock: MessagingPushInstance, Mock {
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var userNotificationCenter_withCompletionReceivedArguments: (
-        center: UNUserNotificationCenter,
-        response: UNNotificationResponse,
-        completionHandler: () -> Void
-    )?
+    public private(set) var userNotificationCenter_withCompletionReceivedArguments: (center: UNUserNotificationCenter, response: UNNotificationResponse, completionHandler: () -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var userNotificationCenter_withCompletionReceivedInvocations: [(
-        center: UNUserNotificationCenter,
-        response: UNNotificationResponse,
-        completionHandler: () -> Void
-    )] = []
+    public private(set) var userNotificationCenter_withCompletionReceivedInvocations: [(center: UNUserNotificationCenter, response: UNNotificationResponse, completionHandler: () -> Void)] = []
     /// Value to return from the mocked function.
     public var userNotificationCenter_withCompletionReturnValue: Bool!
     /**
@@ -316,31 +291,15 @@ public class MessagingPushInstanceMock: MessagingPushInstance, Mock {
      The closure has first priority to return a value for the mocked function. If the closure returns `nil`,
      then the mock will attempt to return the value for `userNotificationCenter_withCompletionReturnValue`
      */
-    public var userNotificationCenter_withCompletionClosure: ((
-        UNUserNotificationCenter,
-        UNNotificationResponse,
-        () -> Void
-    ) -> Bool)?
+    public var userNotificationCenter_withCompletionClosure: ((UNUserNotificationCenter, UNNotificationResponse, @escaping () -> Void) -> Bool)?
 
-    /// Mocked function for `userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response:
-    /// UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void)`. Your opportunity to
-    /// return a mocked value and check result of mock in test code.
-    public func userNotificationCenter(
-        _ center: UNUserNotificationCenter,
-        didReceive response: UNNotificationResponse,
-        withCompletionHandler completionHandler: @escaping () -> Void
-    ) -> Bool {
+    /// Mocked function for `userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) -> Bool {
         mockCalled = true
         userNotificationCenter_withCompletionCallsCount += 1
-        userNotificationCenter_withCompletionReceivedArguments = (
-            center: center,
-            response: response,
-            completionHandler: completionHandler
-        )
-        userNotificationCenter_withCompletionReceivedInvocations
-            .append((center: center, response: response, completionHandler: completionHandler))
-        return userNotificationCenter_withCompletionClosure
-            .map { $0(center, response, completionHandler) } ?? userNotificationCenter_withCompletionReturnValue
+        userNotificationCenter_withCompletionReceivedArguments = (center: center, response: response, completionHandler: completionHandler)
+        userNotificationCenter_withCompletionReceivedInvocations.append((center: center, response: response, completionHandler: completionHandler))
+        return userNotificationCenter_withCompletionClosure.map { $0(center, response, completionHandler) } ?? userNotificationCenter_withCompletionReturnValue
     }
     #endif
 
@@ -355,15 +314,9 @@ public class MessagingPushInstanceMock: MessagingPushInstance, Mock {
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var userNotificationCenterReceivedArguments: (
-        center: UNUserNotificationCenter,
-        response: UNNotificationResponse
-    )?
+    public private(set) var userNotificationCenterReceivedArguments: (center: UNUserNotificationCenter, response: UNNotificationResponse)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var userNotificationCenterReceivedInvocations: [(
-        center: UNUserNotificationCenter,
-        response: UNNotificationResponse
-    )] = []
+    public private(set) var userNotificationCenterReceivedInvocations: [(center: UNUserNotificationCenter, response: UNNotificationResponse)] = []
     /// Value to return from the mocked function.
     public var userNotificationCenterReturnValue: CustomerIOParsedPushPayload?
     /**
@@ -371,17 +324,10 @@ public class MessagingPushInstanceMock: MessagingPushInstance, Mock {
      The closure has first priority to return a value for the mocked function. If the closure returns `nil`,
      then the mock will attempt to return the value for `userNotificationCenterReturnValue`
      */
-    public var userNotificationCenterClosure: (
-        (UNUserNotificationCenter, UNNotificationResponse)
-            -> CustomerIOParsedPushPayload?
-    )?
+    public var userNotificationCenterClosure: ((UNUserNotificationCenter, UNNotificationResponse) -> CustomerIOParsedPushPayload?)?
 
-    /// Mocked function for `userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response:
-    /// UNNotificationResponse)`. Your opportunity to return a mocked value and check result of mock in test code.
-    public func userNotificationCenter(
-        _ center: UNUserNotificationCenter,
-        didReceive response: UNNotificationResponse
-    ) -> CustomerIOParsedPushPayload? {
+    /// Mocked function for `userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse)`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) -> CustomerIOParsedPushPayload? {
         mockCalled = true
         userNotificationCenterCallsCount += 1
         userNotificationCenterReceivedArguments = (center: center, response: response)

--- a/Sources/MessagingPushAPN/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingPushAPN/autogenerated/AutoMockable.generated.swift
@@ -153,8 +153,7 @@ public class MessagingPushAPNInstanceMock: MessagingPushAPNInstance, Mock {
      */
     public var registerDeviceTokenClosure: ((Data) -> Void)?
 
-    /// Mocked function for `registerDeviceToken(apnDeviceToken: Data)`. Your opportunity to return a mocked value and
-    /// check result of mock in test code.
+    /// Mocked function for `registerDeviceToken(apnDeviceToken: Data)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func registerDeviceToken(apnDeviceToken: Data) {
         mockCalled = true
         registerDeviceTokenCallsCount += 1
@@ -175,23 +174,18 @@ public class MessagingPushAPNInstanceMock: MessagingPushAPNInstance, Mock {
     /// The arguments from the *last* time the function was called.
     public private(set) var didRegisterForRemoteNotificationsReceivedArguments: (application: Any, deviceToken: Data)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var didRegisterForRemoteNotificationsReceivedInvocations: [(
-        application: Any,
-        deviceToken: Data
-    )] = []
+    public private(set) var didRegisterForRemoteNotificationsReceivedInvocations: [(application: Any, deviceToken: Data)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
     public var didRegisterForRemoteNotificationsClosure: ((Any, Data) -> Void)?
 
-    /// Mocked function for `application(_ application: Any, didRegisterForRemoteNotificationsWithDeviceToken
-    /// deviceToken: Data)`. Your opportunity to return a mocked value and check result of mock in test code.
+    /// Mocked function for `application(_ application: Any, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func application(_ application: Any, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         mockCalled = true
         didRegisterForRemoteNotificationsCallsCount += 1
         didRegisterForRemoteNotificationsReceivedArguments = (application: application, deviceToken: deviceToken)
-        didRegisterForRemoteNotificationsReceivedInvocations
-            .append((application: application, deviceToken: deviceToken))
+        didRegisterForRemoteNotificationsReceivedInvocations.append((application: application, deviceToken: deviceToken))
         didRegisterForRemoteNotificationsClosure?(application, deviceToken)
     }
 
@@ -207,17 +201,13 @@ public class MessagingPushAPNInstanceMock: MessagingPushAPNInstance, Mock {
     /// The arguments from the *last* time the function was called.
     public private(set) var didFailToRegisterForRemoteNotificationsReceivedArguments: (application: Any, error: Error)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var didFailToRegisterForRemoteNotificationsReceivedInvocations: [(
-        application: Any,
-        error: Error
-    )] = []
+    public private(set) var didFailToRegisterForRemoteNotificationsReceivedInvocations: [(application: Any, error: Error)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
     public var didFailToRegisterForRemoteNotificationsClosure: ((Any, Error) -> Void)?
 
-    /// Mocked function for `application(_ application: Any, didFailToRegisterForRemoteNotificationsWithError error:
-    /// Error)`. Your opportunity to return a mocked value and check result of mock in test code.
+    /// Mocked function for `application(_ application: Any, didFailToRegisterForRemoteNotificationsWithError error: Error)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func application(_ application: Any, didFailToRegisterForRemoteNotificationsWithError error: Error) {
         mockCalled = true
         didFailToRegisterForRemoteNotificationsCallsCount += 1
@@ -240,8 +230,7 @@ public class MessagingPushAPNInstanceMock: MessagingPushAPNInstance, Mock {
      */
     public var deleteDeviceTokenClosure: (() -> Void)?
 
-    /// Mocked function for `deleteDeviceToken()`. Your opportunity to return a mocked value and check result of mock in
-    /// test code.
+    /// Mocked function for `deleteDeviceToken()`. Your opportunity to return a mocked value and check result of mock in test code.
     public func deleteDeviceToken() {
         mockCalled = true
         deleteDeviceTokenCallsCount += 1
@@ -260,15 +249,13 @@ public class MessagingPushAPNInstanceMock: MessagingPushAPNInstance, Mock {
     /// The arguments from the *last* time the function was called.
     public private(set) var trackMetricReceivedArguments: (deliveryID: String, event: Metric, deviceToken: String)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var trackMetricReceivedInvocations: [(deliveryID: String, event: Metric, deviceToken: String)] =
-        []
+    public private(set) var trackMetricReceivedInvocations: [(deliveryID: String, event: Metric, deviceToken: String)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
     public var trackMetricClosure: ((String, Metric, String) -> Void)?
 
-    /// Mocked function for `trackMetric(deliveryID: String, event: Metric, deviceToken: String)`. Your opportunity to
-    /// return a mocked value and check result of mock in test code.
+    /// Mocked function for `trackMetric(deliveryID: String, event: Metric, deviceToken: String)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func trackMetric(deliveryID: String, event: Metric, deviceToken: String) {
         mockCalled = true
         trackMetricCallsCount += 1
@@ -288,15 +275,9 @@ public class MessagingPushAPNInstanceMock: MessagingPushAPNInstance, Mock {
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var didReceiveNotificationRequestReceivedArguments: (
-        request: UNNotificationRequest,
-        contentHandler: (UNNotificationContent) -> Void
-    )?
+    public private(set) var didReceiveNotificationRequestReceivedArguments: (request: UNNotificationRequest, contentHandler: (UNNotificationContent) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var didReceiveNotificationRequestReceivedInvocations: [(
-        request: UNNotificationRequest,
-        contentHandler: (UNNotificationContent) -> Void
-    )] = []
+    public private(set) var didReceiveNotificationRequestReceivedInvocations: [(request: UNNotificationRequest, contentHandler: (UNNotificationContent) -> Void)] = []
     /// Value to return from the mocked function.
     public var didReceiveNotificationRequestReturnValue: Bool!
     /**
@@ -304,22 +285,16 @@ public class MessagingPushAPNInstanceMock: MessagingPushAPNInstance, Mock {
      The closure has first priority to return a value for the mocked function. If the closure returns `nil`,
      then the mock will attempt to return the value for `didReceiveNotificationRequestReturnValue`
      */
-    public var didReceiveNotificationRequestClosure: ((UNNotificationRequest, (UNNotificationContent) -> Void) -> Bool)?
+    public var didReceiveNotificationRequestClosure: ((UNNotificationRequest, @escaping (UNNotificationContent) -> Void) -> Bool)?
 
-    /// Mocked function for `didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping
-    /// (UNNotificationContent) -> Void)`. Your opportunity to return a mocked value and check result of mock in test
-    /// code.
+    /// Mocked function for `didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
     @discardableResult
-    public func didReceive(
-        _ request: UNNotificationRequest,
-        withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
-    ) -> Bool {
+    public func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) -> Bool {
         mockCalled = true
         didReceiveNotificationRequestCallsCount += 1
         didReceiveNotificationRequestReceivedArguments = (request: request, contentHandler: contentHandler)
         didReceiveNotificationRequestReceivedInvocations.append((request: request, contentHandler: contentHandler))
-        return didReceiveNotificationRequestClosure
-            .map { $0(request, contentHandler) } ?? didReceiveNotificationRequestReturnValue
+        return didReceiveNotificationRequestClosure.map { $0(request, contentHandler) } ?? didReceiveNotificationRequestReturnValue
     }
     #endif
 
@@ -338,8 +313,7 @@ public class MessagingPushAPNInstanceMock: MessagingPushAPNInstance, Mock {
      */
     public var serviceExtensionTimeWillExpireClosure: (() -> Void)?
 
-    /// Mocked function for `serviceExtensionTimeWillExpire()`. Your opportunity to return a mocked value and check
-    /// result of mock in test code.
+    /// Mocked function for `serviceExtensionTimeWillExpire()`. Your opportunity to return a mocked value and check result of mock in test code.
     public func serviceExtensionTimeWillExpire() {
         mockCalled = true
         serviceExtensionTimeWillExpireCallsCount += 1

--- a/Sources/MessagingPushFCM/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingPushFCM/autogenerated/AutoMockable.generated.swift
@@ -153,8 +153,7 @@ public class MessagingPushFCMInstanceMock: MessagingPushFCMInstance, Mock {
      */
     public var registerDeviceTokenClosure: ((String?) -> Void)?
 
-    /// Mocked function for `registerDeviceToken(fcmToken: String?)`. Your opportunity to return a mocked value and
-    /// check result of mock in test code.
+    /// Mocked function for `registerDeviceToken(fcmToken: String?)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func registerDeviceToken(fcmToken: String?) {
         mockCalled = true
         registerDeviceTokenCallsCount += 1
@@ -181,8 +180,7 @@ public class MessagingPushFCMInstanceMock: MessagingPushFCMInstance, Mock {
      */
     public var didReceiveRegistrationTokenClosure: ((Any, String?) -> Void)?
 
-    /// Mocked function for `messaging(_ messaging: Any, didReceiveRegistrationToken fcmToken: String?)`. Your
-    /// opportunity to return a mocked value and check result of mock in test code.
+    /// Mocked function for `messaging(_ messaging: Any, didReceiveRegistrationToken fcmToken: String?)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func messaging(_ messaging: Any, didReceiveRegistrationToken fcmToken: String?) {
         mockCalled = true
         didReceiveRegistrationTokenCallsCount += 1
@@ -203,17 +201,13 @@ public class MessagingPushFCMInstanceMock: MessagingPushFCMInstance, Mock {
     /// The arguments from the *last* time the function was called.
     public private(set) var didFailToRegisterForRemoteNotificationsReceivedArguments: (application: Any, error: Error)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var didFailToRegisterForRemoteNotificationsReceivedInvocations: [(
-        application: Any,
-        error: Error
-    )] = []
+    public private(set) var didFailToRegisterForRemoteNotificationsReceivedInvocations: [(application: Any, error: Error)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
     public var didFailToRegisterForRemoteNotificationsClosure: ((Any, Error) -> Void)?
 
-    /// Mocked function for `application(_ application: Any, didFailToRegisterForRemoteNotificationsWithError error:
-    /// Error)`. Your opportunity to return a mocked value and check result of mock in test code.
+    /// Mocked function for `application(_ application: Any, didFailToRegisterForRemoteNotificationsWithError error: Error)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func application(_ application: Any, didFailToRegisterForRemoteNotificationsWithError error: Error) {
         mockCalled = true
         didFailToRegisterForRemoteNotificationsCallsCount += 1
@@ -236,8 +230,7 @@ public class MessagingPushFCMInstanceMock: MessagingPushFCMInstance, Mock {
      */
     public var deleteDeviceTokenClosure: (() -> Void)?
 
-    /// Mocked function for `deleteDeviceToken()`. Your opportunity to return a mocked value and check result of mock in
-    /// test code.
+    /// Mocked function for `deleteDeviceToken()`. Your opportunity to return a mocked value and check result of mock in test code.
     public func deleteDeviceToken() {
         mockCalled = true
         deleteDeviceTokenCallsCount += 1
@@ -256,15 +249,13 @@ public class MessagingPushFCMInstanceMock: MessagingPushFCMInstance, Mock {
     /// The arguments from the *last* time the function was called.
     public private(set) var trackMetricReceivedArguments: (deliveryID: String, event: Metric, deviceToken: String)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var trackMetricReceivedInvocations: [(deliveryID: String, event: Metric, deviceToken: String)] =
-        []
+    public private(set) var trackMetricReceivedInvocations: [(deliveryID: String, event: Metric, deviceToken: String)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
     public var trackMetricClosure: ((String, Metric, String) -> Void)?
 
-    /// Mocked function for `trackMetric(deliveryID: String, event: Metric, deviceToken: String)`. Your opportunity to
-    /// return a mocked value and check result of mock in test code.
+    /// Mocked function for `trackMetric(deliveryID: String, event: Metric, deviceToken: String)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func trackMetric(deliveryID: String, event: Metric, deviceToken: String) {
         mockCalled = true
         trackMetricCallsCount += 1
@@ -284,15 +275,9 @@ public class MessagingPushFCMInstanceMock: MessagingPushFCMInstance, Mock {
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var didReceiveNotificationRequestReceivedArguments: (
-        request: UNNotificationRequest,
-        contentHandler: (UNNotificationContent) -> Void
-    )?
+    public private(set) var didReceiveNotificationRequestReceivedArguments: (request: UNNotificationRequest, contentHandler: (UNNotificationContent) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var didReceiveNotificationRequestReceivedInvocations: [(
-        request: UNNotificationRequest,
-        contentHandler: (UNNotificationContent) -> Void
-    )] = []
+    public private(set) var didReceiveNotificationRequestReceivedInvocations: [(request: UNNotificationRequest, contentHandler: (UNNotificationContent) -> Void)] = []
     /// Value to return from the mocked function.
     public var didReceiveNotificationRequestReturnValue: Bool!
     /**
@@ -300,22 +285,16 @@ public class MessagingPushFCMInstanceMock: MessagingPushFCMInstance, Mock {
      The closure has first priority to return a value for the mocked function. If the closure returns `nil`,
      then the mock will attempt to return the value for `didReceiveNotificationRequestReturnValue`
      */
-    public var didReceiveNotificationRequestClosure: ((UNNotificationRequest, (UNNotificationContent) -> Void) -> Bool)?
+    public var didReceiveNotificationRequestClosure: ((UNNotificationRequest, @escaping (UNNotificationContent) -> Void) -> Bool)?
 
-    /// Mocked function for `didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping
-    /// (UNNotificationContent) -> Void)`. Your opportunity to return a mocked value and check result of mock in test
-    /// code.
+    /// Mocked function for `didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
     @discardableResult
-    public func didReceive(
-        _ request: UNNotificationRequest,
-        withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
-    ) -> Bool {
+    public func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) -> Bool {
         mockCalled = true
         didReceiveNotificationRequestCallsCount += 1
         didReceiveNotificationRequestReceivedArguments = (request: request, contentHandler: contentHandler)
         didReceiveNotificationRequestReceivedInvocations.append((request: request, contentHandler: contentHandler))
-        return didReceiveNotificationRequestClosure
-            .map { $0(request, contentHandler) } ?? didReceiveNotificationRequestReturnValue
+        return didReceiveNotificationRequestClosure.map { $0(request, contentHandler) } ?? didReceiveNotificationRequestReturnValue
     }
     #endif
 
@@ -334,8 +313,7 @@ public class MessagingPushFCMInstanceMock: MessagingPushFCMInstance, Mock {
      */
     public var serviceExtensionTimeWillExpireClosure: (() -> Void)?
 
-    /// Mocked function for `serviceExtensionTimeWillExpire()`. Your opportunity to return a mocked value and check
-    /// result of mock in test code.
+    /// Mocked function for `serviceExtensionTimeWillExpire()`. Your opportunity to return a mocked value and check result of mock in test code.
     public func serviceExtensionTimeWillExpire() {
         mockCalled = true
         serviceExtensionTimeWillExpireCallsCount += 1

--- a/Sources/Templates/AutoMockable.stencil
+++ b/Sources/Templates/AutoMockable.stencil
@@ -87,7 +87,7 @@ class ExampleTest: XCTestCase {
 {% macro swiftifyMethodNameOrDuplicate method %}{% if method|annotated:"DuplicateMethod" %}{{ method.annotations["DuplicateMethod"] }}{% else %}{% call swiftifyMethodName method %}{% endif %}{% endmacro %}
 
 {# Input: method parameter. Output: `ParameterType`, `@escaping ParamType`. Automatically get the info needed or override with `Type=ParamType` annotation (used when using generics) #}
-{% macro parameterTypeName param %}{% if param.typeAttributes.escaping %}{{ param.unwrappedTypeName }}{% elif param|annotated:"Type" %}{{ param.annotations["Type"] }}{% else %}{{ param.typeName }}{% endif %}{% endmacro %}
+{% macro parameterTypeName param nameOnly %}{% if param.typeAttributes.escaping %}{% if not nameOnly %}@escaping {% endif %}{{ param.unwrappedTypeName }}{% elif param|annotated:"Type" %}{{ param.annotations["Type"] }}{% else %}{{ param.typeName }}{% endif %}{% endmacro %}
 
 {# Input: method parameter. Output: value set for annotation  `TypeCast`. Your chance to cast the parameter to whatever you need it to in mocked method body. #}
 {# Example: `// sourcery: TypeCast="as! Foo"` #}
@@ -130,7 +130,7 @@ class ExampleTest: XCTestCase {
      then the mock will attempt to return the value for `{% call swiftifyMethodName method %}ReturnValue`
      {% endif %}
      */
-    {{ type.accessLevel }} var {% call methodClosureName method %}: (({% for param in method.parameters %}{% call parameterTypeName param %}{% if not forloop.last %}, {% endif %}{% endfor %}) {% if method.throws %}throws {% endif %}-> {% if method.isInitializer %}Void{% else %}{% call closureReturnTypeName method %}{% endif %})?
+    {{ type.accessLevel }} var {% call methodClosureName method %}: (({% for param in method.parameters %}{% call parameterTypeName param false %}{% if not forloop.last %}, {% endif %}{% endfor %}) {% if method.throws %}throws {% endif %}-> {% if method.isInitializer %}Void{% else %}{% call closureReturnTypeName method %}{% endif %})?
 {% endmacro %}
 
 {% macro methodClosureCallParameters method %}{% for param in method.parameters %}{% call parameterValueWithCast param %}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
@@ -161,9 +161,9 @@ class ExampleTest: XCTestCase {
     {{ type.accessLevel }} private(set) var {% call swiftifyMethodName method %}ReceivedInvocations: [({% for param in method.parameters %}{%if not param|annotated:"SkipParamCapture" %}{{ param.unwrappedTypeName if param.typeAttributes.escaping else param.typeName }}{{ ', ' if not forloop.last }}{% endif %}{% endfor %})] = []
     {% elif not method.parameters.count == 0 %}
     /// The arguments from the *last* time the function was called. 
-    {{ type.accessLevel }} private(set) var {% call swiftifyMethodName method %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% call parameterTypeName param %}{{ ', ' if not forloop.last }}{% endfor %})?
+    {{ type.accessLevel }} private(set) var {% call swiftifyMethodName method %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% call parameterTypeName param true %}{{ ', ' if not forloop.last }}{% endfor %})?
     /// Arguments from *all* of the times that the function was called. 
-    {{ type.accessLevel }} private(set) var {% call swiftifyMethodName method %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {% call parameterTypeName param %}{{ ', ' if not forloop.last }}{% endfor %})] = []
+    {{ type.accessLevel }} private(set) var {% call swiftifyMethodName method %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {% call parameterTypeName param true %}{{ ', ' if not forloop.last }}{% endfor %})] = []
     {% endif %}
     {% if not method.returnTypeName.isVoid and not method.isInitializer %}
     /// Value to return from the mocked function. 

--- a/Sources/Tracking/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/Tracking/autogenerated/AutoDependencyInjection.generated.swift
@@ -98,12 +98,6 @@ extension DIGraph {
     }
 
     private var newQueueRunnerHook: QueueRunnerHook {
-        TrackingQueueRunner(
-            siteId: siteId,
-            jsonAdapter: jsonAdapter,
-            logger: logger,
-            httpClient: httpClient,
-            sdkConfig: sdkConfig
-        )
+        TrackingQueueRunner(siteId: siteId, jsonAdapter: jsonAdapter, logger: logger, httpClient: httpClient, sdkConfig: sdkConfig)
     }
 }

--- a/Sources/Tracking/autogenerated/AutoMockable.generated.swift
+++ b/Sources/Tracking/autogenerated/AutoMockable.generated.swift
@@ -115,8 +115,7 @@ internal class CleanupRepositoryMock: CleanupRepository, Mock {
      */
     internal var cleanupClosure: (() -> Void)?
 
-    /// Mocked function for `cleanup()`. Your opportunity to return a mocked value and check result of mock in test
-    /// code.
+    /// Mocked function for `cleanup()`. Your opportunity to return a mocked value and check result of mock in test code.
     internal func cleanup() {
         mockCalled = true
         cleanupCallsCount += 1
@@ -318,8 +317,7 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
      */
     public var identifyClosure: ((String, [String: Any]) -> Void)?
 
-    /// Mocked function for `identify(identifier: String, body: [String: Any])`. Your opportunity to return a mocked
-    /// value and check result of mock in test code.
+    /// Mocked function for `identify(identifier: String, body: [String: Any])`. Your opportunity to return a mocked value and check result of mock in test code.
     public func identify(identifier: String, body: [String: Any]) {
         mockCalled = true
         identifyCallsCount += 1
@@ -339,8 +337,7 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
      */
     public var identifyEncodableClosure: ((String, AnyEncodable) -> Void)?
 
-    /// Mocked function for `identify<RequestBody: Encodable>(identifier: String, body: RequestBody)`. Your opportunity
-    /// to return a mocked value and check result of mock in test code.
+    /// Mocked function for `identify<RequestBody: Encodable>(identifier: String, body: RequestBody)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func identify<RequestBody: Encodable>(identifier: String, body: RequestBody) {
         mockCalled = true
         identifyCallsCount += 1
@@ -363,8 +360,7 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
      */
     public var clearIdentifyClosure: (() -> Void)?
 
-    /// Mocked function for `clearIdentify()`. Your opportunity to return a mocked value and check result of mock in
-    /// test code.
+    /// Mocked function for `clearIdentify()`. Your opportunity to return a mocked value and check result of mock in test code.
     public func clearIdentify() {
         mockCalled = true
         clearIdentifyCallsCount += 1
@@ -389,8 +385,7 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
      */
     public var trackClosure: ((String, [String: Any]) -> Void)?
 
-    /// Mocked function for `track(name: String, data: [String: Any])`. Your opportunity to return a mocked value and
-    /// check result of mock in test code.
+    /// Mocked function for `track(name: String, data: [String: Any])`. Your opportunity to return a mocked value and check result of mock in test code.
     public func track(name: String, data: [String: Any]) {
         mockCalled = true
         trackCallsCount += 1
@@ -410,8 +405,7 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
      */
     public var trackEncodableClosure: ((String, AnyEncodable) -> Void)?
 
-    /// Mocked function for `track<RequestBody: Encodable>(name: String, data: RequestBody?)`. Your opportunity to
-    /// return a mocked value and check result of mock in test code.
+    /// Mocked function for `track<RequestBody: Encodable>(name: String, data: RequestBody?)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func track<RequestBody: Encodable>(name: String, data: RequestBody?) {
         mockCalled = true
         trackCallsCount += 1
@@ -438,8 +432,7 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
      */
     public var screenClosure: ((String, [String: Any]) -> Void)?
 
-    /// Mocked function for `screen(name: String, data: [String: Any])`. Your opportunity to return a mocked value and
-    /// check result of mock in test code.
+    /// Mocked function for `screen(name: String, data: [String: Any])`. Your opportunity to return a mocked value and check result of mock in test code.
     public func screen(name: String, data: [String: Any]) {
         mockCalled = true
         screenCallsCount += 1
@@ -459,8 +452,7 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
      */
     public var screenEncodableClosure: ((String, AnyEncodable) -> Void)?
 
-    /// Mocked function for `screen<RequestBody: Encodable>(name: String, data: RequestBody?)`. Your opportunity to
-    /// return a mocked value and check result of mock in test code.
+    /// Mocked function for `screen<RequestBody: Encodable>(name: String, data: RequestBody?)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func screen<RequestBody: Encodable>(name: String, data: RequestBody?) {
         mockCalled = true
         screenCallsCount += 1
@@ -487,8 +479,7 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
      */
     public var registerDeviceTokenClosure: ((String) -> Void)?
 
-    /// Mocked function for `registerDeviceToken(_ deviceToken: String)`. Your opportunity to return a mocked value and
-    /// check result of mock in test code.
+    /// Mocked function for `registerDeviceToken(_ deviceToken: String)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func registerDeviceToken(_ deviceToken: String) {
         mockCalled = true
         registerDeviceTokenCallsCount += 1
@@ -511,8 +502,7 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
      */
     public var deleteDeviceTokenClosure: (() -> Void)?
 
-    /// Mocked function for `deleteDeviceToken()`. Your opportunity to return a mocked value and check result of mock in
-    /// test code.
+    /// Mocked function for `deleteDeviceToken()`. Your opportunity to return a mocked value and check result of mock in test code.
     public func deleteDeviceToken() {
         mockCalled = true
         deleteDeviceTokenCallsCount += 1
@@ -531,15 +521,13 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
     /// The arguments from the *last* time the function was called.
     public private(set) var trackMetricReceivedArguments: (deliveryID: String, event: Metric, deviceToken: String)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var trackMetricReceivedInvocations: [(deliveryID: String, event: Metric, deviceToken: String)] =
-        []
+    public private(set) var trackMetricReceivedInvocations: [(deliveryID: String, event: Metric, deviceToken: String)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
     public var trackMetricClosure: ((String, Metric, String) -> Void)?
 
-    /// Mocked function for `trackMetric(deliveryID: String, event: Metric, deviceToken: String)`. Your opportunity to
-    /// return a mocked value and check result of mock in test code.
+    /// Mocked function for `trackMetric(deliveryID: String, event: Metric, deviceToken: String)`. Your opportunity to return a mocked value and check result of mock in test code.
     public func trackMetric(deliveryID: String, event: Metric, deviceToken: String) {
         mockCalled = true
         trackMetricCallsCount += 1
@@ -588,10 +576,9 @@ internal class DeviceAttributesProviderMock: DeviceAttributesProvider, Mock {
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    internal var getDefaultDeviceAttributesClosure: ((([String: Any]) -> Void) -> Void)?
+    internal var getDefaultDeviceAttributesClosure: ((@escaping ([String: Any]) -> Void) -> Void)?
 
-    /// Mocked function for `getDefaultDeviceAttributes(onComplete: @escaping ([String: Any]) -> Void)`. Your
-    /// opportunity to return a mocked value and check result of mock in test code.
+    /// Mocked function for `getDefaultDeviceAttributes(onComplete: @escaping ([String: Any]) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
     internal func getDefaultDeviceAttributes(onComplete: @escaping ([String: Any]) -> Void) {
         mockCalled = true
         getDefaultDeviceAttributesCallsCount += 1

--- a/Tests/Common/Background Queue/QueueRunRequestTest.swift
+++ b/Tests/Common/Background Queue/QueueRunRequestTest.swift
@@ -22,7 +22,8 @@ class QueueRunRequestTest: UnitTest {
             storage: storageMock,
             requestManager: requestManagerMock,
             logger: log,
-            queryRunner: queryRunner
+            queryRunner: queryRunner,
+            threadUtil: threadUtilStub
         )
 
         // Boilerplate defaults:
@@ -199,7 +200,8 @@ class QueueRunRequestIntegrationTest: IntegrationTest {
             storage: diGraph.queueStorage,
             requestManager: diGraph.queueRequestManager,
             logger: diGraph.logger,
-            queryRunner: diGraph.queueQueryRunner
+            queryRunner: diGraph.queueQueryRunner,
+            threadUtil: threadUtilStub
         )
     }
 

--- a/Tests/Shared/XCTestCaseExtensions.swift
+++ b/Tests/Shared/XCTestCaseExtensions.swift
@@ -71,4 +71,11 @@ public extension XCTestCase {
 
         return onComplete
     }
+
+    // Run block after a delay. Valuable for testing async code.
+    func runAfterDelay(seconds: TimeInterval, block: @escaping () -> Void) {
+        DispatchQueue(label: .random).asyncAfter(deadline: .now() + seconds) {
+            block()
+        }
+    }
 }


### PR DESCRIPTION
Closes: https://github.com/customerio/customerio-ios/issues/248

2.0.2 could encounter an infinite loop and eventually stackoverflow while executing the background queue. This was because the BQ while loop would has an infinite loop running while not waiting for the *async HTTP request* to finish. Running async code in a while loop requires some extra logic that was previously not present. 

Automated unit test added that verifies the BQ while loop runs async tasks in sequential order without causing an infinite loop. 

Still todo: 
- [X] QA smoke tests. RH branch `levi/2.0.2-stackoverflow` created to perform testing for this branch. Use builds from that branch. 