### PR TITLE
chore: fix tests after dependency updates

### DIFF
--- a/Sources/Common/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/Common/autogenerated/AutoDependencyInjection.generated.swift
@@ -349,6 +349,57 @@ extension DIGraph {
 }
 
 extension DIGraphShared {
+    // call in automated test suite to confirm that all dependnecies able to resolve and not cause runtime exceptions.
+    // internal scope so each module can provide their own version of the function with the same name.
+    @available(iOSApplicationExtension, unavailable) // some properties could be unavailable to app extensions so this function must also.
+    func testDependenciesAbleToResolve() -> Int {
+        var countDependenciesResolved = 0
+
+        _ = deviceInfo
+        countDependenciesResolved += 1
+
+        _ = eventBusHandler
+        countDependenciesResolved += 1
+
+        _ = globalDataStore
+        countDependenciesResolved += 1
+
+        _ = threadUtil
+        countDependenciesResolved += 1
+
+        _ = deviceMetricsGrabber
+        countDependenciesResolved += 1
+
+        _ = eventCache
+        countDependenciesResolved += 1
+
+        _ = eventStorage
+        countDependenciesResolved += 1
+
+        _ = jsonAdapter
+        countDependenciesResolved += 1
+
+        _ = dateUtil
+        countDependenciesResolved += 1
+
+        _ = logger
+        countDependenciesResolved += 1
+
+        _ = eventBus
+        countDependenciesResolved += 1
+
+        _ = uIKitWrapper
+        countDependenciesResolved += 1
+
+        _ = httpRequestRunner
+        countDependenciesResolved += 1
+
+        _ = sharedKeyValueStorage
+        countDependenciesResolved += 1
+
+        return countDependenciesResolved
+    }
+
     // Handle classes annotated with InjectRegisterShared
     // DeviceInfo
     public var deviceInfo: DeviceInfo {

--- a/Sources/DataPipeline/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/DataPipeline/autogenerated/AutoDependencyInjection.generated.swift
@@ -72,6 +72,18 @@ extension DIGraph {
 }
 
 extension DIGraphShared {
+    // call in automated test suite to confirm that all dependnecies able to resolve and not cause runtime exceptions.
+    // internal scope so each module can provide their own version of the function with the same name.
+    @available(iOSApplicationExtension, unavailable) // some properties could be unavailable to app extensions so this function must also.
+    func testDependenciesAbleToResolve() -> Int {
+        var countDependenciesResolved = 0
+
+        _ = deviceAttributesProvider
+        countDependenciesResolved += 1
+
+        return countDependenciesResolved
+    }
+
     // Handle classes annotated with InjectRegisterShared
     // DeviceAttributesProvider
     var deviceAttributesProvider: DeviceAttributesProvider {

--- a/Sources/MessagingInApp/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/MessagingInApp/autogenerated/AutoDependencyInjection.generated.swift
@@ -72,6 +72,18 @@ extension DIGraph {
 }
 
 extension DIGraphShared {
+    // call in automated test suite to confirm that all dependnecies able to resolve and not cause runtime exceptions.
+    // internal scope so each module can provide their own version of the function with the same name.
+    @available(iOSApplicationExtension, unavailable) // some properties could be unavailable to app extensions so this function must also.
+    func testDependenciesAbleToResolve() -> Int {
+        var countDependenciesResolved = 0
+
+        _ = inAppProvider
+        countDependenciesResolved += 1
+
+        return countDependenciesResolved
+    }
+
     // Handle classes annotated with InjectRegisterShared
     // InAppProvider
     var inAppProvider: InAppProvider {

--- a/Sources/MessagingPush/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/MessagingPush/autogenerated/AutoDependencyInjection.generated.swift
@@ -74,6 +74,21 @@ extension DIGraph {
 }
 
 extension DIGraphShared {
+    // call in automated test suite to confirm that all dependnecies able to resolve and not cause runtime exceptions.
+    // internal scope so each module can provide their own version of the function with the same name.
+    @available(iOSApplicationExtension, unavailable) // some properties could be unavailable to app extensions so this function must also.
+    func testDependenciesAbleToResolve() -> Int {
+        var countDependenciesResolved = 0
+
+        _ = richPushDeliveryTracker
+        countDependenciesResolved += 1
+
+        _ = httpClient
+        countDependenciesResolved += 1
+
+        return countDependenciesResolved
+    }
+
     // Handle classes annotated with InjectRegisterShared
     // RichPushDeliveryTracker
     var richPushDeliveryTracker: RichPushDeliveryTracker {

--- a/Sources/MessagingPushAPN/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/MessagingPushAPN/autogenerated/AutoDependencyInjection.generated.swift
@@ -60,6 +60,15 @@ extension DIGraph {
 }
 
 extension DIGraphShared {
+    // call in automated test suite to confirm that all dependnecies able to resolve and not cause runtime exceptions.
+    // internal scope so each module can provide their own version of the function with the same name.
+    @available(iOSApplicationExtension, unavailable) // some properties could be unavailable to app extensions so this function must also.
+    func testDependenciesAbleToResolve() -> Int {
+        var countDependenciesResolved = 0
+
+        return countDependenciesResolved
+    }
+
     // Handle classes annotated with InjectRegisterShared
 }
 

--- a/Sources/MessagingPushFCM/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/MessagingPushFCM/autogenerated/AutoDependencyInjection.generated.swift
@@ -60,6 +60,15 @@ extension DIGraph {
 }
 
 extension DIGraphShared {
+    // call in automated test suite to confirm that all dependnecies able to resolve and not cause runtime exceptions.
+    // internal scope so each module can provide their own version of the function with the same name.
+    @available(iOSApplicationExtension, unavailable) // some properties could be unavailable to app extensions so this function must also.
+    func testDependenciesAbleToResolve() -> Int {
+        var countDependenciesResolved = 0
+
+        return countDependenciesResolved
+    }
+
     // Handle classes annotated with InjectRegisterShared
 }
 

--- a/Sources/Templates/AutoDependencyInjection.stencil
+++ b/Sources/Templates/AutoDependencyInjection.stencil
@@ -119,6 +119,21 @@ extension DIGraph {
 }
 
 extension DIGraphShared {
+    // call in automated test suite to confirm that all dependnecies able to resolve and not cause runtime exceptions.
+    // internal scope so each module can provide their own version of the function with the same name.
+    @available(iOSApplicationExtension, unavailable) // some properties could be unavailable to app extensions so this function must also.
+    internal func testDependenciesAbleToResolve() -> Int {
+        var countDependenciesResolved = 0
+
+    {% for dep in types.all where dep|annotated:"InjectRegisterShared" %}
+    {% set class %}{{ dep.annotations["InjectRegisterShared"] }}{% endset %}
+        _ = self.{{ class|lowerFirstLetter }}
+        countDependenciesResolved += 1
+
+    {% endfor %}
+        return countDependenciesResolved
+    }
+
     // Handle classes annotated with InjectRegisterShared
     {% for dep in types.all where dep|annotated:"InjectRegisterShared" %}
     {% set class %}{{ dep.annotations["InjectRegisterShared"] }}{% endset %}

--- a/Sources/Tracking/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/Tracking/autogenerated/AutoDependencyInjection.generated.swift
@@ -86,6 +86,15 @@ extension DIGraph {
 }
 
 extension DIGraphShared {
+    // call in automated test suite to confirm that all dependnecies able to resolve and not cause runtime exceptions.
+    // internal scope so each module can provide their own version of the function with the same name.
+    @available(iOSApplicationExtension, unavailable) // some properties could be unavailable to app extensions so this function must also.
+    func testDependenciesAbleToResolve() -> Int {
+        var countDependenciesResolved = 0
+
+        return countDependenciesResolved
+    }
+
     // Handle classes annotated with InjectRegisterShared
 }
 

--- a/Tests/Common/DIGraphTests.swift
+++ b/Tests/Common/DIGraphTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import SharedTests
 import XCTest
 
-class DIGraphTests: IntegrationTest {
+class DIGraphTests: UnitTest {
     func testDependencyGraphComplete() {
         diGraph.testDependenciesAbleToResolve() // test will fail if an exception occurs while running this function
     }

--- a/Tests/Common/DIGraphTests.swift
+++ b/Tests/Common/DIGraphTests.swift
@@ -5,6 +5,7 @@ import XCTest
 
 class DIGraphTests: UnitTest {
     func testDependencyGraphComplete() {
+        diGraphShared.testDependenciesAbleToResolve() // test will fail if an exception occurs while running this function
         diGraph.testDependenciesAbleToResolve() // test will fail if an exception occurs while running this function
     }
 }

--- a/Tests/Shared/DIGraphTest.swift
+++ b/Tests/Shared/DIGraphTest.swift
@@ -18,7 +18,7 @@ import XCTest
  }
  ```
  */
-open class BaseDIGraphTest: IntegrationTest {
+open class BaseDIGraphTest: UnitTest {
     public func runTest_expectDiGraphResolvesAllDependenciesWithoutError() {
         // Test will try to get an instance of every dependency in the graph.
         // If an exception is thrown, then there is a bug in the graph.

--- a/Tests/Shared/DIGraphTest.swift
+++ b/Tests/Shared/DIGraphTest.swift
@@ -22,9 +22,15 @@ open class BaseDIGraphTest: UnitTest {
     public func runTest_expectDiGraphResolvesAllDependenciesWithoutError() {
         // Test will try to get an instance of every dependency in the graph.
         // If an exception is thrown, then there is a bug in the graph.
+        let numberOfSharedDependenciesResolved = diGraphShared.testDependenciesAbleToResolve()
         let numberOfDependenciesResolved = diGraph.testDependenciesAbleToResolve()
 
         // check to make sure test works as we expect it to. Since the test is automatically generated for us.
+        if numberOfSharedDependenciesResolved <= 0 {
+            XCTFail(
+                "there is probably a bug with the shared dependency injection graph test. 0 depdencies were resolved which is probably a bug."
+            )
+        }
         if numberOfDependenciesResolved <= 0 {
             XCTFail(
                 "there is probably a bug with the dependency injection graph test. 0 depdencies were resolved which is probably a bug."


### PR DESCRIPTION
helps: [MBL-50](https://linear.app/customerio/issue/MBL-50/resolve-test-failures-caused-by-dependency-updates)

###  Changes

- Fixed `DIGraph` tests to inherit `UnitTest` instead of `IntegrationTest`
- Updated stencil so `DIGraphShared` can also be tested for resolving dependencies