### PR TITLE
chore: refactored post initialize to be independent of digraph

### DIFF
--- a/Sources/Common/CustomerIOInstance.swift
+++ b/Sources/Common/CustomerIOInstance.swift
@@ -1,10 +1,6 @@
 import Foundation
 
 public protocol CustomerIOInstance: AutoMockable {
-    var siteId: String? { get }
-    /// Get the current configuration options set for the SDK.
-    var config: SdkConfig? { get }
-
     // MARK: - Profile
 
     /**
@@ -162,8 +158,8 @@ public class CustomerIO: CustomerIOInstance {
         SdkVersion.version
     }
 
-    public var siteId: String? {
-        diGraph?.sdkConfig.siteId
+    private var diGraph: DIGraphShared {
+        DIGraphShared.shared
     }
 
     /**
@@ -178,10 +174,6 @@ public class CustomerIO: CustomerIOInstance {
     // Tip: Use `SdkInitializedUtil` in modules to see if the SDK has been initialized and get data it needs.
     public var implementation: CustomerIOInstance?
 
-    // The 1 place that DiGraph is strongly stored in memory for the SDK.
-    // Exposed for `SdkInitializedUtil`. Not recommended to use this property directly.
-    public var diGraph: DIGraph?
-
     // private constructor to force use of singleton API
     private init() {}
 
@@ -190,9 +182,8 @@ public class CustomerIO: CustomerIOInstance {
     // Any implementation of the interface works for unit tests.
 
     @discardableResult
-    static func setUpSharedInstanceForUnitTest(implementation: CustomerIOInstance, diGraph: DIGraph) -> CustomerIO {
+    static func setUpSharedInstanceForUnitTest(implementation: CustomerIOInstance) -> CustomerIO {
         shared.implementation = implementation
-        shared.diGraph = diGraph
         return shared
     }
 
@@ -201,15 +192,13 @@ public class CustomerIO: CustomerIOInstance {
     }
     #endif
 
-    public static func initializeSharedInstance(with implementation: CustomerIOInstance, diGraph: DIGraph) {
+    public static func initializeSharedInstance(with implementation: CustomerIOInstance) {
         shared.implementation = implementation
-        shared.diGraph = diGraph
-        shared.postInitialize(diGraph: diGraph)
+        shared.postInitialize()
     }
 
-    func postInitialize(diGraph: DIGraph) {
+    func postInitialize() {
         let logger = diGraph.logger
-        let siteId = diGraph.sdkConfig.siteId
 
         // Register the device token during SDK initialization to address device registration issues
         // arising from lifecycle differences between wrapper SDKs and native SDK.
@@ -220,12 +209,8 @@ public class CustomerIO: CustomerIOInstance {
 
         logger
             .info(
-                "Customer.io SDK \(SdkVersion.version) initialized and ready to use for site id: \(siteId)"
+                "Customer.io SDK \(SdkVersion.version) initialized and ready to use"
             )
-    }
-
-    public var config: SdkConfig? {
-        implementation?.config
     }
 
     // MARK: - CustomerIOInstance implementation

--- a/Sources/Common/autogenerated/AutoMockable.generated.swift
+++ b/Sources/Common/autogenerated/AutoMockable.generated.swift
@@ -98,78 +98,6 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
      When setter of the property called, the value given to setter is set here.
      When the getter of the property called, the value set here will be returned. Your chance to mock the property.
      */
-    public var underlyingSiteId: String? = nil
-    /// `true` if the getter or setter of property is called at least once.
-    public var siteIdCalled: Bool {
-        siteIdGetCalled || siteIdSetCalled
-    }
-
-    /// `true` if the getter called on the property at least once.
-    public var siteIdGetCalled: Bool {
-        siteIdGetCallsCount > 0
-    }
-
-    public var siteIdGetCallsCount = 0
-    /// `true` if the setter called on the property at least once.
-    public var siteIdSetCalled: Bool {
-        siteIdSetCallsCount > 0
-    }
-
-    public var siteIdSetCallsCount = 0
-    /// The mocked property with a getter and setter.
-    public var siteId: String? {
-        get {
-            mockCalled = true
-            siteIdGetCallsCount += 1
-            return underlyingSiteId
-        }
-        set(value) {
-            mockCalled = true
-            siteIdSetCallsCount += 1
-            underlyingSiteId = value
-        }
-    }
-
-    /**
-     When setter of the property called, the value given to setter is set here.
-     When the getter of the property called, the value set here will be returned. Your chance to mock the property.
-     */
-    public var underlyingConfig: SdkConfig? = nil
-    /// `true` if the getter or setter of property is called at least once.
-    public var configCalled: Bool {
-        configGetCalled || configSetCalled
-    }
-
-    /// `true` if the getter called on the property at least once.
-    public var configGetCalled: Bool {
-        configGetCallsCount > 0
-    }
-
-    public var configGetCallsCount = 0
-    /// `true` if the setter called on the property at least once.
-    public var configSetCalled: Bool {
-        configSetCallsCount > 0
-    }
-
-    public var configSetCallsCount = 0
-    /// The mocked property with a getter and setter.
-    public var config: SdkConfig? {
-        get {
-            mockCalled = true
-            configGetCallsCount += 1
-            return underlyingConfig
-        }
-        set(value) {
-            mockCalled = true
-            configSetCallsCount += 1
-            underlyingConfig = value
-        }
-    }
-
-    /**
-     When setter of the property called, the value given to setter is set here.
-     When the getter of the property called, the value set here will be returned. Your chance to mock the property.
-     */
     public var underlyingProfileAttributes: [String: Any] = [:]
     /// `true` if the getter or setter of property is called at least once.
     public var profileAttributesCalled: Bool {
@@ -275,12 +203,6 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
     }
 
     public func resetMock() {
-        siteId = nil
-        siteIdGetCallsCount = 0
-        siteIdSetCallsCount = 0
-        config = nil
-        configGetCallsCount = 0
-        configSetCallsCount = 0
         profileAttributesGetCallsCount = 0
         profileAttributesSetCallsCount = 0
         deviceAttributesGetCallsCount = 0

--- a/Sources/DataPipeline/CustomerIO.swift
+++ b/Sources/DataPipeline/CustomerIO.swift
@@ -18,24 +18,20 @@ public extension CustomerIO {
         }
 
         let implementation = DataPipeline.initialize(moduleConfig: cdpConfig)
-
-        let sdkConfig = SdkConfig.Factory.create(siteId: "", apiKey: "", region: .US)
-        let newDiGraph = DIGraph(sdkConfig: sdkConfig)
-
         // set the logLevel for ConsoleLogger
         DIGraphShared.shared.logger.setLogLevel(logLevel)
         // enable Analytics logs accordingly to logLevel
         CustomerIO.shared.setDebugLogsEnabled(logLevel == .debug)
 
-        initialize(implementation: implementation, diGraph: newDiGraph)
+        initialize(implementation: implementation)
     }
 
     /**
      Common initialization method for setting up the shared `CustomerIO` instance.
      This method is intended to be used by both actual implementations and in tests, ensuring that tests closely mimic the real-world implementation.
      */
-    private static func initialize(implementation: DataPipelineInstance, diGraph: DIGraph) {
-        initializeSharedInstance(with: implementation, diGraph: diGraph)
+    private static func initialize(implementation: DataPipelineInstance) {
+        initializeSharedInstance(with: implementation)
     }
 
     #if DEBUG
@@ -45,7 +41,7 @@ public extension CustomerIO {
     @discardableResult
     static func setUpSharedInstanceForIntegrationTest(diGraphShared: DIGraphShared, diGraph: DIGraph, moduleConfig: DataPipelineConfigOptions) -> DataPipelineInstance {
         let implementation = DataPipeline.setUpSharedInstanceForIntegrationTest(diGraphShared: diGraphShared, config: moduleConfig)
-        initialize(implementation: implementation, diGraph: diGraph)
+        initialize(implementation: implementation)
         return implementation
     }
 

--- a/Sources/DataPipeline/CustomerIO.swift
+++ b/Sources/DataPipeline/CustomerIO.swift
@@ -39,7 +39,7 @@ public extension CustomerIO {
     // Integration tests use the actual implementation.
 
     @discardableResult
-    static func setUpSharedInstanceForIntegrationTest(diGraphShared: DIGraphShared, diGraph: DIGraph, moduleConfig: DataPipelineConfigOptions) -> DataPipelineInstance {
+    static func setUpSharedInstanceForIntegrationTest(diGraphShared: DIGraphShared, moduleConfig: DataPipelineConfigOptions) -> DataPipelineInstance {
         let implementation = DataPipeline.setUpSharedInstanceForIntegrationTest(diGraphShared: diGraphShared, config: moduleConfig)
         initialize(implementation: implementation)
         return implementation

--- a/Sources/DataPipeline/DataPipeline.swift
+++ b/Sources/DataPipeline/DataPipeline.swift
@@ -79,13 +79,6 @@ public class DataPipeline: ModuleTopLevelObject<DataPipelineInstance>, DataPipel
         logger.info("\(moduleName) module successfully set up with SDK")
     }
 
-    // Code below this line will be updated in later PRs
-    // TODO: [CDP] Review CustomerIOInstance here after finalizing DataPipelineImplementation
-
-    public var siteId: String? { implementation?.siteId }
-
-    public var config: CioInternalCommon.SdkConfig? { implementation?.config }
-
     // MARK: - DataPipelineInstance implementation
 
     public var profileAttributes: [String: Any] {

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -40,11 +40,6 @@ class DataPipelineImplementation: DataPipelineInstance {
         // add/override device attributes in context for each request
         analytics.add(plugin: deviceAttributesPlugin)
 
-        if let existingDeviceToken = globalDataStore.pushDeviceToken {
-            // if the device token exists, pass it to the plugin and ensure device attributes are updated
-            addDeviceAttributes(token: existingDeviceToken)
-        }
-
         // plugin to publish data pipeline events
         analytics.add(plugin: DataPipelinePublishedEvents(diGraph: diGraph))
 

--- a/Tests/Common/CustomerIOTest.swift
+++ b/Tests/Common/CustomerIOTest.swift
@@ -9,23 +9,25 @@ class CustomerIOTest: UnitTest {
 
     private var customerIO: CustomerIO!
 
-    override func setUp() {
-        super.setUp()
+    override func setUpDependencies() {
+        super.setUpDependencies()
+        diGraphShared.override(value: globalDataStoreMock, forType: GlobalDataStore.self)
+    }
 
-        diGraph.override(value: globalDataStoreMock, forType: GlobalDataStore.self)
-
-        customerIO = CustomerIO.setUpSharedInstanceForUnitTest(implementation: implmentationMock, diGraph: diGraph)
+    override func initializeSDKComponents() -> CustomerIO? {
+        customerIO = CustomerIO.setUpSharedInstanceForUnitTest(implementation: implmentationMock)
+        return customerIO
     }
 
     func test_initialize_givenPushDeviceTokenNotSet_expectRegisterDeviceTokenNotCalled() {
-        customerIO.postInitialize(diGraph: diGraph)
+        customerIO.postInitialize()
         XCTAssertFalse(implmentationMock.registerDeviceTokenCalled)
     }
 
     func test_initialize_givenPushDeviceTokenSet_expectRegisterDeviceTokenCalled() {
         let pushDeviceToken = String.random
         globalDataStoreMock.pushDeviceToken = pushDeviceToken
-        customerIO.postInitialize(diGraph: diGraph)
+        customerIO.postInitialize()
         XCTAssertTrue(implmentationMock.registerDeviceTokenCalled)
     }
 }

--- a/Tests/DataPipeline/Core/UnitTest.swift
+++ b/Tests/DataPipeline/Core/UnitTest.swift
@@ -59,7 +59,7 @@ open class UnitTest: SharedTests.UnitTestBase<CustomerIO> {
         )
 
         // setup shared instance with desired implementation for unit tests
-        customerIO = CustomerIO.setUpSharedInstanceForUnitTest(implementation: implementation, diGraph: diGraph)
+        customerIO = CustomerIO.setUpSharedInstanceForUnitTest(implementation: implementation)
         customerIO.setDebugLogsEnabled(enableLogs)
 
         // wait for analytics queue to start emitting events

--- a/Tests/Shared/Core/UnitTestBase.swift
+++ b/Tests/Shared/Core/UnitTestBase.swift
@@ -14,10 +14,9 @@ import XCTest
 /// For SDK-wide tests, child classes can conveniently inherit from `UnitTest`, designed specifically for testing only SDK APIs.
 open class UnitTestBase<Component>: XCTestCase {
     public let testWriteKey = "test"
-    // Initialize DIGraphShared instantly to closely copy production behavior.
-    // The graph in production is initialized statically and can be accessed using .shared.
-    // This also allows us to override any dependency without waiting for SDK/modules to initialize and setup.
-    public var diGraphShared: DIGraphShared = .init()
+    // Using the .shared instance of the DIGraph to ensure that all tests share the same instance and data.
+    // Overriding it will work the same way as overriding the shared instance of the SDK.
+    public let diGraphShared: DIGraphShared = .shared
     public var log: Logger { diGraphShared.logger }
     public var globalDataStore: GlobalDataStore { diGraphShared.globalDataStore }
 
@@ -118,7 +117,6 @@ open class UnitTestBase<Component>: XCTestCase {
 
         // reset DI graphs to their initial state.
         diGraphShared.reset()
-        diGraphShared = .init()
         diGraph.reset()
         diGraph = nil
     }

--- a/Tests/Tracking/APITest.swift
+++ b/Tests/Tracking/APITest.swift
@@ -30,10 +30,6 @@ class TrackingAPITest: UnitTest {
         // Reference some objects that should be public in the Tracking module
         let _: Region = .EU
         let _: CioLogLevel = .debug
-
-        // Public properties exposed to customers
-        _ = CustomerIO.shared.siteId
-        _ = CustomerIO.shared.config
     }
 
     // SDK wrappers can configure the SDK from a Map.

--- a/Tests/Tracking/Core/UnitTest.swift
+++ b/Tests/Tracking/Core/UnitTest.swift
@@ -33,7 +33,7 @@ open class UnitTest: SharedTests.UnitTestBase<CustomerIO> {
         )
 
         // setup shared instance with desired implementation for unit tests
-        customerIO = CustomerIO.setUpSharedInstanceForUnitTest(implementation: implementation, diGraph: diGraph)
+        customerIO = CustomerIO.setUpSharedInstanceForUnitTest(implementation: implementation)
         customerIO.setDebugLogsEnabled(sdkConfig.logLevel == .debug)
 
         return customerIO


### PR DESCRIPTION
closes: https://linear.app/customerio/issue/MBL-123/remove-postinitialize-from-common

Decouples `postInitialize` from `DIGraph` 