### PR TITLE
feat: expose current SDK config options for reference

### DIFF
--- a/Sources/Tracking/CustomerIO.swift
+++ b/Sources/Tracking/CustomerIO.swift
@@ -4,6 +4,9 @@ import Foundation
 public protocol CustomerIOInstance: AutoMockable {
     var siteId: String? { get }
 
+    /// Get the current configuration options set for the SDK.
+    var config: SdkConfig? { get }
+
     func identify(
         identifier: String,
         body: [String: Any]
@@ -236,6 +239,10 @@ public class CustomerIO: CustomerIOInstance {
             .info(
                 "Customer.io SDK \(SdkVersion.version) initialized and ready to use for site id: \(siteId)"
             )
+    }
+
+    public var config: SdkConfig? {
+        implementation?.config
     }
 
     /**

--- a/Sources/Tracking/CustomerIOImplementation.swift
+++ b/Sources/Tracking/CustomerIOImplementation.swift
@@ -49,6 +49,10 @@ internal class CustomerIOImplementation: CustomerIOInstance {
         self.deviceInfo = diGraph.deviceInfo
     }
 
+    public var config: SdkConfig? {
+        sdkConfig
+    }
+
     public var profileAttributes: [String: Any] {
         get {
             [:]

--- a/Sources/Tracking/autogenerated/AutoMockable.generated.swift
+++ b/Sources/Tracking/autogenerated/AutoMockable.generated.swift
@@ -178,6 +178,42 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
      When setter of the property called, the value given to setter is set here.
      When the getter of the property called, the value set here will be returned. Your chance to mock the property.
      */
+    public var underlyingConfig: SdkConfig? = nil
+    /// `true` if the getter or setter of property is called at least once.
+    public var configCalled: Bool {
+        configGetCalled || configSetCalled
+    }
+
+    /// `true` if the getter called on the property at least once.
+    public var configGetCalled: Bool {
+        configGetCallsCount > 0
+    }
+
+    public var configGetCallsCount = 0
+    /// `true` if the setter called on the property at least once.
+    public var configSetCalled: Bool {
+        configSetCallsCount > 0
+    }
+
+    public var configSetCallsCount = 0
+    /// The mocked property with a getter and setter.
+    public var config: SdkConfig? {
+        get {
+            mockCalled = true
+            configGetCallsCount += 1
+            return underlyingConfig
+        }
+        set(value) {
+            mockCalled = true
+            configSetCallsCount += 1
+            underlyingConfig = value
+        }
+    }
+
+    /**
+     When setter of the property called, the value given to setter is set here.
+     When the getter of the property called, the value set here will be returned. Your chance to mock the property.
+     */
     public var underlyingProfileAttributes: [String: Any] = [:]
     /// `true` if the getter or setter of property is called at least once.
     public var profileAttributesCalled: Bool {
@@ -250,6 +286,9 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
         siteId = nil
         siteIdGetCallsCount = 0
         siteIdSetCallsCount = 0
+        config = nil
+        configGetCallsCount = 0
+        configSetCallsCount = 0
         profileAttributesGetCallsCount = 0
         profileAttributesSetCallsCount = 0
         deviceAttributesGetCallsCount = 0

--- a/Tests/Tracking/APITest.swift
+++ b/Tests/Tracking/APITest.swift
@@ -40,6 +40,10 @@ class TrackingAPITest: UnitTest {
         let _: Region = .EU
         let _: CioLogLevel = .debug
 
+        // Public properties exposed to customers
+        _ = CustomerIO.shared.siteId
+        _ = CustomerIO.shared.config
+
         // Identify
         CustomerIO.shared.identify(identifier: "")
         mock.identify(identifier: "")

--- a/Tests/Tracking/CustomerIOIntegrationTests.swift
+++ b/Tests/Tracking/CustomerIOIntegrationTests.swift
@@ -138,4 +138,11 @@ class CustomerIOIntegrationTests: IntegrationTest {
         XCTAssertEqual(diGraph.queueStorage.getInventory().count, 0)
         XCTAssertEqual(httpRequestRunnerStub.requestCallsCount, 1)
     }
+
+    // MARK: Obtain properties after CIO SDK initialized
+
+    func test_givenSDKInitialized_expectGetSdkConfigInstance() {
+        XCTAssertNotNil(CustomerIO.shared.siteId) // asserts the SDK has been initiaed.
+        XCTAssertNotNil(CustomerIO.shared.config)
+    }
 }


### PR DESCRIPTION
Our sample apps allow you to change the SDK behavior at runtime. In our sample apps, we have a settings screen that allows you to view the currently set SDK configuration values with the ability to modify the values. 

This PR adds a feature to the iOS SDK that allows the sample apps to add this settings screen feature. The sample apps are able to get the currently set SDK config values to display on the screen. 