### PR TITLE
refactor: setup Appium tags for Swift UI sample app

### DIFF
--- a/Apps/CocoaPods-FCM/src/View/Appium.swift
+++ b/Apps/CocoaPods-FCM/src/View/Appium.swift
@@ -1,0 +1,9 @@
+import Foundation
+import SwiftUI
+
+extension View {
+    // Centralized way to set the identifier on a View so Appium can find the view.
+    func setAppiumId(_ viewId: String) -> some View {
+        accessibility(identifier: viewId)
+    }
+}

--- a/Apps/CocoaPods-FCM/src/View/DashboardView.swift
+++ b/Apps/CocoaPods-FCM/src/View/DashboardView.swift
@@ -43,8 +43,81 @@ struct DashboardView: View {
             VStack(spacing: 10) {
                 Text("What would you like to test?")
 
+                ColorButton(title: "Send Random Event") {
+                    CustomerIO.shared.track(
+                        name: String.random,
+                        data: [
+                            "randomAttribute": String.random,
+                            "random_attribute": String.random
+                        ]
+                    )
+                }.setAppiumId("Random Event Button")
+                ColorButton(title: "Send Custom Event") {
+                    showingCustomEventSheet.toggle()
+                }.setAppiumId("Custom Event Button")
+                    .sheet(isPresented: $showingCustomEventSheet, content: {
+                        VStack(spacing: 15) {
+                            TextField("Event name", text: $customEventName)
+                            TextField("Property name", text: $customEventPropertyName)
+                            TextField("Property value", text: $customEventPropertyValue)
+                            Button("Send event") {
+                                CustomerIO.shared.track(name: customEventName, data: [
+                                    customEventPropertyName: customEventPropertyValue
+                                ])
+
+                                showingCustomEventAlert.toggle()
+                            }.alert(isPresented: $showingCustomEventAlert) {
+                                Alert(
+                                    title: Text("Track event sent"),
+                                    dismissButton: .default(Text("OK"))
+                                )
+                            }
+                        }.padding([.leading, .trailing], 50)
+                    })
+                ColorButton(title: "Set Device Attribute") {
+                    showingDeviceAttributesSheet.toggle()
+                }.setAppiumId("Device Attribute Button")
+                    .sheet(isPresented: $showingDeviceAttributesSheet, content: {
+                        VStack(spacing: 15) {
+                            TextField("Attribute name", text: $deviceAttributeName)
+                            TextField("Attribute value", text: $deviceAttributeValue)
+                            Button("Send device attributes") {
+                                CustomerIO.shared.deviceAttributes = [
+                                    deviceAttributeName: deviceAttributeValue
+                                ]
+
+                                showingDeviceAttributesAlert.toggle()
+                            }.alert(isPresented: $showingDeviceAttributesAlert) {
+                                Alert(
+                                    title: Text("Device attribute sent"),
+                                    dismissButton: .default(Text("OK"))
+                                )
+                            }
+                        }.padding([.leading, .trailing], 50)
+                    })
+                ColorButton(title: "Set Profile Attribute") {
+                    showingProfileAttributesSheet.toggle()
+                }.setAppiumId("Profile Attribute Button")
+                    .sheet(isPresented: $showingProfileAttributesSheet, content: {
+                        VStack(spacing: 15) {
+                            TextField("Attribute name", text: $profileAttributeName)
+                            TextField("Attribute value", text: $profileAttributeValue)
+                            Button("Send profile attributes") {
+                                CustomerIO.shared.profileAttributes = [
+                                    profileAttributeName: profileAttributeValue
+                                ]
+
+                                showingProfileAttributesAlert.toggle()
+                            }.alert(isPresented: $showingProfileAttributesAlert) {
+                                Alert(
+                                    title: Text("Profile attribute sent"),
+                                    dismissButton: .default(Text("OK"))
+                                )
+                            }
+                        }.padding([.leading, .trailing], 50)
+                    })
                 if showAskForPushPermissionButton {
-                    ColorButton(title: "Ask for push permission") {
+                    ColorButton(title: "Show Push Prompt") {
                         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { granted, _ in
                             if granted {
                                 DispatchQueue.main.async {
@@ -54,83 +127,13 @@ struct DashboardView: View {
                         }
 
                         showAskForPushPermissionButton = false
-                    }
+                    }.setAppiumId("Show Push Prompt Button")
                 }
-                ColorButton(title: "Send Random Event") {
-                    CustomerIO.shared.track(
-                        name: String.random,
-                        data: [
-                            "randomAttribute": String.random,
-                            "random_attribute": String.random
-                        ]
-                    )
-                }
-                ColorButton(title: "Send Custom Event") {
-                    showingCustomEventSheet.toggle()
-                }.sheet(isPresented: $showingCustomEventSheet, content: {
-                    VStack(spacing: 15) {
-                        TextField("Event name", text: $customEventName)
-                        TextField("Property name", text: $customEventPropertyName)
-                        TextField("Property value", text: $customEventPropertyValue)
-                        Button("Send event") {
-                            CustomerIO.shared.track(name: customEventName, data: [
-                                customEventPropertyName: customEventPropertyValue
-                            ])
-
-                            showingCustomEventAlert.toggle()
-                        }.alert(isPresented: $showingCustomEventAlert) {
-                            Alert(
-                                title: Text("Track event sent"),
-                                dismissButton: .default(Text("OK"))
-                            )
-                        }
-                    }.padding([.leading, .trailing], 50)
-                })
-                ColorButton(title: "Set Device Attributes") {
-                    showingDeviceAttributesSheet.toggle()
-                }.sheet(isPresented: $showingDeviceAttributesSheet, content: {
-                    VStack(spacing: 15) {
-                        TextField("Attribute name", text: $deviceAttributeName)
-                        TextField("Attribute value", text: $deviceAttributeValue)
-                        Button("Send device attributes") {
-                            CustomerIO.shared.deviceAttributes = [
-                                deviceAttributeName: deviceAttributeValue
-                            ]
-
-                            showingDeviceAttributesAlert.toggle()
-                        }.alert(isPresented: $showingDeviceAttributesAlert) {
-                            Alert(
-                                title: Text("Device attribute sent"),
-                                dismissButton: .default(Text("OK"))
-                            )
-                        }
-                    }.padding([.leading, .trailing], 50)
-                })
-                ColorButton(title: "Set Profile Attributes") {
-                    showingProfileAttributesSheet.toggle()
-                }.sheet(isPresented: $showingProfileAttributesSheet, content: {
-                    VStack(spacing: 15) {
-                        TextField("Attribute name", text: $profileAttributeName)
-                        TextField("Attribute value", text: $profileAttributeValue)
-                        Button("Send profile attributes") {
-                            CustomerIO.shared.profileAttributes = [
-                                profileAttributeName: profileAttributeValue
-                            ]
-
-                            showingProfileAttributesAlert.toggle()
-                        }.alert(isPresented: $showingProfileAttributesAlert) {
-                            Alert(
-                                title: Text("Profile attribute sent"),
-                                dismissButton: .default(Text("OK"))
-                            )
-                        }
-                    }.padding([.leading, .trailing], 50)
-                })
                 ColorButton(title: "Logout") {
                     CustomerIO.shared.clearIdentify()
 
                     userManager.logout()
-                }
+                }.setAppiumId("Log Out Button")
                 EnvironmentText()
             }
             .padding()

--- a/Apps/CocoaPods-FCM/src/View/LoginView.swift
+++ b/Apps/CocoaPods-FCM/src/View/LoginView.swift
@@ -15,6 +15,7 @@ struct LoginView: View {
                 SettingsButton {
                     showSettings = true
                 }
+                .setAppiumId("Settings")
                 .frame(maxWidth: .infinity, alignment: .trailing)
                 .padding(.trailing, 10)
                 Spacer()
@@ -25,19 +26,19 @@ struct LoginView: View {
             }
 
             VStack(spacing: 40) { // This view container will be in center of screen.
-                TextField("First name", text: $firstNameText)
-                TextField("Email", text: $emailText)
+                TextField("First name", text: $firstNameText).setAppiumId("First Name Input")
+                TextField("Email", text: $emailText).setAppiumId("Email Input")
                 ColorButton(title: "Login") {
                     CustomerIO.shared.identify(identifier: emailText, body: [
                         "first_name": firstNameText
                     ])
 
                     userManager.userLoggedIn(email: emailText)
-                }
+                }.setAppiumId("Login Button")
                 Button("Generate random login") {
                     firstNameText = String.random.capitalized
                     emailText = "\(firstNameText.lowercased())@customer.io"
-                }
+                }.setAppiumId("Random Login Button")
             }
             .padding([.leading, .trailing], 50)
 

--- a/Apps/CocoaPods-FCM/src/View/SettingsView.swift
+++ b/Apps/CocoaPods-FCM/src/View/SettingsView.swift
@@ -10,14 +10,17 @@ struct SettingsView: View {
     @StateObject private var viewModel = ViewModel()
 
     var body: some View {
+        // TODO: add back button in UI to dismiss screen. add appium ID to it.
+
         VStack(spacing: 5) {
-            SettingsTextField(title: "Tracking URL:", value: $viewModel.settings.trackUrl)
-            SettingsTextField(title: "Site id:", value: $viewModel.settings.siteId)
-            SettingsTextField(title: "API key:", value: $viewModel.settings.apiKey)
+            SettingsTextField(title: "Tracking URL:", value: $viewModel.settings.trackUrl).setAppiumId("Track URL Input")
+            SettingsTextField(title: "Site id:", value: $viewModel.settings.siteId).setAppiumId("Site ID Input")
+            SettingsTextField(title: "API key:", value: $viewModel.settings.apiKey).setAppiumId("API Key Input")
             SettingsTextField(title: "BQ seconds delay:", value: $viewModel.settings.bqSecondsDelay.toStringBinding())
             SettingsTextField(title: "BQ min number tasks:", value: $viewModel.settings.bqMinNumberTasks.toStringBinding())
-            SettingsToggle(title: "Track screens", isOn: $viewModel.settings.trackScreens)
-            SettingsToggle(title: "Track device attributes", isOn: $viewModel.settings.trackDeviceAttributes)
+            SettingsToggle(title: "Track screens", isOn: $viewModel.settings.trackScreens).setAppiumId("Track Screens Toggle")
+            SettingsToggle(title: "Track device attributes", isOn: $viewModel.settings.trackDeviceAttributes).setAppiumId("Track Device Attributes Toggle")
+            SettingsToggle(title: "Debug mode", isOn: $viewModel.settings.debugSdkMode).setAppiumId("Debug Mode Toggle")
 
             ColorButton(title: "Save") {
                 // save settings to device storage for app to re-use when app is restarted
@@ -29,7 +32,11 @@ struct SettingsView: View {
                 }
 
                 done()
-            }
+            }.setAppiumId("Save Settings Button")
+
+            Button("Restore default settings") {
+                settingsManager.restoreSdkDefaultSettings()
+            }.setAppiumId("Restore Default Settings Button")
         }
         .padding([.leading, .trailing], 10)
     }

--- a/Apps/CocoaPods-FCM/test cocoapods.xcodeproj/project.pbxproj
+++ b/Apps/CocoaPods-FCM/test cocoapods.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		F7029ECC29F2C0C300411BCC /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7029ECB29F2C0C300411BCC /* LoginView.swift */; };
 		F7029ECE29F2C1EF00411BCC /* EnvironmentText.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7029ECD29F2C1EF00411BCC /* EnvironmentText.swift */; };
 		F7029ED429F2C82D00411BCC /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7029ED329F2C82D00411BCC /* UserManager.swift */; };
