### PR TITLE
fix: app crash on identify method

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/View/LoginViewController.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/LoginViewController.swift
@@ -94,11 +94,7 @@ class LoginViewController: BaseViewController {
         }
         storage.userEmailId = emailId
         loginRouter?.routeToDashboard()
-        guard let data = body else {
-            CustomerIO.shared.identify(identifier: emailId)
-            return
-        }
-        CustomerIO.shared.identify(identifier: emailId, body: data)
+        CustomerIO.shared.identify(identifier: emailId, body: body)
     }
 
     @objc func settingsTapped() {

--- a/Sources/Common/CustomerIOInstance.swift
+++ b/Sources/Common/CustomerIOInstance.swift
@@ -232,6 +232,18 @@ public class CustomerIO: CustomerIOInstance {
         identifier: String,
         body: RequestBody
     ) {
+        // This code handles a specific scenario where a user
+        // unexpectedly provides a `nil` value for the RequestBody
+        // parameter, which the method isn't designed to handle directly.
+        // To prevent errors and ensure compatibility, this condition checks
+        // if the `body` is `nil`. If it is, it substitutes it with an
+        // EmptyRequestBody() object before passing it along to the
+        // identify(). This replacement safeguards against possible
+        // issues that could arise(eg. app crash). While the `identify`
+        // method itself provide polymorphic capabilities to handle `nil`,
+        // this specific check within this method offers an additional
+        // layer of protection and clarity for this case.
+        // (refer https://github.com/customerio/customerio-ios/blob/94cbf686c3c2a405534cfe908f7166558a3e0b5d/Sources/Tracking/CustomerIO.swift#L71-L75)
         if let optionalValue = body as? Any?, optionalValue == nil {
             implementation?.identify(identifier: identifier, body: EmptyRequestBody())
             return

--- a/Sources/Common/CustomerIOInstance.swift
+++ b/Sources/Common/CustomerIOInstance.swift
@@ -232,6 +232,10 @@ public class CustomerIO: CustomerIOInstance {
         identifier: String,
         body: RequestBody
     ) {
+        if let optionalValue = body as? Any?, optionalValue == nil {
+            implementation?.identify(identifier: identifier, body: EmptyRequestBody())
+            return
+        }
         implementation?.identify(identifier: identifier, body: body)
     }
 


### PR DESCRIPTION
This PR fixes the following scenario: 
Sample app was crashing in a scenario where the user sends `nil` value for body in `identify` method. The specific use case is when a user clicks `Generate Random Login` and attempts to login without a body. 

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After code reviews are approved and you determine this PR is ready to merge, select *Squash and Merge* button on this screen, leave the title and description to the default values, then merge the PR.
