### PR TITLE
chore: moved migration code to helper

### DIFF
--- a/Sources/Tracking/CustomerIO.swift
+++ b/Sources/Tracking/CustomerIO.swift
@@ -40,11 +40,12 @@ public extension CustomerIO {
             configureHandler(&sdkConfig)
         }
 
-        let newDiGraph = DIGraph(sdkConfig: sdkConfig)
-        let implementation = CustomerIOImplementation(diGraph: newDiGraph)
+        let implementation = DataPipeline.initialize(moduleConfig: DataPipelineConfigOptions.Factory.create(sdkConfig: sdkConfig))
 
         // Check if any unprocessed tasks are pending in the background queue.
-        implementation.handleQueueBacklog()
+        let newDiGraph = DIGraph(sdkConfig: sdkConfig)
+        let migrationAssistant = newDiGraph.analyticsMigrationAssistant
+        migrationAssistant.handleQueueBacklog()
 
         initializeSharedInstance(with: implementation, diGraph: newDiGraph)
 
@@ -71,15 +72,17 @@ public extension CustomerIO {
             configureHandler(&newSdkConfig)
         }
 
-        let newDiGraph = DIGraph(sdkConfig: newSdkConfig.toSdkConfig())
-        let implementation = CustomerIOImplementation(diGraph: newDiGraph)
+        let sdkConfig = newSdkConfig.toSdkConfig()
+        let newDiGraph = DIGraph(sdkConfig: sdkConfig)
+        let implementation = DataPipeline.initialize(moduleConfig: DataPipelineConfigOptions.Factory.create(sdkConfig: sdkConfig))
 
         initializeSharedInstance(with: implementation, diGraph: newDiGraph)
     }
 
     // Initialize for Integration Tests
     static func initializeIntegrationTests(diGraph: DIGraph) {
-        let implementation = CustomerIOImplementation(diGraph: diGraph)
-        initializeSharedInstance(with: implementation, diGraph: diGraph)
+        // FIXME: [CDP] Fix tests using DataPipeline
+        // let implementation = CustomerIOImplementation(diGraph: diGraph)
+        // initializeSharedInstance(with: implementation, diGraph: diGraph)
     }
 }

