### PR TITLE
chore: fixed api tests for old initialization

### DIFF
--- a/Sources/MessagingPushAPN/Aliases.swift
+++ b/Sources/MessagingPushAPN/Aliases.swift
@@ -6,6 +6,7 @@ import Foundation
 // implementation that thier app uses (example: CioMessagingPushAPN).
 
 public typealias MessagingPush = CioMessagingPush.MessagingPush
+public typealias MessagingPushConfigOptions = CioMessagingPush.MessagingPushConfigOptions
 #if canImport(UserNotifications)
 public typealias CustomerIOParsedPushPayload = CioMessagingPush.CustomerIOParsedPushPayload
 #endif

--- a/Sources/MessagingPushFCM/Aliases.swift
+++ b/Sources/MessagingPushFCM/Aliases.swift
@@ -6,6 +6,7 @@ import Foundation
 // implementation that thier app uses (example: CioMessagingPushAPN).
 
 public typealias MessagingPush = CioMessagingPush.MessagingPush
+public typealias MessagingPushConfigOptions = CioMessagingPush.MessagingPushConfigOptions
 #if canImport(UserNotifications)
 public typealias CustomerIOParsedPushPayload = CioMessagingPush.CustomerIOParsedPushPayload
 #endif

--- a/Tests/DataPipeline/APITest.swift
+++ b/Tests/DataPipeline/APITest.swift
@@ -1,0 +1,77 @@
+import CioDataPipelines // do not use `@testable` so we can test functions are made public and not `internal`.
+import CioInternalCommon
+import Foundation
+import Segment
+import SharedTests
+import XCTest
+
+/**
+ Contains an example of every public facing SDK function call. This file helps
+ us prevent introducing breaking changes to the SDK by accident. If a public function
+ of the SDK is modified, this test class will not successfully compile. By not compiling,
+ that is a reminder to either fix the compilation and introduce the breaking change or
+ fix the mistake and not introduce the breaking change in the code base.
+ */
+class DataPipelineAPITest: UnitTest {
+    let dictionaryData: [String: Any] = ["foo": true, "bar": ""]
+
+    // Test that public functions are accessible by mocked instances
+    let mock = CustomerIOInstanceMock()
+
+    // This function checks that public functions exist for the SDK and they are callable.
+    // Maybe we forgot to add a function? Maybe we forgot to make a function `public`?
+    func test_allPublicTrackingFunctions() throws {
+        try skipRunningTest()
+
+        // Initialize
+        CustomerIO.initialize(writeKey: "") { (config: inout DataPipelineConfigOptions) in
+            config.autoAddCustomerIODestination = false
+        }
+        CustomerIO.initialize(writeKey: "", logLevel: .debug) { (config: inout DataPipelineConfigOptions) in
+            config.autoAddCustomerIODestination = false
+        }
+
+        checkDeviceProfileAttributes()
+    }
+
+    func checkDeviceProfileAttributes() {
+        // profile attributes
+        CustomerIO.shared.profileAttributes = dictionaryData
+        mock.profileAttributes = dictionaryData
+
+        // device attributes
+        CustomerIO.shared.deviceAttributes = dictionaryData
+        mock.deviceAttributes = dictionaryData
+    }
+
+    func test_allPublicModuleConfigOptions() throws {
+        try skipRunningTest()
+
+        CustomerIO.initialize(writeKey: "", logLevel: .error) { config in
+            config.apiHost = ""
+            config.cdnHost = ""
+            config.flushAt = 10
+            config.flushInterval = 10.0
+            config.autoAddCustomerIODestination = false
+            config.defaultSettings = Settings(writeKey: "")
+            config.flushPolicies = [CountBasedFlushPolicy(), IntervalBasedFlushPolicy()]
+            config.flushQueue = DispatchQueue(label: "")
+            config.operatingMode = OperatingMode.asynchronous
+            config.trackApplicationLifecycleEvents = true
+            config.autoTrackDeviceAttributes = true
+        }
+    }
+
+    func test_autoTrackingScreenViewsPluginOptions() throws {
+        try skipRunningTest()
+
+        _ = AutoTrackingScreenViews(
+            filterAutoScreenViewEvents: { viewController in
+                class MyViewController: UIViewController {}
+
+                return viewController is MyViewController
+            },
+            autoScreenViewBody: { [:] }
+        )
+    }
+}

