### PR TITLE
feat: show a push while app in foreground

### DIFF
--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -10,6 +10,9 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
     @Atomic public private(set) static var shared = MessagingPush()
     private var globalDataStore: GlobalDataStore
 
+    // singleton instance of module configuration
+    @Atomic public static var moduleConfig: MessagingPushConfigOptions = .init()
+
     // testing constructor
     init(implementation: MessagingPushInstance?, globalDataStore: GlobalDataStore, sdkInitializedUtil: SdkInitializedUtil) {
         self.globalDataStore = globalDataStore
@@ -29,7 +32,11 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
 
     // Gets called when MessagingPushAPN.initialize() or MessagingPushFCM.initialize() called.
     @available(iOSApplicationExtension, unavailable)
-    public static func initialize() {
+    public static func initialize(config: MessagingPushConfigOptions? = nil) {
+        if let newConfig = config {
+            moduleConfig = newConfig
+        }
+
         MessagingPush.shared.initializeModuleIfSdkInitialized()
     }
 

--- a/Sources/MessagingPush/MessagingPushConfigOptions.swift
+++ b/Sources/MessagingPush/MessagingPushConfigOptions.swift
@@ -1,16 +1,9 @@
-public struct MessagingPushConfigOptions {
-    // Used to create new instance of MessagingPushConfigOptions when the MessagingPushAPN module is configured.
-    // Each property of the MessagingPushConfigOptions object can be modified by the user.
-    public enum Factory {
-        public static func create() -> MessagingPushConfigOptions {
-            MessagingPushConfigOptions(
-                autoFetchDeviceToken: true
-            )
-        }
-    }
+import CioInternalCommon
 
-    public enum Keys: String { // Constants used to map each of the options in MessagingPushConfigOptions
-        case autoFetchDeviceToken
+public struct MessagingPushConfigOptions {
+    public init() {
+        self.autoFetchDeviceToken = true
+        self.showPushAppInForeground = true
     }
 
     /**
@@ -18,4 +11,23 @@ public struct MessagingPushConfigOptions {
      On fetching the token, SDK will auto-register the device. This value is `true` by default.
      */
     public var autoFetchDeviceToken: Bool
+
+    /**
+     Display push notifications sent by Customer.io while app is in foreground. This value is `true` by default.
+     */
+    public var showPushAppInForeground: Bool
+}
+
+// Add MessagingPush config options to the DIGraph like we do for SdkConfig.
+// Allows dependencies to easily access module configuration via dependency injection
+// in constructor.
+extension DIGraph {
+    var messagingPushConfigOptions: MessagingPushConfigOptions {
+        get {
+            MessagingPush.moduleConfig
+        }
+        set {
+            MessagingPush.moduleConfig = newValue
+        }
+    }
 }

--- a/Sources/MessagingPush/PushClickHandler.swift
+++ b/Sources/MessagingPush/PushClickHandler.swift
@@ -181,7 +181,7 @@ extension PushClickHandlerImpl {
         cio_swizzle_didReceive(center, didReceive: response, withCompletionHandler: completionHandler)
     }
 
-    // Swizzled method that gets called when a push notification gets clicked or swiped away
+    // Swizzled method that gets called before the OS displays the push. Used to determine if a push gets displayed while app is in foreground or not. 
     @objc dynamic func cio_swizzle_willPresent(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         guard let _ = CustomerIOParsedPushPayload.parse(notificationContent: notification.request.content, jsonAdapter: jsonAdapter) else {
             // push not sent from CIO. exit early and ignore request

--- a/Sources/MessagingPush/PushClickHandler.swift
+++ b/Sources/MessagingPush/PushClickHandler.swift
@@ -33,15 +33,18 @@ class PushClickHandlerImpl: NSObject, PushClickHandler, UNUserNotificationCenter
     private let deepLinkUtil: DeepLinkUtil
     private var userNotificationCenter: UserNotificationCenter
 
+    private var messagingPushConfig: MessagingPushConfigOptions
+
     private var customerIO: CustomerIO? {
         sdkInitializedUtil.customerio
     }
 
-    init(jsonAdapter: JsonAdapter, sdkConfig: SdkConfig, deepLinkUtil: DeepLinkUtil, userNotificationCenter: UserNotificationCenter) {
+    init(jsonAdapter: JsonAdapter, sdkConfig: SdkConfig, deepLinkUtil: DeepLinkUtil, userNotificationCenter: UserNotificationCenter, messagingPushConfig: MessagingPushConfigOptions) {
         self.jsonAdapter = jsonAdapter
         self.sdkConfig = sdkConfig
         self.deepLinkUtil = deepLinkUtil
         self.userNotificationCenter = userNotificationCenter
+        self.messagingPushConfig = messagingPushConfig
         self.sdkInitializedUtil = SdkInitializedUtilImpl()
     }
 
@@ -84,6 +87,13 @@ class PushClickHandlerImpl: NSObject, PushClickHandler, UNUserNotificationCenter
             targetSelector: #selector(UNUserNotificationCenterDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:)),
             myClass: PushClickHandlerImpl.self,
             mySelector: #selector(PushClickHandlerImpl.cio_swizzle_didReceive(_:didReceive:withCompletionHandler:))
+        )
+
+        swizzle(
+            targetClass: type(of: delegate),
+            targetSelector: #selector(UNUserNotificationCenterDelegate.userNotificationCenter(_:willPresent:withCompletionHandler:)),
+            myClass: PushClickHandlerImpl.self,
+            mySelector: #selector(PushClickHandlerImpl.cio_swizzle_willPresent(_:willPresent:withCompletionHandler:))
         )
     }
 
@@ -169,6 +179,25 @@ extension PushClickHandlerImpl {
 
         // continue swizzle
         cio_swizzle_didReceive(center, didReceive: response, withCompletionHandler: completionHandler)
+    }
+
+    // Swizzled method that gets called when a push notification gets clicked or swiped away
+    @objc dynamic func cio_swizzle_willPresent(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        guard let _ = CustomerIOParsedPushPayload.parse(notificationContent: notification.request.content, jsonAdapter: jsonAdapter) else {
+            // push not sent from CIO. exit early and ignore request
+            return
+        }
+
+        if messagingPushConfig.showPushAppInForeground {
+            if #available(iOS 14.0, *) {
+                completionHandler([.list, .banner, .badge, .sound])
+            } else {
+                completionHandler([.badge, .sound])
+            }
+        }
+
+        // continue swizzle
+        cio_swizzle_willPresent(center, willPresent: notification, withCompletionHandler: completionHandler)
     }
 }
 

--- a/Sources/MessagingPush/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/MessagingPush/autogenerated/AutoDependencyInjection.generated.swift
@@ -103,7 +103,7 @@ extension DIGraph {
 
     @available(iOSApplicationExtension, unavailable)
     private func _get_pushClickHandler() -> PushClickHandler {
-        PushClickHandlerImpl(jsonAdapter: jsonAdapter, sdkConfig: sdkConfig, deepLinkUtil: deepLinkUtil, userNotificationCenter: userNotificationCenter)
+        PushClickHandlerImpl(jsonAdapter: jsonAdapter, sdkConfig: sdkConfig, deepLinkUtil: deepLinkUtil, userNotificationCenter: userNotificationCenter, messagingPushConfig: messagingPushConfigOptions)
     }
 
     // UserNotificationCenter

--- a/Sources/MessagingPushAPN/MessagingPushAPN.swift
+++ b/Sources/MessagingPushAPN/MessagingPushAPN.swift
@@ -83,13 +83,13 @@ public class MessagingPushAPN: MessagingPushAPNInstance {
     @available(iOSApplicationExtension, unavailable)
     public static func initialize(configOptions configureHandler: ((inout MessagingPushConfigOptions) -> Void)?
     ) {
-        MessagingPush.initialize() // initialize parent module to initialize features shared by APN and FCM modules
-
-        var pushConfigOptions = MessagingPushConfigOptions.Factory.create()
+        var pushConfigOptions = MessagingPushConfigOptions()
 
         if let configureHandler = configureHandler {
             configureHandler(&pushConfigOptions)
         }
+
+        MessagingPush.initialize(config: pushConfigOptions) // initialize parent module to initialize features shared by APN and FCM modules
 
         if pushConfigOptions.autoFetchDeviceToken {
             shared.setupAutoFetchDeviceToken()

--- a/Sources/MessagingPushFCM/MessagingPushFCM.swift
+++ b/Sources/MessagingPushFCM/MessagingPushFCM.swift
@@ -87,13 +87,13 @@ public class MessagingPushFCM: MessagingPushFCMInstance {
     @available(iOSApplicationExtension, unavailable)
     public static func initialize(configOptions configureHandler: ((inout MessagingPushConfigOptions) -> Void)?
     ) {
-        MessagingPush.initialize() // initialize parent module to initialize features shared by APN and FCM modules
-
-        var pushConfigOptions = MessagingPushConfigOptions.Factory.create()
+        var pushConfigOptions = MessagingPushConfigOptions()
 
         if let configureHandler = configureHandler {
             configureHandler(&pushConfigOptions)
         }
+
+        MessagingPush.initialize(config: pushConfigOptions) // initialize parent module to initialize features shared by APN and FCM modules
 
         if pushConfigOptions.autoFetchDeviceToken {
             shared.setupAutoFetchDeviceToken()


### PR DESCRIPTION
Merges into: https://github.com/customerio/customerio-ios/pull/403

Because the SDK will now be automatically handling when a push from CIO is clicked on, the SDK is also responsible for determining if a push is shown while app is in foreground or not. 

Previously, [customers specified this in their host app themselves](https://github.com/customerio/customerio-ios/blob/a2ccebf1dae6d891c8c699005a083a4147241130/Apps/CocoaPods-FCM/src/AppDelegate.swift#L56-L64). Now that customers will no longer need these code in their AppDelegate file, then customers can configure this behavior via SDK config. 

# todo
- add config option to docs