### PR TITLE
fix: add support for local notifications

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
@@ -99,6 +99,8 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             name: "push clicked",
             data: ["push": response.notification.request.content.userInfo]
         )
+
+        completionHandler()
     }
 
     // To test sending of local notifications, display the push while app in foreground. So when you press the button to display local push in the app, you are able to see it and click on it.

--- a/Apps/CocoaPods-FCM/src/AppDelegate.swift
+++ b/Apps/CocoaPods-FCM/src/AppDelegate.swift
@@ -69,6 +69,8 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             name: "push clicked",
             data: ["push": response.notification.request.content.userInfo]
         )
+
+        completionHandler()
     }
 
     // For testing purposes, it's suggested to not include the willPresent function in the AppDelegate.

--- a/Sources/Common/Util/KeyValueStorageKey.swift
+++ b/Sources/Common/Util/KeyValueStorageKey.swift
@@ -7,6 +7,4 @@ public enum KeyValueStorageKey: String {
     case identifiedProfileId
     case pushDeviceToken
     case httpRequestsPauseEnds
-    case pushNotificationsHandledDidReceive
-    case pushNotificationsHandledWillPresent
 }

--- a/Sources/MessagingPush/Extensions/NotificationCenterExtensions.swift
+++ b/Sources/MessagingPush/Extensions/NotificationCenterExtensions.swift
@@ -19,6 +19,10 @@ extension UNNotificationResponse {
     var pushId: String {
         notification.pushId
     }
+
+    var pushDeliveryDate: Date {
+        notification.date
+    }
 }
 
 extension UNNotification {

--- a/Sources/MessagingPush/PushHandling/iOSPushEventListener.swift
+++ b/Sources/MessagingPush/PushHandling/iOSPushEventListener.swift
@@ -128,7 +128,15 @@ class iOSPushEventListener: NSObject, PushEventListener, UNUserNotificationCente
 
         guard !pushHistory.hasHandledPush(pushEvent: .didReceive, pushId: response.pushId, pushDeliveryDate: response.pushDeliveryDate) else {
             // push has already been handled. exit early
-            // Prevents infinite loops if our NotificationCenter delegate calls other delegates via proxy and then those nested delegates calls our delegate again.
+
+            /*
+             Some 3rd party SDKs (such as FCM SDK) have an implementation of swizzling that can create an infinite loop with our notification center proxy. We keep a history of push notifications that have been handled to prevent this infinite loop.
+
+             Example scenario of infinite loop:
+             - This `userNotificationCenter(didReceive:)` function gets called by OS when a push is clicked.
+             - Our notification center proxy calls the FCM SDK’s `userNotificationCenter(didReceive:)` function. FCM's swizzling implementation involves making a call back to the host app's current UserNotificationCenter.delegate (which is our SDK). See code: https://github.com/firebase/firebase-ios-sdk/blob/5890db966963fd76cfd020d68c0067a7741bef06/FirebaseMessaging/Sources/FIRMessagingRemoteNotificationsProxy.m#L498-L504
+             ... this call to the host app's current delegate means that this function is called again. Once this function is called again, we have gotten into an infinite loop.
+             */
             return
         }
 
@@ -140,6 +148,8 @@ class iOSPushEventListener: NSObject, PushEventListener, UNUserNotificationCente
 
             return
         }
+
+        logger?.debug("Push came from CIO. Handle the didReceive event on behalf of the customer.")
 
         if response.didClickOnPush {
             pushClickHandler.pushClicked(parsedPush)
@@ -159,7 +169,8 @@ class iOSPushEventListener: NSObject, PushEventListener, UNUserNotificationCente
 
         guard !pushHistory.hasHandledPush(pushEvent: .willPresent, pushId: notification.pushId, pushDeliveryDate: notification.date) else {
             // push has already been handled. exit early
-            // Prevents infinite loops if our NotificationCenter delegate calls other delegates via proxy and then those nested delegates calls our delegate again.
+
+            // See notes in didReceive function to learn more about this logic of exiting early when we already have handled a push.
             return
         }
 
@@ -172,9 +183,9 @@ class iOSPushEventListener: NSObject, PushEventListener, UNUserNotificationCente
             return
         }
 
-        // Push came from CIO. Handle the push on behalf of the customer.
-        // Make sure to call completionHandler() so the customer does not need to.
+        logger?.debug("Push came from CIO. Handle the willPresent event on behalf of the customer.")
 
+        // Make sure to call completionHandler() so the customer does not need to.
         if moduleConfig.showPushAppInForeground {
             // Tell the OS to show the push while app in foreground using 1 of the below options, depending on version of OS
             if #available(iOS 14.0, *) {

--- a/Sources/MessagingPush/PushHandling/iOSPushEventListener.swift
+++ b/Sources/MessagingPush/PushHandling/iOSPushEventListener.swift
@@ -126,7 +126,7 @@ class iOSPushEventListener: NSObject, PushEventListener, UNUserNotificationCente
         }
         logger?.debug("Push event: didReceive. push: \(response))")
 
