### PR TITLE
test: fix flaky test

### DIFF
--- a/Tests/MessagingPush/MessagingPushTest.swift
+++ b/Tests/MessagingPush/MessagingPushTest.swift
@@ -18,6 +18,7 @@ class MessagignPushTest: IntegrationTest {
 
     func test_initialize_expectOnlyAbleToInitializeOnce_expectInitializeThreadSafe() {
         // Run test multiple times to ensure thread safety. To try and catch a race condition, if one will exist.
+        // I do not suggest running test < 100 times. When bugs existed because of not being thread safe, the test may have to run 50 times until it fails.
         runTest(numberOfTimes: 100) {
             let expectAllThreadsToComplete = expectation(description: "All threads should complete")
             expectAllThreadsToComplete.expectedFulfillmentCount = 2
@@ -34,7 +35,7 @@ class MessagignPushTest: IntegrationTest {
                 expectAllThreadsToComplete.fulfill()
             }
 
-            waitForExpectations()
+            waitForExpectations(1) // test may take up to 1 second to finish because it is running so many times. CI server is a less powerful machine and this test is flaky when we set wait() for < 1 second.
 
             XCTAssertEqual(automaticPushClickHandlingMock.startCallsCount, 1)
         }

--- a/Tests/MessagingPush/PushHandling/ManualPushHandlingTest.swift
+++ b/Tests/MessagingPush/PushHandling/ManualPushHandlingTest.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/Tests/MessagingPush/PushHandling/ManualPushHandlingTest.swift
+++ b/Tests/MessagingPush/PushHandling/ManualPushHandlingTest.swift
@@ -1,1 +1,0 @@
-import Foundation


### PR DESCRIPTION
I have noticed this test function is a bit flaky when running on the CI. 

CI servers are less powerful machines so having the test take a little longer to pass makes sense. 

I don't recommend running the test function less < 100 times so I thought that bumping up the `wait()` function was the best solution. I don't like making a test suite take longer to execute (by bumping the wait() time), but a test suite that sometimes catches bugs and sometimes doesn't (by decreasing the number of times the test runs) sounds worse 🤷‍♀️. 
