### PR TITLE
fix: manual push click handling may not track opened metric

### DIFF
--- a/Sources/MessagingPush/PushHandling/ManualPushHandling.swift
+++ b/Sources/MessagingPush/PushHandling/ManualPushHandling.swift
@@ -81,14 +81,20 @@ extension MessagingPushImplementation {
         }
 
         if response.didClickOnPush {
-            // A hack to get an instance of pushClickHandler without making it a property of the MessagingPushImplementation class. pushClickHandler is not available to app extensions but MessagingPushImplementation is.
-            // We get around this by getting a instance in this function, only.
-            if let pushClickHandler = sdkInitializedUtil.postInitializedData?.diGraph.pushClickHandler {
-                pushClickHandler.pushClicked(parsedPush)
-            }
+            manualPushClickHandling(cioPush: parsedPush)
         }
 
         return parsedPush
+    }
+
+    // Function that contains the logic for when a customer is wanting to manual handle a push click event.
+    // Function created for logic to be testable since automated test suite crashes when trying to access some UserNotification framework classes such as UNUserNotificationCenter.
+    func manualPushClickHandling(cioPush: CustomerIOParsedPushPayload) {
+        // A hack to get an instance of pushClickHandler without making it a property of the MessagingPushImplementation class. pushClickHandler is not available to app extensions but MessagingPushImplementation is.
+        // We get around this by getting a instance in this function, only.
+        if let pushClickHandler = sdkInitializedUtil.postInitializedData?.diGraph.pushClickHandler {
+            pushClickHandler.pushClicked(cioPush)
+        }
     }
 }
 #endif

