### PR TITLE
chore: fix dateextension test case based on timezone

### DIFF
--- a/Sources/Tracking/autogenerated/AutoMockable.generated.swift
+++ b/Sources/Tracking/autogenerated/AutoMockable.generated.swift
@@ -102,11 +102,6 @@ public class DataPipelineMigrationMock: DataPipelineMigration, Mock {
         handleQueueBacklogCallsCount = 0
 
         mockCalled = false // do last as resetting properties above can make this true
-        getAndProcessTaskCallsCount = 0
-        getAndProcessTaskReceivedArguments = nil
-        getAndProcessTaskReceivedInvocations = []
-
-        mockCalled = false // do last as resetting properties above can make this true
     }
 
     // MARK: - handleAlreadyIdentifiedMigratedUser
@@ -149,33 +144,6 @@ public class DataPipelineMigrationMock: DataPipelineMigration, Mock {
         mockCalled = true
         handleQueueBacklogCallsCount += 1
         handleQueueBacklogClosure?()
-    }
-
-    // MARK: - getAndProcessTask
-
-    /// Number of times the function was called.
-    public private(set) var getAndProcessTaskCallsCount = 0
-    /// `true` if the function was ever called.
-    public var getAndProcessTaskCalled: Bool {
-        getAndProcessTaskCallsCount > 0
-    }
-
-    /// The arguments from the *last* time the function was called.
-    public private(set) var getAndProcessTaskReceivedArguments: QueueTaskMetadata?
-    /// Arguments from *all* of the times that the function was called.
-    public private(set) var getAndProcessTaskReceivedInvocations: [QueueTaskMetadata] = []
-    /**
-     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
-     */
-    public var getAndProcessTaskClosure: ((QueueTaskMetadata) -> Void)?
-
-    /// Mocked function for `getAndProcessTask(for task: QueueTaskMetadata)`. Your opportunity to return a mocked value and check result of mock in test code.
-    public func getAndProcessTask(for task: QueueTaskMetadata) {
-        mockCalled = true
-        getAndProcessTaskCallsCount += 1
-        getAndProcessTaskReceivedArguments = task
-        getAndProcessTaskReceivedInvocations.append(task)
-        getAndProcessTaskClosure?(task)
     }
 }
 

--- a/Tests/Common/Extensions/DateExtensionTests.swift
+++ b/Tests/Common/Extensions/DateExtensionTests.swift
@@ -63,16 +63,17 @@ class DateExtensionTest: UnitTest {
     // MARK: formatToIso8601WithMilliseconds
 
     func test_givenDate_formatToIso8601WithMilliseconds_expectString() {
-        let calendar = Calendar.current
+        let calendar = TimeZone(identifier: "UTC")
         var components = DateComponents()
         components.year = 2024
         components.month = 2
         components.day = 1
-        components.hour = 20
+        components.hour = 16
         components.minute = 40
         components.second = 19
+        components.timeZone = TimeZone.current
 
-        guard let givenDate = calendar.date(from: components) else {
+        guard let givenDate = components.date else {
             print("Failed to create date from components")
             return
         }


### PR DESCRIPTION
Fixed date extension test case that was failing due to timezone difference.

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After code reviews are approved and you determine this PR is ready to merge, select *Squash and Merge* button on this screen, leave the title and description to the default values, then merge the PR.
