### PR TITLE
refactor: improve debug logs for UserNotification framework classes

### DIFF
--- a/Sources/MessagingPush/UserNotificationsFramework/Wrappers.swift
+++ b/Sources/MessagingPush/UserNotificationsFramework/Wrappers.swift
@@ -10,7 +10,7 @@ import UserNotifications
  All of these wrappers should be small and simple. Their only job is to convert data types between SDK's abstracted data types and `UserNotifications` data types.
  */
 
-class UNNotificationResponseWrapper: PushNotificationAction {
+struct UNNotificationResponseWrapper: PushNotificationAction {
     public let response: UNNotificationResponse
 
     var push: PushNotification {
@@ -26,7 +26,7 @@ class UNNotificationResponseWrapper: PushNotificationAction {
     }
 }
 
-public class UNNotificationWrapper: PushNotification {
+public struct UNNotificationWrapper: PushNotification {
     // Important: This class can be used to modify a push or read-only access on a push.
     // Return the modified content, first. If that is nil, then return the original content.
     public var notificationContent: UNNotificationContent {


### PR DESCRIPTION
When debugging the sample apps, you will see SDK debug statements when a push event occurs:

(siteid:xyz) Push event: willPresent. push: CioMessagingPush.UNNotificationWrapper
(siteid:xyz) On push action event. push action: CioMessagingPush.UNNotificationResponseWrapper

These log statements are not very useful because they do not actually tell us what the contents are of `UNNotificationWrapper`, for example.

Swift `structs` when they are printed include values of the properties inside of them. So, the debug logs are much more valuable if we change the data types to structs.

I tested this change with sample apps.

commit-id:4aeb187e