### PR TITLE
chore: data pipeline tests base improvements

### DIFF
--- a/Sources/DataPipeline/CustomerIO.swift
+++ b/Sources/DataPipeline/CustomerIO.swift
@@ -23,4 +23,20 @@ public extension CustomerIO {
         let newDiGraph = DIGraph(sdkConfig: sdkConfig)
         initializeSharedInstance(with: implementation, diGraph: newDiGraph)
     }
+
+    #if DEBUG
+    /// Initializer for Integration Tests to update the DataPipeline instances.
+    /// To be used for testing purposes only.
+    static func initializeIntegrationTestsInstance(diGraph: DIGraph) {
+        let moduleConfig = DataPipelineConfigOptions.Factory.create(sdkConfig: diGraph.sdkConfig)
+        let implementation = DataPipeline.createAndSetSharedTestInstance(diGraphShared: DIGraphShared.shared, config: moduleConfig)
+        initializeSharedInstance(with: implementation, diGraph: diGraph)
+    }
+
+    /// Make testing the singleton `instance` possible.
+    /// Note: It's recommended to delete app data before doing this to prevent loading persisted credentials
+    static func resetSharedTestInstance() {
+        DataPipeline.resetSharedTestInstance()
+    }
+    #endif
 }

--- a/Sources/DataPipeline/DataPipeline.swift
+++ b/Sources/DataPipeline/DataPipeline.swift
@@ -31,9 +31,17 @@ public class DataPipeline: ModuleTopLevelObject<DataPipelineInstance>, DataPipel
 
     #if DEBUG
     /// Updates the implementation instance. To be used for testing purposes only.