--- a/Sources/Tracking/CustomerIO.swift
+++ b/Sources/Tracking/CustomerIO.swift
@@ -44,7 +44,7 @@ public extension CustomerIO {
 
         // Check if any unprocessed tasks are pending in the background queue.
         let newDiGraph = DIGraph(sdkConfig: sdkConfig)
-        let migrationAssistant = newDiGraph.analyticsMigrationAssistant
+        let migrationAssistant = newDiGraph.dataPipelineMigrationAssistant
         migrationAssistant.handleQueueBacklog()
 
         initializeSharedInstance(with: implementation, diGraph: newDiGraph)

--- a/Sources/Tracking/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/Tracking/autogenerated/AutoDependencyInjection.generated.swift
@@ -54,34 +54,34 @@ extension DIGraph {
     func testDependenciesAbleToResolve() -> Int {
         var countDependenciesResolved = 0
 
-        _ = analyticsMigrationAssistant
+        _ = dataPipelineMigrationAssistant
         countDependenciesResolved += 1
 
         return countDependenciesResolved
     }
 
-    // AnalyticsMigrationAssistant (singleton)
-    var analyticsMigrationAssistant: AnalyticsMigrationAssistant {
+    // DataPipelineMigrationAssistant (singleton)
+    var dataPipelineMigrationAssistant: DataPipelineMigrationAssistant {
         getOverriddenInstance() ??
-            sharedAnalyticsMigrationAssistant
+            sharedDataPipelineMigrationAssistant
     }
 
-    var sharedAnalyticsMigrationAssistant: AnalyticsMigrationAssistant {
+    var sharedDataPipelineMigrationAssistant: DataPipelineMigrationAssistant {
         // Use a DispatchQueue to make singleton thread safe. You must create unique dispatchqueues instead of using 1 shared one or you will get a crash when trying
         // to call DispatchQueue.sync{} while already inside another DispatchQueue.sync{} call.
-        DispatchQueue(label: "DIGraph_AnalyticsMigrationAssistant_singleton_access").sync {
-            if let overridenDep: AnalyticsMigrationAssistant = getOverriddenInstance() {
+        DispatchQueue(label: "DIGraph_DataPipelineMigrationAssistant_singleton_access").sync {
+            if let overridenDep: DataPipelineMigrationAssistant = getOverriddenInstance() {
                 return overridenDep
             }
-            let existingSingletonInstance = self.singletons[String(describing: AnalyticsMigrationAssistant.self)] as? AnalyticsMigrationAssistant
-            let instance = existingSingletonInstance ?? _get_analyticsMigrationAssistant()
-            self.singletons[String(describing: AnalyticsMigrationAssistant.self)] = instance
+            let existingSingletonInstance = self.singletons[String(describing: DataPipelineMigrationAssistant.self)] as? DataPipelineMigrationAssistant
+            let instance = existingSingletonInstance ?? _get_dataPipelineMigrationAssistant()
+            self.singletons[String(describing: DataPipelineMigrationAssistant.self)] = instance
             return instance
         }
     }
 
-    private func _get_analyticsMigrationAssistant() -> AnalyticsMigrationAssistant {
-        AnalyticsMigrationAssistant(logger: logger, queue: queue, jsonAdapter: jsonAdapter, threadUtil: threadUtil)
+    private func _get_dataPipelineMigrationAssistant() -> DataPipelineMigrationAssistant {
+        DataPipelineMigrationAssistant(logger: logger, queue: queue, jsonAdapter: jsonAdapter, threadUtil: threadUtil)
     }
 }
 

--- a/Sources/Tracking/migration/AnalyticsMigrationAssistant.swift
+++ b/Sources/Tracking/migration/AnalyticsMigrationAssistant.swift
@@ -2,129 +2,29 @@ import CioDataPipelines
 import CioInternalCommon
 import Foundation
 
-/**
- Because of `CustomerIO.shared` being a singleton API, there is always a use-case
- of calling any of the public functions on `CustomerIO` class *before* the SDK has
- been initialized. To make this use case easy to handle, we separate the logic of
- the CustomerIO class into this class. Therefore, it's assumed that as long as
- there is an instance of `CustomerIOImplementation` present, the SDK has been
- initialized successfully.
- */
-// TODO: revisit if its still needed at the end
-class CustomerIOImplementation: CustomerIOInstance {
-    public var siteId: String? {
-        sdkConfig.siteId
-    }
-
+// sourcery: InjectRegister = "AnalyticsMigrationAssistant"
+// sourcery: InjectSingleton
+class AnalyticsMigrationAssistant {
+    private let logger: Logger
     private let backgroundQueue: Queue
     private let jsonAdapter: JsonAdapter
-    private var profileStore: ProfileStore
-    private let logger: Logger
-    private var globalDataStore: GlobalDataStore
-    private let sdkConfig: SdkConfig
     private let threadUtil: ThreadUtil
-
-    static var autoScreenViewBody: (() -> [String: Any])?
 
     /**
      Constructor for singleton, only.
 
      Try loading the credentials previously saved for the singleton instance.
      */
-    init(diGraph: DIGraph) {
-        self.backgroundQueue = diGraph.queue
-        self.jsonAdapter = diGraph.jsonAdapter
-        self.profileStore = diGraph.profileStore
-        self.logger = diGraph.logger
-        self.globalDataStore = diGraph.globalDataStore
-        self.sdkConfig = diGraph.sdkConfig
-        self.threadUtil = diGraph.threadUtil
-        DataPipeline.initialize(moduleConfig: DataPipelineConfigOptions.Factory.create(sdkConfig: sdkConfig))
-    }
-
-    public var config: SdkConfig? {
-        sdkConfig
-    }
-
-    public var profileAttributes: [String: Any] {
-        get { DataPipeline.shared.profileAttributes }
-        set { DataPipeline.shared.profileAttributes = newValue }
-    }
-
-    public var deviceAttributes: [String: Any] {
-        get { DataPipeline.shared.deviceAttributes }
-        set { DataPipeline.shared.deviceAttributes = newValue }
-    }
-
-    public var registeredDeviceToken: String? {
-        DataPipeline.shared.registeredDeviceToken
-    }
-
-    public func identify<RequestBody: Codable>(
-        identifier: String,
-        body: RequestBody
+    init(
+        logger: Logger,
+        queue: Queue,
+        jsonAdapter: JsonAdapter,
+        threadUtil: ThreadUtil
     ) {
-        DataPipeline.shared.identify(identifier: identifier, body: body)
-    }
-
-    public func identify(body: Codable) {
-        DataPipeline.shared.identify(body: body)
-    }
-
-    public func identify(identifier: String, body: [String: Any]) {
-        DataPipeline.shared.identify(identifier: identifier, body: body)
-    }
-
-    public func clearIdentify() {
-        DataPipeline.shared.clearIdentify()
-    }
-
-    public func track<RequestBody: Codable>(
-        name: String,
-        data: RequestBody?
-    ) {
-        DataPipeline.shared.track(name: name, data: data)
-    }
-
-    public func track(name: String, data: [String: Any]) {
-        DataPipeline.shared.track(name: name, data: data)
-    }
-
-    public func screen(name: String, data: [String: Any]) {
-        DataPipeline.shared.screen(name: name, data: data)
-    }
-
-    public func screen<RequestBody: Codable>(
-        name: String,
-        data: RequestBody
-    ) {
-        DataPipeline.shared.screen(name: name, data: data)
-    }
-
-    /**
-     Register a new device token with Customer.io, associated with the current active customer. If there
-     is no active customer, this will fail to register the device
-     */
-    public func registerDeviceToken(_ deviceToken: String) {
-        DataPipeline.shared.registerDeviceToken(deviceToken)
-    }
-
-    /**
-     Delete the currently registered device token
-     */
-    public func deleteDeviceToken() {
-        DataPipeline.shared.deleteDeviceToken()
-    }
-
-    /**
-     Track a push metric
-     */
-    public func trackMetric(
-        deliveryID: String,
-        event: Metric,
-        deviceToken: String
-    ) {
-        DataPipeline.shared.trackMetric(deliveryID: deliveryID, event: event, deviceToken: deviceToken)
+        self.logger = logger
+        self.backgroundQueue = queue
+        self.jsonAdapter = jsonAdapter
+        self.threadUtil = threadUtil
     }
 
     func handleQueueBacklog() {

--- a/Sources/Tracking/migration/AnalyticsMigrationAssistant.swift
+++ b/Sources/Tracking/migration/AnalyticsMigrationAssistant.swift
@@ -4,6 +4,7 @@ import Foundation
 
 // sourcery: InjectRegister = "AnalyticsMigrationAssistant"
 // sourcery: InjectSingleton
+/// Responsible for handling migration of pending tasks from `Tracking` module to `DataPipeline` module.
 class AnalyticsMigrationAssistant {
     private let logger: Logger
     private let backgroundQueue: Queue

--- a/Sources/Tracking/migration/DataPipelineMigrationAssistant.swift
+++ b/Sources/Tracking/migration/DataPipelineMigrationAssistant.swift
@@ -2,10 +2,10 @@ import CioDataPipelines
 import CioInternalCommon
 import Foundation
 
-// sourcery: InjectRegister = "AnalyticsMigrationAssistant"
+// sourcery: InjectRegister = "DataPipelineMigrationAssistant"
 // sourcery: InjectSingleton
 /// Responsible for handling migration of pending tasks from `Tracking` module to `DataPipeline` module.
-class AnalyticsMigrationAssistant {
+class DataPipelineMigrationAssistant {
     private let logger: Logger
     private let backgroundQueue: Queue
     private let jsonAdapter: JsonAdapter


### PR DESCRIPTION
### Changes

- Updated shared implementation instance to refer `DataPipeline.shared` directly
- Removed `CustomerIOImplementation` class
- Introduced `DataPipelineMigrationAssistant` class to hold all migration related code for CIO customers migrating to newer releases