### PR TITLE
test: prevent infinite loop if sdk forwards push event back to itself

### DIFF
--- a/Sources/MessagingPush/PushHandling/PushEventHandlerProxy.swift
+++ b/Sources/MessagingPush/PushHandling/PushEventHandlerProxy.swift
@@ -29,14 +29,6 @@ class PushEventHandlerProxyImpl: PushEventHandlerProxy {
     private var nestedDelegates: [String: PushEventHandler] = [:]
 
     func addPushEventHandler(_ newHandler: PushEventHandler) {
-        // this line below seems fragile. If we change the class name, this could break.
-        // could digraph inject instance of the SDK's intance before setting singleton?
-        let doesDelegateBelongToCio = newHandler is IOSPushEventListener
-
-        guard !doesDelegateBelongToCio else {
-            return
-        }
-
         nestedDelegates[String(describing: newHandler)] = newHandler
     }
 

--- a/Tests/MessagingPush/PushHandling/PushEventHandlerTest.swift
+++ b/Tests/MessagingPush/PushHandling/PushEventHandlerTest.swift
@@ -1,0 +1,41 @@
+@testable import CioMessagingPush
+import Foundation
+import SharedTests
+import XCTest
+
+class PushEventHandlerTest: UnitTest {
+    private var pushEventHandler: PushEventHandler!
+
+    private var pushEventHandlerProxy: PushEventHandlerProxy {
+        diGraph.pushEventHandlerProxy
+    }
+
+    private var pushClickHandler = PushClickHandlerMock()
+
+    override func setUp() {
+        super.setUp()
+
+        pushEventHandler = IOSPushEventListener(jsonAdapter: diGraph.jsonAdapter, pushEventHandlerProxy: pushEventHandlerProxy, moduleConfig: MessagingPushConfigOptions(), pushClickHandler: pushClickHandler, pushHistory: diGraph.pushHistory, logger: log)
+    }
+
+    // MARK: onPushAction
+
+    /*
+     The CIO SDK push event handler forwards push notifications to other push event handlers in the host app.
+
+     But, what if the CIO SDK event handler forwards a push event back to the CIO SDK event handler? This could cause an infinite loop.
+
+     This test simulates that scenario to make sure that an inifinite loop would not happen.
+     */
+    func test_onPushAction_expectNoInfiniteLoopIfSdkForwardsPushEventBacktoSdkAgain() {
+        // The push event handler proxy is what forwards push events to other push event handlers in the app.
+        // To test if an infinite loop would happen, add ourself as a push event handler to get events forwarded to.
+        pushEventHandlerProxy.addPushEventHandler(pushEventHandler)
+
+        // Make sure push is not from CIO otherwise event does not get forwarded.
+        let givenPush = PushNotificationStub.getPushNotSentFromCIO()
+
+        // Send the CIO SDK push event handler an event. If an infinite loop occurs, this test will timeout or crash.
+        pushEventHandler.onPushAction(PushNotificationActionStub(push: givenPush, didClickOnPush: true)) {}
+    }
+}


### PR DESCRIPTION
Closes: https://linear.app/customerio/issue/MBL-70/assert-that-sdk-does-not-forward-push-click-events-to-itself

The CIO SDK push event handler forwards events to other handlers in the host app, allowing multiple push SDKs to be installed simultaneously.

However, forwarding events back to the CIO SDK push event handler could cause an infinite loop. A previous solution to prevent this was removed as it was fragile and not a good long-term fix. This commit adds a test to simulate the scenario to make sure an infinite loop will not occur.

Luckily, the push notification history feature prevents an infinite loop! No additional fix is needed.

Link to code that prevents infinite loop: https://github.com/customerio/customerio-ios/blob/55df69c3200c61bf2abaaa136a70d5de009ea7f0/Sources/MessagingPush/PushHandling/iOSPushEventListener.swift#L31-L34