### PR TITLE
ci: sample apps to stable test group when merge on main

### DIFF
--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -4,8 +4,6 @@ on:
   pull_request: # build sample apps for every commit pushed to an open pull request (including drafts)
   push: 
     branches: [main]
-  release: # build sample apps for every git tag created. These are known as "stable" builds that are suitable for people outside the mobile team. 
-    types: [published]
 
 concurrency: # cancel previous workflow run if one exists. 
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -123,7 +121,7 @@ jobs:
     - name: Build app via Fastlane 
       uses: maierj/fastlane-action@v3.0.0
       with:
-        lane: "build"
+        lane: "ios build"
         subdirectory: "Apps/${{ matrix.sample-app }}"
       env: 
         GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64: ${{ secrets.GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64 }}

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -41,17 +41,15 @@ jobs:
       # 2. Updates metadata files. Such as updating the version number in package.json and adding entries to CHANGELOG.md file.
       # 3. Create git tag and push it to github.
       - name: Deploy git tag via semantic-release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3
         id: semantic-release
         with:
-          # version numbers below can be in many forms: M, M.m, M.m.p
-          semantic_version: 18
           extra_plugins: |
-            conventional-changelog-conventionalcommits@4
-            @semantic-release/changelog@6
-            @semantic-release/git@10
-            @semantic-release/github@8
-            @semantic-release/exec@6
+            conventional-changelog-conventionalcommits
+            @semantic-release/changelog
+            @semantic-release/git
+            @semantic-release/github
+            @semantic-release/exec
         env:
           # Needs to push git commits to repo. Needs write access.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Apps/fastlane/Fastfile
+++ b/Apps/fastlane/Fastfile
@@ -47,7 +47,7 @@ lane :build do
   )
 
   UI.important("Updating the SDK's source code version to non-production version. This allows the sample apps to show the SDK version at runtime for app user to better understand the version of the SDK they are running.")
-  sh("../../../scripts/update-version.sh \"#{new_app_version} (#{new_build_number})\"")
+  sh("../../../scripts/update-version.sh \"#{new_app_version} (#{new_build_number})\" || true") # we add "|| true" to the end to prevent the script from throwing any errors. SDK wrappers use this Fastfile and they might not have this script in the project. 
 
   uses_cocoapods = File.exists?("../Podfile")
   if uses_cocoapods 
@@ -180,23 +180,6 @@ lane :update_ios_app_versions do |arguments|
   # We need to update the app before building with the new version and build numbers. This makes builds easier to find by team members and install them onto devices. 
   # This is usually done by updating Info.plist files. But Xcode 13 removed Info.plist files and made it part of the xcode project. 
   # Therefore, we attempt both methods to update the version numbers. 
-  # Here, we try to update Info.plist files. 
-  Dir.glob("../**/Info.plist").each { |plist_file_path| 
-    plist_file_path = File.expand_path(plist_file_path, Dir.pwd)
-    UI.message("Found Info.plist file #{plist_file_path} to update versions for.")
-
-    # We only want to modify a value in plist file and not add a new value if it doesn't exist in the file yet. 
-    # Therefore, check if a value already exists and it if does, then set a new value. 
-    if !get_info_plist_value(path: plist_file_path, key: "CFBundleVersion").nil? 
-      UI.message("Build version exists in plist file. Going to set new value")
-      set_info_plist_value(path: plist_file_path, key: "CFBundleVersion", value: new_build_number) 
-    end 
-
-    if !get_info_plist_value(path: plist_file_path, key: "CFBundleShortVersionString").nil? 
-      UI.message("Build version string exists in plist file. Going to set new value")
-      set_info_plist_value(path: plist_file_path, key: "CFBundleShortVersionString", value: new_app_version)
-    end 
-  }
 
   # Here, we try to update the xcode project settings. 
   project_path = Dir.glob("../*.xcodeproj").first
@@ -207,6 +190,25 @@ lane :update_ios_app_versions do |arguments|
     target.build_configurations.each do |config|
       config.build_settings['MARKETING_VERSION'] = new_app_version
       config.build_settings['CURRENT_PROJECT_VERSION'] = new_build_number
