### PR TITLE
refactor: setup apn sample app to test local push

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
@@ -101,10 +101,10 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         )
     }
 
-    // For testing purposes, it's suggested to not include the willPresent function in the AppDelegate.
-    // The automatic push click handling feature uses swizzling. A good edge case to test with swizzling is when
-    // there is an optional function of UNUserNotificationCenterDelegate not implemented. By not including willPresent, we are able to test this case.
-//    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+    // To test sending of local notifications, display the push while app in foreground. So when you press the button to display local push in the app, you are able to see it and click on it.
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler([.banner, .badge, .sound])
+    }
 }
 
 // In-app event listeners to handle user's response to in-app messages.

--- a/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
@@ -99,6 +99,8 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             name: "push clicked",
             data: ["push": response.notification.request.content.userInfo]
         )
+
+        completionHandler()
     }
 
     // To test sending of local notifications, display the push while app in foreground. So when you press the button to display local push in the app, you are able to see it and click on it.

--- a/Apps/APN-UIKit/APN UIKit/Base.lproj/Main.storyboard
+++ b/Apps/APN-UIKit/APN UIKit/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="37F-6d-U3o">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="37F-6d-U3o">
     <device id="retina6_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -154,13 +154,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="What would you like to test?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gm6-Cg-tg6">
-                                <rect key="frame" x="10" y="190.66666666666666" width="394" height="27.333333333333343"/>
+                                <rect key="frame" x="10" y="157.66666666666666" width="394" height="27.333333333333343"/>
                                 <fontDescription key="fontDescription" name="Avenir-Book" family="Avenir" pointSize="20"/>
                                 <color key="textColor" red="0.24313725489999999" green="0.24313725489999999" blue="0.24313725489999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalCentering" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="AIH-WX-Xne">
-                                <rect key="frame" x="20" y="258" width="374" height="380"/>
+                                <rect key="frame" x="20" y="225" width="374" height="446"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yOE-0O-ICW" customClass="ThemeButton" customModule="APN_UIKit" customModuleProvider="target">
                                         <rect key="frame" x="94.666666666666686" y="0.0" width="185" height="50"/>
@@ -228,8 +228,21 @@
                                             <action selector="showPushPrompt:" destination="0ax-47-4zI" eventType="touchUpInside" id="Snq-qE-ynP"/>
                                         </connections>
                                     </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QCc-aF-w6r" userLabel="Send local push" customClass="ThemeButton" customModule="APN_UIKit" customModuleProvider="target">
+                                        <rect key="frame" x="94.666666666666686" y="338" width="185" height="34.333333333333314"/>
+                                        <color key="backgroundColor" red="0.23529411759999999" green="0.26274509800000001" blue="0.49019607840000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="185" id="nRx-fT-Ki2"/>
+                                        </constraints>
+                                        <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="Send Local Push"/>
+                                        <connections>
+                                            <action selector="send3rdPartyPush:" destination="0ax-47-4zI" eventType="touchUpInside" id="DR5-oa-iJr"/>
+                                        </connections>
+                                    </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gSy-pH-Zuu" customClass="ThemeButton" customModule="APN_UIKit" customModuleProvider="target">
-                                        <rect key="frame" x="94.666666666666686" y="330" width="185" height="50"/>
+                                        <rect key="frame" x="94.666666666666686" y="396" width="185" height="50"/>
                                         <color key="backgroundColor" red="0.23529411759999999" green="0.26274509800000001" blue="0.49019607840000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <constraints>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="185" id="uv2-HN-pr3"/>
@@ -258,7 +271,7 @@
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="What would you like to test?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mIk-22-9js">
-                                <rect key="frame" x="10" y="163.33333333333334" width="394" height="27.333333333333343"/>
+                                <rect key="frame" x="10" y="130.33333333333334" width="394" height="27.333333333333343"/>
                                 <fontDescription key="fontDescription" name="Avenir-Heavy" family="Avenir" pointSize="20"/>
                                 <color key="textColor" red="0.24313725489999999" green="0.24313725489999999" blue="0.24313725489999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <nil key="highlightedColor"/>

--- a/Apps/APN-UIKit/APN UIKit/View/DashboardViewController.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/DashboardViewController.swift
@@ -143,4 +143,13 @@ class DashboardViewController: BaseViewController {
             }
         }
     }
