### PR TITLE
ci: fix deploy-sdk workflow not running because homebrew not installed

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -27,9 +27,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#homebrew-note
+      - name: Enable homebrew for Linux to install tools with 
+        run: eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" 
+
       - name: Install tools used in workflow 
         run: |
-          brew install sd
+          brew install sd # CLI to replace strings in files 
 
       # Semantic-release tool is used to:
       # 1. Determine the next semantic version for the software during deployment.


### PR DESCRIPTION
deploy-sdk CI workflow when running on `main` branch is currently broken. 

I thought that `brew` would *just work* when running on Linux but I did not know that [you have to enable it before running](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#homebrew-note). 