### PR TITLE
refactor: create cocoapods script to make sdk override easier in sdk wrappers

### DIFF
--- a/scripts/cocoapods_override_sdk.rb
+++ b/scripts/cocoapods_override_sdk.rb
@@ -1,49 +1,59 @@
-def override_cio_sdk 
-  ###
-  # How to configure what version of the iOS SDK is installed on your machine. 
-  #
-  # This is the order of priority for installing:
-  # 
-  # 1. Install local version of CIO SDK, if the source code is found on your local computer. 
-  #    To enable this feature, pass environment variable with the path set to where on your computer the iOS SDK source code is. 
-  install_ios_sdk_local_path = ENV['INSTALL_IOS_SDK_LOCAL'] || nil 
-  # 2. Install from a CIO SDK git branch. 
-  #    To install from a branch, pass environment varible with branch name
-  install_ios_sdk_branch_name = ENV['INSTALL_IOS_SDK_BRANCH'] || nil 
-  # 3. Install version of CIO SDK specified in `/ios/customer_io.podspec` file. 
-  #
-  ###
+# This is a Ruby file designed to be used by our SDK wrapper sample apps if they want to install 
+# a non-production build of the iOS native SDK. 
+# 
+# Here is an example Podfile showing you how to use this script: 
+=begin
 
-  # All of the CIO pods that are listed as dependencies in `/ios/customer_io.podspec` need to be listed here in this array:
-  all_ios_pods_sdk_wrapper_needs = [
+# Import Ruby functions from native SDK to more easily allow installing non-production SDK builds. 
+require 'open-uri'
+IO.copy_stream(URI.open('https://raw.githubusercontent.com/customerio/customerio-ios/main/scripts/cocoapods_override_sdk.rb'), "/tmp/override_cio_sdk.rb")
+load "/tmp/override_cio_sdk.rb"
+
+target 'SampleApp' do
+  # Uncomment only 1 of the lines below to install a version of the iOS SDK 
+  pod 'CustomerIO/MessagingPushAPN', '~> 2.1' # install production build 
+  # install_non_production_ios_sdk_local_path('~/code/customerio-ios/')
+  # install_non_production_ios_sdk_git_branch('name-of-ios-sdk-branch')
+end
+
+target 'Notification Service' do
+  # Uncomment only 1 of the lines below to install a version of the iOS SDK 
+  pod 'CustomerIO/MessagingPushAPN', '~> 2.1' # install production build 
+  # install_non_production_ios_sdk_local_path('~/code/customerio-ios/')
+  # install_non_production_ios_sdk_git_branch('name-of-ios-sdk-branch')
+end
+
+=end 
+
+def install_non_production_ios_sdk_git_branch(branch_name)
+  puts ""
+  puts "⚠️ Installing CIO iOS SDK from git branch #{branch_name}"
+  puts ""
+
+  get_all_cio_pods.each { |podname| 
+    pod podname, :git => "https://github.com/customerio/customerio-ios.git", :branch => branch_name
+  }  
+end 
+
+def install_non_production_ios_sdk_local_path(local_path)
+  local_path = File.expand_path(local_path, Dir.pwd)
+
+  puts ""
+  puts "⚠️ Installing local version of the iOS SDK. Path of iOS SDK: #{local_path}"
+  puts ""
+
+  get_all_cio_pods.each { |podname| 
+    pod podname, :path => local_path
+  }
+end 
+
+def get_all_cio_pods
+  return [
     'CustomerIOCommon',
     'CustomerIOTracking',
     'CustomerIOMessagingInApp',
     'CustomerIOMessagingPush',
-    'CustomerIOMessagingPushAPN'
+    'CustomerIOMessagingPushAPN',
+    'CustomerIOMessagingPushFCM'
   ]
-
-  if install_ios_sdk_local_path != nil then 
-    puts ""
-    puts "⚠️ Installing local version of the iOS SDK. Path of iOS SDK: #{install_ios_sdk_local_path}"
-    puts ""
-
-    all_ios_pods_sdk_wrapper_needs.each { |podname| 
-      pod podname, :path => install_ios_sdk_local_path
-    }
-
-    return true 
-  elsif install_ios_sdk_branch_name != nil then 
-    puts ""
-    puts "⚠️ Installing CIO iOS SDK from git branch #{install_ios_sdk_branch_name}"
-    puts ""
-
-    all_ios_pods_sdk_wrapper_needs.each { |podname| 
-      pod podname, :git => "https://github.com/customerio/customerio-ios.git", :branch => install_ios_sdk_branch_name
-    }
-
-    return true 
-  end 
-
-  return false 
 end 

--- a/scripts/cocoapods_override_sdk.rb
+++ b/scripts/cocoapods_override_sdk.rb
@@ -1,0 +1,49 @@
+def override_cio_sdk 
+  ###
+  # How to configure what version of the iOS SDK is installed on your machine. 
+  #
+  # This is the order of priority for installing:
+  # 
+  # 1. Install local version of CIO SDK, if the source code is found on your local computer. 
+  #    To enable this feature, pass environment variable with the path set to where on your computer the iOS SDK source code is. 
+  install_ios_sdk_local_path = ENV['INSTALL_IOS_SDK_LOCAL'] || nil 
+  # 2. Install from a CIO SDK git branch. 
+  #    To install from a branch, pass environment varible with branch name
+  install_ios_sdk_branch_name = ENV['INSTALL_IOS_SDK_BRANCH'] || nil 
+  # 3. Install version of CIO SDK specified in `/ios/customer_io.podspec` file. 
+  #
+  ###
+
+  # All of the CIO pods that are listed as dependencies in `/ios/customer_io.podspec` need to be listed here in this array:
+  all_ios_pods_sdk_wrapper_needs = [
+    'CustomerIOCommon',
+    'CustomerIOTracking',
+    'CustomerIOMessagingInApp',
+    'CustomerIOMessagingPush',
+    'CustomerIOMessagingPushAPN'
+  ]
+
+  if install_ios_sdk_local_path != nil then 
+    puts ""
+    puts "⚠️ Installing local version of the iOS SDK. Path of iOS SDK: #{install_ios_sdk_local_path}"
+    puts ""
+
+    all_ios_pods_sdk_wrapper_needs.each { |podname| 
+      pod podname, :path => install_ios_sdk_local_path
+    }
+
+    return true 
+  elsif install_ios_sdk_branch_name != nil then 
+    puts ""
+    puts "⚠️ Installing CIO iOS SDK from git branch #{install_ios_sdk_branch_name}"
+    puts ""
+
+    all_ios_pods_sdk_wrapper_needs.each { |podname| 
+      pod podname, :git => "https://github.com/customerio/customerio-ios.git", :branch => install_ios_sdk_branch_name
+    }
+
+    return true 
+  end 
+
+  return false 
+end 


### PR DESCRIPTION
This PR adds a re-usable script for `Podfile` that our SDK wrappers can use. My hope is the comments in the script explain this PR. If there are questions or concerns about this PR, I will update the description in the script to try and explain it better. 

For an example on how to use this script, see [this PR](https://github.com/customerio/amiapp-reactnative/pull/54). 