### PR TITLE
ci: fix installing sd tool needed for deployment

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -28,7 +28,7 @@ jobs:
       # CLI to replace strings in files. The CLI recommends using `cargo install` which is slow. This Action is fast because it downloads pre-built binaries. 
       # If using sd on macos, "brew install" works great. for Linux, this is the recommended way. 
       - name: Install sd CLI to use later in the workflow 
-        run: cargo install sd 
+        uses: kenji-miyake/setup-sd@v1
 
       # Semantic-release tool is used to:
       # 1. Determine the next semantic version for the software during deployment.

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -26,9 +26,10 @@ jobs:
       - uses: actions/checkout@v4
     
       # CLI to replace strings in files. The CLI recommends using `cargo install` which is slow. This Action is fast because it downloads pre-built binaries. 
-      # If using sd on macos, "brew install" works great. for Linux, this is the recommended way. 
+      # If using sd on macos, "brew install" works great. for Linux, this is the recommended way.       
       - name: Install sd CLI to use later in the workflow 
-        uses: kenji-miyake/setup-sd@v1
+        # uses: kenji-miyake/setup-sd@v1
+        uses: levibostian/setup-sd@add-file-extension # Using fork until upstream Action has bug fixed in it. 
 
       # Semantic-release tool is used to:
       # 1. Determine the next semantic version for the software during deployment.

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -28,7 +28,7 @@ jobs:
       # CLI to replace strings in files. The CLI recommends using `cargo install` which is slow. This Action is fast because it downloads pre-built binaries. 
       # If using sd on macos, "brew install" works great. for Linux, this is the recommended way. 
       - name: Install sd CLI to use later in the workflow 
-        uses: kenji-miyake/setup-sd@v1
+        run: cargo install sd 
 
       # Semantic-release tool is used to:
       # 1. Determine the next semantic version for the software during deployment.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,12 @@ concurrency: # cancel previous workflow run if one exists.
 
 jobs:
   automated-tests:
-    runs-on: ubuntu-latest
+    runs-on: macos-13
     permissions:
       checks: write # Need write permission to add test result check.
     steps:
     - uses: actions/checkout@v4
-    - uses: levibostian/setup-sd@add-file-extension
+    - run: cargo install sd 
     - run: ./scripts/update-version-cocoapods.sh "4.4.3"
     # - uses: ./.github/actions/setup-ios
     # # If running tests fails, sometimes it's because of scheme name is wrong. This gives us all available schemes. 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,52 +16,50 @@ jobs:
       checks: write # Need write permission to add test result check.
     steps:
     - uses: actions/checkout@v4
-    - run: cargo install sd 
-    - run: ./scripts/update-version-cocoapods.sh "4.4.3"
-    # - uses: ./.github/actions/setup-ios
-    # # If running tests fails, sometimes it's because of scheme name is wrong. This gives us all available schemes. 
-    # - name: Get XCode schemes 
-    #   run: xcrun xcodebuild -list
+    - uses: ./.github/actions/setup-ios
+    # If running tests fails, sometimes it's because of scheme name is wrong. This gives us all available schemes. 
+    - name: Get XCode schemes 
+      run: xcrun xcodebuild -list
 
-    # - name: Setup Ruby to run Fastlane 
-    #   uses: ruby/setup-ruby@v1
-    #   with:
-    #     ruby-version: '3.0'
-    #     bundler-cache: true # install dependencies in Gemfile, including Fastlane. 
+    - name: Setup Ruby to run Fastlane 
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.0'
+        bundler-cache: true # install dependencies in Gemfile, including Fastlane. 
 
-    # - name: Run tests 
-    #   uses: maierj/fastlane-action@v3.0.0
-    #   with:
-    #     lane: 'scan'
+    - name: Run tests 
+      uses: maierj/fastlane-action@v3.0.0
+      with:
+        lane: 'scan'
 
-    # # https://about.codecov.io/blog/pre-converting-xcresult-files-for-codecov-using-xcresultparser/
-    # - name: Generate code coverage report from .xcresult/ that can be converted to codecov format
-    #   run: |
-    #     brew tap a7ex/homebrew-formulae && brew install xcresultparser
-    #     xcresultparser --output-format cobertura "Customer.io-Package.xcresult" > ".build/coverage.xml"
+    # https://about.codecov.io/blog/pre-converting-xcresult-files-for-codecov-using-xcresultparser/
+    - name: Generate code coverage report from .xcresult/ that can be converted to codecov format
+      run: |
+        brew tap a7ex/homebrew-formulae && brew install xcresultparser
+        xcresultparser --output-format cobertura "Customer.io-Package.xcresult" > ".build/coverage.xml"
   
-    # - name: Upload code coverage report 
-    #   uses: codecov/codecov-action@v3
-    #   with: 
-    #     token: ${{ secrets.CODECOV_UPLOAD_TOKEN }} # not required for public repos, but sometimes uploads fail without it so include it anyway
-    #     files: .build/coverage.xml
-    #     fail_ci_if_error: true # fail if upload fails so we can catch it and fix it right away.
-    #     verbose: true 
+    - name: Upload code coverage report 
+      uses: codecov/codecov-action@v3
+      with: 
+        token: ${{ secrets.CODECOV_UPLOAD_TOKEN }} # not required for public repos, but sometimes uploads fail without it so include it anyway
+        files: .build/coverage.xml
+        fail_ci_if_error: true # fail if upload fails so we can catch it and fix it right away.
+        verbose: true 
 
