### PR TITLE
refactor: remove trackingApiUrl config options from SdkConfig

### DIFF
--- a/Sources/Common/Store/SdkConfig.swift
+++ b/Sources/Common/Store/SdkConfig.swift
@@ -25,7 +25,6 @@ public struct SdkConfig {
                 siteId: siteId,
                 apiKey: apiKey,
                 region: region,
-                trackingApiUrl: region.productionTrackingUrl,
                 autoTrackPushEvents: true,
                 logLevel: CioLogLevel.error
             )
@@ -49,9 +48,6 @@ public struct SdkConfig {
         if let autoTrackPushEvents = params[Keys.autoTrackPushEvents.rawValue] as? Bool {
             self.autoTrackPushEvents = autoTrackPushEvents
         }
-        if let trackingApiUrl = params[Keys.trackingApiUrl.rawValue] as? String, !trackingApiUrl.isEmpty {
-            self.trackingApiUrl = trackingApiUrl
-        }
 
         if let sdkSource = params[Keys.source.rawValue] as? String, let pversion = params[Keys.sourceVersion.rawValue] as? String, let sdkConfigSource = SdkWrapperConfig.Source(rawValue: sdkSource) {
             _sdkWrapperConfig = SdkWrapperConfig(source: sdkConfigSource, version: pversion)
@@ -66,7 +62,6 @@ public struct SdkConfig {
         case apiKey
         case region
         // config features
-        case trackingApiUrl
         case logLevel
         case autoTrackPushEvents
         // SDK wrapper config
@@ -84,13 +79,6 @@ public struct SdkConfig {
     public let region: Region
 
     /**
-     Base URL to use for the Customer.io track API. You will more then likely not modify this value.
-
-     If you override this value, `Region` set when initializing the SDK will be ignored.
-     */
-    public var trackingApiUrl: String
-
-    /**
      Automatic tracking of push events will automatically generate `opened` and `delivered` metrics
      for push notifications sent by Customer.io
      */
@@ -99,10 +87,6 @@ public struct SdkConfig {
     /// To help you get setup with the SDK or debug SDK, change the log level of logs you
     /// wish to view from the SDK.
     public var logLevel: CioLogLevel
-
-    var httpBaseUrls: HttpBaseUrls {
-        HttpBaseUrls(trackingApi: trackingApiUrl)
-    }
 
     // property is used internally so disable swiftlint rule
     /**

--- a/Tests/Tracking/APITest.swift
+++ b/Tests/Tracking/APITest.swift
@@ -35,14 +35,12 @@ class TrackingAPITest: UnitTest {
     // SDK wrappers can configure the SDK from a Map.
     // This test is in API tests as the String keys of the Map are public and need to not break for the SDK wrappers.
     func test_createSdkConfigFromMap() {
-        let trackingApiUrl = String.random
         let autoTrackPushEvents = false
         let logLevel = "info"
         let sdkWrapperSource = "Flutter"
         let sdkWrapperVersion = "1000.33333.4444"
 
         let givenParamsFromSdkWrapper: [String: Any] = [
-            "trackingApiUrl": trackingApiUrl,
             "autoTrackPushEvents": autoTrackPushEvents,
             "logLevel": logLevel,
             "source": sdkWrapperSource,
@@ -52,21 +50,18 @@ class TrackingAPITest: UnitTest {
         var actual = CioSdkConfig.Factory.create(siteId: "", apiKey: "", region: .US)
         actual.modify(params: givenParamsFromSdkWrapper)
 
-        XCTAssertEqual(actual.trackingApiUrl, trackingApiUrl)
         XCTAssertEqual(actual.autoTrackPushEvents, autoTrackPushEvents)
         XCTAssertEqual(actual.logLevel.rawValue, logLevel)
         XCTAssertNotNil(actual._sdkWrapperConfig)
     }
 
     func test_SdkConfigFromMap_givenWrongKeys_expectDefaults() {
-        let trackingApiUrl = String.random
         let autoTrackPushEvents = false
         let logLevel = "info"
         let sdkWrapperSource = "Flutter"
         let sdkWrapperVersion = "1000.33333.4444"
 
         let givenParamsFromSdkWrapper: [String: Any] = [
-            "trackingApiUrlWrong": trackingApiUrl,
             "autoTrackPushEventsWrong": autoTrackPushEvents,
             "logLevelWrong": logLevel,
             "sourceWrong": sdkWrapperSource,
@@ -76,7 +71,6 @@ class TrackingAPITest: UnitTest {
         var actual = CioSdkConfig.Factory.create(siteId: "", apiKey: "", region: .US)
         actual.modify(params: givenParamsFromSdkWrapper)
 
-        XCTAssertEqual(actual.trackingApiUrl, Region.US.productionTrackingUrl)
         XCTAssertEqual(actual.autoTrackPushEvents, true)
         XCTAssertEqual(actual.logLevel.rawValue, CioLogLevel.error.rawValue)
         XCTAssertNil(actual._sdkWrapperConfig)
@@ -85,7 +79,6 @@ class TrackingAPITest: UnitTest {
     func test_SdkConfig_givenNoModification_expectDefaults() {
         let actual = CioSdkConfig.Factory.create(siteId: "", apiKey: "", region: .US)
 
-        XCTAssertEqual(actual.trackingApiUrl, Region.US.productionTrackingUrl)
         XCTAssertEqual(actual.autoTrackPushEvents, true)
         XCTAssertEqual(actual.logLevel.rawValue, CioLogLevel.error.rawValue)
         XCTAssertNil(actual._sdkWrapperConfig)


### PR DESCRIPTION
Part of: https://linear.app/customerio/issue/MBL-120/public-api-remove-unused-properties-from-sdkconfig

None of the code was referencing any of these config options. Therefore, I did not need to make any more modifications to the code besides removing the properties from the Common module.

---

**Stack**:
- #547
- #546
- #540
- #539 ⬅
- #534
- #533
- #532


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*