### PR TITLE
chore: OS conditions for removed and deprecated APIs

### DIFF
--- a/Sources/Common/Util/DeviceInfo.swift
+++ b/Sources/Common/Util/DeviceInfo.swift
@@ -1,24 +1,25 @@
 import Foundation
+
 #if canImport(UIKit)
-import UIKit
+  import UIKit
 #endif
 #if canImport(UserNotifications)
-import UserNotifications
+  import UserNotifications
 #endif
 
 public protocol DeviceInfo: AutoMockable {
-    var deviceManufacturer: String { get }
-    var deviceModel: String? { get }
-    // Version of the OS. Example: "15.2.1" for iOS 15.2.1.
-    var osVersion: String? { get }
-    // OS name. Example: iOS, watchOS
-    var osName: String? { get }
-    var customerAppName: String { get }
-    var customerAppVersion: String { get }
-    var customerBundleId: String { get }
-    var sdkVersion: String { get }
-    var deviceLocale: String { get }
-    func isPushSubscribed(completion: @escaping (Bool) -> Void)
+  var deviceManufacturer: String { get }
+  var deviceModel: String? { get }
+  // Version of the OS. Example: "15.2.1" for iOS 15.2.1.
+  var osVersion: String? { get }
+  // OS name. Example: iOS, watchOS
+  var osName: String? { get }
+  var customerAppName: String { get }
+  var customerAppVersion: String { get }
+  var customerBundleId: String { get }
+  var sdkVersion: String { get }
+  var deviceLocale: String { get }
+  func isPushSubscribed(completion: @escaping (Bool) -> Void)
 }
 
 // To get basic detail about the device SDK is working on
