### PR TITLE
fix: remove occurrence of autoTrackDeviceAttributes from all push modules

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
@@ -55,7 +55,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             .setEventListener(self)
         MessagingPushAPN.initialize { config in
             config.autoFetchDeviceToken = true
-            config.autoTrackDeviceAttributes = self.storage.isTrackDeviceAttrEnabled ?? true
         }
     }
 

--- a/Sources/MessagingPush/MessagingPushConfigOptions.swift
+++ b/Sources/MessagingPush/MessagingPushConfigOptions.swift
@@ -18,8 +18,7 @@ public struct MessagingPushConfigOptions {
             MessagingPushConfigOptions(
                 writeKey: "",
                 autoFetchDeviceToken: true,
-                autoTrackPushEvents: true,
-                autoTrackDeviceAttributes: true
+                autoTrackPushEvents: true
             )
         }
 
@@ -31,15 +30,13 @@ public struct MessagingPushConfigOptions {
             let writeKey = dictionary[Keys.writeKey.rawValue] as? String
             let autoFetchDeviceToken = dictionary[Keys.autoFetchDeviceToken.rawValue] as? Bool
             let autoTrackPushEvents = dictionary[Keys.autoTrackPushEvents.rawValue] as? Bool
-            let autoTrackDeviceAttributes = dictionary[Keys.autoTrackDeviceAttributes.rawValue] as? Bool
 
             // Use default config options as fallback
             let presetConfig = create()
             return MessagingPushConfigOptions(
                 writeKey: writeKey ?? presetConfig.writeKey,
                 autoFetchDeviceToken: autoFetchDeviceToken ?? presetConfig.autoFetchDeviceToken,
-                autoTrackPushEvents: autoTrackPushEvents ?? presetConfig.autoTrackPushEvents,
-                autoTrackDeviceAttributes: autoTrackDeviceAttributes ?? presetConfig.autoTrackDeviceAttributes
+                autoTrackPushEvents: autoTrackPushEvents ?? presetConfig.autoTrackPushEvents
             )
         }
     }
@@ -48,7 +45,6 @@ public struct MessagingPushConfigOptions {
         case writeKey
         case autoFetchDeviceToken
         case autoTrackPushEvents
-        case autoTrackDeviceAttributes
     }
 
     /// internal write key required for NotificationServiceExtension only to track metrics
@@ -63,9 +59,4 @@ public struct MessagingPushConfigOptions {
      for push notifications sent by Customer.io
      */
     public var autoTrackPushEvents: Bool
-    /**
-     Enable this property if you want SDK to automatic tracking of device attributes such as
-     operating system, device locale, device model, app version etc
-     */
-    public var autoTrackDeviceAttributes: Bool
 }


### PR DESCRIPTION
closes https://linear.app/customerio/issue/MBL-85/remove-occurrence-of-autotrackdeviceattributes-from-all-push-modules

Includes:
- Remove all instances of unused property autoTrackDeviceAttributes from the MessagingPush, MessagingPushAPN
- Update sample apps using this property from any of push modules


Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After code reviews are approved and you determine this PR is ready to merge, select *Squash and Merge* button on this screen, leave the title and description to the default values, then merge the PR.