+
+      # Here, we try to update Info.plist files. 
+      # We do that by getting the Info.plist file path from the Xcode project. 
+      if config.build_settings.key?("INFOPLIST_FILE")
+        plist_file_path = File.expand_path("../#{config.build_settings['INFOPLIST_FILE']}", Dir.pwd)
+        UI.message("Found Info.plist file to modify: #{plist_file_path}")
+
+        # We only want to modify a value in plist file and not add a new value if it doesn't exist in the file yet. 
+        # Therefore, check if a value already exists and it if does, then set a new value. 
+        if !get_info_plist_value(path: plist_file_path, key: "CFBundleVersion").nil? 
+          UI.message("Build version exists in plist file. Going to set new value")
+          set_info_plist_value(path: plist_file_path, key: "CFBundleVersion", value: new_build_number) 
+        end 
+
+        if !get_info_plist_value(path: plist_file_path, key: "CFBundleShortVersionString").nil? 
+          UI.message("Build version string exists in plist file. Going to set new value")
+          set_info_plist_value(path: plist_file_path, key: "CFBundleShortVersionString", value: new_app_version)
+        end 
+      end 
     end
   end
   project.save  

--- a/Apps/fastlane/Fastfile
+++ b/Apps/fastlane/Fastfile
@@ -31,52 +31,98 @@ before_all do |lane, options|
   setup_ci
 end
 
-lane :build do
-  download_ci_code_signing_files
-  
-  new_app_version = get_new_app_version()
-  new_build_number = get_new_build_version()
-  build_notes = get_build_notes()
-  test_groups = get_build_test_groups()
+# Functions specific to iOS go in the platform block. 
+platform :ios do 
+  lane :build do
+    download_ci_code_signing_files
+    
+    new_app_version = get_new_app_version()
+    new_build_number = get_new_build_version()
+    build_notes = get_build_notes()
+    test_groups = get_build_test_groups()
 
-  # Modify the source code with the new app version and build number before we compile the iOS app. This is a good idea to do to make installing builds on a test device easier. 
-  # The iOS OS might give errors when trying to install a build of an app if the app is already installed on the device. Having unique build number or app version can avoid those errors. 
-  update_ios_app_versions(
-    build_number: new_build_number,
-    app_version: new_app_version
-  )
+    # Modify the source code with the new app version and build number before we compile the iOS app. This is a good idea to do to make installing builds on a test device easier. 
+    # The iOS OS might give errors when trying to install a build of an app if the app is already installed on the device. Having unique build number or app version can avoid those errors. 
+    update_ios_app_versions(
+      build_number: new_build_number,
+      app_version: new_app_version
+    )
 
-  UI.important("Updating the SDK's source code version to non-production version. This allows the sample apps to show the SDK version at runtime for app user to better understand the version of the SDK they are running.")
-  sh("../../../scripts/update-version.sh \"#{new_app_version} (#{new_build_number})\" || true") # we add "|| true" to the end to prevent the script from throwing any errors. SDK wrappers use this Fastfile and they might not have this script in the project. 
+    UI.important("Updating the SDK's source code version to non-production version. This allows the sample apps to show the SDK version at runtime for app user to better understand the version of the SDK they are running.")
+    sh("../../../scripts/update-version.sh \"#{new_app_version} (#{new_build_number})\" || true") # we add "|| true" to the end to prevent the script from throwing any errors. SDK wrappers use this Fastfile and they might not have this script in the project. 
 
