### PR TITLE
fix: minor only auto update for gist

### DIFF
--- a/CustomerIOMessagingInApp.podspec
+++ b/CustomerIOMessagingInApp.podspec
@@ -21,5 +21,5 @@ Pod::Spec.new do |spec|
   spec.module_name = "CioMessagingInApp"  # the `import X` name when using SDK in Swift files
   
   spec.dependency "CustomerIOTracking", "= #{spec.version.to_s}"
-  spec.dependency "Gist", '~> 3'
+  spec.dependency "Gist", '~> 3.2'
 end

--- a/CustomerIOMessagingInApp.podspec
+++ b/CustomerIOMessagingInApp.podspec
@@ -21,5 +21,6 @@ Pod::Spec.new do |spec|
   spec.module_name = "CioMessagingInApp"  # the `import X` name when using SDK in Swift files
   
   spec.dependency "CustomerIOTracking", "= #{spec.version.to_s}"
-  spec.dependency "Gist", '~> 3.2'
+  # Update to exact version until wrapper SDKs become part of testing pipeline.
+  spec.dependency "Gist", '3.2.1'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -25,8 +25,7 @@ let package = Package(
         // Help for the format of declaring SPM dependencies:
         // https://web.archive.org/web/20220525200227/https://www.timc.dev/posts/understanding-swift-packages/
         //
-        // Note: using `.exact("")` instead of `from: ""` because 3.0.3 will not compile.
-        // Using 3.0.2 for now to not allow upgrading.
+        // Only allowing minor updated until wrapper SDKs become part of testing pipeline.
         .package(name: "Gist", url: "https://github.com/customerio/gist-apple.git", .upToNextMinor(from: "3.2.1"))
     ],
     targets: [        

--- a/Package.swift
+++ b/Package.swift
@@ -25,8 +25,8 @@ let package = Package(
         // Help for the format of declaring SPM dependencies:
         // https://web.archive.org/web/20220525200227/https://www.timc.dev/posts/understanding-swift-packages/
         //
-        // Only allowing minor updated until wrapper SDKs become part of testing pipeline.
-        .package(name: "Gist", url: "https://github.com/customerio/gist-apple.git", .upToNextMinor(from: "3.2.1"))
+        // Update to exact version until wrapper SDKs become part of testing pipeline.
+        .package(name: "Gist", url: "https://github.com/customerio/gist-apple.git", .exact("3.2.1"))
     ],
     targets: [        
         // Common - Code used by multiple modules in the SDK project. 

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         //
         // Note: using `.exact("")` instead of `from: ""` because 3.0.3 will not compile.
         // Using 3.0.2 for now to not allow upgrading.
-        .package(name: "Gist", url: "https://github.com/customerio/gist-apple.git", from: "3.0.4")
+        .package(name: "Gist", url: "https://github.com/customerio/gist-apple.git", .upToNextMinor(from: "3.2.1"))
     ],
     targets: [        
         // Common - Code used by multiple modules in the SDK project. 


### PR DESCRIPTION
Since updates to Gist aren't currently being tested on wrappers, and with more exciting major updates coming through for Gist. We are auto-updating only `minor/patch` releases. 

More context can be found here: https://customerio.slack.com/archives/C01QYDKD0SU/p1684186998625329?thread_ts=1684138499.569099&cid=C01QYDKD0SU

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After code reviews are approved and you determine this PR is ready to merge, select *Squash and Merge* button on this screen, leave the title and description to the default values, then merge the PR.
