### PR TITLE
feat: disable the feature, if a customer needs to

### DIFF
--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -66,7 +66,7 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
         let logger = diGraph.logger
         logger.debug("Setting up MessagingPush module...")
 
-        if Self.shared.moduleConfig.autoPushClickHandling {
+        if diGraph.sdkConfig.autoTrackPushEvents {
             diGraph.automaticPushClickHandling.start()
         }
 

--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -19,7 +19,7 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
     @Atomic private var hasSetupModule = false
 
     // singleton instance of module configuration
-    @Atomic public static var moduleConfig: MessagingPushConfigOptions = .init()
+    @Atomic public var moduleConfig: MessagingPushConfigOptions = .init()
 
     // testing constructor
     init(implementation: MessagingPushInstance?, globalDataStore: GlobalDataStore, sdkInitializedUtil: SdkInitializedUtil) {
@@ -42,7 +42,7 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
     @available(iOSApplicationExtension, unavailable)
     public static func initialize(config: MessagingPushConfigOptions? = nil) {
         if let newConfig = config {
-            moduleConfig = newConfig
+            shared.moduleConfig = newConfig
         }
 
         MessagingPush.shared.initializeModuleIfSdkInitialized()
@@ -66,7 +66,9 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
         let logger = diGraph.logger
         logger.debug("Setting up MessagingPush module...")
 
-        diGraph.automaticPushClickHandling.start()
+        if Self.shared.moduleConfig.autoPushClickHandling {
+            diGraph.automaticPushClickHandling.start()
+        }
 
         logger.info("MessagingPush module setup with SDK")
     }

--- a/Sources/MessagingPush/MessagingPushConfigOptions.swift
+++ b/Sources/MessagingPush/MessagingPushConfigOptions.swift
@@ -4,7 +4,6 @@ public struct MessagingPushConfigOptions {
     public init() {
         self.autoFetchDeviceToken = true
         self.showPushAppInForeground = true
-        self.autoPushClickHandling = true
     }
 
     /**
@@ -15,15 +14,8 @@ public struct MessagingPushConfigOptions {
 
     /**
      Display push notifications sent by Customer.io while app is in foreground. This value is `true` by default.
-
-     Note: Has no effect if auto push click handling is disabled.
      */
     public var showPushAppInForeground: Bool
-
-    /**
-     Enable automatic push click handling by the SDK without the need to write custom code in your iOS app. This is `true` by default.
-     */
-    public var autoPushClickHandling: Bool
 }
 
 // Add MessagingPush config options to the DIGraph like we do for SdkConfig.

--- a/Sources/MessagingPush/MessagingPushConfigOptions.swift
+++ b/Sources/MessagingPush/MessagingPushConfigOptions.swift
@@ -4,6 +4,7 @@ public struct MessagingPushConfigOptions {
     public init() {
         self.autoFetchDeviceToken = true
         self.showPushAppInForeground = true
+        self.autoPushClickHandling = true
     }
 
     /**
@@ -14,8 +15,15 @@ public struct MessagingPushConfigOptions {
 
     /**
      Display push notifications sent by Customer.io while app is in foreground. This value is `true` by default.
+
+     Note: Has no effect if auto push click handling is disabled.
      */
     public var showPushAppInForeground: Bool
+
+    /**
+     Enable automatic push click handling by the SDK without the need to write custom code in your iOS app. This is `true` by default.
+     */
+    public var autoPushClickHandling: Bool
 }
 
 // Add MessagingPush config options to the DIGraph like we do for SdkConfig.
@@ -24,10 +32,10 @@ public struct MessagingPushConfigOptions {
 extension DIGraph {
     var messagingPushConfigOptions: MessagingPushConfigOptions {
         get {
-            MessagingPush.moduleConfig
+            MessagingPush.shared.moduleConfig
         }
         set {
-            MessagingPush.moduleConfig = newValue
+            MessagingPush.shared.moduleConfig = newValue
         }
     }
 }

--- a/Tests/MessagingPush/IntegrationTest.swift
+++ b/Tests/MessagingPush/IntegrationTest.swift
@@ -6,6 +6,10 @@ class IntegrationTest: SharedTests.IntegrationTest {
     private let notificationCenterMock = UserNotificationCenterMock()
 
     override func setUp() {
+        setUp(shouldInitializeModule: true)
+    }
+
+    func setUp(shouldInitializeModule: Bool = true) {
         MessagingPush.resetSharedInstance()
 
         super.setUp()
@@ -17,6 +21,8 @@ class IntegrationTest: SharedTests.IntegrationTest {
         diGraph.override(value: notificationCenterMock, forType: UserNotificationCenter.self)
 
         // Sets up features such as hooks for test to be more realistic to production
-        MessagingPush.initialize()
+        if shouldInitializeModule {
+            MessagingPush.initialize()
+        }
     }
 }

--- a/Tests/MessagingPush/IntegrationTest.swift
+++ b/Tests/MessagingPush/IntegrationTest.swift
@@ -1,3 +1,4 @@
+@testable import CioInternalCommon
 @testable import CioMessagingPush
 import Foundation
 import SharedTests
@@ -6,13 +7,13 @@ class IntegrationTest: SharedTests.IntegrationTest {
     private let notificationCenterMock = UserNotificationCenterMock()
 
     override func setUp() {
-        setUp(shouldInitializeModule: true)
+        setUp(shouldInitializeModule: false, modifySdkConfig: nil)
     }
 
-    func setUp(shouldInitializeModule: Bool = true) {
+    func setUp(shouldInitializeModule: Bool = true, modifySdkConfig: ((inout SdkConfig) -> Void)? = nil) {
         MessagingPush.resetSharedInstance()
 
-        super.setUp()
+        super.setUp(modifySdkConfig: modifySdkConfig)
 
         // CIO is already initialized from super class
 

--- a/Tests/MessagingPush/MessagingPushTest.swift
+++ b/Tests/MessagingPush/MessagingPushTest.swift
@@ -11,7 +11,7 @@ class MessagignPushTest: IntegrationTest {
     override func setUp() {
         super.setUp(shouldInitializeModule: false) // we manually initialize module in test functions.
 
-        diGraph.override(value: automaticPushClickHandlingMock, forType: AutomaticPushClickHandling.self)
+        setupTest()
     }
 
     // MARK: initialize
@@ -47,11 +47,20 @@ class MessagignPushTest: IntegrationTest {
     }
 
     func test_initialize_givenCustomerDisabledAutoPushClickHandling_expectDoNotEnableFeature() {
-        var givenModuleConfig = MessagingPushConfigOptions()
-        givenModuleConfig.autoPushClickHandling = false
+        setupTest { config in
+            config.autoTrackPushEvents = false
+        }
 
-        MessagingPush.initialize(config: givenModuleConfig)
+        MessagingPush.initialize()
 
         XCTAssertFalse(automaticPushClickHandlingMock.startCalled)
+    }
+}
+
+extension MessagignPushTest {
+    func setupTest(modifySdkConfig: ((inout SdkConfig) -> Void)? = nil) {
+        super.setUp(shouldInitializeModule: false, modifySdkConfig: modifySdkConfig)
+
+        diGraph.override(value: automaticPushClickHandlingMock, forType: AutomaticPushClickHandling.self)
     }
 }

--- a/Tests/MessagingPush/MessagingPushTest.swift
+++ b/Tests/MessagingPush/MessagingPushTest.swift
@@ -9,11 +9,9 @@ class MessagignPushTest: IntegrationTest {
     private let automaticPushClickHandlingMock = AutomaticPushClickHandlingMock()
 
     override func setUp() {
-        super.setUp()
+        super.setUp(shouldInitializeModule: false) // we manually initialize module in test functions.
 
         diGraph.override(value: automaticPushClickHandlingMock, forType: AutomaticPushClickHandling.self)
-
-        MessagingPush.resetSharedInstance()
     }
 
     // MARK: initialize
@@ -40,5 +38,20 @@ class MessagignPushTest: IntegrationTest {
 
             XCTAssertEqual(automaticPushClickHandlingMock.startCallsCount, 1)
         }
+    }
+
+    func test_initialize_givenDefaultModuleConfigOptions_expectStartAutoPushClickHandling() {
+        MessagingPush.initialize()
+
+        XCTAssertEqual(automaticPushClickHandlingMock.startCallsCount, 1)
+    }
+
+    func test_initialize_givenCustomerDisabledAutoPushClickHandling_expectDoNotEnableFeature() {
+        var givenModuleConfig = MessagingPushConfigOptions()
+        givenModuleConfig.autoPushClickHandling = false
+
+        MessagingPush.initialize(config: givenModuleConfig)
+
+        XCTAssertFalse(automaticPushClickHandlingMock.startCalled)
     }
 }


### PR DESCRIPTION
In a team call, we discussed the importance of customers being able to disable this feature if they need to. We do not anticipate a customer needing to do this, but because this feature does involve techniques such as swizzling, it's good practice to give customers the option to disable the functionality if they encounter issues in their app's edge case environment. 
