### PR TITLE
refactor: remove background queue config options from SdkConfig

### DIFF
--- a/Sources/Common/Store/SdkConfig.swift
+++ b/Sources/Common/Store/SdkConfig.swift
@@ -27,9 +27,6 @@ public struct SdkConfig {
                 region: region,
                 trackingApiUrl: region.productionTrackingUrl,
                 autoTrackPushEvents: true,
-                backgroundQueueMinNumberOfTasks: 10,
-                backgroundQueueSecondsDelay: 30,
-                backgroundQueueExpiredSeconds: Seconds.secondsFromDays(3),
                 logLevel: CioLogLevel.error
             )
         }
@@ -52,15 +49,6 @@ public struct SdkConfig {
         if let autoTrackPushEvents = params[Keys.autoTrackPushEvents.rawValue] as? Bool {
             self.autoTrackPushEvents = autoTrackPushEvents
         }
-        if let backgroundQueueMinNumberOfTasks = params[Keys.backgroundQueueMinNumberOfTasks.rawValue] as? Int {
-            self.backgroundQueueMinNumberOfTasks = backgroundQueueMinNumberOfTasks
-        }
-        if let backgroundQueueSecondsDelay = params[Keys.backgroundQueueSecondsDelay.rawValue] as? Seconds {
-            self.backgroundQueueSecondsDelay = backgroundQueueSecondsDelay
-        }
-        if let backgroundQueueExpiredSeconds = params[Keys.backgroundQueueExpiredSeconds.rawValue] as? Seconds {
-            self.backgroundQueueExpiredSeconds = backgroundQueueExpiredSeconds
-        }
         if let trackingApiUrl = params[Keys.trackingApiUrl.rawValue] as? String, !trackingApiUrl.isEmpty {
             self.trackingApiUrl = trackingApiUrl
         }
@@ -81,9 +69,6 @@ public struct SdkConfig {
         case trackingApiUrl
         case logLevel
         case autoTrackPushEvents
-        case backgroundQueueMinNumberOfTasks
-        case backgroundQueueSecondsDelay
-        case backgroundQueueExpiredSeconds
         // SDK wrapper config
         case source
         case sourceVersion = "version"
@@ -110,22 +95,6 @@ public struct SdkConfig {
      for push notifications sent by Customer.io
      */
     public var autoTrackPushEvents: Bool
-
-    /**
-     Number of tasks in the background queue before the queue begins operating.
-     This is mostly used during development to test configuration is setup. We do not recommend
-     modifying this value because it impacts battery life of mobile device.
-     */
-    public var backgroundQueueMinNumberOfTasks: Int
-
-    /// The number of seconds to delay running queue after a task has been added to it.
-    public var backgroundQueueSecondsDelay: Seconds
-    /**
-     * The number of seconds old a queue task is when it is "expired" and should be deleted.
-     * We do not recommend modifying this value because it risks losing data or taking up too much
-     * space on the user's device.
-     */
-    public var backgroundQueueExpiredSeconds: Seconds
 
     /// To help you get setup with the SDK or debug SDK, change the log level of logs you
     /// wish to view from the SDK.

--- a/Sources/DataPipeline/DataPipelineConfigOptions.swift
+++ b/Sources/DataPipeline/DataPipelineConfigOptions.swift
@@ -24,10 +24,7 @@ public struct DataPipelineConfigOptions {
 
         public static func create(sdkConfig: SdkConfig) -> DataPipelineConfigOptions {
             let writeKey = "\(sdkConfig.siteId):\(sdkConfig.apiKey)"
-            var result = DataPipelineConfigOptions(writeKey: writeKey)
-            result.flushAt = sdkConfig.backgroundQueueMinNumberOfTasks
-            result.flushInterval = sdkConfig.backgroundQueueSecondsDelay
-            return result
+            return DataPipelineConfigOptions(writeKey: writeKey)
         }
     }
 

--- a/Tests/Tracking/APITest.swift
+++ b/Tests/Tracking/APITest.swift
@@ -37,9 +37,6 @@ class TrackingAPITest: UnitTest {
     func test_createSdkConfigFromMap() {
         let trackingApiUrl = String.random
         let autoTrackPushEvents = false
-        let backgroundQueueMinNumberOfTasks = 10000
-        let backgroundQueueSecondsDelay: TimeInterval = 100000
-        let backgroundQueueExpiredSeconds: TimeInterval = 100000
         let logLevel = "info"
         let sdkWrapperSource = "Flutter"
         let sdkWrapperVersion = "1000.33333.4444"
@@ -47,9 +44,6 @@ class TrackingAPITest: UnitTest {
         let givenParamsFromSdkWrapper: [String: Any] = [
             "trackingApiUrl": trackingApiUrl,
             "autoTrackPushEvents": autoTrackPushEvents,
-            "backgroundQueueMinNumberOfTasks": backgroundQueueMinNumberOfTasks,
-            "backgroundQueueSecondsDelay": backgroundQueueSecondsDelay,
-            "backgroundQueueExpiredSeconds": backgroundQueueExpiredSeconds,
             "logLevel": logLevel,
             "source": sdkWrapperSource,
             "version": sdkWrapperVersion
@@ -60,9 +54,6 @@ class TrackingAPITest: UnitTest {
 
         XCTAssertEqual(actual.trackingApiUrl, trackingApiUrl)
         XCTAssertEqual(actual.autoTrackPushEvents, autoTrackPushEvents)
-        XCTAssertEqual(actual.backgroundQueueMinNumberOfTasks, backgroundQueueMinNumberOfTasks)
-        XCTAssertEqual(actual.backgroundQueueSecondsDelay, backgroundQueueSecondsDelay)
-        XCTAssertEqual(actual.backgroundQueueExpiredSeconds, backgroundQueueExpiredSeconds)
         XCTAssertEqual(actual.logLevel.rawValue, logLevel)
         XCTAssertNotNil(actual._sdkWrapperConfig)
     }
@@ -70,9 +61,6 @@ class TrackingAPITest: UnitTest {
     func test_SdkConfigFromMap_givenWrongKeys_expectDefaults() {
         let trackingApiUrl = String.random
         let autoTrackPushEvents = false
-        let backgroundQueueMinNumberOfTasks = 10000
-        let backgroundQueueSecondsDelay: TimeInterval = 100000
-        let backgroundQueueExpiredSeconds: TimeInterval = 100000
         let logLevel = "info"
         let sdkWrapperSource = "Flutter"
         let sdkWrapperVersion = "1000.33333.4444"
@@ -80,9 +68,6 @@ class TrackingAPITest: UnitTest {
         let givenParamsFromSdkWrapper: [String: Any] = [
             "trackingApiUrlWrong": trackingApiUrl,
             "autoTrackPushEventsWrong": autoTrackPushEvents,
-            "backgroundQueueMinNumberOfTasksWrong": backgroundQueueMinNumberOfTasks,
-            "backgroundQueueSecondsDelayWrong": backgroundQueueSecondsDelay,
-            "backgroundQueueExpiredSecondsWrong": backgroundQueueExpiredSeconds,
             "logLevelWrong": logLevel,
             "sourceWrong": sdkWrapperSource,
             "versionWrong": sdkWrapperVersion
@@ -93,9 +78,6 @@ class TrackingAPITest: UnitTest {
 
         XCTAssertEqual(actual.trackingApiUrl, Region.US.productionTrackingUrl)
         XCTAssertEqual(actual.autoTrackPushEvents, true)
-        XCTAssertEqual(actual.backgroundQueueMinNumberOfTasks, 10)
-        XCTAssertEqual(actual.backgroundQueueSecondsDelay, 30)
-        XCTAssertEqual(actual.backgroundQueueExpiredSeconds, TimeInterval(3 * 86400))
         XCTAssertEqual(actual.logLevel.rawValue, CioLogLevel.error.rawValue)
         XCTAssertNil(actual._sdkWrapperConfig)
     }
@@ -105,9 +87,6 @@ class TrackingAPITest: UnitTest {
 
         XCTAssertEqual(actual.trackingApiUrl, Region.US.productionTrackingUrl)
         XCTAssertEqual(actual.autoTrackPushEvents, true)
-        XCTAssertEqual(actual.backgroundQueueMinNumberOfTasks, 10)
-        XCTAssertEqual(actual.backgroundQueueSecondsDelay, 30)
-        XCTAssertEqual(actual.backgroundQueueExpiredSeconds, TimeInterval(3 * 86400))
         XCTAssertEqual(actual.logLevel.rawValue, CioLogLevel.error.rawValue)
         XCTAssertNil(actual._sdkWrapperConfig)
     }


### PR DESCRIPTION
Part of: https://linear.app/customerio/issue/MBL-120/public-api-remove-unused-properties-from-sdkconfig

The BQ feature that deletes expired tasks will no longer work after this change. Because most of the BQ implementation remains inside of the codebase and has not yet been removed, I commented out the code that is no longer working so the code compiles. The commented out code could be deleted or fixed when the rest of the BQ code is taken care of in the codebase.

---

**Stack**:
- #547
- #546
- #540
- #539
- #534 ⬅
- #533
- #532


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*