### PR TITLE
refactor: uikit sample universal links in push open app, not browser

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
@@ -6,6 +6,7 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var storage = DIGraph.shared.storage
+    var deepLinkHandler = DIGraph.shared.deepLinksHandlerUtil
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
@@ -21,7 +22,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func initializeCioAndInAppListeners() {
-        // Initialise CustomerIO SDK
+        // Initialize CustomerIO SDK
 
         CustomerIO.initialize(siteId: BuildEnvironment.CustomerIO.siteId, apiKey: BuildEnvironment.CustomerIO.apiKey, region: .US) { config in
             config.logLevel = self.storage.isDebugModeEnabled ?? false ? .debug : .none
@@ -36,6 +37,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Add event listeners for in-app. This is not to initialise in-app but event listeners for in-app.
         MessagingInApp.initialize(eventListener: self)
+    }
+
+    // Handle Universal Link deep link from the Customer.io SDK. This function will get called if a push notification
+    // gets clicked that has a Universal Link deep link attached and the app is in the foreground. Otherwise, another function
+    // in your app may get called depending on what technology you use (Scenes, UIKit, Swift UI).
+    //
+    // Learn more: https://customer.io/docs/sdk/ios/push/#universal-links-deep-links
+    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+        guard let universalLinkUrl = userActivity.webpageURL else {
+            return false
+        }
+
+        return deepLinkHandler.handleUniversalLinkDeepLink(universalLinkUrl)
     }
 
     // MARK: UISceneSession Lifecycle

--- a/Apps/APN-UIKit/APN UIKit/SceneDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/SceneDelegate.swift
@@ -66,7 +66,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
     }
 
-    // Universal Links
+    // Universal Links - handling universal links that come into the mobile app, not from the Customer.io SDK.
+    // To handle Universal Links from the Customer.io SDK, see `AppDelegate` file for implementation.
+    // Learn more: https://customer.io/docs/sdk/ios/push/#universal-links-deep-links
     func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
         guard let universalLinkUrl = userActivity.webpageURL else {
             return


### PR DESCRIPTION
If you click a push notification with a Universal Link deep attached in the UIKIt app today, the browser will open instead of the app. 

The sample app was missing [a function from the documentation](https://customer.io/docs/sdk/ios/push/#universal-links-deep-links). With this added `AppDelegate` function, the app opens Universal Links instead of the browser. 

# QA 

Currently, [the sample app builds made in this PR are not able to be tested](https://customerio.slack.com/archives/C01QYDKD0SU/p1684776299768119). The testing thus far has been my own QA testing on my computer. 
