### PR TITLE
refactor: push modules initialization

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
@@ -50,7 +50,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         // Add event listeners for in-app. This is not to initialise in-app but event listeners for in-app.
-        MessagingInApp.initialize(eventListener: self)
+        MessagingInApp
+            .initialize(siteId: siteId, region: .US)
+            .setEventListener(self)
         MessagingPushAPN.initialize { config in
             config.autoFetchDeviceToken = true
         }

--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -7,10 +7,10 @@ import Foundation
   */
 public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, MessagingPushInstance {
     @Atomic public private(set) static var shared = MessagingPush()
+    @Atomic public private(set) static var moduleConfig: MessagingPushConfigOptions = MessagingPushConfigOptions.Factory.create()
     private static let moduleName = "MessagingPush"
 
     private var globalDataStore: GlobalDataStore
-
     // testing constructor
     init(implementation: MessagingPushInstance?, globalDataStore: GlobalDataStore) {
         self.globalDataStore = globalDataStore
@@ -36,41 +36,31 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
     public static func initialize(
         configure configureHandler: ((inout MessagingPushConfigOptions) -> Void)? = nil
     ) -> MessagingPushInstance {
-        var moduleConfig = MessagingPushConfigOptions.Factory.create()
+        var configOptions = moduleConfig
 
         if let configureHandler = configureHandler {
-            configureHandler(&moduleConfig)
+            configureHandler(&configOptions)
         }
 
-        shared.initializeModule(moduleConfig: moduleConfig)
+        shared.initializeModule()
         return shared
     }
 
-    private func initializeModule(moduleConfig: MessagingPushConfigOptions) {
-        if let pushImplementation = getImplementationInstance() {
-            pushImplementation.configure { $0.apply(moduleConfig) }
-            logger.info("\(moduleName) module already initialized. Applying updated config, ignoring re-initialization request.")
+    private func initializeModule() {
+        guard getImplementationInstance() == nil else {
+            logger.info("\(moduleName) module is already initialized. Ignoring redundant initialization request.")
             return
         }
 
         logger.debug("Setting up \(moduleName) module...")
-        let pushImplementation = MessagingPushImplementation(diGraph: DIGraphShared.shared, moduleConfig: moduleConfig)
+        let pushImplementation = MessagingPushImplementation(diGraph: DIGraphShared.shared, moduleConfig: MessagingPush.moduleConfig)
         setImplementationInstance(implementation: pushImplementation)
 
-        // FIXME: [CDP] Update hooks to work as expected
-        // Register MessagingPush module hooks now that the module is being initialized.
-        // let hooks = diGraph.hooksManager
-        // let moduleHookProvider = MessagingInAppModuleHookProvider()
-        // hooks.add(key: .messagingInApp, provider: moduleHookProvider)
         logger.info("\(moduleName) module successfully set up with SDK")
     }
 
     override public func createImplementationInstance() -> MessagingPushInstance? {
         MessagingPush.initialize()
-    }
-
-    public func configure(with configureHandler: @escaping ((inout MessagingPushConfigOptions) -> Void)) {
-        implementation?.configure(with: configureHandler)
     }
 
     /**

--- a/Sources/MessagingPush/MessagingPushConfigOptions.swift
+++ b/Sources/MessagingPush/MessagingPushConfigOptions.swift
@@ -62,12 +62,4 @@ public struct MessagingPushConfigOptions {
      operating system, device locale, device model, app version etc
      */
     public var autoTrackDeviceAttributes: Bool
-
-    /// Applies new configuration to this object
-    /// - Important: Ensure all mutable properties are updated accordingly
-    mutating func apply(_ newConfig: MessagingPushConfigOptions) {
-        autoFetchDeviceToken = newConfig.autoFetchDeviceToken
-        autoTrackPushEvents = newConfig.autoTrackPushEvents
-        autoTrackDeviceAttributes = newConfig.autoTrackDeviceAttributes
-    }
 }

--- a/Sources/MessagingPush/MessagingPushImplementation.swift
+++ b/Sources/MessagingPush/MessagingPushImplementation.swift
@@ -6,7 +6,7 @@ import UserNotifications
 #endif
 
 class MessagingPushImplementation: MessagingPushInstance {
-    var moduleConfig: MessagingPushConfigOptions
+    let moduleConfig: MessagingPushConfigOptions
     let logger: Logger
     let jsonAdapter: JsonAdapter
 
@@ -25,12 +25,6 @@ class MessagingPushImplementation: MessagingPushInstance {
         self.moduleConfig = moduleConfig
         self.logger = diGraph.logger
         self.jsonAdapter = diGraph.jsonAdapter
-    }
-
-    func configure(with configureHandler: @escaping ((inout MessagingPushConfigOptions) -> Void)) {
-        var newConfig = moduleConfig
-        configureHandler(&newConfig)
-        moduleConfig.apply(newConfig)
     }
 
     func deleteDeviceToken() {

--- a/Sources/MessagingPush/MessagingPushInstance.swift
+++ b/Sources/MessagingPush/MessagingPushInstance.swift
@@ -10,7 +10,6 @@ import UserNotifications
 // 1. Cannot be used in an App Extension so therefore, we cannot guarantee that the function
 //    exists in the SDK code at compile time.
 public protocol MessagingPushInstance: AutoMockable {
-    func configure(with configureHandler: @escaping ((inout MessagingPushConfigOptions) -> Void))
     func registerDeviceToken(_ deviceToken: String)
     func deleteDeviceToken()
     func trackMetric(

--- a/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
@@ -162,11 +162,6 @@ public class MessagingPushInstanceMock: MessagingPushInstance, Mock {
 
 
     public func resetMock() {
-        configureCallsCount = 0
-        configureReceivedArguments = nil 
-        configureReceivedInvocations = []
-
-        self.mockCalled = false // do last as resetting properties above can make this true
         registerDeviceTokenCallsCount = 0
         registerDeviceTokenReceivedArguments = nil 
         registerDeviceTokenReceivedInvocations = []
@@ -206,32 +201,6 @@ public class MessagingPushInstanceMock: MessagingPushInstance, Mock {
     #endif 
 
         self.mockCalled = false // do last as resetting properties above can make this true
-    }
-
-    // MARK: - configure
-
-    /// Number of times the function was called.  
-    public private(set) var configureCallsCount = 0
-    /// `true` if the function was ever called. 
-    public var configureCalled: Bool {
-        return configureCallsCount > 0
-    }    
-    /// The arguments from the *last* time the function was called. 
-    public private(set) var configureReceivedArguments: ((inout MessagingPushConfigOptions) -> Void)?
-    /// Arguments from *all* of the times that the function was called. 
-    public private(set) var configureReceivedInvocations: [((inout MessagingPushConfigOptions) -> Void)] = []
-    /** 
-     Set closure to get called when function gets called. Great way to test logic or return a value for the function. 
-     */
-    public var configureClosure: ((@escaping (inout MessagingPushConfigOptions) -> Void) -> Void)?
-
-    /// Mocked function for `configure(with configureHandler: @escaping (inout MessagingPushConfigOptions) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
-    public func configure(with configureHandler: @escaping (inout MessagingPushConfigOptions) -> Void) {
-        self.mockCalled = true
-        configureCallsCount += 1
-        configureReceivedArguments = (configureHandler)
-        configureReceivedInvocations.append((configureHandler))
-        configureClosure?(configureHandler)
     }
 
     // MARK: - registerDeviceToken

--- a/Sources/MessagingPushAPN/MessagingPushAPN.swift
+++ b/Sources/MessagingPushAPN/MessagingPushAPN.swift
@@ -79,18 +79,19 @@ public class MessagingPushAPN: MessagingPushAPNInstance {
      Configure `MessagingPushAPN`.
      Call this function in your app if you want to configure the module.
      */
+    @discardableResult
     @available(iOSApplicationExtension, unavailable)
-    public static func initialize(configOptions configureHandler: ((inout MessagingPushConfigOptions) -> Void)?
-    ) {
-        var pushConfigOptions = MessagingPushConfigOptions.Factory.create()
+    public static func initialize(
+        configure configureHandler: ((inout MessagingPushConfigOptions) -> Void)? = nil
+    ) -> MessagingPushInstance {
+        let implementation = MessagingPush.initialize(configure: configureHandler)
 
-        if let configureHandler = configureHandler {
-            configureHandler(&pushConfigOptions)
-        }
-
+        let pushConfigOptions = MessagingPush.moduleConfig
         if pushConfigOptions.autoFetchDeviceToken {
             shared.setupAutoFetchDeviceToken()
         }
+
+        return implementation
     }
 
     #if canImport(UserNotifications)

--- a/Sources/MessagingPushFCM/MessagingPushFCM.swift
+++ b/Sources/MessagingPushFCM/MessagingPushFCM.swift
@@ -83,18 +83,19 @@ public class MessagingPushFCM: MessagingPushFCMInstance {
      Call this function in your app if you want to initialize and configure the module to
      auto-fetch device token and auto-register device with Customer.io.
      */
+    @discardableResult
     @available(iOSApplicationExtension, unavailable)
-    public static func initialize(configOptions configureHandler: ((inout MessagingPushConfigOptions) -> Void)?
-    ) {
-        var pushConfigOptions = MessagingPushConfigOptions.Factory.create()
+    public static func initialize(
+        configure configureHandler: ((inout MessagingPushConfigOptions) -> Void)? = nil
+    ) -> MessagingPushInstance {
+        let implementation = MessagingPush.initialize(configure: configureHandler)
 
-        if let configureHandler = configureHandler {
-            configureHandler(&pushConfigOptions)
-        }
-
+        let pushConfigOptions = MessagingPush.moduleConfig
         if pushConfigOptions.autoFetchDeviceToken {
             shared.setupAutoFetchDeviceToken()
         }
+
+        return implementation
     }
 
     #if canImport(UserNotifications)


### PR DESCRIPTION
helps: https://github.com/customerio/issues/issues/11650

### Changes

- APN-UIKit `AppDelegate` fix for `MessagingInApp`
- Updated `MessagingPush` to initialize only once
- Removed `configure` option from `MessagingPush`
- Updated `MessagingPushAPN` and `MessagingPushFCM` initialization methods