### PR TITLE
chore: minor lint warnings removed

### DIFF
--- a/Sources/Common/Service/Request/MetricRequest.swift
+++ b/Sources/Common/Service/Request/MetricRequest.swift
@@ -1,4 +1,4 @@
-import CioInternalCommon
+
 import Foundation
 
 // https://customer.io/docs/api/#operation/pushMetrics

--- a/Sources/MessagingPush/PushHandling/ManualPushHandling+UserNotifications.swift
+++ b/Sources/MessagingPush/PushHandling/ManualPushHandling+UserNotifications.swift
@@ -60,7 +60,7 @@ extension MessagingPushImplementation {
         withCompletionHandler completionHandler: @escaping () -> Void
     ) -> Bool {
         // to keep this code DRY, forward the request to another function to perform all the logic:
-        guard let pushContent = userNotificationCenter(center, didReceive: response) else {
+        guard let _ = userNotificationCenter(center, didReceive: response) else {
             // push did not come from CIO
             // Do not call completionHandler() because push did not come from CIO. Another service might have sent it so
             // allow another SDK

--- a/Sources/MessagingPushAPN/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/MessagingPushAPN/autogenerated/AutoDependencyInjection.generated.swift
@@ -54,7 +54,9 @@ extension DIGraph {
     // internal scope so each module can provide their own version of the function with the same name.
     @available(iOSApplicationExtension, unavailable) // some properties could be unavailable to app extensions so this function must also.
     func testDependenciesAbleToResolve() -> Int {
-        return 0
+        var countDependenciesResolved = 0
+
+        return countDependenciesResolved
     }
 }
 

--- a/Sources/MessagingPushAPN/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/MessagingPushAPN/autogenerated/AutoDependencyInjection.generated.swift
@@ -54,9 +54,7 @@ extension DIGraph {
     // internal scope so each module can provide their own version of the function with the same name.
     @available(iOSApplicationExtension, unavailable) // some properties could be unavailable to app extensions so this function must also.
     func testDependenciesAbleToResolve() -> Int {
-        var countDependenciesResolved = 0
-
-        return countDependenciesResolved
+        return 0
     }
 }
 


### PR DESCRIPTION
No functional changes in this PR.
Fixed 3 lint warnings
- Removed 2 unused variables
- Removed non-existing import which is reported as ignored

## How did I make sure this code works?
Built and ran APN UIKit sample app.
I am not sure if the non-existing import removal have impact on other non-native wrappers though. If it is, then I will revert this line from this PR as it would need to be conditioned appropriately 