### PR TITLE
refactor: remove screenview tracking config options from SdkConfig

### DIFF
--- a/Sources/Common/Store/SdkConfig.swift
+++ b/Sources/Common/Store/SdkConfig.swift
@@ -30,9 +30,7 @@ public struct SdkConfig {
                 backgroundQueueMinNumberOfTasks: 10,
                 backgroundQueueSecondsDelay: 30,
                 backgroundQueueExpiredSeconds: Seconds.secondsFromDays(3),
-                logLevel: CioLogLevel.error,
-                autoTrackScreenViews: false,
-                filterAutoScreenViewEvents: nil
+                logLevel: CioLogLevel.error
             )
         }
     }
@@ -53,9 +51,6 @@ public struct SdkConfig {
         // add a way for `params` to override the SDK config option.
         if let autoTrackPushEvents = params[Keys.autoTrackPushEvents.rawValue] as? Bool {
             self.autoTrackPushEvents = autoTrackPushEvents
-        }
-        if let autoTrackScreenViews = params[Keys.autoTrackScreenViews.rawValue] as? Bool {
-            self.autoTrackScreenViews = autoTrackScreenViews
         }
         if let backgroundQueueMinNumberOfTasks = params[Keys.backgroundQueueMinNumberOfTasks.rawValue] as? Int {
             self.backgroundQueueMinNumberOfTasks = backgroundQueueMinNumberOfTasks
@@ -84,7 +79,6 @@ public struct SdkConfig {
         case region
         // config features
         case trackingApiUrl
-        case autoTrackScreenViews
         case logLevel
         case autoTrackPushEvents
         case backgroundQueueMinNumberOfTasks
@@ -136,29 +130,6 @@ public struct SdkConfig {
     /// To help you get setup with the SDK or debug SDK, change the log level of logs you
     /// wish to view from the SDK.
     public var logLevel: CioLogLevel
-
-    /**
-     Automatic tracking of screen views will generate `screen`-type events on every screen transition within
-     your application.
-     */
-    public var autoTrackScreenViews: Bool
-
-    #if canImport(UIKit)
-    /**
-     Filter automatic screenview events to remove events that are irrelevant to your app.
-
-     Return `true` from function if you would like the screenview event to be tracked.
-
-     Default: `nil`, which uses the default filter function packaged by the SDK. Provide a non-nil value to not call the SDK's filtering.
-     */
-    public var filterAutoScreenViewEvents: ((UIViewController) -> Bool)?
-    #endif
-
-    /**
-     Handler to be called by our automatic screen tracker to generate `screen` event body variables. You can use
-     this to override our defaults and pass custom values in the body of the `screen` event
-     */
-    public var autoScreenViewBody: (() -> [String: Any])?
 
     var httpBaseUrls: HttpBaseUrls {
         HttpBaseUrls(trackingApi: trackingApiUrl)

--- a/Tests/Tracking/APITest.swift
+++ b/Tests/Tracking/APITest.swift
@@ -41,7 +41,6 @@ class TrackingAPITest: UnitTest {
         let backgroundQueueSecondsDelay: TimeInterval = 100000
         let backgroundQueueExpiredSeconds: TimeInterval = 100000
         let logLevel = "info"
-        let autoTrackScreenViews = true
         let sdkWrapperSource = "Flutter"
         let sdkWrapperVersion = "1000.33333.4444"
 
@@ -52,7 +51,6 @@ class TrackingAPITest: UnitTest {
             "backgroundQueueSecondsDelay": backgroundQueueSecondsDelay,
             "backgroundQueueExpiredSeconds": backgroundQueueExpiredSeconds,
             "logLevel": logLevel,
-            "autoTrackScreenViews": autoTrackScreenViews,
             "source": sdkWrapperSource,
             "version": sdkWrapperVersion
         ]
@@ -66,7 +64,6 @@ class TrackingAPITest: UnitTest {
         XCTAssertEqual(actual.backgroundQueueSecondsDelay, backgroundQueueSecondsDelay)
         XCTAssertEqual(actual.backgroundQueueExpiredSeconds, backgroundQueueExpiredSeconds)
         XCTAssertEqual(actual.logLevel.rawValue, logLevel)
-        XCTAssertEqual(actual.autoTrackScreenViews, autoTrackScreenViews)
         XCTAssertNotNil(actual._sdkWrapperConfig)
     }
 
@@ -77,7 +74,6 @@ class TrackingAPITest: UnitTest {
         let backgroundQueueSecondsDelay: TimeInterval = 100000
         let backgroundQueueExpiredSeconds: TimeInterval = 100000
         let logLevel = "info"
-        let autoTrackScreenViews = true
         let sdkWrapperSource = "Flutter"
         let sdkWrapperVersion = "1000.33333.4444"
 
@@ -88,7 +84,6 @@ class TrackingAPITest: UnitTest {
             "backgroundQueueSecondsDelayWrong": backgroundQueueSecondsDelay,
             "backgroundQueueExpiredSecondsWrong": backgroundQueueExpiredSeconds,
             "logLevelWrong": logLevel,
-            "autoTrackScreenViewsWrong": autoTrackScreenViews,
             "sourceWrong": sdkWrapperSource,
             "versionWrong": sdkWrapperVersion
         ]
@@ -102,7 +97,6 @@ class TrackingAPITest: UnitTest {
         XCTAssertEqual(actual.backgroundQueueSecondsDelay, 30)
         XCTAssertEqual(actual.backgroundQueueExpiredSeconds, TimeInterval(3 * 86400))
         XCTAssertEqual(actual.logLevel.rawValue, CioLogLevel.error.rawValue)
-        XCTAssertEqual(actual.autoTrackScreenViews, false)
         XCTAssertNil(actual._sdkWrapperConfig)
     }
 
@@ -115,7 +109,6 @@ class TrackingAPITest: UnitTest {
         XCTAssertEqual(actual.backgroundQueueSecondsDelay, 30)
         XCTAssertEqual(actual.backgroundQueueExpiredSeconds, TimeInterval(3 * 86400))
         XCTAssertEqual(actual.logLevel.rawValue, CioLogLevel.error.rawValue)
-        XCTAssertEqual(actual.autoTrackScreenViews, false)
         XCTAssertNil(actual._sdkWrapperConfig)
     }
 }


### PR DESCRIPTION
Part of: https://linear.app/customerio/issue/MBL-120/public-api-remove-unused-properties-from-sdkconfig

None of the code was referencing any of these config options. Therefore, I did not need to make any more modifications to the code besides removing the properties from the Common module.

---

**Stack**:
- #547
- #546
- #540
- #539
- #534
- #533 ⬅
- #532


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*