-    static func setupSharedTestInstance(implementation: DataPipelineInstance, config: DataPipelineConfigOptions) {
+    static func createAndSetSharedTestInstance(diGraphShared: DIGraphShared, config: DataPipelineConfigOptions) -> DataPipelineImplementation {
+        let implementation = DataPipelineImplementation(diGraph: diGraphShared, moduleConfig: config)
         shared.setImplementationInstance(implementation: implementation)
         moduleConfig = config
+        return implementation
+    }
+
+    /// Make testing the singleton `instance` possible.
+    /// Note: It's recommended to delete app data before doing this to prevent loading persisted credentials
+    static func resetSharedTestInstance() {
+        shared = DataPipeline()
     }
     #endif
 

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -201,8 +201,7 @@ class DataPipelineImplementation: DataPipelineInstance {
 
         // Consolidate all Apple platforms under iOS
         deviceAttributesProvider.getDefaultDeviceAttributes { defaultDeviceAttributes in
-            let deviceAttributes: [String: Any] = defaultDeviceAttributes
-                .mergeWith(customAttributes)
+            let deviceAttributes: [String: Any] = defaultDeviceAttributes.mergeWith(customAttributes)
             self.deviceAttributesPlugin.attributes = deviceAttributes
 
             guard self.deviceAttributesPlugin.token != nil else {

--- a/Sources/Tracking/CustomerIO.swift
+++ b/Sources/Tracking/CustomerIO.swift
@@ -78,11 +78,4 @@ public extension CustomerIO {
 
         initializeSharedInstance(with: implementation, diGraph: newDiGraph)
     }
-
-    // Initialize for Integration Tests
-    static func initializeIntegrationTests(diGraph: DIGraph) {
-        // FIXME: [CDP] Fix tests using DataPipeline
-        // let implementation = CustomerIOImplementation(diGraph: diGraph)
-        // initializeSharedInstance(with: implementation, diGraph: diGraph)
-    }
 }

--- a/Tests/Common/Service/UserAgentUtilTest.swift
+++ b/Tests/Common/Service/UserAgentUtilTest.swift
@@ -23,9 +23,9 @@ class UserAgentUtilTest: UnitTest {
     }
 
     override func setUp() {
-        super.setUp { config in
+        super.setUp(modifySdkConfig: { config in
             config._sdkWrapperConfig = self.sdkWrapperConfig
-        }
+        })
 
         userAgentUtil = UserAgentUtilImpl(deviceInfo: deviceInfoMock, sdkConfig: sdkConfig)
     }

--- a/Tests/DataPipeline/DataPipelineImplementation+ScreenViewsTest.swift
+++ b/Tests/DataPipeline/DataPipelineImplementation+ScreenViewsTest.swift
@@ -1,3 +1,4 @@
+@testable import CioDataPipelines
 @testable import CioInternalCommon
 @testable import CioTracking
 import Foundation
@@ -6,9 +7,18 @@ import SwiftUI
 import UIKit
 import XCTest
 
-class CustomerIOImplementationScreenViewsTest: IntegrationTest {
+class DataPipelineImplementationScreenViewsTest: IntegrationTest {
+    private var autoTrackingScreenViews: AutoTrackingScreenViews!
+    private var outputReader: OutputReaderPlugin!
+
     override func setUp() {
         super.setUp()
+
+        // setting up required plugins
+        outputReader = attachPlugin(plugin: OutputReaderPlugin())
+        autoTrackingScreenViews = attachPlugin(plugin: AutoTrackingScreenViews())
+        // wait for analytics queue to start emitting events
+        waitUntilStarted()
 
         // Screenview events are ignored if no profile identified
         CustomerIO.shared.identify(identifier: String.random)
@@ -18,15 +28,13 @@ class CustomerIOImplementationScreenViewsTest: IntegrationTest {
 
     func test_performScreenTracking_givenCustomerProvidesFilter_expectSdkDefaultFilterNotUsed() {
         var customerProvidedFilterCalled = false
-        setUp(modifySdkConfig: { config in
-            config.filterAutoScreenViewEvents = { _ in
-                customerProvidedFilterCalled = true
+        autoTrackingScreenViews.filterAutoScreenViewEvents = { _ in
+            customerProvidedFilterCalled = true
 
-                return true
-            }
-        })
+            return true
+        }
 
-        CustomerIO.shared.performScreenTracking(onViewController: UIAlertController())
+        autoTrackingScreenViews.performScreenTracking(onViewController: UIAlertController())
 
         XCTAssertTrue(customerProvidedFilterCalled)
         assertEventTracked()
@@ -34,14 +42,14 @@ class CustomerIOImplementationScreenViewsTest: IntegrationTest {
 
     // SwiftUI wraps UIKit views and displays them in your app. Therefore, there is a good chance that automatic screenview tracking for a SwiftUI app will try to track screenview events from Views belonging to the SwiftUI framework or UIKit framework. Our SDK, by default, filters those events out.
     func test_performScreenTracking_givenViewFromSwiftUI_expectFalse() {
-        CustomerIO.shared.performScreenTracking(onViewController: SwiftUI.UIHostingController(rootView: Text("")))
+        autoTrackingScreenViews.performScreenTracking(onViewController: SwiftUI.UIHostingController(rootView: Text("")))
 
         assertNoEventTracked()
     }
 
     // Our SDK believes that UIKit framework views are irrelevant to tracking data for customers. Our SDK, by default, filters those events out.
     func test_performScreenTracking_givenViewFromUIKit_expectFalse() {
-        CustomerIO.shared.performScreenTracking(onViewController: UIAlertController())
+        autoTrackingScreenViews.performScreenTracking(onViewController: UIAlertController())
 
         assertNoEventTracked()
     }
@@ -49,7 +57,7 @@ class CustomerIOImplementationScreenViewsTest: IntegrationTest {
     func test_performScreenTracking_givenViewFromHostApp_expectTrue() {
         class ViewInsideOfHostApp: UIViewController {}
 
-        CustomerIO.shared.performScreenTracking(onViewController: ViewInsideOfHostApp())
+        autoTrackingScreenViews.performScreenTracking(onViewController: ViewInsideOfHostApp())
 
         assertEventTracked()
     }
@@ -81,13 +89,13 @@ class CustomerIOImplementationScreenViewsTest: IntegrationTest {
     }
 }
 
-extension CustomerIOImplementationScreenViewsTest {
+extension DataPipelineImplementationScreenViewsTest {
     private func assertNoEventTracked() {
         XCTAssertTrue(diGraph.queueStorage.filterTrackEvents(.trackEvent).isEmpty)
     }
 
     private func assertEventTracked(numberOfEventsAdded: Int = 1) {
-        let screenviewEvents = diGraph.queueStorage.filterTrackEvents(.trackEvent)
+        let screenviewEvents = outputReader.screenEvents
 
         XCTAssertEqual(screenviewEvents.count, numberOfEventsAdded)
     }

--- a/Tests/DataPipeline/DataPipelineImplementation+ScreenViewsTest.swift
+++ b/Tests/DataPipeline/DataPipelineImplementation+ScreenViewsTest.swift
@@ -14,11 +14,12 @@ class DataPipelineImplementationScreenViewsTest: IntegrationTest {
     override func setUp() {
         super.setUp()
 
+        let analytics = CustomerIO.shared.analytics
         // setting up required plugins
-        outputReader = attachPlugin(plugin: OutputReaderPlugin())
-        autoTrackingScreenViews = attachPlugin(plugin: AutoTrackingScreenViews())
+        outputReader = attachPlugin(analytics: analytics, plugin: OutputReaderPlugin())
+        autoTrackingScreenViews = attachPlugin(analytics: analytics, plugin: AutoTrackingScreenViews())
         // wait for analytics queue to start emitting events
-        waitUntilStarted()
+        waitUntilStarted(analytics: analytics)
 
         // Screenview events are ignored if no profile identified
         CustomerIO.shared.identify(identifier: String.random)

--- a/Tests/DataPipeline/DataPipelineInteractionTests.swift
+++ b/Tests/DataPipeline/DataPipelineInteractionTests.swift
@@ -33,8 +33,7 @@ class DataPipelineInteractionTests: UnitTest {
         // setting up analytics for testing
         analytics = implementation.analytics
         // OutputReaderPlugin helps validating interactions with analytics
-        outputReader = OutputReaderPlugin()
-        analytics.add(plugin: outputReader)
+        outputReader = attachPlugin(analytics: analytics, plugin: OutputReaderPlugin())
         // wait for analytics queue to start emitting events
         waitUntilStarted(analytics: analytics)
     }

--- a/Tests/DataPipeline/DataPipelineInteractionTests.swift
+++ b/Tests/DataPipeline/DataPipelineInteractionTests.swift
@@ -427,10 +427,10 @@ class DataPipelineInteractionTests: UnitTest {
     func test_registerDeviceToken_givenProfileIdentified_expectStoreAndRegisterDevice() {
         let givenDeviceToken = String.random
         let givenIdentifier = String.random
-        let givenDefaultAttributes: [String: Any] = ["foo": "bar"]
-        let expectedAttributes = givenDefaultAttributes.mergeWith([
-            "last_used": dateUtilStub.givenNow
-        ])
+        let givenDefaultAttributes: [String: Any] = [
+            "cio_sdk_version": "3.0.0",
+            "push_enabled": true
+        ]
 
         mockDeviceTokenDependencies(defaultAttributes: givenDefaultAttributes)
         customerIO.identify(identifier: givenIdentifier)
@@ -445,14 +445,12 @@ class DataPipelineInteractionTests: UnitTest {
         XCTAssertEqual(deviceUpdatedEvent?.deviceToken, givenDeviceToken)
         XCTAssertEqual(globalDataStoreMock.pushDeviceToken, givenDeviceToken)
 
-        assertDictionariesEqual(expectedAttributes, deviceUpdatedEvent?.properties) { key, expected, actual in
+        assertDictionariesEqual(givenDefaultAttributes, deviceUpdatedEvent?.properties) { key, expected, actual in
             switch key {
-            case "foo":
+            case "cio_sdk_version":
                 XCTAssertEqual((expected[key] as! String), actual[key] as? String)
-            case "last_used":
-                // analytics SDK wraps date in double quotes
-                let actualValue = ((actual[key] as? Encodable)?.toString())?.trimmingCharacters(in: CharacterSet.punctuationCharacters)
-                XCTAssertEqual((expected[key] as! Date).iso8601(), actualValue)
+            case "push_enabled":
+                XCTAssertEqual((expected[key] as! Bool), actual[key] as? Bool)
             default:
                 XCTFail("unexpected key received: '\(key)'")
             }

--- a/Tests/DataPipeline/DataPipelineInteractionTests.swift
+++ b/Tests/DataPipeline/DataPipelineInteractionTests.swift
@@ -27,10 +27,7 @@ class DataPipelineInteractionTests: UnitTest {
         diGraphShared.override(value: eventBusHandlerMock, forType: EventBusHandler.self)
         diGraphShared.override(value: globalDataStoreMock, forType: GlobalDataStore.self)
 
-        let moduleConfig = DataPipelineConfigOptions.Factory.create(writeKey: "test")
-        let implementation = DataPipelineImplementation(diGraph: diGraphShared, moduleConfig: moduleConfig)
-
-        DataPipeline.setupSharedTestInstance(implementation: implementation, config: moduleConfig)
+        let implementation = DataPipeline.createAndSetSharedTestInstance(diGraphShared: diGraphShared, config: dataPipelineModuleConfig)
         customerIO = CustomerIO(implementation: implementation, diGraph: diGraph)
 
         // setting up analytics for testing

--- a/Tests/DataPipeline/DataPipelineInteractionTests.swift
+++ b/Tests/DataPipeline/DataPipelineInteractionTests.swift
@@ -27,11 +27,10 @@ class DataPipelineInteractionTests: UnitTest {
         diGraphShared.override(value: eventBusHandlerMock, forType: EventBusHandler.self)
         diGraphShared.override(value: globalDataStoreMock, forType: GlobalDataStore.self)
 
-        let implementation = DataPipeline.createAndSetSharedTestInstance(diGraphShared: diGraphShared, config: dataPipelineModuleConfig)
-        customerIO = CustomerIO(implementation: implementation, diGraph: diGraph)
+        customerIO = createCustomerIOInstance()
 
         // setting up analytics for testing
-        analytics = implementation.analytics
+        analytics = customerIO.analytics
         // OutputReaderPlugin helps validating interactions with analytics
         outputReader = attachPlugin(analytics: analytics, plugin: OutputReaderPlugin())
         // wait for analytics queue to start emitting events

--- a/Tests/DataPipeline/Support/TestUtilities.swift
+++ b/Tests/DataPipeline/Support/TestUtilities.swift
@@ -77,7 +77,7 @@ extension RawEvent {
 
 // MARK: - Helper Methods
 
-func waitUntilStarted(analytics: Analytics? = DataPipeline.shared.analytics) {
+func waitUntilStarted(analytics: Analytics?) {
     guard let analytics = analytics else { return }
 
     // wait until the startup queue has emptied it's events.
@@ -89,12 +89,13 @@ func waitUntilStarted(analytics: Analytics? = DataPipeline.shared.analytics) {
 }
 
 /// Attaches and returns plugin only if it wasn't attached previously
-func attachPlugin<P: Plugin>(analytics: Analytics? = DataPipeline.shared.analytics, plugin: P) -> P {
-    guard let analytics = analytics else { return plugin }
+func attachPlugin<P: Plugin>(analytics: Analytics?, plugin: P) -> P {
+    guard let analytics = analytics else { fatalError("Analytics instance is nil") }
 
     if analytics.find(pluginType: P.self) != nil {
         fatalError("Plugin \(P.self) is already attached")
     }
+
     analytics.add(plugin: plugin)
     return plugin
 }

--- a/Tests/Shared/IntegrationTest.swift
+++ b/Tests/Shared/IntegrationTest.swift
@@ -1,3 +1,4 @@
+@testable import CioDataPipelines
 @testable import CioInternalCommon
 @testable import CioTracking
 import Foundation
@@ -19,8 +20,11 @@ open class IntegrationTest: UnitTest {
         setUp(modifySdkConfig: nil)
     }
 
-    open func setUp(modifySdkConfig: ((inout SdkConfig) -> Void)? = nil) {
-        super.setUp(modifySdkConfig: modifySdkConfig)
+    open func setUp(
+        modifySdkConfig: ((inout SdkConfig) -> Void)? = nil,
+        modifyModuleConfig: ((inout DataPipelineConfigOptions) -> Void)? = nil
+    ) {
+        super.setUp(modifySdkConfig: modifySdkConfig, modifyModuleConfig: modifyModuleConfig)
 
         sampleDataFilesUtil = SampleDataFilesUtil(fileStore: diGraph.fileStorage)
 
@@ -40,7 +44,7 @@ open class IntegrationTest: UnitTest {
         // Because integration tests try to test in an environment that is as to production as possible, we need to
         // initialize the SDK. This is especially important to have the Tracking module setup.
 
-        CustomerIO.initializeIntegrationTests(diGraph: diGraph)
+        CustomerIO.initializeIntegrationTestsInstance(diGraph: diGraph)
     }
 
     // This class initializes the SDK by default in setUp() for test function convenience because most test functions will need the SDK initialized.

--- a/Tests/Shared/IntegrationTest.swift
+++ b/Tests/Shared/IntegrationTest.swift
@@ -17,14 +17,11 @@ open class IntegrationTest: UnitTest {
     public private(set) var sampleDataFilesUtil: SampleDataFilesUtil!
 
     override open func setUp() {
-        setUp(modifySdkConfig: nil)
+        setUp(modifyModuleConfig: nil)
     }
 
-    open func setUp(
-        modifySdkConfig: ((inout SdkConfig) -> Void)? = nil,
-        modifyModuleConfig: ((inout DataPipelineConfigOptions) -> Void)? = nil
-    ) {
-        super.setUp(modifySdkConfig: modifySdkConfig, modifyModuleConfig: modifyModuleConfig)
+    open func setUp(modifyModuleConfig: ((inout DataPipelineConfigOptions) -> Void)? = nil) {
+        super.setUp(modifyModuleConfig: modifyModuleConfig)
 
         sampleDataFilesUtil = SampleDataFilesUtil(fileStore: diGraph.fileStorage)
 

--- a/Tests/Shared/IntegrationTest.swift
+++ b/Tests/Shared/IntegrationTest.swift
@@ -47,6 +47,7 @@ open class IntegrationTest: UnitTest {
     // This class initializes the SDK by default in setUp() for test function convenience because most test functions will need the SDK initialized.
     // For the test functions that need to test SDK initialization, this function exists to be called by test function.
     public func uninitializeSDK(file: StaticString = #file, line: UInt = #line) {
+        DataPipeline.resetSharedTestInstance()
         CustomerIO.resetSharedInstance()
 
         // confirm that the SDK did get uninitialized

--- a/Tests/Shared/UnitTest.swift
+++ b/Tests/Shared/UnitTest.swift
@@ -1,3 +1,4 @@
+@testable import CioDataPipelines
 @testable import CioInternalCommon
 @testable import CioTracking
 import Foundation
@@ -16,12 +17,16 @@ open class UnitTest: XCTestCase {
     // Prefer to use real instance of key value storage because (1) mocking it is annoying and (2) tests react closely
     // to real app.
     public let testSiteId = "testing"
+    public let testWriteKey = "test"
+
     public var diGraphShared: DIGraphShared!
     public var diGraph: DIGraph!
 
     public var sdkConfig: SdkConfig {
         diGraph!.sdkConfig
     }
+
+    public var dataPipelineModuleConfig: DataPipelineConfigOptions!
 
     public var keyValueStorage: KeyValueStorage {
         diGraph.keyValueStorage
@@ -67,16 +72,25 @@ open class UnitTest: XCTestCase {
         setUp(enableLogs: false)
     }
 
-    public func setUp(siteId: String? = nil, enableLogs: Bool = false, modifySdkConfig: ((inout SdkConfig) -> Void)? = nil) {
+    public func setUp(
+        siteId: String? = nil,
+        writeKey: String? = nil,
+        enableLogs: Bool = false,
+        modifySdkConfig: ((inout SdkConfig) -> Void)? = nil,
+        modifyModuleConfig: ((inout DataPipelineConfigOptions) -> Void)? = nil
+    ) {
+        diGraphShared = DIGraphShared()
+
         var newSdkConfig = SdkConfig.Factory.create(siteId: siteId ?? testSiteId, apiKey: "", region: Region.US)
         if enableLogs {
             newSdkConfig.logLevel = CioLogLevel.debug
         }
-
         modifySdkConfig?(&newSdkConfig)
-
-        diGraphShared = DIGraphShared()
         diGraph = DIGraph(sdkConfig: newSdkConfig)
+
+        var newModuleConfig = DataPipelineConfigOptions.Factory.create(writeKey: writeKey ?? testWriteKey)
+        modifyModuleConfig?(&newModuleConfig)
+        dataPipelineModuleConfig = newModuleConfig
 
         dateUtilStub = DateUtilStub()
         threadUtilStub = ThreadUtilStub()

--- a/Tests/Shared/UnitTest.swift
+++ b/Tests/Shared/UnitTest.swift
@@ -182,4 +182,9 @@ public extension UnitTest {
 
         waitForExpectations(for: [queueExpectation], file: file, line: line)
     }
+
+    func createCustomerIOInstance() -> CustomerIO {
+        let implementation = DataPipeline.createAndSetSharedTestInstance(diGraphShared: diGraphShared, config: dataPipelineModuleConfig)
+        return CustomerIO(implementation: implementation, diGraph: diGraph)
+    }
 }

--- a/Tests/Shared/UnitTest.swift
+++ b/Tests/Shared/UnitTest.swift
@@ -112,6 +112,7 @@ open class UnitTest: XCTestCase {
 
         diGraph.reset()
 
+        DataPipeline.resetSharedTestInstance()
         CustomerIO.resetSharedInstance()
 
         super.tearDown()

--- a/Tests/Shared/extension/CustomerIOExtension.swift
+++ b/Tests/Shared/extension/CustomerIOExtension.swift
@@ -1,0 +1,10 @@
+@testable import CioDataPipelines
+@testable import CioInternalCommon
+import Foundation
+import Segment
+
+public extension CustomerIO {
+    var analytics: Analytics? {
+        (implementation as? DataPipelineImplementation)?.analytics
+    }
+}

--- a/Tests/Tracking/migration/DataPipelineMigrationAssistantTests.swift
+++ b/Tests/Tracking/migration/DataPipelineMigrationAssistantTests.swift
@@ -1,7 +1,6 @@
 @testable import CioDataPipelines
 @testable import CioInternalCommon
 @testable import CioTracking
-@testable import DataPipelineTests
 import Foundation
 @testable import Segment
 import SharedTests
@@ -24,8 +23,7 @@ class DataPipelineMigrationAssistantTests: UnitTest {
         diGraph.override(value: dateUtilStub, forType: DateUtil.self)
         diGraph.override(value: backgroundQueueMock, forType: Queue.self)
 
-        let implementation = DataPipeline.createAndSetSharedTestInstance(diGraphShared: diGraphShared, config: dataPipelineModuleConfig)
-        customerIO = CustomerIO(implementation: implementation, diGraph: diGraph)
+        customerIO = createCustomerIOInstance()
     }
 
     override func tearDown() {

--- a/Tests/Tracking/migration/DataPipelineMigrationAssistantTests.swift
+++ b/Tests/Tracking/migration/DataPipelineMigrationAssistantTests.swift
@@ -1,6 +1,7 @@
 @testable import CioDataPipelines
 @testable import CioInternalCommon
 @testable import CioTracking
+@testable import DataPipelineTests
 import Foundation
 @testable import Segment
 import SharedTests
@@ -23,10 +24,7 @@ class DataPipelineMigrationAssistantTests: UnitTest {
         diGraph.override(value: dateUtilStub, forType: DateUtil.self)
         diGraph.override(value: backgroundQueueMock, forType: Queue.self)
 
-        let moduleConfig = DataPipelineConfigOptions.Factory.create(writeKey: "test")
-        let implementation = DataPipelineImplementation(diGraph: diGraphShared, moduleConfig: moduleConfig)
-
-        DataPipeline.setupSharedTestInstance(implementation: implementation, config: moduleConfig)
+        let implementation = DataPipeline.createAndSetSharedTestInstance(diGraphShared: diGraphShared, config: dataPipelineModuleConfig)
         customerIO = CustomerIO(implementation: implementation, diGraph: diGraph)
     }
 


### PR DESCRIPTION
helps: https://github.com/customerio/issues/issues/11965

###  Changes

- Added helper methods for setting up fake/mocked instances for `DataPipeline` tests
- Fixes and improvements in base `UnitTest` and `IntegrationTest` classes
- Fixed broken test for `last_used` attribute