### PR TITLE
chore: fix tests for deprecated tracking apis

### DIFF
--- a/Sources/Common/autogenerated/AutoMockable.generated.swift
+++ b/Sources/Common/autogenerated/AutoMockable.generated.swift
@@ -170,42 +170,6 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
      When setter of the property called, the value given to setter is set here.
      When the getter of the property called, the value set here will be returned. Your chance to mock the property.
      */
-    public var underlyingRegisteredDeviceToken: String? = nil
-    /// `true` if the getter or setter of property is called at least once.
-    public var registeredDeviceTokenCalled: Bool {
-        registeredDeviceTokenGetCalled || registeredDeviceTokenSetCalled
-    }
-
-    /// `true` if the getter called on the property at least once.
-    public var registeredDeviceTokenGetCalled: Bool {
-        registeredDeviceTokenGetCallsCount > 0
-    }
-
-    public var registeredDeviceTokenGetCallsCount = 0
-    /// `true` if the setter called on the property at least once.
-    public var registeredDeviceTokenSetCalled: Bool {
-        registeredDeviceTokenSetCallsCount > 0
-    }
-
-    public var registeredDeviceTokenSetCallsCount = 0
-    /// The mocked property with a getter and setter.
-    public var registeredDeviceToken: String? {
-        get {
-            mockCalled = true
-            registeredDeviceTokenGetCallsCount += 1
-            return underlyingRegisteredDeviceToken
-        }
-        set(value) {
-            mockCalled = true
-            registeredDeviceTokenSetCallsCount += 1
-            underlyingRegisteredDeviceToken = value
-        }
-    }
-
-    /**
-     When setter of the property called, the value given to setter is set here.
-     When the getter of the property called, the value set here will be returned. Your chance to mock the property.
-     */
     public var underlyingProfileAttributes: [String: Any] = [:]
     /// `true` if the getter or setter of property is called at least once.
     public var profileAttributesCalled: Bool {
@@ -274,6 +238,42 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
         }
     }
 
