### PR TITLE
ci: remove workaround for semantic-release issue skipping deployment

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -51,7 +51,7 @@ jobs:
         id: semantic-release
         with:
           extra_plugins: |
-conventional-changelog-conventionalcommits
+            conventional-changelog-conventionalcommits
             @semantic-release/changelog
             @semantic-release/git
             @semantic-release/github

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -50,9 +50,8 @@ jobs:
         uses: cycjimmy/semantic-release-action@v4
         id: semantic-release
         with:
-          # Hard-coding version as workaround https://github.com/semantic-release/commit-analyzer/issues/517#issuecomment-1697193361
           extra_plugins: |
-            conventional-changelog-conventionalcommits@6.1.0
+conventional-changelog-conventionalcommits
             @semantic-release/changelog
             @semantic-release/git
             @semantic-release/github


### PR DESCRIPTION
semantic-release has fixed the conventional-commits issue in v22. Therefore, we can remove the workaround from our CI configuration. Our CI workflow is setup to automatically download the latest version of semantic-release and all plugins so v22 should be used the next deployment that is done.