### PR TITLE
refactor: add debug logs to help support feature

### DIFF
--- a/Sources/MessagingPush/PushHandling/AutomaticPushClickHandling.swift
+++ b/Sources/MessagingPush/PushHandling/AutomaticPushClickHandling.swift
@@ -40,12 +40,16 @@ protocol AutomaticPushClickHandling: AutoMockable {
 // sourcery: InjectRegister = "AutomaticPushClickHandling"
 class AutomaticPushClickHandlingImpl: AutomaticPushClickHandling {
     private let pushEventListener: PushEventListener
+    private let logger: Logger
 
-    init(pushEventListener: PushEventListener) {
+    init(pushEventListener: PushEventListener, logger: Logger) {
         self.pushEventListener = pushEventListener
+        self.logger = logger
     }
 
     func start() {
+        logger.debug("Starting automatic push click handling.")
+
         pushEventListener.beginListening()
     }
 }

--- a/Sources/MessagingPush/PushHandling/iOSPushEventListener.swift
+++ b/Sources/MessagingPush/PushHandling/iOSPushEventListener.swift
@@ -21,16 +21,18 @@ class IOSPushEventListener: NSObject, PushEventListener, UNUserNotificationCente
     private var moduleConfig: MessagingPushConfigOptions
     private let pushClickHandler: PushClickHandler
     private let pushHistory: PushHistory
+    private let logger: Logger
 
     // Make sure that this proxy is held in-memory.
     private let notificationCenterDelegateProxy = NotificationCenterDelegateProxy()
 
-    init(userNotificationCenter: UserNotificationCenter, jsonAdapter: JsonAdapter, moduleConfig: MessagingPushConfigOptions, pushClickHandler: PushClickHandler, pushHistory: PushHistory) {
+    init(userNotificationCenter: UserNotificationCenter, jsonAdapter: JsonAdapter, moduleConfig: MessagingPushConfigOptions, pushClickHandler: PushClickHandler, pushHistory: PushHistory, logger: Logger) {
         self.userNotificationCenter = userNotificationCenter
         self.jsonAdapter = jsonAdapter
         self.moduleConfig = moduleConfig
         self.pushClickHandler = pushClickHandler
         self.pushHistory = pushHistory
+        self.logger = logger
     }
 
     var delegate: UNUserNotificationCenterDelegate {
@@ -54,6 +56,8 @@ class IOSPushEventListener: NSObject, PushEventListener, UNUserNotificationCente
     }
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        logger.debug("Push event: didReceive. push: \(response))")
+
         guard !pushHistory.hasHandledPush(pushEvent: .didReceive, pushId: response.pushId) else {
             // push has already been handled. exit early
             // Prevents infinite loops if our NotificationCenter delegate calls other delegates via proxy and then those nested delegates calls our delegate again.
@@ -77,6 +81,8 @@ class IOSPushEventListener: NSObject, PushEventListener, UNUserNotificationCente
     }
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        logger.debug("Push event: willPresent. push: \(notification)")
+
         guard !pushHistory.hasHandledPush(pushEvent: .willPresent, pushId: notification.pushId) else {
             // push has already been handled. exit early
             // Prevents infinite loops if our NotificationCenter delegate calls other delegates via proxy and then those nested delegates calls our delegate again.

--- a/Sources/MessagingPush/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/MessagingPush/autogenerated/AutoDependencyInjection.generated.swift
@@ -85,7 +85,7 @@ extension DIGraph {
 
     @available(iOSApplicationExtension, unavailable)
     private var newAutomaticPushClickHandling: AutomaticPushClickHandling {
-        AutomaticPushClickHandlingImpl(pushEventListener: pushEventListener)
+        AutomaticPushClickHandlingImpl(pushEventListener: pushEventListener, logger: logger)
     }
 
     // DeepLinkUtil
@@ -124,7 +124,7 @@ extension DIGraph {
 
     @available(iOSApplicationExtension, unavailable)
     private func _get_pushEventListener() -> PushEventListener {
-        IOSPushEventListener(userNotificationCenter: userNotificationCenter, jsonAdapter: jsonAdapter, moduleConfig: messagingPushConfigOptions, pushClickHandler: pushClickHandler, pushHistory: pushHistory)
+        IOSPushEventListener(userNotificationCenter: userNotificationCenter, jsonAdapter: jsonAdapter, moduleConfig: messagingPushConfigOptions, pushClickHandler: pushClickHandler, pushHistory: pushHistory, logger: logger)
     }
 
     // PushClickHandler


### PR DESCRIPTION
To help us support this feature for customers, I added debug log statements. 

These debug log statement's job is to give us enough information so we can try and reproduce a issue that the customer is experiencing. The logs are not meant to document every line of code executed within this feature. 

Besides the logs added in this PR, a debug log entry already exists when a new UNUserNotificationCenterDelegate gets set on the host app. All of these debug statements combined are the most helpful debug statements I can think of at this time. 
