### PR TITLE
feat: include FCM SDK as a dependency to make FCM push setup easier

### DIFF
--- a/Apps/CocoaPods-FCM/Podfile
+++ b/Apps/CocoaPods-FCM/Podfile
@@ -7,11 +7,18 @@ sdk_local_path = File.join(File.dirname(__FILE__), '../../')
 target 'test cocoapods' do
   pod 'CustomerIOCommon', :path => sdk_local_path
   pod 'CustomerIOTracking', :path => sdk_local_path
-  pod 'CustomerIOMessagingPush', :path => sdk_local_path
-  pod 'CustomerIOMessagingPushFCM', :path => sdk_local_path
+  pod 'CustomerIOMessagingPush', :path => sdk_local_path    
   pod 'CustomerIOMessagingInApp', :path => sdk_local_path
+  pod 'CustomerIOMessagingPushFCM', :path => sdk_local_path
 
-  pod 'FirebaseMessaging', '~> 10.6'
+  # The "CustomerIOMessagingPushFCM" SDK installs the FCM SDK for you, defaulting to the latest version. 
+  # If your app needs to use a specific version of the FCM SDK, you can add the line below to your app's Podfile 
+  # and the version you specify will override the version in the "CustomerIOMessagingPushFCM" SDK. 
+  # 
+  # pod 'FirebaseMessaging', '~> 10.6'
+  # 
+  # See docs to learn the Podfile syntax for specifying version numbers:
+  # https://guides.cocoapods.org/syntax/podfile.html#pod
 
   pod 'SampleAppsCommon', :path => File.join(File.dirname(__FILE__), '../Common')
 end

--- a/CustomerIOMessagingPushFCM.podspec
+++ b/CustomerIOMessagingPushFCM.podspec
@@ -25,5 +25,5 @@ Pod::Spec.new do |spec|
   # Add FCM SDK as a dependency, as our SDK is designed to be compatible with it. 
   # No version is specified which means that by default, the latest version is installed for customers. 
   # Customers can override this by adding the pod to their Podfile themselves to specify a version they want to use. 
-  spec.dependency "FirebaseMessaging"
+  spec.dependency "FirebaseMessaging", ">= 8.7.0", "< 11"
 end

--- a/CustomerIOMessagingPushFCM.podspec
+++ b/CustomerIOMessagingPushFCM.podspec
@@ -21,4 +21,9 @@ Pod::Spec.new do |spec|
   spec.module_name = "CioMessagingPushFCM" # the `import X` name when using SDK in Swift files 
   
   spec.dependency "CustomerIOMessagingPush", "= #{spec.version.to_s}"  
+
+  # Add FCM SDK as a dependency, as our SDK is designed to be compatible with it. 
+  # No version is specified which means that by default, the latest version is installed for customers. 
+  # Customers can override this by adding the pod to their Podfile themselves to specify a version they want to use. 
+  spec.dependency "FirebaseMessaging"
 end

--- a/Package.swift
+++ b/Package.swift
@@ -26,9 +26,10 @@ let package = Package(
         // https://web.archive.org/web/20220525200227/https://www.timc.dev/posts/understanding-swift-packages/
         //
         // Update to exact version until wrapper SDKs become part of testing pipeline.
-        .package(name: "Gist", url: "https://github.com/customerio/gist-apple.git", .exact("3.2.2"))
+        .package(name: "Gist", url: "https://github.com/customerio/gist-apple.git", .exact("3.2.2")),
+        .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git", "8.7.0"..<"11.0.0")
     ],
-    targets: [        
+    targets: [ 
         // Common - Code used by multiple modules in the SDK project. 
         // this module is *not* exposed to the public. It's used internally. 
         .target(name: "CioInternalCommon",
@@ -69,7 +70,7 @@ let package = Package(
                     path: "Tests/MessagingPushAPN"),
         // FCM 
         .target(name: "CioMessagingPushFCM",
-                dependencies: ["CioMessagingPush"],
+                dependencies: ["CioMessagingPush", .product(name: "FirebaseMessaging", package: "Firebase")],
                 path: "Sources/MessagingPushFCM"),
         .testTarget(name: "MessagingPushFCMTests",
                     dependencies: ["CioMessagingPushFCM", "SharedTests"],
@@ -77,7 +78,7 @@ let package = Package(
 
         // Messaging in-app
         .target(name: "CioMessagingInApp",
-                dependencies: ["CioTracking", "Gist"],
+                dependencies: ["CioTracking", .product(name: "Gist", package: "Gist")],
                 path: "Sources/MessagingInApp"),
         .testTarget(name: "MessagingInAppTests",
                     dependencies: ["CioMessagingInApp", "SharedTests"],

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -21,8 +21,10 @@ refactor!: remove onComplete callback from async functions
 
 // The SDK is deployed to multiple dependency management softwares (Cocoapods and Swift Package Manager). 
 // This code tries to prevent forgetting to update metadata files for one but not the other. 
-let isSPMFilesModified = danger.git.modified_files.includes('Package.swift') || danger.git.modified_files.includes('Package.resolved')
-let isCococapodsFilesModified = danger.git.modified_files.filter((filePath) => filePath.endsWith('.podspec')) > 0
+let isSPMFilesModified = danger.git.modified_files.includes('Package.swift') 
+let isCococapodsFilesModified = danger.git.modified_files.filter((filePath) => filePath.endsWith('.podspec')).length > 0
+
+console.log(`SPM files modified: ${isSPMFilesModified}, CocoaPods: ${isCococapodsFilesModified}`)
 
 if (isSPMFilesModified || isCococapodsFilesModified) {
   if (!isSPMFilesModified) { warn("Cocoapods files (*.podspec) were modified but Swift Package Manager files (Package.*) files were not. This is error-prone when updating dependencies in one service but not the other. Double-check that you updated all of the correct files.") }


### PR DESCRIPTION
This PR was inspired by recent conversations in Slack and also [in a RN SDK PR](https://github.com/customerio/customerio-reactnative/pull/149#discussion_r1230945251). 

Including the FCM SDK as a dependency in our iOS SDK adds benefits to the SDK. Mostly, easier setup. 

The consequences of adding the FCM SDK as a dependency is version issues. If the FCM SDK is specified multiple times in a `Podfile` and the version requirements do not match, then cocoapods throws an error. We experienced this in the past which is why we removed the FCM SDK. This PR does not include a version requirement at all meaning that we support the latest version. 

# SDK wrapper compatibility

Native iOS customers and SDK wrapper customers all are asked to manually add the FCM SDK to their `Podfile`. We made this recommendation to allow customers to specify their own version for the FCM SDK. This PR still allows customers to specify a version if they need to. 

That means that if a native or SDK wrapper customer already has the FCM SDK in their Podfile, this PR will not break anything for them. 

# Testing 

In the CocoaPods sample app, I commented and uncommented out [this line](https://github.com/customerio/customerio-ios/blob/1e439e0e31a7dc514e3128067b933a4aa56bdec4/Apps/CocoaPods-FCM/Podfile#L18), ran `pod update` to update the lock file, then diffed the lock file results. 

The only difference that was made in the lock file was:

```
PODS:
  - FirebaseMessaging (10.11.0): <--- this line
    - ...
```

When the line is commented, the lock file shows 10.11.0 which is the latest version. 
When the line is uncommented, the lock file shows 10.6 which is the version the Podfile explicitly specified. 