-    # - name: Upload test report 
-    #   uses: actions/upload-artifact@v3
-    #   with:
-    #     name: xcode-test-report
-    #     path: test-report.*
-    #   if: ${{ always() }}
-    # - name: Publish test results
-    #   uses: mikepenz/action-junit-report@v4      
-    #   with:
-    #     check_name: XCode macOS tests - Results
-    #     report_paths: test-report.xml
-    #     github_token: ${{ secrets.GITHUB_TOKEN }}
-    #     fail_on_failure: true
-    #     require_tests: true
-    #   if: ${{ always() }} # if running tests fails, we still want to parse the test results  
+    - name: Upload test report 
+      uses: actions/upload-artifact@v3
+      with:
+        name: xcode-test-report
+        path: test-report.*
+      if: ${{ always() }}
+    - name: Publish test results
+      uses: mikepenz/action-junit-report@v4      
+      with:
+        check_name: XCode macOS tests - Results
+        report_paths: test-report.xml
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        fail_on_failure: true
+        require_tests: true
+      if: ${{ always() }} # if running tests fails, we still want to parse the test results  
   
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,50 +16,52 @@ jobs:
       checks: write # Need write permission to add test result check.
     steps:
     - uses: actions/checkout@v4
-    - uses: ./.github/actions/setup-ios
-    # If running tests fails, sometimes it's because of scheme name is wrong. This gives us all available schemes. 
-    - name: Get XCode schemes 
-      run: xcrun xcodebuild -list
+    - run: cargo install sd 
+    - run: ./scripts/update-version-cocoapods.sh "4.4.3"
+    # - uses: ./.github/actions/setup-ios
+    # # If running tests fails, sometimes it's because of scheme name is wrong. This gives us all available schemes. 
+    # - name: Get XCode schemes 
+    #   run: xcrun xcodebuild -list
 
-    - name: Setup Ruby to run Fastlane 
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: '3.0'
-        bundler-cache: true # install dependencies in Gemfile, including Fastlane. 
+    # - name: Setup Ruby to run Fastlane 
+    #   uses: ruby/setup-ruby@v1
+    #   with:
+    #     ruby-version: '3.0'
+    #     bundler-cache: true # install dependencies in Gemfile, including Fastlane. 
 
-    - name: Run tests 
-      uses: maierj/fastlane-action@v3.0.0
-      with:
-        lane: 'scan'
+    # - name: Run tests 
+    #   uses: maierj/fastlane-action@v3.0.0
+    #   with:
+    #     lane: 'scan'
 
-    # https://about.codecov.io/blog/pre-converting-xcresult-files-for-codecov-using-xcresultparser/
-    - name: Generate code coverage report from .xcresult/ that can be converted to codecov format
-      run: |
-        brew tap a7ex/homebrew-formulae && brew install xcresultparser
-        xcresultparser --output-format cobertura "Customer.io-Package.xcresult" > ".build/coverage.xml"
+    # # https://about.codecov.io/blog/pre-converting-xcresult-files-for-codecov-using-xcresultparser/
+    # - name: Generate code coverage report from .xcresult/ that can be converted to codecov format
+    #   run: |
+    #     brew tap a7ex/homebrew-formulae && brew install xcresultparser
+    #     xcresultparser --output-format cobertura "Customer.io-Package.xcresult" > ".build/coverage.xml"
   
-    - name: Upload code coverage report 
-      uses: codecov/codecov-action@v3
-      with: 
-        token: ${{ secrets.CODECOV_UPLOAD_TOKEN }} # not required for public repos, but sometimes uploads fail without it so include it anyway
-        files: .build/coverage.xml
-        fail_ci_if_error: true # fail if upload fails so we can catch it and fix it right away.
-        verbose: true 
+    # - name: Upload code coverage report 
+    #   uses: codecov/codecov-action@v3
+    #   with: 
+    #     token: ${{ secrets.CODECOV_UPLOAD_TOKEN }} # not required for public repos, but sometimes uploads fail without it so include it anyway
+    #     files: .build/coverage.xml
+    #     fail_ci_if_error: true # fail if upload fails so we can catch it and fix it right away.
+    #     verbose: true 
 
-    - name: Upload test report 
-      uses: actions/upload-artifact@v3
-      with:
-        name: xcode-test-report
-        path: test-report.*
-      if: ${{ always() }}
-    - name: Publish test results
-      uses: mikepenz/action-junit-report@v4      
-      with:
-        check_name: XCode macOS tests - Results
-        report_paths: test-report.xml
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        fail_on_failure: true
-        require_tests: true
-      if: ${{ always() }} # if running tests fails, we still want to parse the test results  
+    # - name: Upload test report 
+    #   uses: actions/upload-artifact@v3
+    #   with:
+    #     name: xcode-test-report
+    #     path: test-report.*
+    #   if: ${{ always() }}
+    # - name: Publish test results
+    #   uses: mikepenz/action-junit-report@v4      
+    #   with:
+    #     check_name: XCode macOS tests - Results
+    #     report_paths: test-report.xml
+    #     github_token: ${{ secrets.GITHUB_TOKEN }}
+    #     fail_on_failure: true
+    #     require_tests: true
+    #   if: ${{ always() }} # if running tests fails, we still want to parse the test results  
   
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,12 @@ concurrency: # cancel previous workflow run if one exists.
 
 jobs:
   automated-tests:
-    runs-on: macos-13
+    runs-on: ubuntu-latest
     permissions:
       checks: write # Need write permission to add test result check.
     steps:
     - uses: actions/checkout@v4
-    - run: cargo install sd 
+    - uses: levibostian/setup-sd@add-file-extension
     - run: ./scripts/update-version-cocoapods.sh "4.4.3"
     # - uses: ./.github/actions/setup-ios
     # # If running tests fails, sometimes it's because of scheme name is wrong. This gives us all available schemes. 


### PR DESCRIPTION
Deployments on `main` are currently broken because of a GH action that we use. 

This PR updates the GH action to an action that I have found to work. This is a workaround to get deployments working again until the original GH action gets fixed. 