### PR TITLE
fix: update the gist version in podspec

### DIFF
--- a/CustomerIOMessagingInApp.podspec
+++ b/CustomerIOMessagingInApp.podspec
@@ -21,5 +21,5 @@ Pod::Spec.new do |spec|
   spec.module_name = "CioMessagingInApp"  # the `import X` name when using SDK in Swift files
   
   spec.dependency "CustomerIOTracking", "= #{spec.version.to_s}"
-  spec.dependency "Gist", '~> 3.0.2'
+  spec.dependency "Gist", '~> 3.0.4'
 end

--- a/CustomerIOMessagingInApp.podspec
+++ b/CustomerIOMessagingInApp.podspec
@@ -21,5 +21,5 @@ Pod::Spec.new do |spec|
   spec.module_name = "CioMessagingInApp"  # the `import X` name when using SDK in Swift files
   
   spec.dependency "CustomerIOTracking", "= #{spec.version.to_s}"
-  spec.dependency "Gist", '~> 2.2.1'
+  spec.dependency "Gist", '~> 3.0.2'
 end

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/customerio/gist-apple.git",
         "state": {
           "branch": null,
-          "revision": "667cc2942eb94ccd8d2e3706605c8b81eaaa39e6",
-          "version": "3.0.2"
+          "revision": "adaad36bff16078b8dd23cb9771efbdc5de9b903",
+          "version": "3.0.4"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         //
         // Note: using `.exact("")` instead of `from: ""` because 3.0.3 will not compile.
         // Using 3.0.2 for now to not allow upgrading.
-        .package(name: "Gist", url: "https://github.com/customerio/gist-apple.git", .exact("3.0.2"))
+        .package(name: "Gist", url: "https://github.com/customerio/gist-apple.git", from: "3.0.4")
     ],
     targets: [        
         // Common - Code used by multiple modules in the SDK project. 


### PR DESCRIPTION
We missed this and only updated the `SPM`

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request. A bot will *squash and merge* the pull request for you after the label is added. 