### PR TITLE
refactor: get lint passing

### DIFF
--- a/Sources/MessagingPush/PushHandling/iOSPushEventListener.swift
+++ b/Sources/MessagingPush/PushHandling/iOSPushEventListener.swift
@@ -92,6 +92,20 @@ class iOSPushEventListener: NSObject, PushEventListener, UNUserNotificationCente
             completionHandler([]) // do not show push while app in foreground
         }
     }
+
+    // Swizzle method convenient when original and swizzled methods both belong to same class.
+    func swizzle(forClass: AnyClass, original: Selector, new: Selector) {
+        guard let originalMethod = class_getInstanceMethod(forClass, original) else { return }
+        guard let swizzledMethod = class_getInstanceMethod(forClass, new) else { return }
+
+        let didAddMethod = class_addMethod(forClass, original, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod))
+
+        if didAddMethod {
+            class_replaceMethod(forClass, new, method_getImplementation(originalMethod), method_getTypeEncoding(originalMethod))
+        } else {
+            method_exchangeImplementations(originalMethod, swizzledMethod)
+        }
+    }
 }
 
 // This is a bit confusing and makes the code a little more complex. However, it's the most reliable way found to get UNUserNotificationCenter.delegate swizzling to work by using an extension.
@@ -118,21 +132,5 @@ extension UNUserNotificationCenter {
         // Instead of providing the given 'delegate', provide CIO SDK's click handler.
         // This will force our SDK to be the 1 push click handler of the app instead of the given 'delegate'.
         cio_swizzled_setDelegate(delegate: diGraph.pushEventListener.delegate)
-    }
-}
-
-// TODO: cleanup duplicate swizzle functions all over codebase.
-
-// Swizzle method convenient when original and swizzled methods both belong to same class.
-func swizzle(forClass: AnyClass, original: Selector, new: Selector) {
-    guard let originalMethod = class_getInstanceMethod(forClass, original) else { return }
-    guard let swizzledMethod = class_getInstanceMethod(forClass, new) else { return }
-
-    let didAddMethod = class_addMethod(forClass, original, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod))
-
-    if didAddMethod {
-        class_replaceMethod(forClass, new, method_getImplementation(originalMethod), method_getTypeEncoding(originalMethod))
-    } else {
-        method_exchangeImplementations(originalMethod, swizzledMethod)
     }
 }

