### PR TITLE
chore: automatic device attributes cleanup

### DIFF
--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -11,6 +11,7 @@ class DataPipelineImplementation: DataPipelineInstance {
     private let deviceAttributesProvider: DeviceAttributesProvider
     private let dateUtil: DateUtil
     private let deviceInfo: DeviceInfo
+    private let deviceAttributesPlugin: DeviceAttributes
 
     init(diGraph: DIGraphShared, moduleConfig: DataPipelineConfigOptions) {
         self.moduleConfig = moduleConfig
@@ -23,6 +24,8 @@ class DataPipelineImplementation: DataPipelineInstance {
         self.dateUtil = diGraph.dateUtil
         self.deviceInfo = diGraph.deviceInfo
 
+        self.deviceAttributesPlugin = DeviceAttributes(autoTrackDeviceAttributes: moduleConfig.autoTrackDeviceAttributes)
+
         initialize(diGraph: diGraph)
     }
 
@@ -33,6 +36,9 @@ class DataPipelineImplementation: DataPipelineInstance {
             customerIODestination.analytics = analytics
             analytics.add(plugin: customerIODestination)
         }
+
+        // add/override device attributes in context for each request
+        analytics.add(plugin: deviceAttributesPlugin)
 
         if let existingDeviceToken = globalDataStore.pushDeviceToken {
             // if the device token exists, pass it to the plugin and ensure device attributes are updated
@@ -265,18 +271,6 @@ extension DataPipelineImplementation {
     /// returns user id for currently identifier profile
     var registeredUserId: String? {
         analytics.userId
-    }
-
-    /// returns DeviceAttributes if attached; if not, attaches them and then returns the instance
-    private var deviceAttributesPlugin: DeviceAttributes {
-        let attributesPlugin: DeviceAttributes
-        if let plugin = analytics.find(pluginType: DeviceAttributes.self) {
-            attributesPlugin = plugin
-        } else {
-            attributesPlugin = DeviceAttributes(autoTrackDeviceAttributes: moduleConfig.autoTrackDeviceAttributes)
-            analytics.add(plugin: attributesPlugin)
-        }
-        return attributesPlugin
     }
 }
 

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -273,7 +273,7 @@ extension DataPipelineImplementation {
         if let plugin = analytics.find(pluginType: DeviceAttributes.self) {
             attributesPlugin = plugin
         } else {
-            attributesPlugin = DeviceAttributes()
+            attributesPlugin = DeviceAttributes(autoTrackDeviceAttributes: moduleConfig.autoTrackDeviceAttributes)
             analytics.add(plugin: attributesPlugin)
         }
         return attributesPlugin

--- a/Sources/DataPipeline/Plugins/DeviceAttributes.swift
+++ b/Sources/DataPipeline/Plugins/DeviceAttributes.swift
@@ -9,7 +9,11 @@ class DeviceAttributes: Plugin {
     public var token: String?
     public var attributes: [String: Any]?
 
-    public required init() {}
+    public var autoTrackDeviceAttributes: Bool
+
+    public required init(autoTrackDeviceAttributes: Bool) {
+        self.autoTrackDeviceAttributes = autoTrackDeviceAttributes
+    }
 
     public func execute<T: RawEvent>(event: T?) -> T? {
         guard var workingEvent = event,
@@ -30,7 +34,7 @@ class DeviceAttributes: Plugin {
                 workingEvent.context = try JSON(context)
             }
             if let attributes = attributes {
-                if let device = context[keyPath: "device"] as? [String: Any] {
+                if let device = context[keyPath: "device"] as? [String: Any], autoTrackDeviceAttributes {
                     context["device"] = device.mergeWith(attributes)
                 } else {
                     context["device"] = attributes

--- a/Sources/DataPipeline/Plugins/DeviceAttributes.swift
+++ b/Sources/DataPipeline/Plugins/DeviceAttributes.swift
@@ -7,7 +7,7 @@ class DeviceAttributes: Plugin {
     public weak var analytics: Analytics?
 
     public var token: String?
-    public var attributes: [String: Any]?
+    public var attributes: [String: Any] = [:]
 
     public var autoTrackDeviceAttributes: Bool
 
@@ -33,14 +33,13 @@ class DeviceAttributes: Plugin {
                 context[keyPath: "device.token"] = token
                 workingEvent.context = try JSON(context)
             }
-            if let attributes = attributes {
-                if let device = context[keyPath: "device"] as? [String: Any], autoTrackDeviceAttributes {
-                    context["device"] = device.mergeWith(attributes)
-                } else {
-                    context["device"] = attributes
-                }
-                workingEvent.context = try JSON(context)
+
+            if let device = context[keyPath: "device"] as? [String: Any], autoTrackDeviceAttributes {
+                context["device"] = device.mergeWith(attributes)
+            } else {
+                context["device"] = attributes
             }
+            workingEvent.context = try JSON(context)
         } catch {
             analytics?.reportInternalError(error)
         }

--- a/Tests/DataPipeline/DataPipelineInteractionTests.swift
+++ b/Tests/DataPipeline/DataPipelineInteractionTests.swift
@@ -321,9 +321,6 @@ class DataPipelineInteractionTests: IntegrationTest {
             config.autoTrackDeviceAttributes = false
         })
 
-        mockDeviceAttributes()
-
-        customerIO.deviceAttributes = [:]
         customerIO.track(name: String.random)
 
         XCTAssertEqual(outputReader.events.count, 1)

--- a/Tests/DataPipeline/Support/Segment.swift
+++ b/Tests/DataPipeline/Support/Segment.swift
@@ -67,6 +67,13 @@ extension RawEvent {
         return nil
     }
 
+    var deviceAttributes: [String: Any]? {
+        if let context = context?.dictionaryValue {
+            return context[keyPath: "device"] as? [String: Any]
+        }
+        return nil
+    }
+
     var properties: [String: Any]? {
         if let event = self as? TrackEvent {
             return event.properties?.dictionaryValue


### PR DESCRIPTION
closes: https://linear.app/customerio/issue/MBL-107/automatic-device-attributes

If `autoTrackDeviceAttributes` is `enabled` we need to restrict Segment added attributes as well. 