### PR TITLE
fix: one of the manual push tracking functions doesnt track metrics

### DIFF
--- a/Sources/MessagingPush/PushHandling/ManualPushHandling+UserNotifications.swift
+++ b/Sources/MessagingPush/PushHandling/ManualPushHandling+UserNotifications.swift
@@ -59,11 +59,12 @@ extension MessagingPushImplementation {
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
     ) -> Bool {
-        let push = UNNotificationWrapper(notification: response.notification)
-
-        guard push.isPushSentFromCio else {
-            // Exit early without calling completionHandler so that customer calls it instead.
-
+        // to keep this code DRY, forward the request to another function to perform all the logic:
+        guard let pushContent = userNotificationCenter(center, didReceive: response) else {
+            // push did not come from CIO
+            // Do not call completionHandler() because push did not come from CIO. Another service might have sent it so
+            // allow another SDK
+            // to call the completionHandler()
             return false
         }
 


### PR DESCRIPTION
While reviewing the diff for the new automatic push click handling feature, I noticed that one of the changes I made would result in push metrics not being reported, for one of the manual push tracking functions in our public API.

I reverted this function back to logic that is similar to what you see in `main` to fix the issue.

Now that our push module can have automated tests written against it, we can catch bugs like this in the future. Writing these tests is out of scope for this bug fix and can be introduced in the future.