--- a/Sources/MessagingPush/PushHandling/iOSPushEventListener.swift
+++ b/Sources/MessagingPush/PushHandling/iOSPushEventListener.swift
@@ -15,7 +15,7 @@ protocol PushEventListener: AutoMockable {
 //
 // sourcery: InjectRegister = "PushEventListener"
 // sourcery: InjectSingleton
-class iOSPushEventListener: NSObject, PushEventListener, UNUserNotificationCenterDelegate {
+class IOSPushEventListener: NSObject, PushEventListener, UNUserNotificationCenterDelegate {
     private var userNotificationCenter: UserNotificationCenter
     private let jsonAdapter: JsonAdapter
     private var moduleConfig: MessagingPushConfigOptions

--- a/Sources/MessagingPush/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/MessagingPush/autogenerated/AutoDependencyInjection.generated.swift
@@ -61,6 +61,9 @@ extension DIGraph {
         _ = deepLinkUtil
         countDependenciesResolved += 1
 
+        _ = pushEventListener
+        countDependenciesResolved += 1
+
         _ = pushClickHandler
         countDependenciesResolved += 1
 
@@ -68,9 +71,6 @@ extension DIGraph {
         countDependenciesResolved += 1
 
         _ = userNotificationCenter
-        countDependenciesResolved += 1
-
-        _ = pushEventListener
         countDependenciesResolved += 1
 
         return countDependenciesResolved
@@ -98,6 +98,33 @@ extension DIGraph {
     @available(iOSApplicationExtension, unavailable)
     private var newDeepLinkUtil: DeepLinkUtil {
         DeepLinkUtilImpl(logger: logger, uiKitWrapper: uIKitWrapper)
+    }
+
+    // PushEventListener (singleton)
+    @available(iOSApplicationExtension, unavailable)
+    var pushEventListener: PushEventListener {
+        getOverriddenInstance() ??
+            sharedPushEventListener
+    }
+
+    @available(iOSApplicationExtension, unavailable)
+    var sharedPushEventListener: PushEventListener {
+        // Use a DispatchQueue to make singleton thread safe. You must create unique dispatchqueues instead of using 1 shared one or you will get a crash when trying
+        // to call DispatchQueue.sync{} while already inside another DispatchQueue.sync{} call.
+        DispatchQueue(label: "DIGraph_PushEventListener_singleton_access").sync {
+            if let overridenDep: PushEventListener = getOverriddenInstance() {
+                return overridenDep
+            }
+            let existingSingletonInstance = self.singletons[String(describing: PushEventListener.self)] as? PushEventListener
+            let instance = existingSingletonInstance ?? _get_pushEventListener()
+            self.singletons[String(describing: PushEventListener.self)] = instance
+            return instance
+        }
+    }
+
+    @available(iOSApplicationExtension, unavailable)
+    private func _get_pushEventListener() -> PushEventListener {
+        IOSPushEventListener(userNotificationCenter: userNotificationCenter, jsonAdapter: jsonAdapter, moduleConfig: messagingPushConfigOptions, pushClickHandler: pushClickHandler)
     }
 
     // PushClickHandler
@@ -130,33 +157,6 @@ extension DIGraph {
 
     private var newUserNotificationCenter: UserNotificationCenter {
         UserNotificationCenterImpl()
-    }
-
-    // PushEventListener (singleton)
-    @available(iOSApplicationExtension, unavailable)
-    var pushEventListener: PushEventListener {
-        getOverriddenInstance() ??
-            sharedPushEventListener
-    }
-
-    @available(iOSApplicationExtension, unavailable)
-    var sharedPushEventListener: PushEventListener {
-        // Use a DispatchQueue to make singleton thread safe. You must create unique dispatchqueues instead of using 1 shared one or you will get a crash when trying
-        // to call DispatchQueue.sync{} while already inside another DispatchQueue.sync{} call.
-        DispatchQueue(label: "DIGraph_PushEventListener_singleton_access").sync {
-            if let overridenDep: PushEventListener = getOverriddenInstance() {
-                return overridenDep
-            }
-            let existingSingletonInstance = self.singletons[String(describing: PushEventListener.self)] as? PushEventListener
-            let instance = existingSingletonInstance ?? _get_pushEventListener()
-            self.singletons[String(describing: PushEventListener.self)] = instance
-            return instance
-        }
-    }
-
-    @available(iOSApplicationExtension, unavailable)
-    private func _get_pushEventListener() -> PushEventListener {
-        iOSPushEventListener(userNotificationCenter: userNotificationCenter, jsonAdapter: jsonAdapter, moduleConfig: messagingPushConfigOptions, pushClickHandler: pushClickHandler)
     }
 }
 

--- a/Tests/MessagingPush/PushHandling/PushClickHandlerTest.swift
+++ b/Tests/MessagingPush/PushHandling/PushClickHandlerTest.swift
@@ -126,6 +126,7 @@ extension PushClickHandlerTest {
     func getPush(content: [AnyHashable: Any], deliveryId: String = .random, deviceToken: String = .random) -> CustomerIOParsedPushPayload {
         var content = content
 
+        // swiftlint:disable:next force_cast
         let notificationContent = UNNotificationContent().mutableCopy() as! UNMutableNotificationContent
 
         content["CIO-Delivery-ID"] = deliveryId


### PR DESCRIPTION
fixing all lint errors in `levi/reliable-open-metrics` branch