### PR TITLE
feat: get currently registered device token

### DIFF
--- a/Apps/CocoaPods-FCM/src/View/SettingsView.swift
+++ b/Apps/CocoaPods-FCM/src/View/SettingsView.swift
@@ -156,7 +156,7 @@ struct SettingsView: View {
         init() {
             self.settingsManager = CioSettingsManager()
             self.keyValueStorage = KeyValueStore()
-            self.pushToken = keyValueStorage.pushToken ?? "(none)"
+            self.pushToken = CustomerIO.shared.registeredDeviceToken ?? "(none)"
             self.settings = settingsManager.appSetSettings ?? CioSettings.getFromCioSdk()
         }
 

--- a/Sources/Tracking/CustomerIO.swift
+++ b/Sources/Tracking/CustomerIO.swift
@@ -21,6 +21,8 @@ public protocol CustomerIOInstance: AutoMockable {
         body: RequestBody
     )
 
+    var registeredDeviceToken: String? { get }
+
     func clearIdentify()
 
     func track(
@@ -236,6 +238,18 @@ public class CustomerIO: CustomerIOInstance {
             .info(
                 "Customer.io SDK \(SdkVersion.version) initialized and ready to use for site id: \(siteId)"
             )
+    }
+
+    /**
+     Use `registeredDeviceToken` to fetch the current FCM/APN device token.
+     This returns an optional string value.
+     Example use:
+     ```
+     CustomerIO.shared.registeredDeviceToken
+     ```
+     */
+    public var registeredDeviceToken: String? {
+        implementation?.registeredDeviceToken
     }
 
     public var config: SdkConfig? {

--- a/Sources/Tracking/CustomerIOImplementation.swift
+++ b/Sources/Tracking/CustomerIOImplementation.swift
@@ -72,6 +72,10 @@ class CustomerIOImplementation: CustomerIOInstance {
         }
     }
 
+    public var registeredDeviceToken: String? {
+        globalDataStore.pushDeviceToken
+    }
+
     // this function could use a refactor. It's long and complex. Our automated tests are what keeps us feeling
     // confident in the code, but the code here is difficult to maintain.
     // swiftlint:disable:next function_body_length

--- a/Sources/Tracking/autogenerated/AutoMockable.generated.swift
+++ b/Sources/Tracking/autogenerated/AutoMockable.generated.swift
@@ -214,6 +214,42 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
      When setter of the property called, the value given to setter is set here.
      When the getter of the property called, the value set here will be returned. Your chance to mock the property.
      */
+    public var underlyingRegisteredDeviceToken: String? = nil
+    /// `true` if the getter or setter of property is called at least once.
+    public var registeredDeviceTokenCalled: Bool {
+        registeredDeviceTokenGetCalled || registeredDeviceTokenSetCalled
+    }
+
+    /// `true` if the getter called on the property at least once.
+    public var registeredDeviceTokenGetCalled: Bool {
+        registeredDeviceTokenGetCallsCount > 0
+    }
+
+    public var registeredDeviceTokenGetCallsCount = 0
+    /// `true` if the setter called on the property at least once.
+    public var registeredDeviceTokenSetCalled: Bool {
+        registeredDeviceTokenSetCallsCount > 0
+    }
+
+    public var registeredDeviceTokenSetCallsCount = 0
+    /// The mocked property with a getter and setter.
+    public var registeredDeviceToken: String? {
+        get {
+            mockCalled = true
+            registeredDeviceTokenGetCallsCount += 1
+            return underlyingRegisteredDeviceToken
+        }
+        set(value) {
+            mockCalled = true
+            registeredDeviceTokenSetCallsCount += 1
+            underlyingRegisteredDeviceToken = value
+        }
+    }
+
+    /**
+     When setter of the property called, the value given to setter is set here.
+     When the getter of the property called, the value set here will be returned. Your chance to mock the property.
+     */
     public var underlyingProfileAttributes: [String: Any] = [:]
     /// `true` if the getter or setter of property is called at least once.
     public var profileAttributesCalled: Bool {
@@ -289,6 +325,9 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
         config = nil
         configGetCallsCount = 0
         configSetCallsCount = 0
+        registeredDeviceToken = nil
+        registeredDeviceTokenGetCallsCount = 0
+        registeredDeviceTokenSetCallsCount = 0
         profileAttributesGetCallsCount = 0
         profileAttributesSetCallsCount = 0
         deviceAttributesGetCallsCount = 0

--- a/Tests/Tracking/CustomerIOImplementationTest.swift
+++ b/Tests/Tracking/CustomerIOImplementationTest.swift
@@ -298,7 +298,6 @@ class CustomerIOImplementationTest: UnitTest {
 
     func test_registeredDeviceToken_givenDeviceTokenAlreadySaved_expectToken() {
         let givenDeviceToken = String.random
-        profileStoreMock.identifier = nil
         customerIO.registerDeviceToken(givenDeviceToken)
 
         XCTAssertEqual(customerIO.registeredDeviceToken, givenDeviceToken)

--- a/Tests/Tracking/CustomerIOImplementationTest.swift
+++ b/Tests/Tracking/CustomerIOImplementationTest.swift
@@ -296,6 +296,18 @@ class CustomerIOImplementationTest: UnitTest {
         XCTAssertEqual(globalDataStoreMock.pushDeviceToken, givenDeviceToken)
     }
 
+    func test_registeredDeviceToken_givenDeviceTokenAlreadySaved_expectToken() {
+        let givenDeviceToken = String.random
+        profileStoreMock.identifier = nil
+        customerIO.registerDeviceToken(givenDeviceToken)
+
+        XCTAssertEqual(customerIO.registeredDeviceToken, givenDeviceToken)
+    }
+
+    func test_registeredDeviceToken_givenDeviceTokenNotSaved_expectNil() {
+        XCTAssertNil(customerIO.registeredDeviceToken)
+    }
+
     func test_registerDeviceToken_givenCustomerIdentified_expectAddTaskToQueue_expectStoreDeviceToken() {
         let givenDeviceToken = String.random
         let givenIdentifier = String.random


### PR DESCRIPTION
To fetch the already stored device token from the SDK. 
This feature will require the customer to write the code (as they do today) in AppDelegate to register the device when the token is generated. This feature **_does not_** auto save the token.

This PR is an attempt to elevate https://github.com/customerio/issues/issues/11181.

### Steps to test the feature - same for APN and FCM apps
1.
- Launch iOS app 
- Login into the app
- Tap on settings button on the top-right corner
- Check if device token shown in device token field
  
2.
- Launch iOS app 
- Tap on settings button on the top-right corner
- Check if device token shown in device token field

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After code reviews are approved and you determine this PR is ready to merge, select *Squash and Merge* button on this screen, leave the title and description to the default values, then merge the PR.
