### PR TITLE
chore: metric event name update

### DIFF
--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -227,8 +227,7 @@ class DataPipelineImplementation: DataPipelineInstance {
             properties["recipient"] = token
         }
 
-        // TODO: [CDP] Reverify event name before going live
-        analytics.track(name: "Journeys Delivery Metric", properties: properties)
+        analytics.track(name: "Report Delivery Event", properties: properties)
     }
 }
 
@@ -326,8 +325,7 @@ extension DataPipelineImplementation {
             "deliveryId": deliveryId,
             "recipient": token
         ])
-        // TODO: [CDP] Reverify event name before going live
-        var trackPushMetricEvent = TrackEvent(event: "Journeys Delivery Metric", properties: try? JSON(properties))
+        var trackPushMetricEvent = TrackEvent(event: "Report Delivery Event", properties: try? JSON(properties))
         trackPushMetricEvent.timestamp = timestamp
         analytics.process(event: trackPushMetricEvent)
     }


### PR DESCRIPTION
helps: https://github.com/customerio/issues/issues/11609

### Changes

- Updated track metric event name from `Journeys Delivery Metric` to `Report Delivery Event`, the payload remains the same ([slack thread](https://customerio.slack.com/archives/C01QYDKD0SU/p1702680918308849))
- Removed TODO as the name has been confirmed