### PR TITLE
chore: data pipeline tests base setup

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -81,6 +81,9 @@ let package = Package(
         .target(name: "CioDataPipelines",
                 dependencies: ["CioInternalCommon", .product(name: "Segment", package: "Segment")],
                 path: "Sources/DataPipeline"),
+        .testTarget(name: "DataPipelineTests",
+                    dependencies: ["SharedTests"],
+                    path: "Tests/DataPipeline"),
 
         // APN
         .target(name: "CioMessagingPushAPN",

--- a/Sources/DataPipeline/DataPipeline.swift
+++ b/Sources/DataPipeline/DataPipeline.swift
@@ -29,6 +29,14 @@ public class DataPipeline: ModuleTopLevelObject<DataPipelineInstance>, DataPipel
         super.init(moduleName: Self.moduleName)
     }
 
+    #if DEBUG
+    /// Updates the implementation instance. To be used for testing purposes only.
+    static func setupSharedTestInstance(implementation: DataPipelineInstance, config: DataPipelineConfigOptions) {
+        shared.setImplementationInstance(implementation: implementation)
+        moduleConfig = config
+    }
+    #endif
+
     /**
      Initializes the shared `instance` of `DataPipeline`.
      This function is automatically called when the SDK initialization is called, which should ideally be done on app launch,

--- a/Tests/DataPipeline/DataPipelineInteractionTests.swift
+++ b/Tests/DataPipeline/DataPipelineInteractionTests.swift
@@ -4,7 +4,7 @@ import Foundation
 import SharedTests
 import XCTest
 
-class CustomerIOImplementationTest: UnitTest {
+class DataPipelineInteractionTests: UnitTest {
     private var implementation: CustomerIOImplementation!
     // When calling CustomerIOInstance functions in the test functions, use this `CustomerIO` instance.
     // This is a workaround until this code base contains implementation tests. There have been bugs
@@ -452,7 +452,7 @@ class CustomerIOImplementationTest: UnitTest {
     }
 }
 
-extension CustomerIOImplementationTest {
+extension DataPipelineInteractionTests {
     private func createMetaDataTask(forType type: QueueTaskType) -> QueueTaskMetadata {
         let givenTask = IdentifyProfileQueueTaskData(identifier: String.random, attributesJsonString: "null")
         let encoder = JSONEncoder()

--- a/Tests/DataPipeline/Support/TestUtilities.swift
+++ b/Tests/DataPipeline/Support/TestUtilities.swift
@@ -1,0 +1,46 @@
+import Foundation
+@testable import Segment
+import XCTest
+
+// MARK: - Helper Plugins
+
+class OutputReaderPlugin: Plugin {
+    let type: PluginType
+    var analytics: Analytics?
+
+    var events = [RawEvent]()
+    var lastEvent: RawEvent?
+
+    init() {
+        self.type = .after
+    }
+
+    func execute<T>(event: T?) -> T? where T: RawEvent {
+        lastEvent = event
+        var eventSummary = ""
+
+        if let event = event {
+            eventSummary += " Event type: \(event.type ?? "nil")"
+            events.append(event)
+            if let event = event as? TrackEvent {
+                eventSummary += " Event type: \(event.event)"
+            }
+        }
+
+        // Prints event summary to help in debugging tests during development
+        print("[CIO]-[OutputReaderPlugin] \(eventSummary)")
+        return event
+    }
+}
+
+// MARK: - Helper Methods
+
+func waitUntilStarted(analytics: Analytics?) {
+    guard let analytics = analytics else { return }
+    // wait until the startup queue has emptied it's events.
+    if let startupQueue = analytics.find(pluginType: StartupQueue.self) {
+        while startupQueue.running != true {
+            RunLoop.main.run(until: Date.distantPast)
+        }
+    }
+}


### PR DESCRIPTION
helps: https://github.com/customerio/issues/issues/11965

###  Changes

- Setting up tests environment for `DataPipeline`
- Updated `DataPipeline` so it can work with fake instances
- Added support methods to make testing `DataPipeline` easier
- Changed the name from `CustomerIOImplementationTest` to `DataPipelineInteractionTests` so it is easier to track updated tests


_**Note:** This is the main PR where we'll add more test changes later on_