-        guard !pushHistory.hasHandledPush(pushEvent: .didReceive, pushId: response.pushId) else {
+        guard !pushHistory.hasHandledPush(pushEvent: .didReceive, pushId: response.pushId, pushDeliveryDate: response.pushDeliveryDate) else {
             // push has already been handled. exit early
             // Prevents infinite loops if our NotificationCenter delegate calls other delegates via proxy and then those nested delegates calls our delegate again.
             return
@@ -157,7 +157,7 @@ class iOSPushEventListener: NSObject, PushEventListener, UNUserNotificationCente
         }
         logger?.debug("Push event: willPresent. push: \(notification)")
 
-        guard !pushHistory.hasHandledPush(pushEvent: .willPresent, pushId: notification.pushId) else {
+        guard !pushHistory.hasHandledPush(pushEvent: .willPresent, pushId: notification.pushId, pushDeliveryDate: notification.date) else {
             // push has already been handled. exit early
             // Prevents infinite loops if our NotificationCenter delegate calls other delegates via proxy and then those nested delegates calls our delegate again.
             return

--- a/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
@@ -630,9 +630,9 @@ class PushHistoryMock: PushHistory, Mock {
     }
 
     /// The arguments from the *last* time the function was called.
-    private(set) var hasHandledPushReceivedArguments: (pushEvent: PushHistoryEvent, pushId: String)?
+    private(set) var hasHandledPushReceivedArguments: (pushEvent: PushHistoryEvent, pushId: String, pushDeliveryDate: Date)?
     /// Arguments from *all* of the times that the function was called.
-    private(set) var hasHandledPushReceivedInvocations: [(pushEvent: PushHistoryEvent, pushId: String)] = []
+    private(set) var hasHandledPushReceivedInvocations: [(pushEvent: PushHistoryEvent, pushId: String, pushDeliveryDate: Date)] = []
     /// Value to return from the mocked function.
     var hasHandledPushReturnValue: Bool!
     /**
@@ -640,15 +640,15 @@ class PushHistoryMock: PushHistory, Mock {
      The closure has first priority to return a value for the mocked function. If the closure returns `nil`,
      then the mock will attempt to return the value for `hasHandledPushReturnValue`
      */
-    var hasHandledPushClosure: ((PushHistoryEvent, String) -> Bool)?
+    var hasHandledPushClosure: ((PushHistoryEvent, String, Date) -> Bool)?
 
-    /// Mocked function for `hasHandledPush(pushEvent: PushHistoryEvent, pushId: String)`. Your opportunity to return a mocked value and check result of mock in test code.
-    func hasHandledPush(pushEvent: PushHistoryEvent, pushId: String) -> Bool {
+    /// Mocked function for `hasHandledPush(pushEvent: PushHistoryEvent, pushId: String, pushDeliveryDate: Date)`. Your opportunity to return a mocked value and check result of mock in test code.
+    func hasHandledPush(pushEvent: PushHistoryEvent, pushId: String, pushDeliveryDate: Date) -> Bool {
         mockCalled = true
         hasHandledPushCallsCount += 1
-        hasHandledPushReceivedArguments = (pushEvent: pushEvent, pushId: pushId)
-        hasHandledPushReceivedInvocations.append((pushEvent: pushEvent, pushId: pushId))
-        return hasHandledPushClosure.map { $0(pushEvent, pushId) } ?? hasHandledPushReturnValue
+        hasHandledPushReceivedArguments = (pushEvent: pushEvent, pushId: pushId, pushDeliveryDate: pushDeliveryDate)
+        hasHandledPushReceivedInvocations.append((pushEvent: pushEvent, pushId: pushId, pushDeliveryDate: pushDeliveryDate))
+        return hasHandledPushClosure.map { $0(pushEvent, pushId, pushDeliveryDate) } ?? hasHandledPushReturnValue
     }
 }
 


### PR DESCRIPTION
This PR [as well as APN sample app setup PR](https://github.com/customerio/customerio-ios/pull/443) adds support for local push notifications [to the reliable opened push metrics feature](https://github.com/customerio/issues/issues/11289). 

The current implementation has a bug that could make handling local push notifications not work. 

### Expected behavior of the SDK 

* Local push notification with a hard-coded/non-unique identifier is displayed on the device. 
* Push gets clicked. 
* Host app is able to handle that local push getting clicked. 

### Actual behavior 

* Local push notification with a hard-coded/non-unique identifier is displayed on the device. 
* Push gets clicked. 
* Host app is able to handle that local push getting clicked *one time*. 
* If you try and display the local push 2+ times and click on it, the host app will not get a callback to handle the push getting clicked. 

# The solution  

This PR fixes this bug by storing the push ID *and* the date that the push request was sent to the device. Previously, the SDK was only using the push ID which may be hard-coded and not unique. By also using the date, we can feel more confident that a local push with the same push ID can be handled 2+ times. 

I also switched the push history implementation to in-memory instead of persistent. Having an in-memory store is easier to maintain in the future since it can get re-created when app killed. The push history store's purpose is to prevent infinite loops from occurring. I cannot think of a scenario where we need to persist the pushes handled between app launches. 