### PR TITLE
ci: fix danger rules not catching SPM and cocoapods rule

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -21,8 +21,10 @@ refactor!: remove onComplete callback from async functions
 
 // The SDK is deployed to multiple dependency management softwares (Cocoapods and Swift Package Manager). 
 // This code tries to prevent forgetting to update metadata files for one but not the other. 
-let isSPMFilesModified = danger.git.modified_files.includes('Package.swift') || danger.git.modified_files.includes('Package.resolved')
-let isCococapodsFilesModified = danger.git.modified_files.filter((filePath) => filePath.endsWith('.podspec')) > 0
+let isSPMFilesModified = danger.git.modified_files.includes('Package.swift') 
+let isCococapodsFilesModified = danger.git.modified_files.filter((filePath) => filePath.endsWith('.podspec')).length > 0
+
+console.log(`SPM files modified: ${isSPMFilesModified}, CocoaPods: ${isCococapodsFilesModified}`)
 
 if (isSPMFilesModified || isCococapodsFilesModified) {
   if (!isSPMFilesModified) { warn("Cocoapods files (*.podspec) were modified but Swift Package Manager files (Package.*) files were not. This is error-prone when updating dependencies in one service but not the other. Double-check that you updated all of the correct files.") }


### PR DESCRIPTION
Closes: https://github.com/customerio/issues/issues/9257

# Tested 
* `danger pr https://github.com/customerio/customerio-ios/pull/303` failed because that PR only modified 1 of the files. 
* `danger pr https://github.com/customerio/customerio-ios/pull/333` passed because both files were modified. 