### PR TITLE
build: edit git hooks to not block pushing.

### DIFF
--- a/Sources/Common/Store/QueueInventoryMemoryStore.swift
+++ b/Sources/Common/Store/QueueInventoryMemoryStore.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 // In-memory store of the BQ inventory. This acts as a cache to unnecessary reading the file system from the file system.
-internal protocol QueueInventoryMemoryStore {
+protocol QueueInventoryMemoryStore {
     var inventory: [QueueTaskMetadata]? { get set }
 }
 

--- a/Sources/Common/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/Common/autogenerated/AutoDependencyInjection.generated.swift
@@ -391,12 +391,12 @@ extension DIGraph {
     }
 
     // QueueInventoryMemoryStore (singleton)
-    internal var queueInventoryMemoryStore: QueueInventoryMemoryStore {
+    var queueInventoryMemoryStore: QueueInventoryMemoryStore {
         getOverriddenInstance() ??
             sharedQueueInventoryMemoryStore
     }
 
-    internal var sharedQueueInventoryMemoryStore: QueueInventoryMemoryStore {
+    var sharedQueueInventoryMemoryStore: QueueInventoryMemoryStore {
         // Use a DispatchQueue to make singleton thread safe. You must create unique dispatchqueues instead of using 1 shared one or you will get a crash when trying
         // to call DispatchQueue.sync{} while already inside another DispatchQueue.sync{} call.
         DispatchQueue(label: "DIGraph_QueueInventoryMemoryStore_singleton_access").sync {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -14,4 +14,5 @@ pre-push:
   commands:
     lint: 
       # Run linter giving you errors to fix. 
-      run: make lint
+      # By using `|| true`, we do not block you from pushing code. Running lint here is designed to give you feedback on your code before pushing it.
+      run: make lint || true


### PR DESCRIPTION
Sometimes I have a branch that is a work in progress that I want to `git push`. Today, if there is a lint error, I am not able to push as it will be blocked by git hooks. 

Sometimes I know that I have lint errors, but at the time, it's not worth my time to fix those lint errors. I believe that git hooks are great to give you early feedback to fix things, but not make it a requirement (that should be done on the CI level to block PRs into `main`). 

This PR continues to run lint to show errors, but doesn't block you from pushing with errors. Our CI does require that you fix lint errors so that's where the requirement will come.  