+		F70F4CDD2A3B91DA00037B91 /* Appium.swift in Sources */ = {isa = PBXBuildFile; fileRef = F70F4CDC2A3B91DA00037B91 /* Appium.swift */; };
 		F73134642919570600CD43D9 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = F73134632919570600CD43D9 /* App.swift */; };
 		F73134662919570600CD43D9 /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F73134652919570600CD43D9 /* DashboardView.swift */; };
 		F73134682919570700CD43D9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F73134672919570700CD43D9 /* Assets.xcassets */; };
@@ -74,6 +75,7 @@
 		F7029ECB29F2C0C300411BCC /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		F7029ECD29F2C1EF00411BCC /* EnvironmentText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentText.swift; sourceTree = "<group>"; };
 		F7029ED329F2C82D00411BCC /* UserManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
+		F70F4CDC2A3B91DA00037B91 /* Appium.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Appium.swift; sourceTree = "<group>"; };
 		F73134602919570600CD43D9 /* test cocoapods.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "test cocoapods.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F73134632919570600CD43D9 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 		F73134652919570600CD43D9 /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
@@ -152,6 +154,7 @@
 				F73134652919570600CD43D9 /* DashboardView.swift */,
 				F7029ECB29F2C0C300411BCC /* LoginView.swift */,
 				F7C1C58D29F2D39300067998 /* SettingsView.swift */,
