### PR TITLE
ci: build sample apps on main branch pushes

### DIFF
--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -2,6 +2,8 @@ name: Build sample apps
 
 on: 
   pull_request: # build sample apps for every commit pushed to an open pull request (including drafts)
+  push: 
+    branches: [main]
   release: # build sample apps for every git tag created. These are known as "stable" builds that are suitable for people outside the mobile team. 
     types: [published]
 
@@ -66,11 +68,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Install tools used in workflow
-      run: |
-        brew install xcbeautify    
-        brew install sd
-
     - name: Set up Xcode to version we determine 
       uses: maxim-lobanov/setup-xcode@v1
       with:
@@ -120,8 +117,8 @@ jobs:
       if: steps.check_podfile_exists.outputs.files_exists == 'true'
       run: make install_cocoapods_dependencies app=CocoaPods-FCM
 
-      # - name: Dump GitHub Action metadata because Fastlane uses it. Viewing it here helps debug JSON parsing code in Firebase. 
-    #   run: cat $GITHUB_EVENT_PATH
+    - name: Dump GitHub Action metadata because Fastlane uses it. Viewing it here helps debug JSON parsing code in Firebase. 
+      run: cat $GITHUB_EVENT_PATH
 
     - name: Build app via Fastlane 
       uses: maierj/fastlane-action@v3.0.0

--- a/Apps/fastlane/Fastfile
+++ b/Apps/fastlane/Fastfile
@@ -79,8 +79,19 @@ lane :build do
       "build type: release",
       "version: #{new_app_version}"
     )
+  elsif github.is_commit_pushed
+    UI.message("Looks like GitHub Actions was triggered by a commit being pushed to a branch. I will build this sample app from this new commit pushed.")
+    UI.message("Populating notes to include helpful information from this event...")
+
+    new_app_version = github.push_branch
+
+    build_notes.append(
+      "build type: commit pushed to branch",
+      "branch: #{new_app_version}",
+      "commit hash: #{github.push_commit_hash}"
+    )
   else 
-    UI.message("This is not a pull request or push. Going to ignore the event.")        
+    UI.message("This is not an event that I care about. Going to ignore the event.")        
     return 
   end
 
@@ -186,6 +197,10 @@ class GitHub
     @github_context = github_context
   end 
 
+  def is_commit_pushed
+    @github_context["head_commit"] != nil
+  end 
+
   def is_git_tag_created
     @github_context["release"] != nil 
   end 
@@ -198,6 +213,17 @@ class GitHub
 
   def release_git_tag_created
     return @github_context["release"]["tag_name"]
+  end 
+
+  # Functions below only meant for when a github actions event is a git tag created 
+
+  def push_branch
+    # the branch name is: "refs/heads/<name-here>". We use gsub to string replace and remove "refs/heads/" part to only get the branch name
+    return @github_context["ref"].gsub!('refs/heads/', '')
+  end 
+
+  def push_commit_hash
+    return @github_context["head_commit"]["id"]
   end 
 
   # Functions below only meant for when a github actions event is a pull request 


### PR DESCRIPTION
At this time, sample apps are only being built for pull requests. However, these can be unstable. We need the ability to download *stable* versions of our sample apps for work that is completed. 

This PR makes builds of the sample apps when PRs are merged to the `main` branch.