### PR TITLE
fix: cocoapods APN customers app not compiling

### DIFF
--- a/Apps/CocoaPods-FCM/Podfile
+++ b/Apps/CocoaPods-FCM/Podfile
@@ -11,6 +11,10 @@ target 'test cocoapods' do
   pod 'CustomerIOMessagingInApp', :path => sdk_local_path
   pod 'CustomerIOMessagingPushFCM', :path => sdk_local_path
 
+  # Adding APN for internal testing, only. Code from this pod is not used at runtime. 
+  # We need to confirm that cocoapods customers can compile their apps with this pod installed. 
+  pod 'CustomerIOMessagingPushAPN', :path => sdk_local_path
+
   # The "CustomerIOMessagingPushFCM" SDK installs the FCM SDK for you, defaulting to the latest version. 
   # If your app needs to use a specific version of the FCM SDK, you can add the line below to your app's Podfile 
   # and the version you specify will override the version in the "CustomerIOMessagingPushFCM" SDK. 
@@ -28,4 +32,8 @@ target 'Rich Push Notification Service Extension' do
   pod 'CustomerIOTracking', :path => sdk_local_path
   pod 'CustomerIOMessagingPush', :path => sdk_local_path
   pod 'CustomerIOMessagingPushFCM', :path => sdk_local_path
+
+  # Adding APN for internal testing, only. Code from this pod is not used at runtime. 
+  # We need to confirm that cocoapods customers can compile their apps with this pod installed. 
+  pod 'CustomerIOMessagingPushAPN', :path => sdk_local_path
 end 

--- a/Sources/MessagingPushAPN/MessagingPushAPN+PushConfigs.swift
+++ b/Sources/MessagingPushAPN/MessagingPushAPN+PushConfigs.swift
@@ -2,6 +2,7 @@ import Foundation
 import UIKit
 
 extension MessagingPushAPN {
+    @available(iOSApplicationExtension, unavailable)
     func setupAutoFetchDeviceToken() {
         // Swizzle method `didRegisterForRemoteNotificationsWithDeviceToken`
         swizzleDidRegisterForRemoteNotifications()
@@ -9,6 +10,7 @@ extension MessagingPushAPN {
         UIApplication.shared.registerForRemoteNotifications()
     }
 
+    @available(iOSApplicationExtension, unavailable)
     private func swizzleDidRegisterForRemoteNotifications() {
         let appDelegate = UIApplication.shared.delegate
         let appDelegateClass: AnyClass? = object_getClass(appDelegate)


### PR DESCRIPTION
Fixes: https://github.com/customerio/customerio-ios/issues/178#issuecomment-1821464983

The CI server was not able to catch this bug for us because this bug is specific to APN and cocoapods. Our CI server is only testing cocoapods and FCM. 

This PR modifies CI tests to now test for APN compilation as well to prevent bugs like this in future.
