### PR TITLE
chore: added rich push delivery tracking

### DIFF
--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -36,14 +36,29 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
     public static func initialize(
         configure configureHandler: ((inout MessagingPushConfigOptions) -> Void)? = nil
     ) -> MessagingPushInstance {
-        var configOptions = moduleConfig
-
         if let configureHandler = configureHandler {
-            configureHandler(&configOptions)
+            // pass current config reference to update it without needing to recreate
+            configureHandler(&moduleConfig)
         }
 
         shared.initializeModule()
         return shared
+    }
+
+    /// MessagingPush initializer for Notification Service Extension
+    @available(iOS, unavailable)
+    @available(iOSApplicationExtension, introduced: 13.0)
+    @discardableResult
+    public static func initialize(
+        writeKey: String,
+        configure configureHandler: ((inout MessagingPushConfigOptions) -> Void)? = nil
+    ) -> MessagingPushInstance {
+        initialize { config in
+            config.writeKey = writeKey
+            if let configureHandler = configureHandler {
+                configureHandler(&config)
+            }
+        }
     }
 
     private func initializeModule() {

--- a/Sources/MessagingPush/MessagingPushConfigOptions.swift
+++ b/Sources/MessagingPush/MessagingPushConfigOptions.swift
@@ -16,6 +16,7 @@ public struct MessagingPushConfigOptions {
     public enum Factory {
         public static func create() -> MessagingPushConfigOptions {
             MessagingPushConfigOptions(
+                writeKey: "",
                 autoFetchDeviceToken: true,
                 autoTrackPushEvents: true,
                 autoTrackDeviceAttributes: true
@@ -27,6 +28,7 @@ public struct MessagingPushConfigOptions {
             // If one isn't provided, use current value instead.
 
             // Construct object with all required parameters. Each config option should be updated from `dictionary` only if available.
+            let writeKey = dictionary[Keys.writeKey.rawValue] as? String
             let autoFetchDeviceToken = dictionary[Keys.autoFetchDeviceToken.rawValue] as? Bool
             let autoTrackPushEvents = dictionary[Keys.autoTrackPushEvents.rawValue] as? Bool
             let autoTrackDeviceAttributes = dictionary[Keys.autoTrackDeviceAttributes.rawValue] as? Bool
@@ -34,6 +36,7 @@ public struct MessagingPushConfigOptions {
             // Use default config options as fallback
             let presetConfig = create()
             return MessagingPushConfigOptions(
+                writeKey: writeKey ?? presetConfig.writeKey,
                 autoFetchDeviceToken: autoFetchDeviceToken ?? presetConfig.autoFetchDeviceToken,
                 autoTrackPushEvents: autoTrackPushEvents ?? presetConfig.autoTrackPushEvents,
                 autoTrackDeviceAttributes: autoTrackDeviceAttributes ?? presetConfig.autoTrackDeviceAttributes
@@ -42,11 +45,14 @@ public struct MessagingPushConfigOptions {
     }
 
     public enum Keys: String { // Constants used to map each of the options in MessagingPushConfigOptions
+        case writeKey
         case autoFetchDeviceToken
         case autoTrackPushEvents
         case autoTrackDeviceAttributes
     }
 
+    /// internal write key required for NotificationServiceExtension only to track metrics
+    var writeKey: String
     /**
      Enable automatic fetching of device token by the SDK without the need to write custom code by the customer.
      On fetching the token, SDK will auto-register the device. This value is `true` by default.

--- a/Sources/MessagingPush/MessagingPushImplementation.swift
+++ b/Sources/MessagingPush/MessagingPushImplementation.swift
@@ -10,18 +10,21 @@ class MessagingPushImplementation: MessagingPushInstance {
     let logger: Logger
     let jsonAdapter: JsonAdapter
     let eventBusHandler: EventBusHandler
+    let richPushDeliveryTracker: RichPushDeliveryTracker
 
     /// testing init
     init(
         moduleConfig: MessagingPushConfigOptions,
         logger: Logger,
         jsonAdapter: JsonAdapter,
-        eventBusHandler: EventBusHandler
+        eventBusHandler: EventBusHandler,
+        richPushDeliveryTracker: RichPushDeliveryTracker
     ) {
         self.moduleConfig = moduleConfig
         self.logger = logger
         self.jsonAdapter = jsonAdapter
         self.eventBusHandler = eventBusHandler
+        self.richPushDeliveryTracker = richPushDeliveryTracker
     }
 
     init(diGraph: DIGraphShared, moduleConfig: MessagingPushConfigOptions) {
@@ -29,6 +32,7 @@ class MessagingPushImplementation: MessagingPushInstance {
         self.logger = diGraph.logger
         self.jsonAdapter = diGraph.jsonAdapter
         self.eventBusHandler = diGraph.eventBusHandler
+        self.richPushDeliveryTracker = diGraph.richPushDeliveryTracker
     }
 
     func deleteDeviceToken() {
@@ -41,6 +45,14 @@ class MessagingPushImplementation: MessagingPushInstance {
 
     func trackMetric(deliveryID: String, event: Metric, deviceToken: String) {
         eventBusHandler.postEvent(TrackMetricEvent(deliveryID: deliveryID, event: event.rawValue, deviceToken: deviceToken))
+    }
+
+    func trackMetricFromNSE(
+        deliveryID: String,
+        event: Metric,
+        deviceToken: String
+    ) {
+        richPushDeliveryTracker.trackMetric(token: deviceToken, event: event, deliveryId: deliveryID) { _ in }
     }
 
     #if canImport(UserNotifications)

--- a/Sources/MessagingPush/RichPush/MessagingPush+RichPush.swift
+++ b/Sources/MessagingPush/RichPush/MessagingPush+RichPush.swift
@@ -63,7 +63,7 @@ extension MessagingPushImplementation {
             logger.info("automatically tracking push metric: delivered")
             logger.debug("parsed deliveryId \(deliveryID), deviceToken: \(deviceToken)")
 
-            trackMetric(deliveryID: deliveryID, event: .delivered, deviceToken: deviceToken)
+            trackMetricFromNSE(deliveryID: deliveryID, event: .delivered, deviceToken: deviceToken)
         }
 
         if let richPushContent = CustomerIOParsedPushPayload.parse(

--- a/Sources/MessagingPush/RichPush/RichPushDeliveryTracker.swift
+++ b/Sources/MessagingPush/RichPush/RichPushDeliveryTracker.swift
@@ -1,0 +1,43 @@
+import CioInternalCommon
+import Foundation
+
+// sourcery: InjectRegisterShared = "RichPushDeliveryTracker"
+class RichPushDeliveryTracker {
+    let httpClient: HttpClient
+    let logger: Logger
+
+    init(httpClient: HttpClient, logger: Logger) {
+        self.httpClient = httpClient
+        self.logger = logger
+    }
+
+    func trackMetric(token: String, event: Metric, deliveryId: String, timestamp: String? = nil, onComplete: @escaping (Result<Void, HttpRequestError>) -> Void) {
+        let properties: [String: Any] = [
+            "anonymousId": deliveryId,
+            "properties": [
+                "recipient": token,
+                "metric": event.rawValue,
+                "deliveryId": deliveryId
+            ],
+            "event": "Report Delivery Event"
+        ]
+
+        let endpoint: CIOApiEndpoint = .trackNSEPushDeliveryMetrics
+        guard let httpParams = HttpRequestParams(
+            endpoint: endpoint,
+            baseUrl: RichPushHttpClient.defaultAPIHost,
+            headers: nil,
+            body: try? JSONSerialization.data(withJSONObject: properties)
+        ) else {
+            logger.error("Error constructing HTTP request. Endpoint: \(endpoint)")
+            return onComplete(.failure(.noRequestMade(nil)))
+        }
+
+        httpClient.request(httpParams) { result in
+            switch result {
+            case .success: onComplete(.success(()))
+            case .failure(let httpError): onComplete(.failure(httpError))
+            }
+        }
+    }
+}

--- a/Sources/MessagingPush/RichPush/RichPushHttpClient.swift
+++ b/Sources/MessagingPush/RichPush/RichPushHttpClient.swift
@@ -1,0 +1,192 @@
+import CioInternalCommon
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+// sourcery: InjectRegisterShared = "HttpClient"
+public class RichPushHttpClient: HttpClient {
+    private let httpRequestRunner: HttpRequestRunner
+    private let jsonAdapter: JsonAdapter
+    private let logger: Logger
+    private let cioApiSession: URLSession // only used to call the CIO API.
+    private let publicSession: URLSession // session used to call servers accessible to the public (such as CDNs)
+    private var allSessions: [URLSession] {
+        [cioApiSession, publicSession]
+    }
+
+    public func request(_ params: CioInternalCommon.HttpRequestParams, onComplete: @escaping (Result<Data, CioInternalCommon.HttpRequestError>) -> Void) {
+        httpRequestRunner
+            .request(
+                params: params,
+                session: getSessionForRequest(url: params.url)
+            ) { [weak self] data, response, error in
+                guard let self = self else { return }
+
+                if let error = error {
+                    logger.error("Error sending request \(error.localizedDescription).")
+                    if let error = self.isUrlError(error) {
+                        return onComplete(.failure(error))
+                    }
+
+                    return onComplete(.failure(.noRequestMade(error)))
+                } else if let httpResponse = response {
+                    if httpResponse.statusCode < 300 {
+                        guard let data = data else {
+                            return onComplete(.failure(.noRequestMade(nil)))
+                        }
+
+                        onComplete(.success(data))
+                    } else {
+                        logger.error("""
+                        \(httpResponse.statusCode) HTTP status code response.
+                        Error description: \(httpResponse.description)
+                        """)
+
+                        let unsuccessfulStatusCodeError: HttpRequestError =
+                            .unsuccessfulStatusCode(
+                                httpResponse.statusCode,
+                                apiMessage: getErrorMessageFromServerResponse(responseBody: data)
+                            )
+                        onComplete(.failure(unsuccessfulStatusCodeError))
+                    }
+                }
+            }
+    }
+
+    func getSessionForRequest(url: URL) -> URLSession {
+        let cioApiHostname = URL(string: Self.defaultAPIHost)!.host
+        let requestHostname = url.host
+        let isRequestToCIOApi = cioApiHostname == requestHostname
+
+        return isRequestToCIOApi ? cioApiSession : publicSession
+    }
+
+    private func getErrorMessageFromServerResponse(responseBody: Data?) -> String {
+        guard let data = responseBody, var errorBodyString = data.string else {
+            return "(server did not give a response)"
+        }
+
+        // don't log errors for JSON mapping since we are trying to decode *multiple* error classes.
+        // we are bound to fail more often and don't want to log errors that are not super helpful to us.
+        if let errorMessageBody: ErrorMessageResponse = jsonAdapter.fromJson(
+            data,
+            logErrors: false
+        ) {
+            errorBodyString = errorMessageBody.meta.error
+        } else if let errorMessageBody: ErrorsMessageResponse = jsonAdapter.fromJson(
+            data,
+            logErrors: false
+        ) {
+            errorBodyString = errorMessageBody.meta.errors.joined(separator: ",")
+        }
+        return errorBodyString
+    }
+
+    private func isUrlError(_ error: Error) -> HttpRequestError? {
+        guard let urlError = error as? URLError else { return nil }
+
+        switch urlError.code {
+        case .notConnectedToInternet, .networkConnectionLost, .timedOut:
+            return .noOrBadNetwork(urlError)
+        case .cancelled:
+            return .cancelled
+        default: return nil
+        }
+    }
+
+    public func downloadFile(url: URL, fileType: DownloadFileType, onComplete: @escaping (URL?) -> Void) {
+        httpRequestRunner.downloadFile(
+            url: url,
+            fileType: fileType,
+            session: getSessionForRequest(url: url),
+            onComplete: onComplete
+        )
+    }
+
+    public func cancel(finishTasks: Bool) {
+        if finishTasks {
+            allSessions.forEach { $0.finishTasksAndInvalidate() }
+        } else {
+            allSessions.forEach { $0.invalidateAndCancel() }
+        }
+    }
+
+    init(
+        jsonAdapter: JsonAdapter,
+        httpRequestRunner: HttpRequestRunner,
+        logger: Logger,
+        deviceInfo: DeviceInfo
+    ) {
+        self.httpRequestRunner = httpRequestRunner
+        self.jsonAdapter = jsonAdapter
+        self.logger = logger
+
+        self.publicSession = Self.getBasicSession()
+        self.cioApiSession = Self.getCIOApiSession(
+            key: MessagingPush.moduleConfig.writeKey,
+            userAgentHeaderValue: deviceInfo.getUserAgentHeaderValue()
+        )
+    }
+
+    deinit {
+        self.cancel(finishTasks: true)
+    }
+}
+
+extension RichPushHttpClient {
+    public static let defaultAPIHost = "https://cdp.customer.io/v1"
+
+    static func authorizationHeaderForWriteKey(_ key: String) -> String {
+        var returnHeader = ""
+        if let encodedRawHeader = key.data(using: .utf8) {
+            returnHeader = encodedRawHeader.base64EncodedString(options: NSData.Base64EncodingOptions(rawValue: 0))
+        }
+        return returnHeader
+    }
+
+    static func getCIOsessionHeader(
+        writeKey: String,
+        userAgentHeaderValue: String
+    ) -> [String: String] {
+        let basicAuthHeaderString = "Basic \(authorizationHeaderForWriteKey(writeKey))"
+
+        return ["Content-Type": "application/json; charset=utf-8",
+                "User-Agent": userAgentHeaderValue,
+                "Authorization": basicAuthHeaderString]
+    }
+
+    static func getBasicSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.httpMaximumConnectionsPerHost = 2
+        configuration.allowsCellularAccess = true
+        let session = URLSession(configuration: configuration, delegate: nil, delegateQueue: nil)
+        return session
+    }
+
+    static func getCIOApiSession(key: String, userAgentHeaderValue: String) -> URLSession {
+        let urlSessionConfig = getBasicSession().configuration
+
+        urlSessionConfig.httpAdditionalHeaders = getCIOsessionHeader(writeKey: key, userAgentHeaderValue: userAgentHeaderValue)
+
+        return URLSession(configuration: urlSessionConfig, delegate: nil, delegateQueue: nil)
+    }
+}
+
+extension DeviceInfo {
+    func getUserAgentHeaderValue() -> String {
+        var userAgent = "Customer.io NSE Client/\(sdkVersion)"
+
+        // Append device details if available
+        if let deviceModel = deviceModel,
+           let osName = osName,
+           let osVersion = osVersion {
+            userAgent += " (\(deviceModel); \(osName) \(osVersion))"
+        }
+
+        // App details
+        userAgent += " \(customerBundleId)/\(customerAppVersion)"
+
+        return userAgent
+    }
+}

--- a/Sources/MessagingPush/RichPush/RichPushRequestHandler.swift
+++ b/Sources/MessagingPush/RichPush/RichPushRequestHandler.swift
@@ -20,19 +20,18 @@ class RichPushRequestHandler {
         let existingRequest = requests[requestId]
         if existingRequest != nil { return }
 
-        // FIXME: [CDP] Evaluate and fix
-        // let diGraph = DIGraphShared.shared
-        // let httpClient = diGraph.httpClient
+        let diGraph = DIGraphShared.shared
+        let httpClient = diGraph.httpClient
 
-        // let newRequest = RichPushRequest(
-        //     pushContent: content,
-        //     request: request,
-        //     httpClient: httpClient,
-        //     completionHandler: completionHandler
-        // )
-        // requests[requestId] = newRequest
+        let newRequest = RichPushRequest(
+            pushContent: content,
+            request: request,
+            httpClient: httpClient,
+            completionHandler: completionHandler
+        )
+        requests[requestId] = newRequest
 
-        // newRequest.start()
+        newRequest.start()
     }
 
     func stopAll() {

--- a/Sources/MessagingPush/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/MessagingPush/autogenerated/AutoDependencyInjection.generated.swift
@@ -75,6 +75,25 @@ extension DIGraph {
 
 extension DIGraphShared {
     // Handle classes annotated with InjectRegisterShared
+    // RichPushDeliveryTracker
+    var richPushDeliveryTracker: RichPushDeliveryTracker {
+        getOverriddenInstance() ??
+            newRichPushDeliveryTracker
+    }
+
+    private var newRichPushDeliveryTracker: RichPushDeliveryTracker {
+        RichPushDeliveryTracker(httpClient: httpClient, logger: logger)
+    }
+
+    // HttpClient
+    public var httpClient: HttpClient {
+        getOverriddenInstance() ??
+            newHttpClient
+    }
+
+    private var newHttpClient: HttpClient {
+        RichPushHttpClient(jsonAdapter: jsonAdapter, httpRequestRunner: httpRequestRunner, logger: logger, deviceInfo: deviceInfo)
+    }
 }
 
 // swiftlint:enable all


### PR DESCRIPTION
helps: https://linear.app/customerio/issue/MOB-13/http-layer-for-nse
root ticket: https://github.com/customerio/issues/issues/11953

TLDR (work required): We need to add an HTTP layer that exists in the `Messaging Push` module when a push is received in NSE, we can just use that HTTP client to track the delivery for us. HTTP client is going to use the CIO data pipeline API endpoint. 

## Problem: 
Currently, HTTP client implementation was meant to stay in the `common` layer, but not anymore, if we are only utilizing the HTTP client rich push notification, downloading URL/ tracking metric. The implementation should be `Messaging` module-specific as well.  

## Solution:
This PR does the following:
- Add HTTP client implementation in the Messaging Push since it's the only module that utilizes it. 
- Add logic for tracking metrics for push

What this PR isn't doing:
- Clean up unused HTTP client code implementation, usage in tracking, etc. The cleaning of tracking code and unused methods of HTTP client etc would be in another PR, otherwise, they would make the review harder. 
