### PR TITLE
refactor: remove autoTrackDeviceAttributes from SdkConfig

### DIFF
--- a/Sources/Common/Store/SdkConfig.swift
+++ b/Sources/Common/Store/SdkConfig.swift
@@ -32,8 +32,7 @@ public struct SdkConfig {
                 backgroundQueueExpiredSeconds: Seconds.secondsFromDays(3),
                 logLevel: CioLogLevel.error,
                 autoTrackScreenViews: false,
-                filterAutoScreenViewEvents: nil,
-                autoTrackDeviceAttributes: true
+                filterAutoScreenViewEvents: nil
             )
         }
     }
@@ -52,9 +51,6 @@ public struct SdkConfig {
         // Define default values here in constructor instead of in struct properties. This is by design so in the future if we add
         // a new SDK config option to the struct, we get a compiler error here in the constructor reminding us that we need to
         // add a way for `params` to override the SDK config option.
-        if let autoTrackDeviceAttributes = params[Keys.autoTrackDeviceAttributes.rawValue] as? Bool {
-            self.autoTrackDeviceAttributes = autoTrackDeviceAttributes
-        }
         if let autoTrackPushEvents = params[Keys.autoTrackPushEvents.rawValue] as? Bool {
             self.autoTrackPushEvents = autoTrackPushEvents
         }
@@ -88,7 +84,6 @@ public struct SdkConfig {
         case region
         // config features
         case trackingApiUrl
-        case autoTrackDeviceAttributes
         case autoTrackScreenViews
         case logLevel
         case autoTrackPushEvents
@@ -164,12 +159,6 @@ public struct SdkConfig {
      this to override our defaults and pass custom values in the body of the `screen` event
      */
     public var autoScreenViewBody: (() -> [String: Any])?
-
-    /**
-     Enable this property if you want SDK to automatic tracking of device attributes such as
-     operating system, device locale, device model, app version etc
-     */
-    public var autoTrackDeviceAttributes: Bool
 
     var httpBaseUrls: HttpBaseUrls {
         HttpBaseUrls(trackingApi: trackingApiUrl)

--- a/Sources/DataPipeline/DataPipelineConfigOptions.swift
+++ b/Sources/DataPipeline/DataPipelineConfigOptions.swift
@@ -25,7 +25,6 @@ public struct DataPipelineConfigOptions {
         public static func create(sdkConfig: SdkConfig) -> DataPipelineConfigOptions {
             let writeKey = "\(sdkConfig.siteId):\(sdkConfig.apiKey)"
             var result = DataPipelineConfigOptions(writeKey: writeKey)
-            result.autoTrackDeviceAttributes = sdkConfig.autoTrackDeviceAttributes
             result.flushAt = sdkConfig.backgroundQueueMinNumberOfTasks
             result.flushInterval = sdkConfig.backgroundQueueSecondsDelay
             return result

--- a/Tests/DataPipeline/Util/DeviceAttributesProviderTest.swift
+++ b/Tests/DataPipeline/Util/DeviceAttributesProviderTest.swift
@@ -1,6 +1,5 @@
 @testable import CioDataPipelines
 @testable import CioInternalCommon
-@testable import CioTracking
 import Foundation
 import SharedTests
 import XCTest
@@ -27,7 +26,7 @@ class DeviceAttributesProviderTest: UnitTest {
     }
 
     func test_getDefaultDeviceAttributes_givenTrackingDeviceAttributesDisabled_expectEmptyAttributes() {
-        super.setUp(modifySdkConfig: { config in
+        super.setUp(modifyModuleConfig: { config in
             config.autoTrackDeviceAttributes = false
         })
 
@@ -46,7 +45,7 @@ class DeviceAttributesProviderTest: UnitTest {
     }
 
     func test_getDefaultDeviceAttributes_givenTrackingDeviceAttributesEnabled_expectGetSomeAttributes() {
-        super.setUp(modifySdkConfig: { config in
+        super.setUp(modifyModuleConfig: { config in
             config.autoTrackDeviceAttributes = true
         })
 

--- a/Tests/Tracking/APITest.swift
+++ b/Tests/Tracking/APITest.swift
@@ -42,7 +42,6 @@ class TrackingAPITest: UnitTest {
         let backgroundQueueExpiredSeconds: TimeInterval = 100000
         let logLevel = "info"
         let autoTrackScreenViews = true
-        let autoTrackDeviceAttributes = false
         let sdkWrapperSource = "Flutter"
         let sdkWrapperVersion = "1000.33333.4444"
 
@@ -54,7 +53,6 @@ class TrackingAPITest: UnitTest {
             "backgroundQueueExpiredSeconds": backgroundQueueExpiredSeconds,
             "logLevel": logLevel,
             "autoTrackScreenViews": autoTrackScreenViews,
-            "autoTrackDeviceAttributes": autoTrackDeviceAttributes,
             "source": sdkWrapperSource,
             "version": sdkWrapperVersion
         ]
@@ -69,7 +67,6 @@ class TrackingAPITest: UnitTest {
         XCTAssertEqual(actual.backgroundQueueExpiredSeconds, backgroundQueueExpiredSeconds)
         XCTAssertEqual(actual.logLevel.rawValue, logLevel)
         XCTAssertEqual(actual.autoTrackScreenViews, autoTrackScreenViews)
-        XCTAssertEqual(actual.autoTrackDeviceAttributes, autoTrackDeviceAttributes)
         XCTAssertNotNil(actual._sdkWrapperConfig)
     }
 
@@ -81,7 +78,6 @@ class TrackingAPITest: UnitTest {
         let backgroundQueueExpiredSeconds: TimeInterval = 100000
         let logLevel = "info"
         let autoTrackScreenViews = true
-        let autoTrackDeviceAttributes = false
         let sdkWrapperSource = "Flutter"
         let sdkWrapperVersion = "1000.33333.4444"
 
@@ -93,7 +89,6 @@ class TrackingAPITest: UnitTest {
             "backgroundQueueExpiredSecondsWrong": backgroundQueueExpiredSeconds,
             "logLevelWrong": logLevel,
             "autoTrackScreenViewsWrong": autoTrackScreenViews,
-            "autoTrackDeviceAttributesWrong": autoTrackDeviceAttributes,
             "sourceWrong": sdkWrapperSource,
             "versionWrong": sdkWrapperVersion
         ]
@@ -108,7 +103,6 @@ class TrackingAPITest: UnitTest {
         XCTAssertEqual(actual.backgroundQueueExpiredSeconds, TimeInterval(3 * 86400))
         XCTAssertEqual(actual.logLevel.rawValue, CioLogLevel.error.rawValue)
         XCTAssertEqual(actual.autoTrackScreenViews, false)
-        XCTAssertEqual(actual.autoTrackDeviceAttributes, true)
         XCTAssertNil(actual._sdkWrapperConfig)
     }
 
@@ -122,7 +116,6 @@ class TrackingAPITest: UnitTest {
         XCTAssertEqual(actual.backgroundQueueExpiredSeconds, TimeInterval(3 * 86400))
         XCTAssertEqual(actual.logLevel.rawValue, CioLogLevel.error.rawValue)
         XCTAssertEqual(actual.autoTrackScreenViews, false)
-        XCTAssertEqual(actual.autoTrackDeviceAttributes, true)
         XCTAssertNil(actual._sdkWrapperConfig)
     }
 }


### PR DESCRIPTION
Part of: https://linear.app/customerio/issue/MBL-120/public-api-remove-unused-properties-from-sdkconfig

Remove `autoTrackDeviceAttributes` from Common/SdkConfig object. The code base has already been modified to use the CDP module `autoTrackDeviceAttributes` config option. Including in CDP APITests. So, no additional tests or changes need to be made beyond removing the property from the codebase.

---

**Stack**:
- #547
- #546
- #540
- #539
- #534
- #533
- #532 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*