+    /**
+     When setter of the property called, the value given to setter is set here.
+     When the getter of the property called, the value set here will be returned. Your chance to mock the property.
+     */
+    public var underlyingRegisteredDeviceToken: String? = nil
+    /// `true` if the getter or setter of property is called at least once.
+    public var registeredDeviceTokenCalled: Bool {
+        registeredDeviceTokenGetCalled || registeredDeviceTokenSetCalled
+    }
+
+    /// `true` if the getter called on the property at least once.
+    public var registeredDeviceTokenGetCalled: Bool {
+        registeredDeviceTokenGetCallsCount > 0
+    }
+
+    public var registeredDeviceTokenGetCallsCount = 0
+    /// `true` if the setter called on the property at least once.
+    public var registeredDeviceTokenSetCalled: Bool {
+        registeredDeviceTokenSetCallsCount > 0
+    }
+
+    public var registeredDeviceTokenSetCallsCount = 0
+    /// The mocked property with a getter and setter.
+    public var registeredDeviceToken: String? {
+        get {
+            mockCalled = true
+            registeredDeviceTokenGetCallsCount += 1
+            return underlyingRegisteredDeviceToken
+        }
+        set(value) {
+            mockCalled = true
+            registeredDeviceTokenSetCallsCount += 1
+            underlyingRegisteredDeviceToken = value
+        }
+    }
+
     public func resetMock() {
         siteId = nil
         siteIdGetCallsCount = 0
@@ -281,13 +281,13 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
         config = nil
         configGetCallsCount = 0
         configSetCallsCount = 0
-        registeredDeviceToken = nil
-        registeredDeviceTokenGetCallsCount = 0
-        registeredDeviceTokenSetCallsCount = 0
         profileAttributesGetCallsCount = 0
         profileAttributesSetCallsCount = 0
         deviceAttributesGetCallsCount = 0
         deviceAttributesSetCallsCount = 0
+        registeredDeviceToken = nil
+        registeredDeviceTokenGetCallsCount = 0
+        registeredDeviceTokenSetCallsCount = 0
         identifyCallsCount = 0
         identifyReceivedArguments = nil
         identifyReceivedInvocations = []
@@ -297,11 +297,15 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
         identifyEncodableReceivedInvocations = []
 
         mockCalled = false // do last as resetting properties above can make this true
-        identifyAnonymousEncodableReceivedArguments = nil
-        identifyAnonymousEncodableReceivedInvocations = []
+        clearIdentifyCallsCount = 0
 
         mockCalled = false // do last as resetting properties above can make this true
-        clearIdentifyCallsCount = 0
+        registerDeviceTokenCallsCount = 0
+        registerDeviceTokenReceivedArguments = nil
+        registerDeviceTokenReceivedInvocations = []
+
+        mockCalled = false // do last as resetting properties above can make this true
+        deleteDeviceTokenCallsCount = 0
 
         mockCalled = false // do last as resetting properties above can make this true
         trackCallsCount = 0
@@ -322,14 +326,6 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
         screenEncodableReceivedInvocations = []
 
         mockCalled = false // do last as resetting properties above can make this true
-        registerDeviceTokenCallsCount = 0
-        registerDeviceTokenReceivedArguments = nil
-        registerDeviceTokenReceivedInvocations = []
-
-        mockCalled = false // do last as resetting properties above can make this true
-        deleteDeviceTokenCallsCount = 0
-
-        mockCalled = false // do last as resetting properties above can make this true
         trackMetricCallsCount = 0
         trackMetricReceivedArguments = nil
         trackMetricReceivedInvocations = []
@@ -347,61 +343,41 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var identifyReceivedArguments: (identifier: String, body: [String: Any])?
+    public private(set) var identifyReceivedArguments: (userId: String, traits: [String: Any]?)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var identifyReceivedInvocations: [(identifier: String, body: [String: Any])] = []
+    public private(set) var identifyReceivedInvocations: [(userId: String, traits: [String: Any]?)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    public var identifyClosure: ((String, [String: Any]) -> Void)?
+    public var identifyClosure: ((String, [String: Any]?) -> Void)?
 
-    /// Mocked function for `identify(identifier: String, body: [String: Any])`. Your opportunity to return a mocked value and check result of mock in test code.
-    public func identify(identifier: String, body: [String: Any]) {
+    /// Mocked function for `identify(userId: String, traits: [String: Any]?)`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func identify(userId: String, traits: [String: Any]?) {
         mockCalled = true
         identifyCallsCount += 1
-        identifyReceivedArguments = (identifier: identifier, body: body)
-        identifyReceivedInvocations.append((identifier: identifier, body: body))
-        identifyClosure?(identifier, body)
+        identifyReceivedArguments = (userId: userId, traits: traits)
+        identifyReceivedInvocations.append((userId: userId, traits: traits))
+        identifyClosure?(userId, traits)
     }
 
     // MARK: - identify<RequestBody: Codable>
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var identifyEncodableReceivedArguments: (identifier: String, body: AnyEncodable)?
+    public private(set) var identifyEncodableReceivedArguments: (userId: String, traits: AnyEncodable)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var identifyEncodableReceivedInvocations: [(identifier: String, body: AnyEncodable)] = []
+    public private(set) var identifyEncodableReceivedInvocations: [(userId: String, traits: AnyEncodable)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
     public var identifyEncodableClosure: ((String, AnyEncodable) -> Void)?
 
-    /// Mocked function for `identify<RequestBody: Codable>(identifier: String, body: RequestBody)`. Your opportunity to return a mocked value and check result of mock in test code.
-    public func identify<RequestBody: Codable>(identifier: String, body: RequestBody) {
+    /// Mocked function for `identify<RequestBody: Codable>(userId: String, traits: RequestBody?)`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func identify<RequestBody: Codable>(userId: String, traits: RequestBody?) {
         mockCalled = true
         identifyCallsCount += 1
-        identifyEncodableReceivedArguments = (identifier: identifier, body: AnyEncodable(body))
-        identifyEncodableReceivedInvocations.append((identifier: identifier, body: AnyEncodable(body)))
-        identifyEncodableClosure?(identifier, AnyEncodable(body))
-    }
-
-    // MARK: - identify
-
-    /// The arguments from the *last* time the function was called.
-    public private(set) var identifyAnonymousEncodableReceivedArguments: Codable?
-    /// Arguments from *all* of the times that the function was called.
-    public private(set) var identifyAnonymousEncodableReceivedInvocations: [Codable] = []
-    /**
-     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
-     */
-    public var identifyAnonymousEncodableClosure: ((Codable) -> Void)?
-
-    /// Mocked function for `identify(body: Codable)`. Your opportunity to return a mocked value and check result of mock in test code.
-    public func identify(body: Codable) {
-        mockCalled = true
-        identifyCallsCount += 1
-        identifyAnonymousEncodableReceivedArguments = body
-        identifyAnonymousEncodableReceivedInvocations.append(body)
-        identifyAnonymousEncodableClosure?(body)
+        identifyEncodableReceivedArguments = (userId: userId, traits: AnyEncodable(traits))
+        identifyEncodableReceivedInvocations.append((userId: userId, traits: AnyEncodable(traits)))
+        identifyEncodableClosure?(userId, AnyEncodable(traits))
     }
 
     // MARK: - clearIdentify
@@ -423,100 +399,6 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
         mockCalled = true
         clearIdentifyCallsCount += 1
         clearIdentifyClosure?()
-    }
-
-    // MARK: - track
-
-    /// Number of times the function was called.
-    public private(set) var trackCallsCount = 0
-    /// `true` if the function was ever called.
-    public var trackCalled: Bool {
-        trackCallsCount > 0
-    }
-
-    /// The arguments from the *last* time the function was called.
-    public private(set) var trackReceivedArguments: (name: String, data: [String: Any])?
-    /// Arguments from *all* of the times that the function was called.
-    public private(set) var trackReceivedInvocations: [(name: String, data: [String: Any])] = []
-    /**
-     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
-     */
-    public var trackClosure: ((String, [String: Any]) -> Void)?
-
-    /// Mocked function for `track(name: String, data: [String: Any])`. Your opportunity to return a mocked value and check result of mock in test code.
-    public func track(name: String, data: [String: Any]) {
-        mockCalled = true
-        trackCallsCount += 1
-        trackReceivedArguments = (name: name, data: data)
-        trackReceivedInvocations.append((name: name, data: data))
-        trackClosure?(name, data)
-    }
-
-    // MARK: - track<RequestBody: Codable>
-
-    /// The arguments from the *last* time the function was called.
-    public private(set) var trackEncodableReceivedArguments: (name: String, data: AnyEncodable)?
-    /// Arguments from *all* of the times that the function was called.
-    public private(set) var trackEncodableReceivedInvocations: [(name: String, data: AnyEncodable)] = []
-    /**
-     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
-     */
-    public var trackEncodableClosure: ((String, AnyEncodable) -> Void)?
-
-    /// Mocked function for `track<RequestBody: Codable>(name: String, data: RequestBody?)`. Your opportunity to return a mocked value and check result of mock in test code.
-    public func track<RequestBody: Codable>(name: String, data: RequestBody?) {
-        mockCalled = true
-        trackCallsCount += 1
-        trackEncodableReceivedArguments = (name: name, data: AnyEncodable(data))
-        trackEncodableReceivedInvocations.append((name: name, data: AnyEncodable(data)))
-        trackEncodableClosure?(name, AnyEncodable(data))
-    }
-
-    // MARK: - screen
-
-    /// Number of times the function was called.
-    public private(set) var screenCallsCount = 0
-    /// `true` if the function was ever called.
-    public var screenCalled: Bool {
-        screenCallsCount > 0
-    }
-
-    /// The arguments from the *last* time the function was called.
-    public private(set) var screenReceivedArguments: (name: String, data: [String: Any])?
-    /// Arguments from *all* of the times that the function was called.
-    public private(set) var screenReceivedInvocations: [(name: String, data: [String: Any])] = []
-    /**
-     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
-     */
-    public var screenClosure: ((String, [String: Any]) -> Void)?
-
-    /// Mocked function for `screen(name: String, data: [String: Any])`. Your opportunity to return a mocked value and check result of mock in test code.
-    public func screen(name: String, data: [String: Any]) {
-        mockCalled = true
-        screenCallsCount += 1
-        screenReceivedArguments = (name: name, data: data)
-        screenReceivedInvocations.append((name: name, data: data))
-        screenClosure?(name, data)
-    }
-
-    // MARK: - screen<RequestBody: Codable>
-
-    /// The arguments from the *last* time the function was called.
-    public private(set) var screenEncodableReceivedArguments: (name: String, data: AnyEncodable)?
-    /// Arguments from *all* of the times that the function was called.
-    public private(set) var screenEncodableReceivedInvocations: [(name: String, data: AnyEncodable)] = []
-    /**
-     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
-     */
-    public var screenEncodableClosure: ((String, AnyEncodable) -> Void)?
-
-    /// Mocked function for `screen<RequestBody: Codable>(name: String, data: RequestBody?)`. Your opportunity to return a mocked value and check result of mock in test code.
-    public func screen<RequestBody: Codable>(name: String, data: RequestBody?) {
-        mockCalled = true
-        screenCallsCount += 1
-        screenEncodableReceivedArguments = (name: name, data: AnyEncodable(data))
-        screenEncodableReceivedInvocations.append((name: name, data: AnyEncodable(data)))
-        screenEncodableClosure?(name, AnyEncodable(data))
     }
 
     // MARK: - registerDeviceToken
@@ -565,6 +447,100 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
         mockCalled = true
         deleteDeviceTokenCallsCount += 1
         deleteDeviceTokenClosure?()
+    }
+
+    // MARK: - track
+
+    /// Number of times the function was called.
+    public private(set) var trackCallsCount = 0
+    /// `true` if the function was ever called.
+    public var trackCalled: Bool {
+        trackCallsCount > 0
+    }
+
+    /// The arguments from the *last* time the function was called.
+    public private(set) var trackReceivedArguments: (name: String, properties: [String: Any]?)?
+    /// Arguments from *all* of the times that the function was called.
+    public private(set) var trackReceivedInvocations: [(name: String, properties: [String: Any]?)] = []
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     */
+    public var trackClosure: ((String, [String: Any]?) -> Void)?
+
+    /// Mocked function for `track(name: String, properties: [String: Any]?)`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func track(name: String, properties: [String: Any]?) {
+        mockCalled = true
+        trackCallsCount += 1
+        trackReceivedArguments = (name: name, properties: properties)
+        trackReceivedInvocations.append((name: name, properties: properties))
+        trackClosure?(name, properties)
+    }
+
+    // MARK: - track<RequestBody: Codable>
+
+    /// The arguments from the *last* time the function was called.
+    public private(set) var trackEncodableReceivedArguments: (name: String, properties: AnyEncodable)?
+    /// Arguments from *all* of the times that the function was called.
+    public private(set) var trackEncodableReceivedInvocations: [(name: String, properties: AnyEncodable)] = []
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     */
+    public var trackEncodableClosure: ((String, AnyEncodable) -> Void)?
+
+    /// Mocked function for `track<RequestBody: Codable>(name: String, properties: RequestBody?)`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func track<RequestBody: Codable>(name: String, properties: RequestBody?) {
+        mockCalled = true
+        trackCallsCount += 1
+        trackEncodableReceivedArguments = (name: name, properties: AnyEncodable(properties))
+        trackEncodableReceivedInvocations.append((name: name, properties: AnyEncodable(properties)))
+        trackEncodableClosure?(name, AnyEncodable(properties))
+    }
+
+    // MARK: - screen
+
+    /// Number of times the function was called.
+    public private(set) var screenCallsCount = 0
+    /// `true` if the function was ever called.
+    public var screenCalled: Bool {
+        screenCallsCount > 0
+    }
+
+    /// The arguments from the *last* time the function was called.
+    public private(set) var screenReceivedArguments: (title: String, properties: [String: Any]?)?
+    /// Arguments from *all* of the times that the function was called.
+    public private(set) var screenReceivedInvocations: [(title: String, properties: [String: Any]?)] = []
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     */
+    public var screenClosure: ((String, [String: Any]?) -> Void)?
+
+    /// Mocked function for `screen(title: String, properties: [String: Any]?)`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func screen(title: String, properties: [String: Any]?) {
+        mockCalled = true
+        screenCallsCount += 1
+        screenReceivedArguments = (title: title, properties: properties)
+        screenReceivedInvocations.append((title: title, properties: properties))
+        screenClosure?(title, properties)
+    }
+
+    // MARK: - screen<RequestBody: Codable>
+
+    /// The arguments from the *last* time the function was called.
+    public private(set) var screenEncodableReceivedArguments: (title: String, properties: AnyEncodable)?
+    /// Arguments from *all* of the times that the function was called.
+    public private(set) var screenEncodableReceivedInvocations: [(title: String, properties: AnyEncodable)] = []
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     */
+    public var screenEncodableClosure: ((String, AnyEncodable) -> Void)?
+
+    /// Mocked function for `screen<RequestBody: Codable>(title: String, properties: RequestBody?)`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func screen<RequestBody: Codable>(title: String, properties: RequestBody?) {
+        mockCalled = true
+        screenCallsCount += 1
+        screenEncodableReceivedArguments = (title: title, properties: AnyEncodable(properties))
+        screenEncodableReceivedInvocations.append((title: title, properties: AnyEncodable(properties)))
+        screenEncodableClosure?(title, AnyEncodable(properties))
     }
 
     // MARK: - trackMetric

