### PR TITLE
fix: memory exception during SDK initialization async tasks

### DIFF
--- a/Sources/Tracking/CustomerIO.swift
+++ b/Sources/Tracking/CustomerIO.swift
@@ -118,7 +118,7 @@ public class CustomerIO: CustomerIOInstance {
     var diGraph: DIGraph?
 
     // strong reference to repository to prevent garbage collection as it runs tasks in async.
-    private var cleanupRepository: CleanupRepository?
+    @Atomic private var cleanupRepository: CleanupRepository?
 
     // private constructor to force use of singleton API
     private init() {}
@@ -215,8 +215,6 @@ public class CustomerIO: CustomerIOInstance {
         let logger = diGraph.logger
         let siteId = diGraph.sdkConfig.siteId
 
-        cleanupRepository = diGraph.cleanupRepository
-
         // Register Tracking module hooks now that the module is being initialized.
         hooks.add(key: .tracking, provider: TrackingModuleHookProvider())
 
@@ -227,9 +225,20 @@ public class CustomerIO: CustomerIOInstance {
             registerDeviceToken(token)
         }
 
-        // run cleanup in background to prevent locking the UI thread
-        threadUtil.runBackground { [weak self] in
-            self?.cleanupRepository?.cleanup()
+        // Only run async operations 1 time, no matter how many times the SDK initializes.
+        // Exceptions can occur when:
+        // - Instance of CleanupRepository created in thread A. Schedules async operation to occur on background thread.
+        // - New instance of CleanupRepository created by thread B.
+        // - Async operation in background thread begins. Tries to reference repository instance that was created by thread A, where it got scheduled.
+        // - Memory exception thrown because old repository instance from thread A is gone.
+        if cleanupRepository == nil { // Using cleanupRepository instance to determine if this has been run before.
+            cleanupRepository = diGraph.cleanupRepository
+
+            // run cleanup in background to prevent locking the UI thread
+            threadUtil.runBackground { [weak self] in
+                // Crash occurs on line below if repository gets re-assigned
+                self?.cleanupRepository?.cleanup()
+            }
         }
 
         logger

--- a/Tests/Tracking/CustomerIOIntegrationTests.swift
+++ b/Tests/Tracking/CustomerIOIntegrationTests.swift
@@ -156,4 +156,11 @@ class CustomerIOIntegrationTests: IntegrationTest {
         XCTAssertEqual(CustomerIO.shared.config!.siteId, givenSiteId)
         XCTAssertEqual(CustomerIO.shared.config!.apiKey, givenApiKey)
     }
+
+    // Note: It's very important that this is an integration test that uses *real* instances of ThreadUtil to run code in a real background thread and the dependencies in SDK initialization, such as CleanupRepository, are all real instances.
+    func test_initializeSdk_givenCallMultipleTimes_expectNoExceptions() {
+        for _ in 0 ..< 1000 {
+            CustomerIO.initialize(siteId: .random, apiKey: .random, region: .US, configure: nil)
+        }
+    }
 }


### PR DESCRIPTION
This is a bug fix to resolve [issue reported by React Native customer](https://github.com/customerio/customerio-reactnative/issues/168). 

- I created integration test to reproduce the issue. The test suite crashes when running the newly added test. 
- I wrote the bug fix in the `CustomerIO` class. Test passes after bug fix implemented. 