### PR TITLE
fix: when queue cannot find task, expect queue runs next task

### DIFF
--- a/Sources/Common/Background Queue/QueueRunRequest.swift
+++ b/Sources/Common/Background Queue/QueueRunRequest.swift
@@ -95,7 +95,7 @@ public class CioQueueRunRequest: QueueRunRequest {
 
                 // The task failed to execute like a HTTP failure. Update `lastFailedTask`.
                 updateWhileLoopLogicVariables(didTaskFail: true, taskJustExecuted: nextTaskToRunInventoryItem)
-                break
+                continue // quit loop early and move to next task.
             }
 
             logger.debug("queue tasks left to run: \(queueInventory.count)")


### PR DESCRIPTION
Through reviewing a set of SDK debug logs recently, I noticed the queue can get into an edge case that prevents it from ever finishing. Blocking the queue from running any more tasks while the app is in memory. 

I was able to reproduce the issue through a test and then implemented a bug fix. 

# Tasks 
- [ ] Release bug fix on wrapper SDKs 