### PR TITLE
choree: added missing aliases

### DIFF
--- a/Sources/DataPipeline/Type/Aliases.swift
+++ b/Sources/DataPipeline/Type/Aliases.swift
@@ -1,3 +1,4 @@
+import CioInternalCommon
 import Foundation
 import Segment
 
@@ -26,3 +27,6 @@ public typealias IdentifyEvent = Segment.IdentifyEvent
 public typealias Settings = Segment.Settings
 public typealias FlushPolicy = Segment.FlushPolicy
 public typealias OperatingMode = Segment.OperatingMode
+
+public typealias Metric = CioInternalCommon.Metric
+public typealias CustomerIO = CioInternalCommon.CustomerIO


### PR DESCRIPTION
These aliases are already added for the `CIOTracking` module but were missed for the `CIODatePipeline` module. 