+
+    @IBAction func send3rdPartyPush(_ sender: UIButton) {
+        // Display a local push notification on the system. This will test compatability when a push is clicked that was not sent by Customer.io.
+        let content = UNMutableNotificationContent()
+        content.title = "local push"
+        content.body = "Try clicking me and see host app handle the push instead of Customer.io SDK"
+        let request = UNNotificationRequest(identifier: "local-push-not-from-cio", content: content, trigger: nil)
+        UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
+    }
 }

--- a/Apps/CocoaPods-FCM/src/AppDelegate.swift
+++ b/Apps/CocoaPods-FCM/src/AppDelegate.swift
@@ -69,6 +69,8 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             name: "push clicked",
             data: ["push": response.notification.request.content.userInfo]
         )
+
+        completionHandler()
     }
 
     // For testing purposes, it's suggested to not include the willPresent function in the AppDelegate.

--- a/Sources/Common/Util/KeyValueStorageKey.swift
+++ b/Sources/Common/Util/KeyValueStorageKey.swift
@@ -7,6 +7,4 @@ public enum KeyValueStorageKey: String {
     case identifiedProfileId
     case pushDeviceToken
     case httpRequestsPauseEnds
-    case pushNotificationsHandledDidReceive
-    case pushNotificationsHandledWillPresent
 }

--- a/Sources/MessagingPush/Extensions/NotificationCenterExtensions.swift
+++ b/Sources/MessagingPush/Extensions/NotificationCenterExtensions.swift
@@ -19,6 +19,10 @@ extension UNNotificationResponse {
     var pushId: String {
         notification.pushId
     }
+
+    var pushDeliveryDate: Date {
+        notification.date
+    }
 }
 
 extension UNNotification {

--- a/Sources/MessagingPush/PushHandling/iOSPushEventListener.swift
+++ b/Sources/MessagingPush/PushHandling/iOSPushEventListener.swift
@@ -126,9 +126,17 @@ class iOSPushEventListener: NSObject, PushEventListener, UNUserNotificationCente
         }
         logger?.debug("Push event: didReceive. push: \(response))")
 
-        guard !pushHistory.hasHandledPush(pushEvent: .didReceive, pushId: response.pushId) else {
+        guard !pushHistory.hasHandledPush(pushEvent: .didReceive, pushId: response.pushId, pushDeliveryDate: response.pushDeliveryDate) else {
             // push has already been handled. exit early
-            // Prevents infinite loops if our NotificationCenter delegate calls other delegates via proxy and then those nested delegates calls our delegate again.
+
+            /*
+             Some 3rd party SDKs (such as FCM SDK) have an implementation of swizzling that can create an infinite loop with our notification center proxy. We keep a history of push notifications that have been handled to prevent this infinite loop.
+
+             Example scenario of infinite loop:
+             - This `userNotificationCenter(didReceive:)` function gets called by OS when a push is clicked.
+             - Our notification center proxy calls the FCM SDK’s `userNotificationCenter(didReceive:)` function. FCM's swizzling implementation involves making a call back to the host app's current UserNotificationCenter.delegate (which is our SDK). See code: https://github.com/firebase/firebase-ios-sdk/blob/5890db966963fd76cfd020d68c0067a7741bef06/FirebaseMessaging/Sources/FIRMessagingRemoteNotificationsProxy.m#L498-L504
+             ... this call to the host app's current delegate means that this function is called again. Once this function is called again, we have gotten into an infinite loop.
+             */
             return
         }
 
@@ -140,6 +148,8 @@ class iOSPushEventListener: NSObject, PushEventListener, UNUserNotificationCente
 
             return
         }
+
+        logger?.debug("Push came from CIO. Handle the didReceive event on behalf of the customer.")
 
         if response.didClickOnPush {
             pushClickHandler.pushClicked(parsedPush)
@@ -157,9 +167,10 @@ class iOSPushEventListener: NSObject, PushEventListener, UNUserNotificationCente
         }
         logger?.debug("Push event: willPresent. push: \(notification)")
 