-  uses_cocoapods = File.exists?("../Podfile")
-  if uses_cocoapods 
-    UI.message "Project uses CocoaPods. Going to skip SPM dependency downloading."
+    uses_cocoapods = File.exists?("../Podfile")
+    if uses_cocoapods 
+      UI.message "Project uses CocoaPods. Going to skip SPM dependency downloading."
+    end 
+    
+    # prevents builds from being flaky. As app sizese get bigger, it takes fastlane longer to initialize the build process. Increase this value to compensate for that. 
+    ENV["FASTLANE_XCODEBUILD_SETTINGS_RETRIES"] = "10" 
+
+    build_ios_app(
+      export_method: "ad-hoc",
+      configuration: "Release",
+      xcodebuild_formatter: "xcbeautify"
+    )
+
+    # function 'setup_google_bucket_access' is a re-usable function inside of apple-code-signing Fastfile that we imported. 
+    # This allows you to create a temporary file from a GitHub secret for added convenience. 
+    # When uploading the build to Firebase App Distribution, the CI server needs to authenticate with Firebase. This is done with a 
+    # Google Cloud Service Account json creds file. The base64 encoded value of this service account file is stored as this secret.  
+    service_credentials_file_path = setup_google_bucket_access(
+      environment_variable_key: "FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64"
+    )
+    
+    firebase_app_distribution(
+      service_credentials_file: service_credentials_file_path,
+      groups: test_groups,
+      release_notes: build_notes
+    )
+  end
+
+  lane :update_ios_app_versions do |arguments| 
+    new_build_number = arguments[:build_number]
+    new_app_version = arguments[:app_version]
+
+    # We need to update the app before building with the new version and build numbers. This makes builds easier to find by team members and install them onto devices. 
+    # This is usually done by updating Info.plist files. But Xcode 13 removed Info.plist files and made it part of the xcode project. 
+    # Therefore, we attempt both methods to update the version numbers. 
+
+    # Here, we try to update the xcode project settings. 
+    project_path = Dir.glob("../*.xcodeproj").first
+    project_path = File.expand_path(project_path, Dir.pwd)
+    UI.message("Using found Xcode project path: #{project_path}")
+    project = Xcodeproj::Project.open(project_path)
+    project.targets.each do |target|
+      target.build_configurations.each do |config|
+        config.build_settings['MARKETING_VERSION'] = new_app_version
+        config.build_settings['CURRENT_PROJECT_VERSION'] = new_build_number
+
+        # Here, we try to update Info.plist files. 
+        # We do that by getting the Info.plist file path from the Xcode project. 
+        if config.build_settings.key?("INFOPLIST_FILE")
+          plist_file_path = File.expand_path("../#{config.build_settings['INFOPLIST_FILE']}", Dir.pwd)
+          UI.message("Found Info.plist file to modify: #{plist_file_path}")
+
+          # We only want to modify a value in plist file and not add a new value if it doesn't exist in the file yet. 
+          # Therefore, check if a value already exists and it if does, then set a new value. 
+          if !get_info_plist_value(path: plist_file_path, key: "CFBundleVersion").nil? 
+            UI.message("Build version exists in plist file. Going to set new value")
+            set_info_plist_value(path: plist_file_path, key: "CFBundleVersion", value: new_build_number) 
+          end 
+
+          if !get_info_plist_value(path: plist_file_path, key: "CFBundleShortVersionString").nil? 
+            UI.message("Build version string exists in plist file. Going to set new value")
+            set_info_plist_value(path: plist_file_path, key: "CFBundleShortVersionString", value: new_app_version)
+          end 
+        end 
+      end
+    end
+    project.save  
   end 
-  
-  # prevents builds from being flaky. As app sizese get bigger, it takes fastlane longer to initialize the build process. Increase this value to compensate for that. 
-  ENV["FASTLANE_XCODEBUILD_SETTINGS_RETRIES"] = "10" 
+end 
 
-  build_ios_app(
-    export_method: "ad-hoc",
-    configuration: "Release",
-    xcodebuild_formatter: "xcbeautify"
-  )
-
-  # function 'setup_google_bucket_access' is a re-usable function inside of apple-code-signing Fastfile that we imported. 
-  # This allows you to create a temporary file from a GitHub secret for added convenience. 
-  # When uploading the build to Firebase App Distribution, the CI server needs to authenticate with Firebase. This is done with a 
-  # Google Cloud Service Account json creds file. The base64 encoded value of this service account file is stored as this secret.  
-  service_credentials_file_path = setup_google_bucket_access(
-    environment_variable_key: "FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64"
-  )
-  
-  firebase_app_distribution(
-    service_credentials_file: service_credentials_file_path,
-    groups: test_groups,
-    release_notes: build_notes
-  )
-end
+# Functions not specific to iOS go below. 
 
 lane :get_new_app_version do 
   new_app_version = "" # this will get populated later depending on if this is a PR or not. 
@@ -86,12 +132,7 @@ lane :get_new_app_version do
     UI.message("Looks like GitHub Actions was triggered by a commit pushed to an open pull request.")
     UI.message("The app version will be the branch name.")
 
-    new_app_version = github.pr_source_branch    
-  elsif github.is_git_tag_created
-    UI.message("Looks like GitHub Actions was triggered by a new git tag being pushed to the project.")
-    UI.message("The app version will be the git tag.")
-
-    new_app_version = github.release_git_tag_created    
+    new_app_version = github.pr_source_branch   
   elsif github.is_commit_pushed
     UI.message("Looks like GitHub Actions was triggered by a commit being pushed to a branch. I will build this sample app from this new commit pushed.")
     UI.message("Populating notes to include helpful information from this event...")
@@ -138,11 +179,6 @@ lane :get_build_notes do
       "source branch: #{github.pr_source_branch}",
       "destination branch: #{github.pr_destination_branch}"
     )
