### PR TITLE
fix: enable logging for gist

### DIFF
--- a/Sources/MessagingInApp/MessagingInAppImplementation.swift
+++ b/Sources/MessagingInApp/MessagingInAppImplementation.swift
@@ -5,6 +5,7 @@ import Foundation
 class MessagingInAppImplementation: MessagingInAppInstance {
     private let siteId: String
     private let region: Region
+    private let logLevel: CioLogLevel
     private let logger: CioInternalCommon.Logger
     private var queue: Queue
     private var jsonAdapter: JsonAdapter
@@ -18,6 +19,7 @@ class MessagingInAppImplementation: MessagingInAppInstance {
         self.siteId = diGraph.sdkConfig.siteId
         self.region = diGraph.sdkConfig.region
         self.logger = diGraph.logger
+        self.logLevel = diGraph.sdkConfig.logLevel
         self.queue = diGraph.queue
         self.jsonAdapter = diGraph.jsonAdapter
         self.inAppProvider = diGraph.inAppProvider
@@ -26,7 +28,7 @@ class MessagingInAppImplementation: MessagingInAppInstance {
     }
 
     func initialize() {
-        inAppProvider.initialize(siteId: siteId, region: region, delegate: self)
+        inAppProvider.initialize(siteId: siteId, region: region, delegate: self, enableLogging: logLevel == .debug)
 
         // if identifier is already present, set the userToken again so in case if the customer was already identified and
         // module was added later on, we can notify gist about it.

--- a/Sources/MessagingInApp/Provider/InAppProvider.swift
+++ b/Sources/MessagingInApp/Provider/InAppProvider.swift
@@ -3,7 +3,7 @@ import Foundation
 
 // wrapper around Gist SDK to make it mockable
 protocol InAppProvider: AutoMockable {
-    func initialize(siteId: String, region: Region, delegate: GistDelegate)
+    func initialize(siteId: String, region: Region, delegate: GistDelegate, enableLogging: Bool)
     func setProfileIdentifier(_ id: String)
     func clearIdentify()
     func setRoute(_ route: String)
@@ -12,8 +12,8 @@ protocol InAppProvider: AutoMockable {
 
 // sourcery: InjectRegister = "InAppProvider"
 class GistInAppProvider: InAppProvider {
-    func initialize(siteId: String, region: Region, delegate: GistDelegate) {
-        Gist.shared.setup(siteId: siteId, dataCenter: region.rawValue)
+    func initialize(siteId: String, region: Region, delegate: GistDelegate, enableLogging: Bool = false) {
+        Gist.shared.setup(siteId: siteId, dataCenter: region.rawValue, logging: enableLogging)
         Gist.shared.delegate = delegate
     }
 

--- a/Sources/MessagingInApp/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingInApp/autogenerated/AutoMockable.generated.swift
@@ -277,21 +277,21 @@ class InAppProviderMock: InAppProvider, Mock {
     }
 
     /// The arguments from the *last* time the function was called.
-    private(set) var initializeReceivedArguments: (siteId: String, region: Region, delegate: GistDelegate)?
+    private(set) var initializeReceivedArguments: (siteId: String, region: Region, delegate: GistDelegate, enableLogging: Bool)?
     /// Arguments from *all* of the times that the function was called.
-    private(set) var initializeReceivedInvocations: [(siteId: String, region: Region, delegate: GistDelegate)] = []
+    private(set) var initializeReceivedInvocations: [(siteId: String, region: Region, delegate: GistDelegate, enableLogging: Bool)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    var initializeClosure: ((String, Region, GistDelegate) -> Void)?
+    var initializeClosure: ((String, Region, GistDelegate, Bool) -> Void)?
 
-    /// Mocked function for `initialize(siteId: String, region: Region, delegate: GistDelegate)`. Your opportunity to return a mocked value and check result of mock in test code.
-    func initialize(siteId: String, region: Region, delegate: GistDelegate) {
+    /// Mocked function for `initialize(siteId: String, region: Region, delegate: GistDelegate, enableLogging: Bool)`. Your opportunity to return a mocked value and check result of mock in test code.
+    func initialize(siteId: String, region: Region, delegate: GistDelegate, enableLogging: Bool) {
         mockCalled = true
         initializeCallsCount += 1
-        initializeReceivedArguments = (siteId: siteId, region: region, delegate: delegate)
-        initializeReceivedInvocations.append((siteId: siteId, region: region, delegate: delegate))
-        initializeClosure?(siteId, region, delegate)
+        initializeReceivedArguments = (siteId: siteId, region: region, delegate: delegate, enableLogging: enableLogging)
+        initializeReceivedInvocations.append((siteId: siteId, region: region, delegate: delegate, enableLogging: enableLogging))
+        initializeClosure?(siteId, region, delegate, enableLogging)
     }
 
     // MARK: - setProfileIdentifier


### PR DESCRIPTION
Currently, Gist is following a different logger than CIO. This PR just enabled gist logging in case CIO logging is enabled. 

More context: https://customerio.slack.com/archives/C01QYDKD0SU/p1707896913866299