--- a/Sources/MessagingPush/PushHandling/PushClickHandler.swift
+++ b/Sources/MessagingPush/PushHandling/PushClickHandler.swift
@@ -31,8 +31,6 @@ class PushClickHandlerImpl: PushClickHandler {
 
         // Now we are ready to handle the push click.
 
-        // Do not check SdkConfig if automatic push tracking is enabled. Always track opened metric.
-        // This function is also called by manual push click handling.
         customerIO.trackMetric(deliveryID: parsedPush.deliveryId, event: .opened, deviceToken: parsedPush.deviceToken)
 
         // Cleanup files on device that were used when the push was displayed. Files are no longer

--- a/Sources/MessagingPush/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/MessagingPush/autogenerated/AutoDependencyInjection.generated.swift
@@ -136,7 +136,7 @@ extension DIGraph {
 
     @available(iOSApplicationExtension, unavailable)
     private var newPushClickHandler: PushClickHandler {
-        PushClickHandlerImpl(sdkConfig: sdkConfig, deepLinkUtil: deepLinkUtil, pushHistory: pushHistory, customerIO: customerIOInstance)
+        PushClickHandlerImpl(deepLinkUtil: deepLinkUtil, pushHistory: pushHistory, customerIO: customerIOInstance)
     }
 
     // PushHistory

--- a/Sources/Tracking/CustomerIO.swift
+++ b/Sources/Tracking/CustomerIO.swift
@@ -427,6 +427,10 @@ public class CustomerIO: CustomerIOInstance {
 // Convenient way for other modules to access CustomerIOInstance as well as being able to mock CustomerIOInstance.
 public extension DIGraph {
     var customerIOInstance: CustomerIOInstance {
-        CustomerIO.shared
+        if let override: CustomerIOInstance = getOverriddenInstance() {
+            return override
+        }
+
+        return CustomerIO.shared
     }
 } // swiftlint:disable:this file_length

--- a/Tests/MessagingPush/IntegrationTest.swift
+++ b/Tests/MessagingPush/IntegrationTest.swift
@@ -2,6 +2,7 @@
 @testable import CioMessagingPush
 import Foundation
 import SharedTests
+import UserNotifications
 
 class IntegrationTest: SharedTests.IntegrationTest {
     private let notificationCenterMock = UserNotificationCenterMock()
@@ -25,5 +26,19 @@ class IntegrationTest: SharedTests.IntegrationTest {
         if shouldInitializeModule {
             MessagingPush.initialize()
         }
+    }
+
+    func getPush(content: [AnyHashable: Any], deliveryId: String = .random, deviceToken: String = .random) -> CustomerIOParsedPushPayload {
+        var content = content
+
+        // swiftlint:disable:next force_cast
+        let notificationContent = UNNotificationContent().mutableCopy() as! UNMutableNotificationContent
+
+        content["CIO-Delivery-ID"] = deliveryId
+        content["CIO-Delivery-Token"] = deviceToken
+
+        notificationContent.userInfo = content
+
+        return CustomerIOParsedPushPayload.parse(notificationContent: notificationContent, jsonAdapter: jsonAdapter)!
     }
 }

--- a/Tests/MessagingPush/MessagingPushTest.swift
+++ b/Tests/MessagingPush/MessagingPushTest.swift
@@ -18,6 +18,7 @@ class MessagignPushTest: IntegrationTest {
 
     func test_initialize_expectOnlyAbleToInitializeOnce_expectInitializeThreadSafe() {
         // Run test multiple times to ensure thread safety. To try and catch a race condition, if one will exist.
+        // I do not suggest running test < 100 times. When bugs existed because of not being thread safe, the test may have to run 50 times until it fails.
         runTest(numberOfTimes: 100) {
             let expectAllThreadsToComplete = expectation(description: "All threads should complete")
             expectAllThreadsToComplete.expectedFulfillmentCount = 2
@@ -34,7 +35,7 @@ class MessagignPushTest: IntegrationTest {
                 expectAllThreadsToComplete.fulfill()
             }
 
-            waitForExpectations()
+            waitForExpectations(1) // test may take up to 1 second to finish because it is running so many times. CI server is a less powerful machine and this test is flaky when we set wait() for < 1 second.
 
             XCTAssertEqual(automaticPushClickHandlingMock.startCallsCount, 1)
         }

--- a/Tests/MessagingPush/PushHandling/ManualPushHandlingTest.swift
+++ b/Tests/MessagingPush/PushHandling/ManualPushHandlingTest.swift
@@ -1,0 +1,37 @@
+@testable import CioMessagingPush
+@testable import CioTracking
+import Foundation
+import SharedTests
+import XCTest
+
+class ManualPushHandlingIntegrationTests: IntegrationTest {
+    private let customerIOMock = CustomerIOInstanceMock()
+
+    // The manual push click handling functions are currently housed in `MessagingPushImplementation`. Get instance for integration test.
+    private var messagingPush: MessagingPushImplementation {
+        MessagingPush.shared.implementation as! MessagingPushImplementation
+    }
+
+    override func setUp() {
+        super.setUp { config in
+            config.autoTrackPushEvents = false // we are testing manual push tracking. Disable automatic push tracking feature.
+        }
+
+        diGraph.override(value: customerIOMock, forType: CustomerIOInstance.self)
+    }
+
+    // MARK: opened push metrics
+
+    func test_expectTrackOpenedMetrics() {
+        let givenDeliveryId = String.random
+        let givenDeviceToken = String.random
+
+        let cioPush = getPush(content: [:], deliveryId: givenDeliveryId, deviceToken: givenDeviceToken)
+
+        messagingPush.manualPushClickHandling(cioPush: cioPush)
+
+        XCTAssertEqual(customerIOMock.trackMetricCallsCount, 1)
+        XCTAssertEqual(customerIOMock.trackMetricReceivedArguments?.deliveryID, givenDeliveryId)
+        XCTAssertEqual(customerIOMock.trackMetricReceivedArguments?.deviceToken, givenDeviceToken)
+    }
+}

--- a/Tests/MessagingPush/PushHandling/PushClickHandlerTest.swift
+++ b/Tests/MessagingPush/PushHandling/PushClickHandlerTest.swift
@@ -6,7 +6,7 @@ import SharedTests
 import UserNotifications
 import XCTest
 
-class PushClickHandlerTest: UnitTest {
+class PushClickHandlerTest: IntegrationTest {
     private var pushClickHandler: PushClickHandler!
 
     private let deepLinkUtilMock = DeepLinkUtilMock()
@@ -93,21 +93,5 @@ class PushClickHandlerTest: UnitTest {
         pushHistoryMock.hasHandledPushClickReturnValue = false
         pushClickHandler.pushClicked(givenPush)
         XCTAssertEqual(customerIOMock.trackMetricCallsCount, 1)
-    }
-}
-
-extension PushClickHandlerTest {
-    func getPush(content: [AnyHashable: Any], deliveryId: String = .random, deviceToken: String = .random) -> CustomerIOParsedPushPayload {
-        var content = content
-
-        // swiftlint:disable:next force_cast
-        let notificationContent = UNNotificationContent().mutableCopy() as! UNMutableNotificationContent
-
-        content["CIO-Delivery-ID"] = deliveryId
-        content["CIO-Delivery-Token"] = deviceToken
-
-        notificationContent.userInfo = content
-
-        return CustomerIOParsedPushPayload.parse(notificationContent: notificationContent, jsonAdapter: jsonAdapter)!
     }
 }

--- a/Tests/MessagingPush/PushHandling/PushClickHandlerTest.swift
+++ b/Tests/MessagingPush/PushHandling/PushClickHandlerTest.swift
@@ -10,16 +10,12 @@ class PushClickHandlerTest: IntegrationTest {
     private var pushClickHandler: PushClickHandler!
 
     private let deepLinkUtilMock = DeepLinkUtilMock()
-    private let pushHistoryMock = PushHistoryMock()
     private let customerIOMock = CustomerIOInstanceMock()
 
     override func setUp() {
         super.setUp()
 
-        // Set default values of mocks to avoid having to add to every test function.
-        pushHistoryMock.hasHandledPushClickReturnValue = false
-
-        pushClickHandler = PushClickHandlerImpl(deepLinkUtil: deepLinkUtilMock, pushHistory: pushHistoryMock, customerIO: customerIOMock)
+        pushClickHandler = PushClickHandlerImpl(deepLinkUtil: deepLinkUtilMock, customerIO: customerIOMock)
     }
 
     // MARK: pushClicked
@@ -67,31 +63,6 @@ class PushClickHandlerTest: IntegrationTest {
 
         pushClickHandler.pushClicked(givenPush)
 
-        XCTAssertEqual(customerIOMock.trackMetricCallsCount, 1)
-    }
-
-    func test_pushClicked_expectIgnoreRequestIfAlreadyHandledPush() {
-        // Note: Using push tracking as our indicator if a request is ignored
-
-        // Indicate we have already processed the push
-        pushHistoryMock.hasHandledPushReturnValue = true
-
-        let givenPush = getPush(content: [
-            "CIO": [
-                "push": [
-                    "image": "https://example.com/image.png"
-                ]
-            ]
-        ])
-
-        pushClickHandler.pushClicked(givenPush)
-
-        // Assert request was ignored
-        XCTAssertEqual(customerIOMock.trackMetricCallsCount, 0)
-
-        // To be thorough, call again and make sure assertions change as expected
-        pushHistoryMock.hasHandledPushReturnValue = false
-        pushClickHandler.pushClicked(givenPush)
         XCTAssertEqual(customerIOMock.trackMetricCallsCount, 1)
     }
 }


### PR DESCRIPTION
Fixes a bug I discovered. See [comment](https://github.com/customerio/customerio-ios/pull/438/files#r1428173254) that explains bug. 

Added automated tests to verify bug fix. 