### PR TITLE
fix: cache queue inventory for lower CPU usage while running queue

### DIFF
--- a/Sources/Common/Background Queue/QueueStorage.swift
+++ b/Sources/Common/Background Queue/QueueStorage.swift
@@ -94,9 +94,16 @@ public class FileManagerQueueStorage: QueueStorage {
             return false
         }
 
-        self.inventory = inventory
+        // the inventory is the BQ's single source of truth for what tasks are in the BQ. It's important that the inventory cache reflects what's in SDK storage so only update
+        // it after we successfully save the storage.
+        // If there is a failed save to file system, the item added to the BQ will get ignored to try and keep the SDK into an error-free state.
+        let successfullySavedInStorage = fileStorage.save(type: .queueInventory, contents: data, fileId: nil)
 
-        return fileStorage.save(type: .queueInventory, contents: data, fileId: nil)
+        if successfullySavedInStorage {
+            self.inventory = inventory // update cache
+        }
+
+        return successfullySavedInStorage
     }
 
     public func create(

--- a/Sources/Common/Background Queue/QueueStorage.swift
+++ b/Sources/Common/Background Queue/QueueStorage.swift
@@ -48,8 +48,37 @@ public class FileManagerQueueStorage: QueueStorage {
     private let lock: Lock
 
     private var inventory: [QueueTaskMetadata]? {
-        get { inventoryStore.inventory }
-        set { inventoryStore.inventory = newValue }
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+
+            if let inventoryCache = inventoryStore.inventory {
+                return inventoryCache
+            }
+
+            guard let data = fileStorage.get(type: .queueInventory, fileId: nil) else { return nil }
+            guard let readInventory: [QueueTaskMetadata] = jsonAdapter.fromJson(data) else { return nil }
+            inventoryStore.inventory = readInventory // set in-memory cache for next time getter is called
+
+            return readInventory
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+
+            guard let data = jsonAdapter.toJson(newValue) else {
+                return
+            }
+
+            // the inventory is the BQ's single source of truth for what tasks are in the BQ. It's important that the inventory cache reflects what's in SDK storage so only update
+            // it after we successfully save the storage.
+            // If there is a failed save to file system, the item added to the BQ will get ignored to try and keep the SDK into an error-free state.
+            let successfullySavedInStorage = fileStorage.save(type: .queueInventory, contents: data, fileId: nil)
+
+            if successfullySavedInStorage {
+                inventoryStore.inventory = newValue // update cache
+            }
+        }
     }
 
     init(
@@ -72,38 +101,20 @@ public class FileManagerQueueStorage: QueueStorage {
     }
 
     public func getInventory() -> [QueueTaskMetadata] {
-        lock.lock()
-        defer { lock.unlock() }
-
-        if let inventory = inventory {
-            return inventory
-        }
-
-        guard let data = fileStorage.get(type: .queueInventory, fileId: nil) else { return [] }
-        let readInventory: [QueueTaskMetadata] = jsonAdapter.fromJson(data) ?? []
-        inventory = readInventory
-
-        return readInventory
+        inventory ?? []
     }
 
     public func saveInventory(_ inventory: [QueueTaskMetadata]) -> Bool {
-        lock.lock()
-        defer { lock.unlock() }
+        // Logic of saving inventory was moved into the `inventory` setter.
+        // However, to keep backwards compatibility with the API of this function (returning a Bool),
+        // we have this below logic to check if the inventory was successfully saved.
+        let inventoryBeforeSave = getInventory() // getInventory reads from the in-memory cache so they are performant to perform.
+        self.inventory = inventory
+        let inventoryAfterSave = getInventory()
 
-        guard let data = jsonAdapter.toJson(inventory) else {
-            return false
-        }
+        let inventorySavedSuccessfully = inventoryBeforeSave != inventoryAfterSave
 
-        // the inventory is the BQ's single source of truth for what tasks are in the BQ. It's important that the inventory cache reflects what's in SDK storage so only update
-        // it after we successfully save the storage.
-        // If there is a failed save to file system, the item added to the BQ will get ignored to try and keep the SDK into an error-free state.
-        let successfullySavedInStorage = fileStorage.save(type: .queueInventory, contents: data, fileId: nil)
-
-        if successfullySavedInStorage {
-            self.inventory = inventory // update cache
-        }
-
-        return successfullySavedInStorage
+        return inventorySavedSuccessfully
     }
 
     public func create(

--- a/Sources/Common/Store/QueueInventoryMemoryStore.swift
+++ b/Sources/Common/Store/QueueInventoryMemoryStore.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+internal protocol QueueInventoryMemoryStore {
+    var inventory: [QueueTaskMetadata]? { get set }
+}
+
+// sourcery: InjectRegister = "QueueInventoryMemoryStore"
+// sourcery: InjectSingleton
+class QueueInventoryMemoryStoreImpl: QueueInventoryMemoryStore {
+    @Atomic var inventory: [QueueTaskMetadata]?
+}

--- a/Sources/Common/Store/QueueInventoryMemoryStore.swift
+++ b/Sources/Common/Store/QueueInventoryMemoryStore.swift
@@ -1,9 +1,13 @@
 import Foundation
 
+// In-memory store of the BQ inventory. This acts as a cache to unnecessary reading the file system from the file system.
 internal protocol QueueInventoryMemoryStore {
     var inventory: [QueueTaskMetadata]? { get set }
 }
 
+// The in-memory store should be a singleton to be re-used during the lifecycle of the SDK.
+// Try to keep this class small because it's a singleton.
+//
 // sourcery: InjectRegister = "QueueInventoryMemoryStore"
 // sourcery: InjectSingleton
 class QueueInventoryMemoryStoreImpl: QueueInventoryMemoryStore {

--- a/Sources/Common/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/Common/autogenerated/AutoDependencyInjection.generated.swift
@@ -113,6 +113,9 @@ extension DIGraph {
         _ = lockManager
         countDependenciesResolved += 1
 
+        _ = queueInventoryMemoryStore
+        countDependenciesResolved += 1
+
         _ = dateUtil
         countDependenciesResolved += 1
 
@@ -350,7 +353,7 @@ extension DIGraph {
     }
 
     private var newQueueStorage: QueueStorage {
-        FileManagerQueueStorage(fileStorage: fileStorage, jsonAdapter: jsonAdapter, lockManager: lockManager, sdkConfig: sdkConfig, logger: logger, dateUtil: dateUtil)
+        FileManagerQueueStorage(fileStorage: fileStorage, jsonAdapter: jsonAdapter, lockManager: lockManager, sdkConfig: sdkConfig, logger: logger, dateUtil: dateUtil, inventoryStore: queueInventoryMemoryStore)
     }
 
     // JsonAdapter
@@ -385,6 +388,30 @@ extension DIGraph {
 
     private func _get_lockManager() -> LockManager {
         LockManager()
+    }
+
+    // QueueInventoryMemoryStore (singleton)
+    internal var queueInventoryMemoryStore: QueueInventoryMemoryStore {
+        getOverriddenInstance() ??
+            sharedQueueInventoryMemoryStore
+    }
+
+    internal var sharedQueueInventoryMemoryStore: QueueInventoryMemoryStore {
+        // Use a DispatchQueue to make singleton thread safe. You must create unique dispatchqueues instead of using 1 shared one or you will get a crash when trying
+        // to call DispatchQueue.sync{} while already inside another DispatchQueue.sync{} call.
+        DispatchQueue(label: "DIGraph_QueueInventoryMemoryStore_singleton_access").sync {
+            if let overridenDep: QueueInventoryMemoryStore = getOverriddenInstance() {
+                return overridenDep
+            }
+            let existingSingletonInstance = self.singletons[String(describing: QueueInventoryMemoryStore.self)] as? QueueInventoryMemoryStore
+            let instance = existingSingletonInstance ?? _get_queueInventoryMemoryStore()
+            self.singletons[String(describing: QueueInventoryMemoryStore.self)] = instance
+            return instance
+        }
+    }
+
+    private func _get_queueInventoryMemoryStore() -> QueueInventoryMemoryStore {
+        QueueInventoryMemoryStoreImpl()
     }
 
     // DateUtil

--- a/Tests/Common/Background Queue/QueueStorageTest.swift
+++ b/Tests/Common/Background Queue/QueueStorageTest.swift
@@ -17,7 +17,8 @@ class QueueStorageTest: UnitTest {
             lockManager: lockManager,
             sdkConfig: sdkConfig,
             logger: log,
-            dateUtil: dateUtilStub
+            dateUtil: dateUtilStub,
+            inventoryStore: diGraph.queueInventoryMemoryStore
         )
     }
 
@@ -110,7 +111,8 @@ class QueueStorageIntegrationTest: UnitTest {
             lockManager: lockManager,
             sdkConfig: sdkConfig,
             logger: log,
-            dateUtil: dateUtilStub
+            dateUtil: dateUtilStub,
+            inventoryStore: diGraph.queueInventoryMemoryStore
         )
     }
 
@@ -125,6 +127,20 @@ class QueueStorageIntegrationTest: UnitTest {
     func test_getInventory_givenSavedPreviousInventory_expectGetExistingInventory() {
         let expected = [QueueTaskMetadata.random]
         _ = storage.saveInventory(expected)
+
+        let actual = storage.getInventory()
+
+        XCTAssertEqual(actual, expected)
+    }
+
+    // The queue inventory has an in-memory store. Test that the inventory is also persisted so when in-memory store recreated, invetory is still valid.
+    func test_getInventory_givenRecreateSdk_expectInventoryIsPersisted() {
+        let expected = [QueueTaskMetadata.random]
+        _ = storage.saveInventory(expected)
+
+        XCTAssertTrue(diGraph.queueInventoryMemoryStore.inventory != nil)
+        setUp() // recreate storage instance and it's dependencies
+        XCTAssertTrue(diGraph.queueInventoryMemoryStore.inventory == nil)
 
         let actual = storage.getInventory()
 

--- a/Tests/Common/Background Queue/QueueStorageTest.swift
+++ b/Tests/Common/Background Queue/QueueStorageTest.swift
@@ -40,6 +40,18 @@ class QueueStorageTest: UnitTest {
         XCTAssertFalse(actual)
     }
 
+    // MARK: getInventory
+
+    func test_getInventory_expectReadFromFileSystemOnce_expectUseCache() {
+        fileStorageMock.getReturnValue = "[]".data!
+
+        _ = storage.getInventory()
+        XCTAssertEqual(fileStorageMock.getCallsCount, 1)
+
+        _ = storage.getInventory()
+        XCTAssertEqual(fileStorageMock.getCallsCount, 1)
+    }
+
     // MARK: create
 
     func test_create_givenFileStorageDoesNotSaveTask_expectDoNotUpdateInventory_expectFalse() {


### PR DESCRIPTION
Part of https://github.com/customerio/issues/issues/10950

This PR introduces a cache for the BQ inventory. This cache reduces the number of times the SDK needs to read the BQ inventory from the file system. This reduction in file system writes reduces the CPU usage of the SDK while the BQ runs. 

# todo

- [x] QA sample apps