### PR TITLE
ci: fix github ref in npm publish step of deploy action

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -14,6 +14,7 @@ jobs:
     name: Deploy git tag
     runs-on: ubuntu-latest
     outputs:
+      new_release_git_head: ${{ steps.semantic-release.outputs.new_release_git_head }}
       new_release_published: ${{ steps.semantic-release.outputs.new_release_published }}
       new_release_version: ${{ steps.semantic-release.outputs.new_release_version }}
     steps:
@@ -124,6 +125,8 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.deploy-git-tag.outputs.new_release_git_head }}
       - name: Install cocoapods
         run: gem install cocoapods
       - name: Push CustomerIOCommon


### PR DESCRIPTION
The `deploy-cocoapods` job was checking out the $GITHUB_REF that triggered the workflow. The prior job (deploy-git-tag) bumps the version in the podspecs and updates the changelog, which would not be picked up by the final job.

See https://github.com/customerio/customerio-reactnative/pull/100 for more information.

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-android/develop/docs/dev-notes/GIT-WORKFLOW.md).
- [x] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request.
- [x] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1).
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After code reviews are approved and you determine this PR is ready to merge, select *Squash and Merge* button on this screen, leave the title and description to the default values, then merge the PR.