-  elsif github.is_git_tag_created
-    build_notes.append(
-      "build type: release",
-      "version: #{new_app_version}"
-    )
   elsif github.is_commit_pushed
     build_notes.append(
       "build type: commit pushed to branch",
@@ -162,8 +198,10 @@ lane :get_build_test_groups do
   test_groups = ['all-builds'] # send all builds to group 'all-builds'. Therefore, set it here and we will not remove it. 
   github = GitHub.new()
     
-  if github.is_git_tag_created
-    test_groups.append("stable-builds") # git tag builds are builds should be considered more stable and are suitable for non-mobile team members to be invited to install.     
+  # To avoid giving potentially unstable builds of our sample apps to certain members of the organization, we only send builds to "stable" group uncertain certain situations. 
+  # If a commit is merged into main, it's considered stable because we deploy to production on merges to main. 
+  if github.is_commit_pushed && github.push_branch == "main"
+    test_groups.append("stable-builds")
   end
 
   test_groups = test_groups.join(", ")
@@ -171,47 +209,6 @@ lane :get_build_test_groups do
   UI.important("Test group names that will be added to this build: #{test_groups}")
 
   test_groups # return value 
-end 
-
-lane :update_ios_app_versions do |arguments| 
-  new_build_number = arguments[:build_number]
-  new_app_version = arguments[:app_version]
-
-  # We need to update the app before building with the new version and build numbers. This makes builds easier to find by team members and install them onto devices. 
-  # This is usually done by updating Info.plist files. But Xcode 13 removed Info.plist files and made it part of the xcode project. 
-  # Therefore, we attempt both methods to update the version numbers. 
-
-  # Here, we try to update the xcode project settings. 
-  project_path = Dir.glob("../*.xcodeproj").first
-  project_path = File.expand_path(project_path, Dir.pwd)
-  UI.message("Using found Xcode project path: #{project_path}")
-  project = Xcodeproj::Project.open(project_path)
-  project.targets.each do |target|
-    target.build_configurations.each do |config|
-      config.build_settings['MARKETING_VERSION'] = new_app_version
-      config.build_settings['CURRENT_PROJECT_VERSION'] = new_build_number
-
-      # Here, we try to update Info.plist files. 
-      # We do that by getting the Info.plist file path from the Xcode project. 
-      if config.build_settings.key?("INFOPLIST_FILE")
-        plist_file_path = File.expand_path("../#{config.build_settings['INFOPLIST_FILE']}", Dir.pwd)
-        UI.message("Found Info.plist file to modify: #{plist_file_path}")
-
-        # We only want to modify a value in plist file and not add a new value if it doesn't exist in the file yet. 
-        # Therefore, check if a value already exists and it if does, then set a new value. 
-        if !get_info_plist_value(path: plist_file_path, key: "CFBundleVersion").nil? 
-          UI.message("Build version exists in plist file. Going to set new value")
-          set_info_plist_value(path: plist_file_path, key: "CFBundleVersion", value: new_build_number) 
-        end 
-
-        if !get_info_plist_value(path: plist_file_path, key: "CFBundleShortVersionString").nil? 
-          UI.message("Build version string exists in plist file. Going to set new value")
-          set_info_plist_value(path: plist_file_path, key: "CFBundleShortVersionString", value: new_app_version)
-        end 
-      end 
-    end
-  end
-  project.save  
 end 
 
 # Parse JSON out of GitHub Context JSON when being executed on GitHub Actions. 
@@ -229,21 +226,11 @@ class GitHub
     @github_context["head_commit"] != nil
   end 
 
-  def is_git_tag_created
-    @github_context["release"] != nil 
-  end 
-
   def is_pull_request
     @github_context["pull_request"] != nil 
-  end   
+  end
 
-  # Functions below only meant for when a github actions event is a git tag created 
-
-  def release_git_tag_created
-    return @github_context["release"]["tag_name"]
-  end 
-
-  # Functions below only meant for when a github actions event is a git tag created 
+  # Functions below only meant for when a github actions event is a push event 
 
   def push_branch
     # the branch name is: "refs/heads/<name-here>". We use gsub to string replace and remove "refs/heads/" part to only get the branch name


### PR DESCRIPTION
When building sample apps, builds are either considered stable or unstable. We like to separate the two so unstable builds go to our squad members and stable goes to everyone else. That way we can avoid non-squad members from installing unstable builds of our apps we make. 

Previously, I setup the CI to make stable app builds when a new git tag was made. However, I have since noticed that this method has consequences to it and takes more work. 

This PR instead changes our CI sample apps building to consider all builds on the `main`  branch to be stable. 

# Notes: 
- Before merging, make a PR on Android SDK repo to test against this branch. Make sure sample apps build on Android successfully from this branch. 
- I have tested this[ branch against RH](https://github.com/customerio/RemoteHabits-iOS/pull/88/) with success. 