--- a/Tests/MessagingPushAPN/APITest.swift
+++ b/Tests/MessagingPushAPN/APITest.swift
@@ -18,6 +18,12 @@ class MessagingPushAPNAPITest: UnitTest {
     func test_allPublicFunctions() throws {
         try skipRunningTest()
 
+        // This is the `initialize()` function that's available to Notification Service Extension and not available
+        // to other targets (such as iOS).
+        // You should be able to uncomment the initialize() function below and should get compile errors saying that the
+        // function is not available to iOS.
+        // MessagingPush.initialize(writeKey: "") { (config: inout MessagingPushConfigOptions) in }
+
         MessagingPush.shared.registerDeviceToken(apnDeviceToken: Data())
         mock.registerDeviceToken(apnDeviceToken: Data())
 

--- a/Tests/MessagingPushFCM/APITest.swift
+++ b/Tests/MessagingPushFCM/APITest.swift
@@ -18,6 +18,12 @@ class MessagingPushFCMAPITest: UnitTest {
     func test_allPublicFunctions() throws {
         try skipRunningTest()
 
+        // This is the `initialize()` function that's available to Notification Service Extension and not available
+        // to other targets (such as iOS).
+        // You should be able to uncomment the initialize() function below and should get compile errors saying that the
+        // function is not available to iOS.
+        // MessagingPush.initialize(writeKey: "") { (config: inout MessagingPushConfigOptions) in }
+
         MessagingPush.shared.registerDeviceToken(fcmToken: "")
         mock.registerDeviceToken(fcmToken: "")
 

--- a/Tests/Tracking/APITest.swift
+++ b/Tests/Tracking/APITest.swift
@@ -33,16 +33,6 @@ class TrackingAPITest: UnitTest {
     func test_allPublicTrackingFunctions() throws {
         try skipRunningTest()
 
-        // Initialize
-        CustomerIO.initialize(siteId: "", apiKey: "", region: .EU) { (config: inout CioSdkConfig) in
-            config.autoTrackPushEvents = false
-        }
-        // There is another `initialize()` function that's available to Notification Service Extension and not available
-        // to other targets (such as iOS).
-        // You should be able to uncomment the initialize() function below and should get compile errors saying that the
-        // function is not available to iOS.
-        // CustomerIO.initialize(siteId: "", apiKey: "", region: .EU) { (config: inout CioNotificationServiceExtensionSdkConfig) in }
-
         // Reference some objects that should be public in the Tracking module
         let _: Region = .EU
         let _: CioLogLevel = .debug
@@ -103,25 +93,6 @@ class TrackingAPITest: UnitTest {
         // device attributes
         CustomerIO.shared.deviceAttributes = dictionaryData
         mock.deviceAttributes = dictionaryData
-    }
-
-    func test_allPublicSdkConfigOptions() throws {
-        try skipRunningTest()
-
-        CustomerIO.initialize(siteId: "", apiKey: "", region: .EU) { config in
-            config.trackingApiUrl = ""
-            config.autoTrackPushEvents = true
-            config.backgroundQueueMinNumberOfTasks = 10
-            config.backgroundQueueSecondsDelay = 10
-            config.logLevel = .error
-            config.autoTrackPushEvents = false
-            config.autoScreenViewBody = { [:] }
-            config.filterAutoScreenViewEvents = { viewController in
-                class MyViewController: UIViewController {}
-
-                return viewController is MyViewController
-            }
-        }
     }
 
     // SDK wrappers can configure the SDK from a Map.


### PR DESCRIPTION
helps: [MBL-103](https://linear.app/customerio/issue/MBL-103/public-api-remove-existing-initialization-method-using-siteid-and)

###  Changes

- Added alias for `MessagingPushConfigOptions` to `FCM` and `APN`
- Moved old `APITest` from `Tracking` to appropriate modules including `DataPipeline`, `MessagingPushAPN` and `MessagingPushFCM`