### PR TITLE
chore: added alias for loglevel

### DIFF
--- a/Sources/DataPipeline/Type/Aliases.swift
+++ b/Sources/DataPipeline/Type/Aliases.swift
@@ -30,3 +30,4 @@ public typealias OperatingMode = Segment.OperatingMode
 
 public typealias Metric = CioInternalCommon.Metric
 public typealias CustomerIO = CioInternalCommon.CustomerIO
+public typealias CioLogLevel = CioInternalCommon.CioLogLevel


### PR DESCRIPTION
To provide logLevel, folks shouldn't need to add the `CioCommon` dependency. 