### PR TITLE
ci: build with xcode 15 beta

### DIFF
--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -51,6 +51,9 @@ jobs:
     strategy:
       fail-fast: false # if one sample app fails to build, let the other sample apps continue to build and not cancel them. 
       matrix: # Use a matrix allowing us to build multiple apps in parallel. Just add an entry to the matrix and it will build! 
+        xcode-version:
+        - "14"
+        - "15.0-beta"
         sample-app: 
         # List all sample apps you want to have compiled. 
         # List item is name of directory inside of "Apps" directory for the corresponding app to compile. 
@@ -63,14 +66,14 @@ jobs:
             apn-or-fcm: FCM
 
     runs-on: macos-13
-    name: Building app...${{ matrix.sample-app }}
+    name: Building app...${{ matrix.sample-app }} using Xcode ${{ matrix.xcode-version }}
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Xcode to version we determine 
+    - name: Set up Xcode (${{ matrix.xcode-version }})
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: 14
+        xcode-version: ${{ matrix.xcode-version }}
 
     - name: Install CLI tools used in CI script 
       run: |

--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -50,10 +50,7 @@ jobs:
       pull-requests: write # comment on pull request with build information 
     strategy:
       fail-fast: false # if one sample app fails to build, let the other sample apps continue to build and not cancel them. 
-      matrix: # Use a matrix allowing us to build multiple apps in parallel. Just add an entry to the matrix and it will build! 
-        xcode-version:
-        - "14"
-        - "15.0-beta"
+      matrix: # Use a matrix allowing us to build multiple apps in parallel. Just add an entry to the matrix and it will build!
         sample-app: 
         # List all sample apps you want to have compiled. 
         # List item is name of directory inside of "Apps" directory for the corresponding app to compile. 
@@ -66,14 +63,14 @@ jobs:
             apn-or-fcm: FCM
 
     runs-on: macos-13
-    name: Building app...${{ matrix.sample-app }} using Xcode ${{ matrix.xcode-version }}
+    name: Building app...${{ matrix.sample-app }}
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Xcode (${{ matrix.xcode-version }})
+    - name: Set up Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: ${{ matrix.xcode-version }}
+        xcode-version: "15.0-beta"
 
     - name: Install CLI tools used in CI script 
       run: |
@@ -139,7 +136,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         # the variables APP_BUILD_NUMBER, APP_VERSION_STRING are created when fastlane runs "build". 
         body: |
-          * ${{ matrix.sample-app }}, Xcode ${{ matrix.xcode-version }}: `${{ env.APP_VERSION_STRING }} (${{ env.APP_BUILD_NUMBER }})`
+          * ${{ matrix.sample-app }}: `${{ env.APP_VERSION_STRING }} (${{ env.APP_BUILD_NUMBER }})`
         edit-mode: append # append new line to the existing PR comment to build a list of all sample app builds. 
 
     - name: Update sample builds PR comment with build failure message 
@@ -149,5 +146,5 @@ jobs:
         comment-id: ${{ needs.update-pr-comment.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}
         body: |
-          * ${{ matrix.sample-app }}, Xcode ${{ matrix.xcode-version }}: Build failed. See [CI job logs](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}) to determine the issue and try re-building. 
+          * ${{ matrix.sample-app }}: Build failed. See [CI job logs](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}) to determine the issue and try re-building. 
         edit-mode: append # append new line to the existing PR comment to build a list of all sample app builds. 

--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -139,7 +139,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         # the variables APP_BUILD_NUMBER, APP_VERSION_STRING are created when fastlane runs "build". 
         body: |
-          * ${{ matrix.sample-app }}: `${{ env.APP_VERSION_STRING }} (${{ env.APP_BUILD_NUMBER }})`
+          * ${{ matrix.sample-app }}, Xcode ${{ matrix.xcode-version }}: `${{ env.APP_VERSION_STRING }} (${{ env.APP_BUILD_NUMBER }})`
         edit-mode: append # append new line to the existing PR comment to build a list of all sample app builds. 
 
     - name: Update sample builds PR comment with build failure message 
@@ -149,5 +149,5 @@ jobs:
         comment-id: ${{ needs.update-pr-comment.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}
         body: |
-          * ${{ matrix.sample-app }}: Build failed. See [CI job logs](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}) to determine the issue and try re-building. 
+          * ${{ matrix.sample-app }}, Xcode ${{ matrix.xcode-version }}: Build failed. See [CI job logs](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}) to determine the issue and try re-building. 
         edit-mode: append # append new line to the existing PR comment to build a list of all sample app builds. 


### PR DESCRIPTION
Part of ticket https://github.com/customerio/issues/issues/11139

To verify that customers can compile their apps with our SDK installed, this PR enables Xcode15 beta builds on the CI. 

I expect that once 15 goes stable, we can make 15 the default and drop compiling on CI with 14. 

I checked the [CI logs](https://github.com/customerio/customerio-ios/actions/runs/5904453500/job/16016675787?pr=373) and it looks like it ran as expected. The latest Xcode 15 beta 6 got installed and fastlane used xcode 15 for compiling the app. 