### PR TITLE
ci: xcode15 stable instead of beta

### DIFF
--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Set up Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: "15.0-beta"
+        xcode-version: "15"
 
     - name: Install CLI tools used in CI script 
       run: |


### PR DESCRIPTION
I noticed on `main` that sample apps are not building anymore. Looks like it's because xcode 15 is no longer in beta and so xcode version `15-beta` is not installing. This PR attempts to fix CI building of sample apps to fix `main`. 
