### PR TITLE
ci: set workaround for semantic-release issue skipping deployment

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -50,8 +50,9 @@ jobs:
         uses: cycjimmy/semantic-release-action@v3
         id: semantic-release
         with:
+          # Hard-coding version as workaround https://github.com/semantic-release/commit-analyzer/issues/517#issuecomment-1697193361
           extra_plugins: |
-            conventional-changelog-conventionalcommits
+            conventional-changelog-conventionalcommits@6.1.0
             @semantic-release/changelog
             @semantic-release/git
             @semantic-release/github


### PR DESCRIPTION
SDK is experiencing [known issue of semantic-release](https://github.com/semantic-release/commit-analyzer/issues/517) to exit early before deployment is performed. 

This PR implements workaround. 