### PR TITLE
ci: sample apps user-agent compatible with backend

### DIFF
--- a/Apps/fastlane/Fastfile
+++ b/Apps/fastlane/Fastfile
@@ -53,7 +53,7 @@ platform :ios do
     if File.exist?(version_update_script_path)
       UI.important("Updating the SDK's source code version to non-production version. This allows the sample apps to show the SDK version at runtime for app user to better understand the version of the SDK they are running.")
 
-      sh("#{version_update_script_path} \"#{new_app_version} (#{new_build_number})\"")
+      sh("#{version_update_script_path} \"#{new_app_version}.#{new_build_number}\"")
     end 
 
     uses_cocoapods = File.exists?("../Podfile")


### PR DESCRIPTION
The `()` in user-agent might cause problems with our backend parsing user-agent. [Learn more](https://customerio.slack.com/archives/C01QYDKD0SU/p1686069849968289?thread_ts=1686002124.298969&cid=C01QYDKD0SU)
