### PR TITLE
fix: ensure messages are only shown once

### DIFF
--- a/Sources/Common/autogenerated/AutoMockable.generated.swift
+++ b/Sources/Common/autogenerated/AutoMockable.generated.swift
@@ -134,7 +134,7 @@ public class DeviceInfoMock: DeviceInfo, Mock {
      When setter of the property called, the value given to setter is set here.
      When the getter of the property called, the value set here will be returned. Your chance to mock the property.
      */
-    public var underlyingDeviceModel: String?
+    public var underlyingDeviceModel: String? = nil
     /// `true` if the getter or setter of property is called at least once.
     public var deviceModelCalled: Bool {
         deviceModelGetCalled || deviceModelSetCalled
@@ -170,7 +170,7 @@ public class DeviceInfoMock: DeviceInfo, Mock {
      When setter of the property called, the value given to setter is set here.
      When the getter of the property called, the value set here will be returned. Your chance to mock the property.
      */
-    public var underlyingOsVersion: String?
+    public var underlyingOsVersion: String? = nil
     /// `true` if the getter or setter of property is called at least once.
     public var osVersionCalled: Bool {
         osVersionGetCalled || osVersionSetCalled
@@ -206,7 +206,7 @@ public class DeviceInfoMock: DeviceInfo, Mock {
      When setter of the property called, the value given to setter is set here.
      When the getter of the property called, the value set here will be returned. Your chance to mock the property.
      */
-    public var underlyingOsName: String?
+    public var underlyingOsName: String? = nil
     /// `true` if the getter or setter of property is called at least once.
     public var osNameCalled: Bool {
         osNameGetCalled || osNameSetCalled
@@ -494,7 +494,7 @@ class DeviceMetricsGrabberMock: DeviceMetricsGrabber, Mock {
      When setter of the property called, the value given to setter is set here.
      When the getter of the property called, the value set here will be returned. Your chance to mock the property.
      */
-    var underlyingAppBundleId: String?
+    var underlyingAppBundleId: String? = nil
     /// `true` if the getter or setter of property is called at least once.
     var appBundleIdCalled: Bool {
         appBundleIdGetCalled || appBundleIdSetCalled
@@ -679,7 +679,7 @@ public class GlobalDataStoreMock: GlobalDataStore, Mock {
      When setter of the property called, the value given to setter is set here.
      When the getter of the property called, the value set here will be returned. Your chance to mock the property.
      */
-    public var underlyingPushDeviceToken: String?
+    public var underlyingPushDeviceToken: String? = nil
     /// `true` if the getter or setter of property is called at least once.
     public var pushDeviceTokenCalled: Bool {
         pushDeviceTokenGetCalled || pushDeviceTokenSetCalled
@@ -715,7 +715,7 @@ public class GlobalDataStoreMock: GlobalDataStore, Mock {
      When setter of the property called, the value given to setter is set here.
      When the getter of the property called, the value set here will be returned. Your chance to mock the property.
      */
-    public var underlyingHttpRequestsPauseEnds: Date?
+    public var underlyingHttpRequestsPauseEnds: Date? = nil
     /// `true` if the getter or setter of property is called at least once.
     public var httpRequestsPauseEndsCalled: Bool {
         httpRequestsPauseEndsGetCalled || httpRequestsPauseEndsSetCalled
@@ -1125,7 +1125,7 @@ class HttpRetryPolicyMock: HttpRetryPolicy, Mock {
      When setter of the property called, the value given to setter is set here.
      When the getter of the property called, the value set here will be returned. Your chance to mock the property.
      */
-    var underlyingNextSleepTime: Seconds?
+    var underlyingNextSleepTime: Seconds? = nil
     /// `true` if the getter or setter of property is called at least once.
     var nextSleepTimeCalled: Bool {
         nextSleepTimeGetCalled || nextSleepTimeSetCalled
@@ -1298,7 +1298,7 @@ public class ModuleHookProviderMock: ModuleHookProvider, Mock {
      When setter of the property called, the value given to setter is set here.
      When the getter of the property called, the value set here will be returned. Your chance to mock the property.
      */
-    public var underlyingProfileIdentifyHook: ProfileIdentifyHook?
+    public var underlyingProfileIdentifyHook: ProfileIdentifyHook? = nil
     /// `true` if the getter or setter of property is called at least once.
     public var profileIdentifyHookCalled: Bool {
         profileIdentifyHookGetCalled || profileIdentifyHookSetCalled
@@ -1510,7 +1510,7 @@ public class ProfileStoreMock: ProfileStore, Mock {
      When setter of the property called, the value given to setter is set here.
      When the getter of the property called, the value set here will be returned. Your chance to mock the property.
      */
-    public var underlyingIdentifier: String?
+    public var underlyingIdentifier: String? = nil
     /// `true` if the getter or setter of property is called at least once.
     public var identifierCalled: Bool {
         identifierGetCalled || identifierSetCalled

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -94,8 +94,7 @@ public class Gist: GistDelegate {
         let queueId = message.queueId
 
         // Skip shown messages
-        if queueId != nil &&
-            shownMessageQueueIds.contains(queueId!) {
+        if queueId != nil && shownMessageQueueIds.contains(queueId!) {
             Logger.instance.info(message: "Message \(queueId!) already shown, skipping.")
             return
         }

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -57,22 +57,12 @@ public class Gist: GistDelegate {
     // MARK: Message Actions
 
     public func showMessage(_ message: Message, position: MessagePosition = .center) -> Bool {
-        guard let queueId = message.queueId else {
-            Logger.instance.error(message: "Message does not have a queueId.")
-            return false
-        }
 
-        if shownMessageQueueIds.contains(queueId) {
-            Logger.instance.info(message: "Message \(queueId) already shown, skipping.")
-            return false
-        }
-        
         if let messageManager = getModalMessageManager() {
             Logger.instance.info(message: "Message cannot be displayed, \(messageManager.currentMessage.messageId) is being displayed.")
         } else {
             let messageManager = createMessageManager(siteId: siteId, message: message)
             messageManager.showMessage(position: position)
-            shownMessageQueueIds.insert(queueId)
             return true
         }
         return false
@@ -95,6 +85,13 @@ public class Gist: GistDelegate {
     // MARK: Events
 
     public func messageShown(message: Message) {
+        let queueId = message.queueId
+        
+        if queueId != nil && shownMessageQueueIds.contains(queueId!) {
+            Logger.instance.info(message: "Message \(queueId!) already shown, skipping.")
+            return
+        }
+
         Logger.instance.debug(message: "Message with route: \(message.messageId) shown")
         if message.gistProperties.persistent != true {
             logMessageView(message: message)
@@ -102,6 +99,10 @@ public class Gist: GistDelegate {
             Logger.instance.debug(message: "Persistent message shown, skipping logging view")
         }
         delegate?.messageShown(message: message)
+        
+        if queueId != nil {
+            shownMessageQueueIds.insert(queueId!)
+        }
     }
 
     public func messageDismissed(message: Message) {

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -57,8 +57,13 @@ public class Gist: GistDelegate {
     // MARK: Message Actions
 
     public func showMessage(_ message: Message, position: MessagePosition = .center) -> Bool {
-        if shownMessageQueueIds.contains(message.queueId) {
-            Logger.instance.info(message: "Message \(message.queueId) already shown, skipping.")
+        guard let queueId = message.queueId else {
+            Logger.instance.error(message: "Message does not have a queueId.")
+            return false
+        }
+
+        if shownMessageQueueIds.contains(queueId) {
+            Logger.instance.info(message: "Message \(queueId) already shown, skipping.")
             return false
         }
         
@@ -67,7 +72,7 @@ public class Gist: GistDelegate {
         } else {
             let messageManager = createMessageManager(siteId: siteId, message: message)
             messageManager.showMessage(position: position)
-            shownMessageQueueIds.insert(message.queueId)
+            shownMessageQueueIds.insert(queueId)
             return true
         }
         return false

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -77,6 +77,12 @@ public class Gist: GistDelegate {
         if let id = instanceId, let messageManager = messageManager(instanceId: id) {
             messageManager.removePersistentMessage()
             messageManager.dismissMessage(completionHandler: completionHandler)
+            
+            // Mark persistent message shown
+            let queueId = messageManager.currentMessage.queueId
+            if queueId != nil && messageManager.currentMessage.gistProperties.persistent == true {
+                shownMessageQueueIds.insert(queueId!)
+            }
         } else {
             getModalMessageManager()?.dismissMessage(completionHandler: completionHandler)
         }
@@ -87,7 +93,9 @@ public class Gist: GistDelegate {
     public func messageShown(message: Message) {
         let queueId = message.queueId
         
-        if queueId != nil && shownMessageQueueIds.contains(queueId!) {
+        // Skip shown messages
+        if queueId != nil &&
+            shownMessageQueueIds.contains(queueId!) {
             Logger.instance.info(message: "Message \(queueId!) already shown, skipping.")
             return
         }
@@ -100,7 +108,8 @@ public class Gist: GistDelegate {
         }
         delegate?.messageShown(message: message)
         
-        if queueId != nil {
+        // Mark message shown, unless it is persistent. Those only get marked upon dismissal
+        if queueId != nil && message.gistProperties.persistent != true {
             shownMessageQueueIds.insert(queueId!)
         }
     }

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -4,7 +4,7 @@ import UIKit
 public class Gist: GistDelegate {
     private var messageQueueManager = MessageQueueManager()
     private var messageManagers: [MessageManager] = []
-    private var shownMessageQueueIds: Set<String> = []
+    internal var shownMessageQueueIds: Set<String> = []
     public var siteId: String = ""
     public var dataCenter: String = ""
 
@@ -84,12 +84,6 @@ public class Gist: GistDelegate {
     // MARK: Events
 
     public func messageShown(message: Message) {
-        // Skip shown messages
-        if let queueId = message.queueId, shownMessageQueueIds.contains(queueId) {
-            Logger.instance.info(message: "Message \(queueId) already shown, skipping.")
-            return
-        }
-
         Logger.instance.debug(message: "Message with route: \(message.messageId) shown")
         if message.gistProperties.persistent != true {
             logMessageView(message: message)

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -57,7 +57,6 @@ public class Gist: GistDelegate {
     // MARK: Message Actions
 
     public func showMessage(_ message: Message, position: MessagePosition = .center) -> Bool {
-
         if let messageManager = getModalMessageManager() {
             Logger.instance.info(message: "Message cannot be displayed, \(messageManager.currentMessage.messageId) is being displayed.")
         } else {
@@ -80,7 +79,7 @@ public class Gist: GistDelegate {
 
             // Mark persistent message shown
             let queueId = messageManager.currentMessage.queueId
-            if queueId != nil && messageManager.currentMessage.gistProperties.persistent == true {
+            if queueId != nil, messageManager.currentMessage.gistProperties.persistent == true {
                 shownMessageQueueIds.insert(queueId!)
             }
         } else {
@@ -94,7 +93,7 @@ public class Gist: GistDelegate {
         let queueId = message.queueId
 
         // Skip shown messages
-        if queueId != nil && shownMessageQueueIds.contains(queueId!) {
+        if queueId != nil, shownMessageQueueIds.contains(queueId!) {
             Logger.instance.info(message: "Message \(queueId!) already shown, skipping.")
             return
         }
@@ -108,7 +107,7 @@ public class Gist: GistDelegate {
         delegate?.messageShown(message: message)
 
         // Mark message shown, unless it is persistent. Those only get marked upon dismissal
-        if queueId != nil && message.gistProperties.persistent != true {
+        if queueId != nil, message.gistProperties.persistent != true {
             shownMessageQueueIds.insert(queueId!)
         }
     }

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -4,6 +4,7 @@ import UIKit
 public class Gist: GistDelegate {
     private var messageQueueManager = MessageQueueManager()
     private var messageManagers: [MessageManager] = []
+    private var shownMessageQueueIds: Set<String> = []
     public var siteId: String = ""
     public var dataCenter: String = ""
 
@@ -56,11 +57,17 @@ public class Gist: GistDelegate {
     // MARK: Message Actions
 
     public func showMessage(_ message: Message, position: MessagePosition = .center) -> Bool {
+        if shownMessageQueueIds.contains(message.queueId) {
+            Logger.instance.info(message: "Message \(message.queueId) already shown, skipping.")
+            return false
+        }
+        
         if let messageManager = getModalMessageManager() {
             Logger.instance.info(message: "Message cannot be displayed, \(messageManager.currentMessage.messageId) is being displayed.")
         } else {
             let messageManager = createMessageManager(siteId: siteId, message: message)
             messageManager.showMessage(position: position)
+            shownMessageQueueIds.insert(message.queueId)
             return true
         }
         return false

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -84,10 +84,8 @@ public class Gist: GistDelegate {
     // MARK: Events
 
     public func messageShown(message: Message) {
-        let queueId = message.queueId
-
         // Skip shown messages
-        if let queueId = queueId, shownMessageQueueIds.contains(queueId) {
+        if let queueId = message.queueId, shownMessageQueueIds.contains(queueId) {
             Logger.instance.info(message: "Message \(queueId) already shown, skipping.")
             return
         }

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -77,7 +77,7 @@ public class Gist: GistDelegate {
         if let id = instanceId, let messageManager = messageManager(instanceId: id) {
             messageManager.removePersistentMessage()
             messageManager.dismissMessage(completionHandler: completionHandler)
-            
+
             // Mark persistent message shown
             let queueId = messageManager.currentMessage.queueId
             if queueId != nil && messageManager.currentMessage.gistProperties.persistent == true {
@@ -92,7 +92,7 @@ public class Gist: GistDelegate {
 
     public func messageShown(message: Message) {
         let queueId = message.queueId
-        
+
         // Skip shown messages
         if queueId != nil &&
             shownMessageQueueIds.contains(queueId!) {
@@ -107,7 +107,7 @@ public class Gist: GistDelegate {
             Logger.instance.debug(message: "Persistent message shown, skipping logging view")
         }
         delegate?.messageShown(message: message)
-        
+
         // Mark message shown, unless it is persistent. Those only get marked upon dismissal
         if queueId != nil && message.gistProperties.persistent != true {
             shownMessageQueueIds.insert(queueId!)

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -4,7 +4,7 @@ import UIKit
 public class Gist: GistDelegate {
     private var messageQueueManager = MessageQueueManager()
     private var messageManagers: [MessageManager] = []
-    internal var shownMessageQueueIds: Set<String> = []
+    var shownMessageQueueIds: Set<String> = []
     public var siteId: String = ""
     public var dataCenter: String = ""
 

--- a/Sources/MessagingInApp/Gist/Managers/MessageQueueManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/MessageQueueManager.swift
@@ -89,6 +89,12 @@ class MessageQueueManager {
     }
 
     private func handleMessage(message: Message) {
+        // Skip shown messages
+        if let queueId = message.queueId, Gist.shared.shownMessageQueueIds.contains(queueId) {
+            Logger.instance.info(message: "Message with queueId: \(queueId) already shown, skipping.")
+            return
+        }
+        
         let position = message.gistProperties.position
 
         if let routeRule = message.gistProperties.routeRule {

--- a/Sources/MessagingInApp/Gist/Managers/MessageQueueManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/MessageQueueManager.swift
@@ -94,7 +94,7 @@ class MessageQueueManager {
             Logger.instance.info(message: "Message with queueId: \(queueId) already shown, skipping.")
             return
         }
-        
+
         let position = message.gistProperties.position
 
         if let routeRule = message.gistProperties.routeRule {

--- a/Sources/Tracking/autogenerated/AutoMockable.generated.swift
+++ b/Sources/Tracking/autogenerated/AutoMockable.generated.swift
@@ -142,7 +142,7 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
      When setter of the property called, the value given to setter is set here.
      When the getter of the property called, the value set here will be returned. Your chance to mock the property.
      */
-    public var underlyingSiteId: String?
+    public var underlyingSiteId: String? = nil
     /// `true` if the getter or setter of property is called at least once.
     public var siteIdCalled: Bool {
         siteIdGetCalled || siteIdSetCalled
@@ -178,7 +178,7 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
      When setter of the property called, the value given to setter is set here.
      When the getter of the property called, the value set here will be returned. Your chance to mock the property.
      */
-    public var underlyingConfig: SdkConfig?
+    public var underlyingConfig: SdkConfig? = nil
     /// `true` if the getter or setter of property is called at least once.
     public var configCalled: Bool {
         configGetCalled || configSetCalled
@@ -685,7 +685,7 @@ public class SdkInitializedUtilMock: SdkInitializedUtil, Mock {
      When setter of the property called, the value given to setter is set here.
      When the getter of the property called, the value set here will be returned. Your chance to mock the property.
      */
-    public var underlyingCustomerio: CustomerIO?
+    public var underlyingCustomerio: CustomerIO? = nil
     /// `true` if the getter or setter of property is called at least once.
     public var customerioCalled: Bool {
         customerioGetCalled || customerioSetCalled
@@ -757,7 +757,7 @@ public class SdkInitializedUtilMock: SdkInitializedUtil, Mock {
      When setter of the property called, the value given to setter is set here.
      When the getter of the property called, the value set here will be returned. Your chance to mock the property.
      */
-    public var underlyingPostInitializedData: (siteId: String, diGraph: DIGraph)?
+    public var underlyingPostInitializedData: (siteId: String, diGraph: DIGraph)? = nil
     /// `true` if the getter or setter of property is called at least once.
     public var postInitializedDataCalled: Bool {
         postInitializedDataGetCalled || postInitializedDataSetCalled


### PR DESCRIPTION
The idea is to keep track of the shown messages by queueId (which is unique per message) and skip the shown ones

This is based on the same solution applied for gist-web: https://github.com/customerio/gist-web/pull/26

Task: https://github.com/customerio/issues/issues/11967

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [x] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [x] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After code reviews are approved and you determine this PR is ready to merge, select *Squash and Merge* button on this screen, leave the title and description to the default values, then merge the PR.
