### PR TITLE
docs: add note SDK wrappers using constants in SdkConfig

### DIFF
--- a/Sources/Common/Store/SdkConfig.swift
+++ b/Sources/Common/Store/SdkConfig.swift
@@ -73,6 +73,8 @@ public struct SdkConfig {
         }
     }
 
+    // Constants that SDK wrappers can use with `modify` function for setting configuration options with strings. 
+    // It's important to keep these values backwards compatible to avoid breaking SDK wrappers. 
     public enum Keys: String { // Constants used to map each of the options in SdkConfig
         // configure workspace environment
         case siteId


### PR DESCRIPTION
I didn't realize until reading [this pr](https://github.com/customerio/customerio-flutter/pull/21/) that it's quite important that we keep the `SdkConfig.Keys` object `public` and keep the values backwards compatible for the SDK wrappers. 

Added a comment to note this. 