### PR TITLE
fix: fixes an issue with multiple timers being scheduled

### DIFF
--- a/Sources/MessagingInApp/Gist/Managers/MessageQueueManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/MessageQueueManager.swift
@@ -3,11 +3,16 @@ import UIKit
 
 class MessageQueueManager {
     var interval: Double = 600
-    private var queueTimer: Timer!
+    private var queueTimer: Timer?
     // The local message store is used to keep messages that can't be displayed because the route rule doesnt match.
     private var localMessageStore: [String: Message] = [:]
 
     func setup(skipQueueCheck: Bool = false) {
+        if let queueTimer {
+            queueTimer.invalidate()
+            self.queueTimer = nil
+        }
+        
         queueTimer = Timer.scheduledTimer(
             timeInterval: interval,
             target: self,


### PR DESCRIPTION
While testing on standalone I noticed that timers weren't being stopped when a new one was scheduled, this should fix the issue.