--- a/Sources/Tracking/migration/DataPipelineMigrationAssistant.swift
+++ b/Sources/Tracking/migration/DataPipelineMigrationAssistant.swift
@@ -48,7 +48,7 @@ class DataPipelineMigrationAssistant: DataPipelineMigration {
         // currently logged-in user for seamless processing of events.
         if DataPipeline.shared.analytics.userId == nil {
             if let identifier = profileStore.identifier {
-                DataPipeline.shared.identify(identifier: identifier)
+                CustomerIO.shared.identify(userId: identifier)
                 // Remove identifier from storage
                 // so same profile can not be re-identifed
                 profileStore.identifier = nil

--- a/Tests/DataPipeline/APITest.swift
+++ b/Tests/DataPipeline/APITest.swift
@@ -14,6 +14,11 @@ import XCTest
  */
 class DataPipelineAPITest: UnitTest {
     let dictionaryData: [String: Any] = ["foo": true, "bar": ""]
+    struct CodableExample: Codable {
+        let foo: String
+    }
+
+    let codedData = CodableExample(foo: "")
 
     // Test that public functions are accessible by mocked instances
     let mock = CustomerIOInstanceMock()
@@ -30,6 +35,47 @@ class DataPipelineAPITest: UnitTest {
         CustomerIO.initialize(writeKey: "", logLevel: .debug) { (config: inout DataPipelineConfigOptions) in
             config.autoAddCustomerIODestination = false
         }
+
+        // Identify
+        CustomerIO.shared.identify(userId: "")
+        mock.identify(userId: "", traits: nil)
+        CustomerIO.shared.identify(userId: "", traits: dictionaryData)
+        mock.identify(userId: "", traits: dictionaryData)
+        CustomerIO.shared.identify(userId: "", traits: codedData)
+        mock.identify(userId: "", traits: codedData)
+
+        // clear identify
+        CustomerIO.shared.clearIdentify()
+        mock.clearIdentify()
+
+        // event tracking
+        CustomerIO.shared.track(name: "")
+        mock.track(name: "", properties: nil)
+        CustomerIO.shared.track(name: "", properties: dictionaryData)
+        mock.track(name: "", properties: dictionaryData)
+        CustomerIO.shared.track(name: "", properties: codedData)
+        mock.track(name: "", properties: codedData)
+
+        // screen tracking
+        CustomerIO.shared.screen(title: "")
+        mock.screen(title: "", properties: nil)
+        CustomerIO.shared.screen(title: "", properties: dictionaryData)
+        mock.screen(title: "", properties: dictionaryData)
+        CustomerIO.shared.screen(title: "", properties: codedData)
+        mock.screen(title: "", properties: codedData)
+
+        // register push token
+        CustomerIO.shared.registerDeviceToken("")
+        mock.registerDeviceToken("")
+
+        // delete push token
+        CustomerIO.shared.deleteDeviceToken()
+        mock.deleteDeviceToken()
+
+        // track push metric
+        let metric = Metric.delivered
+        CustomerIO.shared.trackMetric(deliveryID: "", event: metric, deviceToken: "")
+        mock.trackMetric(deliveryID: "", event: metric, deviceToken: "")
 
         checkDeviceProfileAttributes()
     }

--- a/Tests/DataPipeline/DataPipelineCompatibilityTests.swift
+++ b/Tests/DataPipeline/DataPipelineCompatibilityTests.swift
@@ -59,7 +59,7 @@ class DataPipelineCompatibilityTests: IntegrationTest {
         let givenIdentifier = String.random
         let givenBody: [String: Any] = ["first_name": "Dana", "age": 30]
 
-        customerIO.identify(identifier: givenIdentifier, body: givenBody)
+        customerIO.identify(userId: givenIdentifier, traits: givenBody)
 
         let allEvents = readTypeFromStorage(key: Storage.Constants.events)
         let filteredEvents = allEvents.filter { $0.eventType == "identify" }
@@ -229,7 +229,7 @@ class DataPipelineCompatibilityTests: IntegrationTest {
         let givenData: [String: Any] = ["first_name": "Dana", "age": 30]
 
         customerIO.identify(userId: String.random)
-        customerIO.track(name: givenEvent, data: givenData)
+        customerIO.track(name: givenEvent, properties: givenData)
 
         let allEvents = readTypeFromStorage(key: Storage.Constants.events)
         let filteredEvents = allEvents.filter { $0.eventType == "track" }
@@ -274,7 +274,7 @@ class DataPipelineCompatibilityTests: IntegrationTest {
         let givenData: [String: Any] = ["first_name": "Dana", "age": 30]
 
         customerIO.identify(userId: String.random)
-        customerIO.screen(name: givenScreen, data: givenData)
+        customerIO.screen(title: givenScreen, properties: givenData)
 
         let allEvents = readTypeFromStorage(key: Storage.Constants.events)
         let filteredEvents = allEvents.filter { $0.eventType == "screen" }

--- a/Tests/DataPipeline/DataPipelineCompatibilityTests.swift
+++ b/Tests/DataPipeline/DataPipelineCompatibilityTests.swift
@@ -52,7 +52,7 @@ class DataPipelineCompatibilityTests: IntegrationTest {
         }
 
         XCTAssertEqual(savedEvent[keyPath: "userId"] as? String, givenIdentifier)
-        XCTAssertTrue(savedEvent[mapKeyPath: "traits"]?.isEmpty ?? false)
+        XCTAssertNil(savedEvent[mapKeyPath: "traits"])
     }
 
     func test_identifyWithAttributes_expectFinalJSONHasCorrectKeysAndValues() {

--- a/Tests/DataPipeline/DataPipelineInteractionTests.swift
+++ b/Tests/DataPipeline/DataPipelineInteractionTests.swift
@@ -54,7 +54,7 @@ class DataPipelineInteractionTests: IntegrationTest {
         }
 
         XCTAssertEqual(identifyEvent.userId, givenIdentifier)
-        XCTAssertMatches(identifyEvent.traits?.dictionaryValue, [:])
+        XCTAssertNil(identifyEvent.traits)
     }
 
     func test_identify_expectSetNewProfileWithAttributes() {

--- a/Tests/DataPipeline/DataPipelineInteractionTests.swift
+++ b/Tests/DataPipeline/DataPipelineInteractionTests.swift
@@ -45,7 +45,7 @@ class DataPipelineInteractionTests: IntegrationTest {
         customerIO.identify(userId: givenIdentifier)
 
         XCTAssertEqual(analytics.userId, givenIdentifier)
-        XCTAssertEqual(analytics.traits()?.count, 0)
+        XCTAssertNil(analytics.traits())
 
         XCTAssertEqual(outputReader.identifyEvents.count, 1)
         guard let identifyEvent = outputReader.identifyEvents.last else {

--- a/Tests/DataPipeline/DataPipelineInteractionTests.swift
+++ b/Tests/DataPipeline/DataPipelineInteractionTests.swift
@@ -349,7 +349,7 @@ class DataPipelineInteractionTests: IntegrationTest {
         customerIO.identify(userId: givenIdentifier)
         outputReader.resetPlugin()
 
-        customerIO.track(name: String.random, data: givenData)
+        customerIO.track(name: String.random, properties: givenData)
 
         XCTAssertEqual(outputReader.events.count, 1)
         guard let trackEvent = outputReader.lastEvent as? TrackEvent else {
@@ -374,7 +374,7 @@ class DataPipelineInteractionTests: IntegrationTest {
         outputReader.resetPlugin()
 
         let data: EmptyRequestBody? = nil
-        customerIO.track(name: String.random, data: data)
+        customerIO.track(name: String.random, properties: data)
 
         XCTAssertEqual(outputReader.events.count, 1)
         guard let trackEvent = outputReader.lastEvent as? TrackEvent else {
@@ -412,7 +412,7 @@ class DataPipelineInteractionTests: IntegrationTest {
         outputReader.resetPlugin()
         eventBusHandlerMock.resetMock()
 
-        customerIO.screen(name: givenScreen, data: givenData)
+        customerIO.screen(title: givenScreen, properties: givenData)
 
         XCTAssertEqual(outputReader.events.count, 1)
         guard let screenEvent = outputReader.lastEvent as? ScreenEvent else {

--- a/Tests/Tracking/APITest.swift
+++ b/Tests/Tracking/APITest.swift
@@ -11,14 +11,8 @@ import XCTest
  that is a reminder to either fix the compilation and introduce the breaking change or
  fix the mistake and not introduce the breaking change in the code base.
  */
+
 class TrackingAPITest: UnitTest {
-    let dictionaryData: [String: Any] = ["foo": true, "bar": ""]
-    struct CodableExample: Codable {
-        let foo: String
-    }
-
-    let codedData = CodableExample(foo: "")
-
     // Test that public functions are accessible by mocked instances
     let mock = CustomerIOInstanceMock()
 
@@ -40,59 +34,6 @@ class TrackingAPITest: UnitTest {
         // Public properties exposed to customers
         _ = CustomerIO.shared.siteId
         _ = CustomerIO.shared.config
-
-        // Identify
-        CustomerIO.shared.identify(identifier: "")
-        mock.identify(identifier: "")
-        CustomerIO.shared.identify(identifier: "", body: dictionaryData)
-        mock.identify(identifier: "", body: dictionaryData)
-        CustomerIO.shared.identify(identifier: "", body: codedData)
-        mock.identify(identifier: "", body: codedData)
-
-        // clear identify
-        CustomerIO.shared.clearIdentify()
-        mock.clearIdentify()
-
-        // event tracking
-        CustomerIO.shared.track(name: "")
-        mock.track(name: "")
-        CustomerIO.shared.track(name: "", data: dictionaryData)
-        mock.track(name: "", data: dictionaryData)
-        CustomerIO.shared.track(name: "", data: codedData)
-        mock.track(name: "", data: codedData)
-
-        // screen tracking
-        CustomerIO.shared.screen(name: "")
-        mock.screen(name: "")
-        CustomerIO.shared.screen(name: "", data: dictionaryData)
-        mock.screen(name: "", data: dictionaryData)
-        CustomerIO.shared.screen(name: "", data: codedData)
-        mock.screen(name: "", data: codedData)
-
-        // register push token
-        CustomerIO.shared.registerDeviceToken("")
-        mock.registerDeviceToken("")
-
-        // delete push token
-        CustomerIO.shared.deleteDeviceToken()
-        mock.deleteDeviceToken()
-
-        // track push metric
-        let metric = Metric.delivered
-        CustomerIO.shared.trackMetric(deliveryID: "", event: metric, deviceToken: "")
-        mock.trackMetric(deliveryID: "", event: metric, deviceToken: "")
-
-        checkDeviceProfileAttributes()
-    }
-
-    func checkDeviceProfileAttributes() {
-        // profile attributes
-        CustomerIO.shared.profileAttributes = dictionaryData
-        mock.profileAttributes = dictionaryData
-
-        // device attributes
-        CustomerIO.shared.deviceAttributes = dictionaryData
-        mock.deviceAttributes = dictionaryData
     }
 
     // SDK wrappers can configure the SDK from a Map.

--- a/Tests/Tracking/CustomerIOMockTest.swift
+++ b/Tests/Tracking/CustomerIOMockTest.swift
@@ -1,3 +1,4 @@
+@testable import CioDataPipelines
 @testable import CioInternalCommon
 @testable import CioTracking
 import Foundation
@@ -37,7 +38,7 @@ class CustomerIOMockTest: UnitTest {
 
         // You can receive the generic `body` that was sent to the Customer.io `identify()` call.
         // Because of Swift generics, you must get the `.value` and cast it:
-        let actualBody: ExampleIdentifyRequestBody? = cioMock.identifyEncodableReceivedArguments?.body
+        let actualBody: ExampleIdentifyRequestBody? = cioMock.identifyEncodableReceivedArguments?.traits
             .value as? ExampleIdentifyRequestBody
         // Now, you can run checks against the `body` that was actually passed to `identify()`.
         XCTAssertNotNil(actualBody)
@@ -60,7 +61,7 @@ class ExampleRepository {
     ) {
         // call your code for your app to login the user with email and password.
         // then, identify the customer in Customer.io
-        cio.identify(identifier: email, body: ExampleIdentifyRequestBody(firstName: firstName))
+        cio.identify(userId: email, traits: ExampleIdentifyRequestBody(firstName: firstName))
 
         onComplete(.success(()))
     }

--- a/Tests/Tracking/migration/DataPipelineMigrationAssistantTests.swift
+++ b/Tests/Tracking/migration/DataPipelineMigrationAssistantTests.swift
@@ -106,7 +106,7 @@ class DataPipelineMigrationAssistantTests: UnitTest {
 
     func test_givenUserOnCDPIdentified_expectNoUpdate() {
         let givenIdentifier = String.random
-        DataPipeline.shared.identify(identifier: givenIdentifier)
+        CustomerIO.shared.identify(userId: givenIdentifier)
         XCTAssertNotNil(migrationAssistant.handleAlreadyIdentifiedMigratedUser())
         XCTAssertEqual(DataPipeline.shared.analytics.userId, givenIdentifier)
         XCTAssertNil(profileStoreMock.identifier)
@@ -114,7 +114,7 @@ class DataPipelineMigrationAssistantTests: UnitTest {
 
     func test_givenUserOnCDPIdentified_expectMigrationCodeRunOnce() {
         let givenIdentifier = String.random
-        DataPipeline.shared.identify(identifier: givenIdentifier)
+        CustomerIO.shared.identify(userId: givenIdentifier)
         XCTAssertNotNil(migrationAssistant.handleAlreadyIdentifiedMigratedUser())
         XCTAssertEqual(DataPipeline.shared.analytics.userId, givenIdentifier)
         XCTAssertNil(profileStoreMock.identifier)


### PR DESCRIPTION
helps: [MBL-102](https://linear.app/customerio/issue/MBL-102/public-api-deprecate-tracking-apis-to-trigger-compile-time-errors)

### Changes

- Auto generated file updates from #537 
- Fixed tests broken due to changes in mentioned PR
- Updated public api tests to match the expectations