-        guard !pushHistory.hasHandledPush(pushEvent: .willPresent, pushId: notification.pushId) else {
+        guard !pushHistory.hasHandledPush(pushEvent: .willPresent, pushId: notification.pushId, pushDeliveryDate: notification.date) else {
             // push has already been handled. exit early
-            // Prevents infinite loops if our NotificationCenter delegate calls other delegates via proxy and then those nested delegates calls our delegate again.
+
+            // See notes in didReceive function to learn more about this logic of exiting early when we already have handled a push.
             return
         }
 
@@ -172,9 +183,9 @@ class iOSPushEventListener: NSObject, PushEventListener, UNUserNotificationCente
             return
         }
 
-        // Push came from CIO. Handle the push on behalf of the customer.
-        // Make sure to call completionHandler() so the customer does not need to.
+        logger?.debug("Push came from CIO. Handle the willPresent event on behalf of the customer.")
 
+        // Make sure to call completionHandler() so the customer does not need to.
         if moduleConfig.showPushAppInForeground {
             // Tell the OS to show the push while app in foreground using 1 of the below options, depending on version of OS
             if #available(iOS 14.0, *) {

--- a/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
@@ -630,9 +630,9 @@ class PushHistoryMock: PushHistory, Mock {
     }
 
     /// The arguments from the *last* time the function was called.
-    private(set) var hasHandledPushReceivedArguments: (pushEvent: PushHistoryEvent, pushId: String)?
+    private(set) var hasHandledPushReceivedArguments: (pushEvent: PushHistoryEvent, pushId: String, pushDeliveryDate: Date)?
     /// Arguments from *all* of the times that the function was called.
-    private(set) var hasHandledPushReceivedInvocations: [(pushEvent: PushHistoryEvent, pushId: String)] = []
+    private(set) var hasHandledPushReceivedInvocations: [(pushEvent: PushHistoryEvent, pushId: String, pushDeliveryDate: Date)] = []
     /// Value to return from the mocked function.
     var hasHandledPushReturnValue: Bool!
     /**
@@ -640,15 +640,15 @@ class PushHistoryMock: PushHistory, Mock {
      The closure has first priority to return a value for the mocked function. If the closure returns `nil`,
      then the mock will attempt to return the value for `hasHandledPushReturnValue`
      */
-    var hasHandledPushClosure: ((PushHistoryEvent, String) -> Bool)?
+    var hasHandledPushClosure: ((PushHistoryEvent, String, Date) -> Bool)?
 
-    /// Mocked function for `hasHandledPush(pushEvent: PushHistoryEvent, pushId: String)`. Your opportunity to return a mocked value and check result of mock in test code.
-    func hasHandledPush(pushEvent: PushHistoryEvent, pushId: String) -> Bool {
+    /// Mocked function for `hasHandledPush(pushEvent: PushHistoryEvent, pushId: String, pushDeliveryDate: Date)`. Your opportunity to return a mocked value and check result of mock in test code.
+    func hasHandledPush(pushEvent: PushHistoryEvent, pushId: String, pushDeliveryDate: Date) -> Bool {
         mockCalled = true
         hasHandledPushCallsCount += 1
-        hasHandledPushReceivedArguments = (pushEvent: pushEvent, pushId: pushId)
-        hasHandledPushReceivedInvocations.append((pushEvent: pushEvent, pushId: pushId))
-        return hasHandledPushClosure.map { $0(pushEvent, pushId) } ?? hasHandledPushReturnValue
+        hasHandledPushReceivedArguments = (pushEvent: pushEvent, pushId: pushId, pushDeliveryDate: pushDeliveryDate)
+        hasHandledPushReceivedInvocations.append((pushEvent: pushEvent, pushId: pushId, pushDeliveryDate: pushDeliveryDate))
+        return hasHandledPushClosure.map { $0(pushEvent, pushId, pushDeliveryDate) } ?? hasHandledPushReturnValue
     }
 }
 


### PR DESCRIPTION
The APN sample app currently does not have a way to test 3rd party click handlers are called. The FCM sample apps all do as well as RN APN and Expo APN. This is the last app that needs a way to test this. 

I added a new button to the UI of the app that when you press it, it displays a local push notification on the device that you can click on. When you click it, you should see that the `AppDelegate` click handler callback functions get called to handle this push getting clicked. 

For FCM sample apps, we can use [firebase console](https://console.firebase.google.com/u/0/project/remote-habits/notification/compose) to send a FCM push that is not sent from CIO for testing. For APN, a tool like that does not exist. We instead use local push to test pushes sent not from CIO. 