+				F70F4CDC2A3B91DA00037B91 /* Appium.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -431,6 +434,7 @@
 			files = (
 				F7BAFCC129195AB700DFAC6E /* AppDelegate.swift in Sources */,
 				F78E3D772A05588E00641391 /* ColorExtensions.swift in Sources */,
+				F70F4CDD2A3B91DA00037B91 /* Appium.swift in Sources */,
 				F76F5D8829F2E3A7004DF836 /* BindingExtensions.swift in Sources */,
 				F7029EC629F2B3B100411BCC /* EnvironmentUtil.swift in Sources */,
 				F7F4B9BF2A0AACC300557900 /* BuildEnvironment.swift in Sources */,

--- a/Apps/Common/Source/Manager/CioSettingsManager.swift
+++ b/Apps/Common/Source/Manager/CioSettingsManager.swift
@@ -10,6 +10,10 @@ public class CioSettingsManager {
         keyValueStorage.cioSettings != nil
     }
 
+    public func restoreSdkDefaultSettings() {
+        appSetSettings = nil
+    }
+
     public var appSetSettings: CioSettings? {
         get {
             if let appSetSettings = keyValueStorage.cioSettings {

--- a/Apps/Common/Source/Model/CioSettings.swift
+++ b/Apps/Common/Source/Model/CioSettings.swift
@@ -10,6 +10,7 @@ public struct CioSettings: Codable {
     public var bqSecondsDelay: TimeInterval
     public var bqMinNumberTasks: Int
     public var trackScreens: Bool
+    public var debugSdkMode: Bool
     public var trackDeviceAttributes: Bool
 
     public func configureCioSdk(config: inout CioSdkConfig) {
@@ -18,6 +19,7 @@ public struct CioSettings: Codable {
         config.backgroundQueueMinNumberOfTasks = bqMinNumberTasks
         config.autoTrackScreenViews = trackScreens
         config.autoTrackDeviceAttributes = trackDeviceAttributes
+        config.logLevel = debugSdkMode ? .debug : .error
     }
 
     static func getFromCioSdk() -> CioSettings {
@@ -30,6 +32,7 @@ public struct CioSettings: Codable {
             bqSecondsDelay: sdkConfig.backgroundQueueSecondsDelay,
             bqMinNumberTasks: sdkConfig.backgroundQueueMinNumberOfTasks,
             trackScreens: sdkConfig.autoTrackScreenViews,
+            debugSdkMode: sdkConfig.logLevel == .debug,
             trackDeviceAttributes: sdkConfig.autoTrackDeviceAttributes
         )
     }

--- a/Apps/Common/Source/Model/CioSettings.swift
+++ b/Apps/Common/Source/Model/CioSettings.swift
@@ -19,7 +19,10 @@ public struct CioSettings: Codable {
         config.backgroundQueueMinNumberOfTasks = bqMinNumberTasks
         config.autoTrackScreenViews = trackScreens
         config.autoTrackDeviceAttributes = trackDeviceAttributes
-        config.logLevel = debugSdkMode ? .debug : .error
+
+        if debugSdkMode {
+            config.logLevel = .debug
+        }
     }
 
     static func getFromCioSdk() -> CioSettings {


### PR DESCRIPTION
Part of: https://github.com/customerio/issues/issues/9818

Sets identifiers to each of the existing Views in the app for Appium tests to reference. 

I am not sure how to run Appium tests against the sample app to verify that I used the correct method of adding IDs to views for Appium to use. So I am not sure [if the method I used](https://github.com/customerio/customerio-ios/pull/334/files#diff-d67db103c287986efd5bb55c8b0d335544d1e5ac4aa1c57cd6364a33c44fbe4aR7) is correct. However, since the logic is encapsulated, we should be able to fix issues with 1 line of code. 

# Note: 

I see that linter has failed on PR because of a `TODO` I added. I plan to add the back button in a future PR. This PR is not being merged into `main` so I plan to keep this lint error and fix it in future PR before `main` merge. 

