### PR TITLE
test: prevent false positives in url encoding tests

### DIFF
--- a/Tests/Common/Service/HttpEndpointTest.swift
+++ b/Tests/Common/Service/HttpEndpointTest.swift
@@ -7,13 +7,15 @@ class HttpEndpointTest: UnitTest {
     private let defaultEndpoint = CIOApiEndpoint.findAccountRegion
     private var httpBaseUrls: HttpBaseUrls!
 
+    private let defaultHost = "https://customer.io"
+
     override func setUp() {
         super.setUp()
 
-        setHttpBaseUrls()
+        setHttpBaseUrls(trackingApi: defaultHost)
     }
 
-    private func setHttpBaseUrls(trackingApi: String = Region.US.productionTrackingUrl) {
+    private func setHttpBaseUrls(trackingApi: String) {
         httpBaseUrls = HttpBaseUrls(trackingApi: trackingApi)
     }
 
@@ -46,29 +48,17 @@ class HttpEndpointTest: UnitTest {
     }
 
     func test_getUrlString_givenPathWithSpecialCharacters_expectEncodedPath() {
-        let identifierWithSpecialChar = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]@!$&'()*+,;=%"
-        let endpoint = CIOApiEndpoint.identifyCustomer(identifier: identifierWithSpecialChar)
+        let actual = CIOApiEndpoint.identifyCustomer(identifier: "-._~:/|?#[]@!$&'()*+,;=%").getUrlString(baseUrls: httpBaseUrls)
 
-        let rawPath = "/api/v1/customers/\(identifierWithSpecialChar)"
-        let expectedPath = rawPath.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? rawPath
-
-        let expected = "https://customer.io\(expectedPath)"
-
-        setHttpBaseUrls(trackingApi: "https://customer.io")
-
-        let actual = endpoint.getUrlString(baseUrls: httpBaseUrls)
+        let expected = "\(defaultHost)/api/v1/customers/-._~:/%7C%3F%23%5B%5D@!$&\'()*+,;=%25"
 
         XCTAssertEqual(actual, expected)
     }
 
-    func test_getUrl_givenUnencodedPathWithSpecialCharacter_expectValidUrl() {
+    func test_getUrl_givenUnencodedPathWithSpecialCharacter_expectReceiveAURL() {
         let identifierWithSpecialChar = "social-login|1234567890abcde"
         let endpoint = CIOApiEndpoint.identifyCustomer(identifier: identifierWithSpecialChar)
 
-        setHttpBaseUrls(trackingApi: "https://customer.io")
-
-        let actualUrl = endpoint.getUrl(baseUrls: httpBaseUrls)
-
-        XCTAssertNotNil(actualUrl, "Expected valid URL but got nil. Ensure path is encoded correctly.")
+        XCTAssertNotNil(endpoint.getUrl(baseUrls: httpBaseUrls), "Expected valid URL but got nil. Ensure path is encoded correctly.")
     }
 }


### PR DESCRIPTION
I noticed a test function in the code where the function under test `getUrlString` and the test function `test_getUrlString_givenPathWithSpecialCharacters_expectEncodedPath` both contained some identical code `addingPercentEncoding`. 

When a test function and the code under test contain identical code, I tend to have less confidence in the test function because if, for example, there is a bug in the SDK's use of `addingPercentEncoding`, the test function would not catch this bug because the test function itself would also contain the bug. 

To prevent false positives such as this, I modified the test function body to use a hard-coded value as the expected result. This should help us feel more confident in the test function and it's purpose. Bonus: anyone viewing the test function and the hard-coded expected value can see an example return value from the `getUrlString` function which is good for developer experience. 

# todo
 
- [ ] PR blocked until [slack conversation](https://customerio.slack.com/archives/C01QYDKD0SU/p1694200319312109) resolved. PR may require some modifications after conversation. 