### PR TITLE
fix: access modifier for metric

### DIFF
--- a/Sources/Common/Service/Request/PushMetric.swift
+++ b/Sources/Common/Service/Request/PushMetric.swift
@@ -7,7 +7,7 @@ public enum Metric: String, Codable {
     case converted
 }
 
-extension Metric {
+public extension Metric {
     static func getEvent(from metricStr: String) -> Metric? {
         Metric(rawValue: metricStr.lowercased())
     }


### PR DESCRIPTION
To be able to be used from wrappers it needs not to be internal. 

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request. A bot will *squash and merge* the pull request for you after the label is added. 