@@ -27,86 +28,86 @@ public protocol DeviceInfo: AutoMockable {
 //
 // sourcery: InjectRegister = "DeviceInfo"
 public class CIODeviceInfo: DeviceInfo {
-    public var deviceManufacturer: String = "Apple"
+  public var deviceManufacturer: String = "Apple"
 
-    public var deviceModel: String? {
-        #if canImport(UIKit)
-        return UIDevice.deviceModelCode
-        #else
-        return nil
-        #endif
-    }
+  public var deviceModel: String? {
+    #if canImport(UIKit)
+      return UIDevice.deviceModelCode
+    #else
+      return nil
+    #endif
+  }
 
-    public var osVersion: String? {
-        #if canImport(UIKit)
-        return UIDevice.current.systemVersion
-        #else
-        return nil
-        #endif
-    }
+  public var osVersion: String? {
+    #if canImport(UIKit)
+      return UIDevice.current.systemVersion
+    #else
+      return nil
+    #endif
+  }
 
-    public var osName: String? {
-        #if canImport(UIKit)
-        return UIDevice.current.systemName
-        #else
-        return nil
-        #endif
-    }
+  public var osName: String? {
+    #if canImport(UIKit)
+      return UIDevice.current.systemName
+    #else
+      return nil
+    #endif
+  }
 
-    public var customerAppName: String {
-        Bundle.main.infoDictionary?["CFBundleName"] as? String ?? ""
-    }
+  public var customerAppName: String {
+    Bundle.main.infoDictionary?["CFBundleName"] as? String ?? ""
+  }
 
-    public var customerAppVersion: String {
-        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
-    }
+  public var customerAppVersion: String {
+    Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+  }
 
-    public var customerBundleId: String {
-        Bundle.main.bundleIdentifier ?? ""
-    }
+  public var customerBundleId: String {
+    Bundle.main.bundleIdentifier ?? ""
+  }
 
-    public var sdkVersion: String {
-        SdkVersion.version
-    }
+  public var sdkVersion: String {
+    SdkVersion.version
+  }
 
-    // Requirements:
-    // 1. Use - instead of _
-    // 2. We prefer to get the OS language that the user has set. First try to return that. If that does not succeed
-    // we default to the language set for the host app. The language returned for that will only return languagues
-    // that the app supports. If OS set to "es" but app does not support Spanish, then "es" will not be returned.
-    public var deviceLocale: String {
-        if let osSetLanguage = Locale.preferredLanguages.first {
-            let locale = Locale(identifier: osSetLanguage)
-          let getLangCodeAndRegion: () -> (String?, String?) = {
-            if #available(iOS 16, *), #available(visionOS 1.0, *) {
-              return (locale.language.languageCode?.identifier, locale.region?.identifier)
-            } else {
-              return (locale.languageCode, locale.regionCode)
-            }
-          }
-          
-          let (languageCode, regionCode) = getLangCodeAndRegion()
-          
-            if let languageCode = languageCode, let regionCode = regionCode {
-                return "\(languageCode)-\(regionCode)"
-            }
+  // Requirements:
+  // 1. Use - instead of _
+  // 2. We prefer to get the OS language that the user has set. First try to return that. If that does not succeed
+  // we default to the language set for the host app. The language returned for that will only return languagues
+  // that the app supports. If OS set to "es" but app does not support Spanish, then "es" will not be returned.
+  public var deviceLocale: String {
+    if let osSetLanguage = Locale.preferredLanguages.first {
+      let locale = Locale(identifier: osSetLanguage)
+      let getLangCodeAndRegion: () -> (String?, String?) = {
+        if #available(iOS 16, *), #available(visionOS 1.0, *) {
+          return (locale.language.languageCode?.identifier, locale.region?.identifier)
+        } else {
+          return (locale.languageCode, locale.regionCode)
         }
+      }
 
-        return Locale.current.identifier.replacingOccurrences(of: "_", with: "-")
+      let (languageCode, regionCode) = getLangCodeAndRegion()
+
+      if let languageCode = languageCode, let regionCode = regionCode {
+        return "\(languageCode)-\(regionCode)"
+      }
     }
 
-    public func isPushSubscribed(completion: @escaping (Bool) -> Void) {
-        #if canImport(UserNotifications)
-        let current = UNUserNotificationCenter.current()
-        current.getNotificationSettings(completionHandler: { settings in
-            if settings.authorizationStatus == .authorized {
-                completion(true)
-                return
-            }
-            completion(false)
-        })
-        #else
+    return Locale.current.identifier.replacingOccurrences(of: "_", with: "-")
+  }
+
+  public func isPushSubscribed(completion: @escaping (Bool) -> Void) {
+    #if canImport(UserNotifications)
+      let current = UNUserNotificationCenter.current()
+      current.getNotificationSettings(completionHandler: { settings in
+        if settings.authorizationStatus == .authorized {
+          completion(true)
+          return
+        }
         completion(false)
-        #endif
-    }
+      })
+    #else
+      completion(false)
+    #endif
+  }
 }

--- a/Sources/Common/Util/DeviceInfo.swift
+++ b/Sources/Common/Util/DeviceInfo.swift
@@ -1,25 +1,25 @@
 import Foundation
 
 #if canImport(UIKit)
-  import UIKit
+import UIKit
 #endif
 #if canImport(UserNotifications)
-  import UserNotifications
+import UserNotifications
 #endif
 
 public protocol DeviceInfo: AutoMockable {
-  var deviceManufacturer: String { get }
-  var deviceModel: String? { get }
-  // Version of the OS. Example: "15.2.1" for iOS 15.2.1.
-  var osVersion: String? { get }
-  // OS name. Example: iOS, watchOS
-  var osName: String? { get }
-  var customerAppName: String { get }
-  var customerAppVersion: String { get }
-  var customerBundleId: String { get }
-  var sdkVersion: String { get }
-  var deviceLocale: String { get }
-  func isPushSubscribed(completion: @escaping (Bool) -> Void)
+    var deviceManufacturer: String { get }
+    var deviceModel: String? { get }
+    // Version of the OS. Example: "15.2.1" for iOS 15.2.1.
+    var osVersion: String? { get }
+    // OS name. Example: iOS, watchOS
+    var osName: String? { get }
+    var customerAppName: String { get }
+    var customerAppVersion: String { get }
+    var customerBundleId: String { get }
+    var sdkVersion: String { get }
+    var deviceLocale: String { get }
+    func isPushSubscribed(completion: @escaping (Bool) -> Void)
 }
 
 // To get basic detail about the device SDK is working on
@@ -28,86 +28,86 @@ public protocol DeviceInfo: AutoMockable {
 //
 // sourcery: InjectRegister = "DeviceInfo"
 public class CIODeviceInfo: DeviceInfo {
-  public var deviceManufacturer: String = "Apple"
+    public var deviceManufacturer: String = "Apple"
 
-  public var deviceModel: String? {
-    #if canImport(UIKit)
-      return UIDevice.deviceModelCode
-    #else
-      return nil
-    #endif
-  }
-
-  public var osVersion: String? {
-    #if canImport(UIKit)
-      return UIDevice.current.systemVersion
-    #else
-      return nil
-    #endif
-  }
-
-  public var osName: String? {
-    #if canImport(UIKit)
-      return UIDevice.current.systemName
-    #else
-      return nil
-    #endif
-  }
-
-  public var customerAppName: String {
-    Bundle.main.infoDictionary?["CFBundleName"] as? String ?? ""
-  }
-
-  public var customerAppVersion: String {
-    Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
-  }
-
-  public var customerBundleId: String {
-    Bundle.main.bundleIdentifier ?? ""
-  }
-
-  public var sdkVersion: String {
-    SdkVersion.version
-  }
-
-  // Requirements:
-  // 1. Use - instead of _
-  // 2. We prefer to get the OS language that the user has set. First try to return that. If that does not succeed
-  // we default to the language set for the host app. The language returned for that will only return languagues
-  // that the app supports. If OS set to "es" but app does not support Spanish, then "es" will not be returned.
-  public var deviceLocale: String {
-    if let osSetLanguage = Locale.preferredLanguages.first {
-      let locale = Locale(identifier: osSetLanguage)
-      let getLangCodeAndRegion: () -> (String?, String?) = {
-        if #available(iOS 16, *), #available(visionOS 1.0, *) {
-          return (locale.language.languageCode?.identifier, locale.region?.identifier)
-        } else {
-          return (locale.languageCode, locale.regionCode)
-        }
-      }
-
-      let (languageCode, regionCode) = getLangCodeAndRegion()
-
-      if let languageCode = languageCode, let regionCode = regionCode {
-        return "\(languageCode)-\(regionCode)"
-      }
+    public var deviceModel: String? {
+        #if canImport(UIKit)
+        return UIDevice.deviceModelCode
+        #else
+        return nil
+        #endif
     }
 
-    return Locale.current.identifier.replacingOccurrences(of: "_", with: "-")
-  }
+    public var osVersion: String? {
+        #if canImport(UIKit)
+        return UIDevice.current.systemVersion
+        #else
+        return nil
+        #endif
+    }
 
-  public func isPushSubscribed(completion: @escaping (Bool) -> Void) {
-    #if canImport(UserNotifications)
-      let current = UNUserNotificationCenter.current()
-      current.getNotificationSettings(completionHandler: { settings in
-        if settings.authorizationStatus == .authorized {
-          completion(true)
-          return
+    public var osName: String? {
+        #if canImport(UIKit)
+        return UIDevice.current.systemName
+        #else
+        return nil
+        #endif
+    }
+
+    public var customerAppName: String {
+        Bundle.main.infoDictionary?["CFBundleName"] as? String ?? ""
+    }
+
+    public var customerAppVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+    }
+
+    public var customerBundleId: String {
+        Bundle.main.bundleIdentifier ?? ""
+    }
+
+    public var sdkVersion: String {
+        SdkVersion.version
+    }
+
+    // Requirements:
+    // 1. Use - instead of _
+    // 2. We prefer to get the OS language that the user has set. First try to return that. If that does not succeed
+    // we default to the language set for the host app. The language returned for that will only return languagues
+    // that the app supports. If OS set to "es" but app does not support Spanish, then "es" will not be returned.
+    public var deviceLocale: String {
+        if let osSetLanguage = Locale.preferredLanguages.first {
+            let locale = Locale(identifier: osSetLanguage)
+            let getLangCodeAndRegion: () -> (String?, String?) = {
+                if #available(iOS 16, *), #available(visionOS 1.0, *) {
+                    return (locale.language.languageCode?.identifier, locale.region?.identifier)
+                } else {
+                    return (locale.languageCode, locale.regionCode)
+                }
+            }
+
+            let (languageCode, regionCode) = getLangCodeAndRegion()
+
+            if let languageCode, let regionCode {
+                return "\(languageCode)-\(regionCode)"
+            }
         }
+
+        return Locale.current.identifier.replacingOccurrences(of: "_", with: "-")
+    }
+
+    public func isPushSubscribed(completion: @escaping (Bool) -> Void) {
+        #if canImport(UserNotifications)
+        let current = UNUserNotificationCenter.current()
+        current.getNotificationSettings(completionHandler: { settings in
+            if settings.authorizationStatus == .authorized {
+                completion(true)
+                return
+            }
+            completion(false)
+        })
+        #else
         completion(false)
-      })
-    #else
-      completion(false)
-    #endif
-  }
+        #endif
+    }
 }

--- a/Sources/Common/Util/DeviceInfo.swift
+++ b/Sources/Common/Util/DeviceInfo.swift
@@ -77,9 +77,17 @@ public class CIODeviceInfo: DeviceInfo {
     public var deviceLocale: String {
         if let osSetLanguage = Locale.preferredLanguages.first {
             let locale = Locale(identifier: osSetLanguage)
-
-            if let languageCode = locale.languageCode,
-               let regionCode = locale.regionCode {
+          let getLangCodeAndRegion: () -> (String?, String?) = {
+            if #available(iOS 16, *), #available(visionOS 1.0, *) {
+              return (locale.language.languageCode?.identifier, locale.region?.identifier)
+            } else {
+              return (locale.languageCode, locale.regionCode)
+            }
+          }
+          
+          let (languageCode, regionCode) = getLangCodeAndRegion()
+          
+            if let languageCode = languageCode, let regionCode = regionCode {
                 return "\(languageCode)-\(regionCode)"
             }
         }

--- a/Sources/Tracking/CustomerIOImplementation+ScreenViews.swift
+++ b/Sources/Tracking/CustomerIOImplementation+ScreenViews.swift
@@ -174,7 +174,7 @@ import Foundation
 #else
   extension CustomerIOImplementation {
     func setupAutoScreenviewTracking() {
-      // XXX: log warning that tracking is not available
+        // XXX: log warning that tracking is not available
     }
   }
 #endif

--- a/Sources/Tracking/CustomerIOImplementation+ScreenViews.swift
+++ b/Sources/Tracking/CustomerIOImplementation+ScreenViews.swift
@@ -151,7 +151,9 @@ extension UIViewController {
                 }
             }
         } else { // keyWindow is deprecated in iOS 13.0*
+          #if os(iOS)
             return UIApplication.shared.keyWindow?.rootViewController
+          #endif
         }
 
         return nil

--- a/Sources/Tracking/CustomerIOImplementation+ScreenViews.swift
+++ b/Sources/Tracking/CustomerIOImplementation+ScreenViews.swift
@@ -2,145 +2,148 @@ import CioInternalCommon
 import Foundation
 
 #if canImport(UIKit)
-  import UIKit
+import UIKit
 
-  // screen view tracking is not available for notification service extension. disable all functions having to deal with
-  // screen view tracking feature.
-  @available(iOSApplicationExtension, unavailable)
-  extension CustomerIO {
+// screen view tracking is not available for notification service extension. disable all functions having to deal with
+// screen view tracking feature.
+@available(iOSApplicationExtension, unavailable)
+extension CustomerIO {
     func setupAutoScreenviewTracking() {
-      swizzle(
-        forClass: UIViewController.self,
-        original: #selector(UIViewController.viewDidAppear(_:)),
-        new: #selector(UIViewController.cio_swizzled_UIKit_viewDidAppear(_:))
-      )
-      swizzle(
-        forClass: UIViewController.self,
-        original: #selector(UIViewController.viewDidDisappear(_:)),
-        new: #selector(UIViewController.cio_swizzled_UIKit_viewDidDisappear(_:))
-      )
+        swizzle(
+            forClass: UIViewController.self,
+            original: #selector(UIViewController.viewDidAppear(_:)),
+            new: #selector(UIViewController.cio_swizzled_UIKit_viewDidAppear(_:))
+        )
+        swizzle(
+            forClass: UIViewController.self,
+            original: #selector(UIViewController.viewDidDisappear(_:)),
+            new: #selector(UIViewController.cio_swizzled_UIKit_viewDidDisappear(_:))
+        )
     }
 
     private func swizzle(forClass: AnyClass, original: Selector, new: Selector) {
-      guard let originalMethod = class_getInstanceMethod(forClass, original) else { return }
-      guard let swizzledMethod = class_getInstanceMethod(forClass, new) else { return }
-      method_exchangeImplementations(originalMethod, swizzledMethod)
+        guard let originalMethod = class_getInstanceMethod(forClass, original) else {
+            return
+        }
+        guard let swizzledMethod = class_getInstanceMethod(forClass, new) else {
+            return
+        }
+        method_exchangeImplementations(originalMethod, swizzledMethod)
     }
 
     func performScreenTracking(onViewController viewController: UIViewController) {
-      guard let diGraph = diGraph else {
-        return  // SDK not initialized yet. Therefore, we ignore event.
-      }
-
-      guard let name = viewController.getNameForAutomaticScreenViewTracking() else {
-        diGraph.logger.info(
-          "Automatic screenview tracking event ignored for \(viewController). Could not determine name to use for screen."
-        )
-        return
-      }
-
-      // Before we track event, apply a filter to remove events that could be unhelpful.
-      let customerOverridenFilter = diGraph.sdkConfig.filterAutoScreenViewEvents
-      let defaultSdkFilter: (UIViewController) -> Bool = { viewController in
-        let isViewFromApple = viewController.bundleIdOfView?.hasPrefix("com.apple") ?? false
-
-        if isViewFromApple {
-          return false  // filter out events that come from Apple's frameworks. We consider those irrelevant for customers.
+        guard let diGraph else {
+            return // SDK not initialized yet. Therefore, we ignore event.
         }
 
-        // Views from customer's app or 3rd party SDKs are considered relevant and are tracked.
-        return true
-      }
+        guard let name = viewController.getNameForAutomaticScreenViewTracking() else {
+            diGraph.logger.info(
+                "Automatic screenview tracking event ignored for \(viewController). Could not determine name to use for screen."
+            )
+            return
+        }
 
-      let filter = customerOverridenFilter ?? defaultSdkFilter
-      let shouldTrackEvent = filter(viewController)
+        // Before we track event, apply a filter to remove events that could be unhelpful.
+        let customerOverridenFilter = diGraph.sdkConfig.filterAutoScreenViewEvents
+        let defaultSdkFilter: (UIViewController) -> Bool = { viewController in
+            let isViewFromApple = viewController.bundleIdOfView?.hasPrefix("com.apple") ?? false
 
-      guard shouldTrackEvent else {
-        let isUsingSdkDefaultFilter = customerOverridenFilter == nil
-        diGraph.logger.debug(
-          "automatic screenview ignored for, \(name):\(viewController.bundleIdOfView ?? ""). It was filtered out. Is using sdk default filter: \(isUsingSdkDefaultFilter)"
-        )
-        return  // event has been filtered out. Ignore it.
-      }
+            if isViewFromApple {
+                return false // filter out events that come from Apple's frameworks. We consider those irrelevant for customers.
+            }
 
-      let addionalScreenViewData = CustomerIOImplementation.autoScreenViewBody?() ?? [:]
-      automaticScreenView(name: name, data: addionalScreenViewData)
+            // Views from customer's app or 3rd party SDKs are considered relevant and are tracked.
+            return true
+        }
+
+        let filter = customerOverridenFilter ?? defaultSdkFilter
+        let shouldTrackEvent = filter(viewController)
+
+        guard shouldTrackEvent else {
+            let isUsingSdkDefaultFilter = customerOverridenFilter == nil
+            diGraph.logger.debug(
+                "automatic screenview ignored for, \(name):\(viewController.bundleIdOfView ?? ""). It was filtered out. Is using sdk default filter: \(isUsingSdkDefaultFilter)"
+            )
+            return // event has been filtered out. Ignore it.
+        }
+
+        let addionalScreenViewData = CustomerIOImplementation.autoScreenViewBody?() ?? [:]
+        automaticScreenView(name: name, data: addionalScreenViewData)
     }
-  }
+}
 
-  // screen view tracking is not available for notification service extension. disable all functions having to deal with
-  // screen view tracking feature.
-  @available(iOSApplicationExtension, unavailable)
-  extension UIViewController {
+// screen view tracking is not available for notification service extension. disable all functions having to deal with
+// screen view tracking feature.
+@available(iOSApplicationExtension, unavailable)
+extension UIViewController {
     @objc func cio_swizzled_UIKit_viewDidAppear(_ animated: Bool) {
-      performAutomaticScreenTracking()
+        performAutomaticScreenTracking()
 
-      // this function looks like recursion, but it's how you call ViewController.viewDidAppear.
-      cio_swizzled_UIKit_viewDidAppear(animated)
+        // this function looks like recursion, but it's how you call ViewController.viewDidAppear.
+        cio_swizzled_UIKit_viewDidAppear(animated)
     }
 
     // capture the screen we are at when the previous ViewController got removed from the view stack.
     @objc func cio_swizzled_UIKit_viewDidDisappear(_ animated: Bool) {
-      // this function looks like recursion, but it's how you call ViewController.viewDidDisappear.
-      cio_swizzled_UIKit_viewDidDisappear(animated)
+        // this function looks like recursion, but it's how you call ViewController.viewDidDisappear.
+        cio_swizzled_UIKit_viewDidDisappear(animated)
 
-      performAutomaticScreenTracking()
+        performAutomaticScreenTracking()
     }
 
     func performAutomaticScreenTracking() {
-      var rootViewController = viewIfLoaded?.window?.rootViewController
-      if rootViewController == nil {
-        rootViewController = getActiveRootViewController()
-      }
-      guard
-        let viewController = getVisibleViewController(fromRootViewController: rootViewController)
-      else {
-        return
-      }
+        var rootViewController = viewIfLoaded?.window?.rootViewController
+        if rootViewController == nil {
+            rootViewController = getActiveRootViewController()
+        }
+        guard
+            let viewController = getVisibleViewController(fromRootViewController: rootViewController)
+        else {
+            return
+        }
 
-      CustomerIO.shared.performScreenTracking(onViewController: viewController)
+        CustomerIO.shared.performScreenTracking(onViewController: viewController)
     }
 
     func getNameForAutomaticScreenViewTracking() -> String? {
-      let nameOfViewControllerClass = String(describing: type(of: self))
+        let nameOfViewControllerClass = String(describing: type(of: self))
 
-      let name = nameOfViewControllerClass.replacingOccurrences(
-        of: "ViewController",
-        with: "",
-        options: .caseInsensitive
-      )
-      if !name.isEmpty {
-        return name
-      }
+        let name = nameOfViewControllerClass.replacingOccurrences(
+            of: "ViewController",
+            with: "",
+            options: .caseInsensitive
+        )
+        if !name.isEmpty {
+            return name
+        }
 
-      if title != nil {
-        return title
-      }
+        if title != nil {
+            return title
+        }
 
-      return nil
+        return nil
     }
 
     /**
      Finds the top most view controller in the navigation controller/ tab bar controller stack or if it is presented
      */
     private func getVisibleViewController(
-      fromRootViewController rootViewController: UIViewController?
+        fromRootViewController rootViewController: UIViewController?
     )
-      -> UIViewController?
-    {
-      if let navigationController = rootViewController as? UINavigationController {
-        return getVisibleViewController(
-          fromRootViewController: navigationController.visibleViewController)
-      }
-      if let tabController = rootViewController as? UITabBarController {
-        if let selected = tabController.selectedViewController {
-          return getVisibleViewController(fromRootViewController: selected)
+        -> UIViewController? {
+        if let navigationController = rootViewController as? UINavigationController {
+            return getVisibleViewController(
+                fromRootViewController: navigationController.visibleViewController)
         }
-      }
-      if let presented = rootViewController?.presentedViewController {
-        return getVisibleViewController(fromRootViewController: presented)
-      }
-      return rootViewController
+        if let tabController = rootViewController as? UITabBarController {
+            if let selected = tabController.selectedViewController {
+                return getVisibleViewController(fromRootViewController: selected)
+            }
+        }
+        if let presented = rootViewController?.presentedViewController {
+            return getVisibleViewController(fromRootViewController: presented)
+        }
+        return rootViewController
     }
 
     /**
@@ -149,32 +152,32 @@ import Foundation
      - returns: If window is not found then this function returns nil else returns the root view controller
      */
     private func getActiveRootViewController() -> UIViewController? {
-      if let viewController = UIApplication.shared.delegate?.window??.rootViewController {
-        return viewController
-      } else if #available(iOS 13.0, *) {
-        for scene in UIApplication.shared.connectedScenes {
-          if scene.activationState == .foregroundActive, let windowScene = scene as? UIWindowScene {
-            if let sceneDelegate = windowScene.delegate as? UIWindowSceneDelegate {
-              if let sceneWindow = sceneDelegate.window {
-                return sceneWindow?.rootViewController
-              }
+        if let viewController = UIApplication.shared.delegate?.window??.rootViewController {
+            return viewController
+        } else if #available(iOS 13.0, *) {
+            for scene in UIApplication.shared.connectedScenes {
+                if scene.activationState == .foregroundActive, let windowScene = scene as? UIWindowScene {
+                    if let sceneDelegate = windowScene.delegate as? UIWindowSceneDelegate {
+                        if let sceneWindow = sceneDelegate.window {
+                            return sceneWindow?.rootViewController
+                        }
+                    }
+                }
             }
-          }
+        } else { // keyWindow is deprecated in iOS 13.0*
+            #if os(iOS)
+            return UIApplication.shared.keyWindow?.rootViewController
+            #endif
         }
-      } else {  // keyWindow is deprecated in iOS 13.0*
-        #if os(iOS)
-          return UIApplication.shared.keyWindow?.rootViewController
-        #endif
-      }
 
-      return nil
+        return nil
     }
-  }
+}
 
 #else
-  extension CustomerIOImplementation {
+extension CustomerIOImplementation {
     func setupAutoScreenviewTracking() {
         // XXX: log warning that tracking is not available
     }
-  }
+}
 #endif

--- a/Sources/Tracking/CustomerIOImplementation+ScreenViews.swift
+++ b/Sources/Tracking/CustomerIOImplementation+ScreenViews.swift
@@ -1,135 +1,146 @@
 import CioInternalCommon
 import Foundation
-#if canImport(UIKit)
-import UIKit
 
-// screen view tracking is not available for notification service extension. disable all functions having to deal with
-// screen view tracking feature.
-@available(iOSApplicationExtension, unavailable)
-extension CustomerIO {
+#if canImport(UIKit)
+  import UIKit
+
+  // screen view tracking is not available for notification service extension. disable all functions having to deal with
+  // screen view tracking feature.
+  @available(iOSApplicationExtension, unavailable)
+  extension CustomerIO {
     func setupAutoScreenviewTracking() {
-        swizzle(
-            forClass: UIViewController.self,
-            original: #selector(UIViewController.viewDidAppear(_:)),
-            new: #selector(UIViewController.cio_swizzled_UIKit_viewDidAppear(_:))
-        )
-        swizzle(
-            forClass: UIViewController.self,
-            original: #selector(UIViewController.viewDidDisappear(_:)),
-            new: #selector(UIViewController.cio_swizzled_UIKit_viewDidDisappear(_:))
-        )
+      swizzle(
+        forClass: UIViewController.self,
+        original: #selector(UIViewController.viewDidAppear(_:)),
+        new: #selector(UIViewController.cio_swizzled_UIKit_viewDidAppear(_:))
+      )
+      swizzle(
+        forClass: UIViewController.self,
+        original: #selector(UIViewController.viewDidDisappear(_:)),
+        new: #selector(UIViewController.cio_swizzled_UIKit_viewDidDisappear(_:))
+      )
     }
 
     private func swizzle(forClass: AnyClass, original: Selector, new: Selector) {
-        guard let originalMethod = class_getInstanceMethod(forClass, original) else { return }
-        guard let swizzledMethod = class_getInstanceMethod(forClass, new) else { return }
-        method_exchangeImplementations(originalMethod, swizzledMethod)
+      guard let originalMethod = class_getInstanceMethod(forClass, original) else { return }
+      guard let swizzledMethod = class_getInstanceMethod(forClass, new) else { return }
+      method_exchangeImplementations(originalMethod, swizzledMethod)
     }
 
     func performScreenTracking(onViewController viewController: UIViewController) {
-        guard let diGraph = diGraph else {
-            return // SDK not initialized yet. Therefore, we ignore event.
+      guard let diGraph = diGraph else {
+        return  // SDK not initialized yet. Therefore, we ignore event.
+      }
+
+      guard let name = viewController.getNameForAutomaticScreenViewTracking() else {
+        diGraph.logger.info(
+          "Automatic screenview tracking event ignored for \(viewController). Could not determine name to use for screen."
+        )
+        return
+      }
+
+      // Before we track event, apply a filter to remove events that could be unhelpful.
+      let customerOverridenFilter = diGraph.sdkConfig.filterAutoScreenViewEvents
+      let defaultSdkFilter: (UIViewController) -> Bool = { viewController in
+        let isViewFromApple = viewController.bundleIdOfView?.hasPrefix("com.apple") ?? false
+
+        if isViewFromApple {
+          return false  // filter out events that come from Apple's frameworks. We consider those irrelevant for customers.
         }
 
-        guard let name = viewController.getNameForAutomaticScreenViewTracking() else {
-            diGraph.logger.info("Automatic screenview tracking event ignored for \(viewController). Could not determine name to use for screen.")
-            return
-        }
+        // Views from customer's app or 3rd party SDKs are considered relevant and are tracked.
+        return true
+      }
 
-        // Before we track event, apply a filter to remove events that could be unhelpful.
-        let customerOverridenFilter = diGraph.sdkConfig.filterAutoScreenViewEvents
-        let defaultSdkFilter: (UIViewController) -> Bool = { viewController in
-            let isViewFromApple = viewController.bundleIdOfView?.hasPrefix("com.apple") ?? false
+      let filter = customerOverridenFilter ?? defaultSdkFilter
+      let shouldTrackEvent = filter(viewController)
 
-            if isViewFromApple {
-                return false // filter out events that come from Apple's frameworks. We consider those irrelevant for customers.
-            }
+      guard shouldTrackEvent else {
+        let isUsingSdkDefaultFilter = customerOverridenFilter == nil
+        diGraph.logger.debug(
+          "automatic screenview ignored for, \(name):\(viewController.bundleIdOfView ?? ""). It was filtered out. Is using sdk default filter: \(isUsingSdkDefaultFilter)"
+        )
+        return  // event has been filtered out. Ignore it.
+      }
 
-            // Views from customer's app or 3rd party SDKs are considered relevant and are tracked.
-            return true
-        }
-
-        let filter = customerOverridenFilter ?? defaultSdkFilter
-        let shouldTrackEvent = filter(viewController)
-
-        guard shouldTrackEvent else {
-            let isUsingSdkDefaultFilter = customerOverridenFilter == nil
-            diGraph.logger.debug("automatic screenview ignored for, \(name):\(viewController.bundleIdOfView ?? ""). It was filtered out. Is using sdk default filter: \(isUsingSdkDefaultFilter)")
-            return // event has been filtered out. Ignore it.
-        }
-
-        let addionalScreenViewData = CustomerIOImplementation.autoScreenViewBody?() ?? [:]
-        automaticScreenView(name: name, data: addionalScreenViewData)
+      let addionalScreenViewData = CustomerIOImplementation.autoScreenViewBody?() ?? [:]
+      automaticScreenView(name: name, data: addionalScreenViewData)
     }
-}
+  }
 
-// screen view tracking is not available for notification service extension. disable all functions having to deal with
-// screen view tracking feature.
-@available(iOSApplicationExtension, unavailable)
-extension UIViewController {
+  // screen view tracking is not available for notification service extension. disable all functions having to deal with
+  // screen view tracking feature.
+  @available(iOSApplicationExtension, unavailable)
+  extension UIViewController {
     @objc func cio_swizzled_UIKit_viewDidAppear(_ animated: Bool) {
-        performAutomaticScreenTracking()
+      performAutomaticScreenTracking()
 
-        // this function looks like recursion, but it's how you call ViewController.viewDidAppear.
-        cio_swizzled_UIKit_viewDidAppear(animated)
+      // this function looks like recursion, but it's how you call ViewController.viewDidAppear.
+      cio_swizzled_UIKit_viewDidAppear(animated)
     }
 
     // capture the screen we are at when the previous ViewController got removed from the view stack.
     @objc func cio_swizzled_UIKit_viewDidDisappear(_ animated: Bool) {
-        // this function looks like recursion, but it's how you call ViewController.viewDidDisappear.
-        cio_swizzled_UIKit_viewDidDisappear(animated)
+      // this function looks like recursion, but it's how you call ViewController.viewDidDisappear.
+      cio_swizzled_UIKit_viewDidDisappear(animated)
 
-        performAutomaticScreenTracking()
+      performAutomaticScreenTracking()
     }
 
     func performAutomaticScreenTracking() {
-        var rootViewController = viewIfLoaded?.window?.rootViewController
-        if rootViewController == nil {
-            rootViewController = getActiveRootViewController()
-        }
-        guard let viewController = getVisibleViewController(fromRootViewController: rootViewController) else {
-            return
-        }
+      var rootViewController = viewIfLoaded?.window?.rootViewController
+      if rootViewController == nil {
+        rootViewController = getActiveRootViewController()
+      }
+      guard
+        let viewController = getVisibleViewController(fromRootViewController: rootViewController)
+      else {
+        return
+      }
 
-        CustomerIO.shared.performScreenTracking(onViewController: viewController)
+      CustomerIO.shared.performScreenTracking(onViewController: viewController)
     }
 
     func getNameForAutomaticScreenViewTracking() -> String? {
-        let nameOfViewControllerClass = String(describing: type(of: self))
+      let nameOfViewControllerClass = String(describing: type(of: self))
 
-        let name = nameOfViewControllerClass.replacingOccurrences(
-            of: "ViewController",
-            with: "",
-            options: .caseInsensitive
-        )
-        if !name.isEmpty {
-            return name
-        }
+      let name = nameOfViewControllerClass.replacingOccurrences(
+        of: "ViewController",
+        with: "",
+        options: .caseInsensitive
+      )
+      if !name.isEmpty {
+        return name
+      }
 
-        if title != nil {
-            return title
-        }
+      if title != nil {
+        return title
+      }
 
-        return nil
+      return nil
     }
 
     /**
      Finds the top most view controller in the navigation controller/ tab bar controller stack or if it is presented
      */
-    private func getVisibleViewController(fromRootViewController rootViewController: UIViewController?)
-        -> UIViewController? {
-        if let navigationController = rootViewController as? UINavigationController {
-            return getVisibleViewController(fromRootViewController: navigationController.visibleViewController)
+    private func getVisibleViewController(
+      fromRootViewController rootViewController: UIViewController?
+    )
+      -> UIViewController?
+    {
+      if let navigationController = rootViewController as? UINavigationController {
+        return getVisibleViewController(
+          fromRootViewController: navigationController.visibleViewController)
+      }
+      if let tabController = rootViewController as? UITabBarController {
+        if let selected = tabController.selectedViewController {
+          return getVisibleViewController(fromRootViewController: selected)
         }
-        if let tabController = rootViewController as? UITabBarController {
-            if let selected = tabController.selectedViewController {
-                return getVisibleViewController(fromRootViewController: selected)
-            }
-        }
-        if let presented = rootViewController?.presentedViewController {
-            return getVisibleViewController(fromRootViewController: presented)
-        }
-        return rootViewController
+      }
+      if let presented = rootViewController?.presentedViewController {
+        return getVisibleViewController(fromRootViewController: presented)
+      }
+      return rootViewController
     }
 
     /**
@@ -138,32 +149,32 @@ extension UIViewController {
      - returns: If window is not found then this function returns nil else returns the root view controller
      */
     private func getActiveRootViewController() -> UIViewController? {
-        if let viewController = UIApplication.shared.delegate?.window??.rootViewController {
-            return viewController
-        } else if #available(iOS 13.0, *) {
-            for scene in UIApplication.shared.connectedScenes {
-                if scene.activationState == .foregroundActive, let windowScene = scene as? UIWindowScene {
-                    if let sceneDelegate = windowScene.delegate as? UIWindowSceneDelegate {
-                        if let sceneWindow = sceneDelegate.window {
-                            return sceneWindow?.rootViewController
-                        }
-                    }
-                }
+      if let viewController = UIApplication.shared.delegate?.window??.rootViewController {
+        return viewController
+      } else if #available(iOS 13.0, *) {
+        for scene in UIApplication.shared.connectedScenes {
+          if scene.activationState == .foregroundActive, let windowScene = scene as? UIWindowScene {
+            if let sceneDelegate = windowScene.delegate as? UIWindowSceneDelegate {
+              if let sceneWindow = sceneDelegate.window {
+                return sceneWindow?.rootViewController
+              }
             }
-        } else { // keyWindow is deprecated in iOS 13.0*
-          #if os(iOS)
-            return UIApplication.shared.keyWindow?.rootViewController
-          #endif
+          }
         }
+      } else {  // keyWindow is deprecated in iOS 13.0*
+        #if os(iOS)
+          return UIApplication.shared.keyWindow?.rootViewController
+        #endif
+      }
 
-        return nil
+      return nil
     }
-}
+  }
 
 #else
-extension CustomerIOImplementation {
+  extension CustomerIOImplementation {
     func setupAutoScreenviewTracking() {
-        // XXX: log warning that tracking is not available
+      // XXX: log warning that tracking is not available
     }
-}
+  }
 #endif


### PR DESCRIPTION
## Context
This PR does not introduce any functional changes. It only aimed at handling warnings and compile error due to deprecated APIs and one removed API in VisionOS 1.0

## How did I make sure this did not break anything?
- Manually build APN UIKit app to make sure the compiled code is not stripped out for iOS and device locale new API works as expected
- Same on VisionOS which uses SwiftUI. `keyWindow` call is stripped out
