### PR TITLE
ci: fix deploy action slack variable

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -2,7 +2,7 @@ name: Deploy SDK
 
 on:
   push:
-    branches: [main, v1] # all branches where deployments currently occur. Make sure this list matches list of branches in  `.releaserc` file. 
+    branches: [main, v1] # all branches where deployments currently occur. Make sure this list matches list of branches in  `.releaserc` file.
 
 permissions:
   contents: write # access to push the git tag
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       new_release_published: ${{ steps.semantic-release.outputs.new_release_published }}
+      new_release_version: ${{ steps.semantic-release.outputs.new_release_version }}
     steps:
       - uses: actions/checkout@v3
 
@@ -165,7 +166,7 @@ jobs:
                       "type": "section",
                       "text": {
                           "type": "mrkdwn",
-                          "text": "*Version ${{ github.event.release.tag_name }}*\n\niOS SDK deployment progress:\n ~1. <https://github.com/${{github.repository}}/releases/tag/${{ github.event.release.tag_name }}|create git tag and deploy to Swift Package Manager>~\n~2. deploy to cocoapods~\n\nBecause it's hard to automatically verify cocoapods get deployed, it's recommended to manually verify if cocoapods got deployed successfully by checking for cococapods emails or https://github.com/cocoaPods/specs to see if new commit was added for the release."
+                          "text": "*Version ${{ needs.deploy-git-tag.outputs.new_release_version }}*\n\niOS SDK deployment progress:\n ~1. <https://github.com/${{github.repository}}/releases/tag/${{ needs.deploy-git-tag.outputs.new_release_version }}|create git tag and deploy to Swift Package Manager>~\n~2. deploy to cocoapods~\n\nBecause it's hard to automatically verify cocoapods get deployed, it's recommended to manually verify if cocoapods got deployed successfully by checking for cococapods emails or https://github.com/cocoaPods/specs to see if new commit was added for the release."
                       }
                   }
               ]


### PR DESCRIPTION
Fixes a release tag variable leftover from #261. Since the workflow is no longer triggered on a release, it needs to be adjusted.

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [x] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [x] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [x] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After pull request is approved, and you determine it's ready **add the label "Ready to merge"** to the pull request. A bot will *squash and merge* the pull request for you after the label is added. 