### PR TITLE
refactor: improvement - optional fields for custom events, device and profile attributes

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/View/Customisation/CustomDataViewController.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/Customisation/CustomDataViewController.swift
@@ -89,7 +89,8 @@ class CustomDataViewController: BaseViewController {
         }
         
         if canEventFail() {
-            toastMessage = "Custom event sent without any data might result in API failure."
+            // Toast message might need to be changed based on squad discussion
+            toastMessage = "Event sent.\nNote:- Custom event sent without any data might result in API failure."
         }
         showToast(withMessage: toastMessage)
     }

--- a/Apps/APN-UIKit/APN UIKit/View/Customisation/CustomDataViewController.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/Customisation/CustomDataViewController.swift
@@ -61,35 +61,36 @@ class CustomDataViewController: BaseViewController {
         }
     }
 
-    func isAllTextFieldsValid() -> Bool {
+    func canEventFail() -> Bool {
         if source == .customEvents {
-            return !eventNameTextField.isTextTrimEmpty
+            return eventNameTextField.isTextTrimEmpty
         } else {
-            return !(propertyValueTextField.isTextTrimEmpty || propertyNameTextField.isTextTrimEmpty)
+            return (propertyValueTextField.isTextTrimEmpty || propertyNameTextField.isTextTrimEmpty)
         }
     }
 
     // MARK: - Actions
 
     @IBAction func sendCustomData(_ sender: UIButton) {
-//        if !isAllTextFieldsValid() {
-//            showToast(withMessage: "Please fill all * marked fields.")
-//            return
-//        }
-
         guard let propName = propertyNameTextField.text, let propValue = propertyValueTextField.text else {
             return
         }
+        var toastMessage = ""
         if source == .customEvents {
             guard let eventName = eventNameTextField.text else { return }
             CustomerIO.shared.track(name: eventName, data: [propName: propValue])
-            showToast(withMessage: "Custom event tracked successfully")
+            toastMessage = "Custom event tracked successfully"
         } else if source == .deviceAttributes {
             CustomerIO.shared.deviceAttributes = [propName: propValue]
-            showToast(withMessage: "Device attribute set successfully.")
+            toastMessage = "Device attribute set successfully."
         } else if source == .profileAttributes {
             CustomerIO.shared.profileAttributes = [propName: propValue]
-            showToast(withMessage: "Profile attribute set successfully.")
+            toastMessage = "Profile attribute set successfully."
         }
+        
+        if canEventFail() {
+            toastMessage = "Custom event sent without any data might result in API failure."
+        }
+        showToast(withMessage: toastMessage)
     }
 }

--- a/Apps/APN-UIKit/APN UIKit/View/Customisation/CustomDataViewController.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/Customisation/CustomDataViewController.swift
@@ -31,6 +31,7 @@ class CustomDataViewController: BaseViewController {
         super.viewDidLoad()
         addAccessibilityIdentifiersForAppium()
     }
+
     func addAccessibilityIdentifiersForAppium() {
         if source == .customEvents {
             setAppiumAccessibilityIdTo(eventNameTextField, value: "Event Name Input")
@@ -45,7 +46,7 @@ class CustomDataViewController: BaseViewController {
         let backButton = UIBarButtonItem()
         backButton.accessibilityIdentifier = "Back Button"
         backButton.isAccessibilityElement = true
-        self.navigationController?.navigationBar.topItem?.backBarButtonItem = backButton
+        navigationController?.navigationBar.topItem?.backBarButtonItem = backButton
     }
 
     func customizeScreenBasedOnSource() {
@@ -87,7 +88,6 @@ class CustomDataViewController: BaseViewController {
             CustomerIO.shared.profileAttributes = [propName: propValue]
             toastMessage = "Profile attribute set successfully."
         }
-        
         if canEventFail() {
             // Toast message might need to be changed based on squad discussion
             toastMessage = "Event sent.\nNote:- Custom event sent without any data might result in API failure."

--- a/Apps/APN-UIKit/APN UIKit/View/Customisation/CustomDataViewController.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/Customisation/CustomDataViewController.swift
@@ -72,10 +72,10 @@ class CustomDataViewController: BaseViewController {
     // MARK: - Actions
 
     @IBAction func sendCustomData(_ sender: UIButton) {
-        if !isAllTextFieldsValid() {
-            showToast(withMessage: "Please fill all * marked fields.")
-            return
-        }
+//        if !isAllTextFieldsValid() {
+//            showToast(withMessage: "Please fill all * marked fields.")
+//            return
+//        }
 
         guard let propName = propertyNameTextField.text, let propValue = propertyValueTextField.text else {
             return


### PR DESCRIPTION
No required fields for custom events, device attributes and profile attributes in sample apps so that positive and negative test cases can be covered.

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After code reviews are approved and you determine this PR is ready to merge, select *Squash and Merge* button on this screen, leave the title and description to the default values, then merge the PR.
