### PR TITLE
refactor: remove siteId, apiKey, and region from SdkConfig

### DIFF
--- a/Sources/Common/Service/Request/MetricRequest.swift
+++ b/Sources/Common/Service/Request/MetricRequest.swift
@@ -1,4 +1,3 @@
-import CioInternalCommon
 import Foundation
 
 // https://customer.io/docs/api/#operation/pushMetrics

--- a/Sources/Common/Store/GlobalDataStore.swift
+++ b/Sources/Common/Store/GlobalDataStore.swift
@@ -12,48 +12,6 @@ public protocol GlobalDataStore: AutoMockable {
     func deleteAll()
 }
 
-// sourcery: InjectRegister = "GlobalDataStore"
-public class CioGlobalDataStore: GlobalDataStore {
-    private let keyValueStorage: KeyValueStorage
-
-    public var pushDeviceToken: String? {
-        get {
-            keyValueStorage.string(.pushDeviceToken)
-        }
-        set {
-            keyValueStorage.setString(newValue, forKey: .pushDeviceToken)
-        }
-    }
-
-    public var httpRequestsPauseEnds: Date? {
-        get {
-            keyValueStorage.date(.httpRequestsPauseEnds)
-        }
-        set {
-            keyValueStorage.setDate(newValue, forKey: .httpRequestsPauseEnds)
-        }
-    }
-
-    public init(keyValueStorage: KeyValueStorage) {
-        self.keyValueStorage = keyValueStorage
-
-        self.keyValueStorage.switchToGlobalDataStore()
-    }
-
-    // How to get instance before DI graph is constructed
-    public static func getInstance() -> GlobalDataStore {
-        let newInstance = UserDefaultsKeyValueStorage(
-            sdkConfig: SdkConfig.Factory.create(siteId: "", apiKey: "", region: .US),
-            deviceMetricsGrabber: DeviceMetricsGrabberImpl()
-        )
-        return CioGlobalDataStore(keyValueStorage: newInstance)
-    }
-
-    public func deleteAll() {
-        keyValueStorage.deleteAll()
-    }
-}
-
 // sourcery: InjectRegisterShared = "GlobalDataStore"
 public class CioSharedDataStore: GlobalDataStore {
     private let keyValueStorage: SharedKeyValueStorage
@@ -78,14 +36,6 @@ public class CioSharedDataStore: GlobalDataStore {
 
     public init(keyValueStorage: SharedKeyValueStorage) {
         self.keyValueStorage = keyValueStorage
-    }
-
-    // How to get instance before DI graph is constructed
-    public static func getInstance() -> GlobalDataStore {
-        let newInstance = UserDefaultsSharedKeyValueStorage(
-            deviceMetricsGrabber: DeviceMetricsGrabberImpl()
-        )
-        return CioSharedDataStore(keyValueStorage: newInstance)
     }
 
     public func deleteAll() {

--- a/Sources/Common/Store/SdkConfig.swift
+++ b/Sources/Common/Store/SdkConfig.swift
@@ -20,11 +20,8 @@ public struct SdkConfig {
     // Used to create new instance of SdkConfig when the SDK is initialized.
     // Then, each property of the SdkConfig object can be modified by the user.
     public enum Factory {
-        public static func create(siteId: String, apiKey: String, region: Region) -> SdkConfig {
+        public static func create() -> SdkConfig {
             SdkConfig(
-                siteId: siteId,
-                apiKey: apiKey,
-                region: region,
                 logLevel: CioLogLevel.error
             )
         }
@@ -53,25 +50,12 @@ public struct SdkConfig {
     // Constants that SDK wrappers can use with `modify` function for setting configuration options with strings.
     // It's important to keep these values backwards compatible to avoid breaking SDK wrappers.
     public enum Keys: String { // Constants used to map each of the options in SdkConfig
-        // configure workspace environment
-        case siteId
-        case apiKey
-        case region
         // config features
         case logLevel
         // SDK wrapper config
         case source
         case sourceVersion = "version"
     }
-
-    /// Immutable property to store the workspace site id set during SDK initialization.
-    public let siteId: String
-
-    /// Immutable property to store the workspace api key set during SDK initialization.
-    public let apiKey: String
-
-    /// Immutable property to store the workspace Region set during SDK initialization.
-    public let region: Region
 
     /// To help you get setup with the SDK or debug SDK, change the log level of logs you
     /// wish to view from the SDK.

--- a/Sources/Common/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/Common/autogenerated/AutoDependencyInjection.generated.swift
@@ -56,9 +56,6 @@ extension DIGraph {
         _ = deviceInfo
         countDependenciesResolved += 1
 
-        _ = globalDataStore
-        countDependenciesResolved += 1
-
         _ = profileStore
         countDependenciesResolved += 1
 
@@ -115,16 +112,6 @@ extension DIGraph {
 
     private var newDeviceInfo: DeviceInfo {
         CIODeviceInfo()
-    }
-
-    // GlobalDataStore
-    public var globalDataStore: GlobalDataStore {
-        getOverriddenInstance() ??
-            newGlobalDataStore
-    }
-
-    private var newGlobalDataStore: GlobalDataStore {
-        CioGlobalDataStore(keyValueStorage: keyValueStorage)
     }
 
     // ProfileStore
@@ -304,7 +291,7 @@ extension DIGraph {
     }
 
     private var newKeyValueStorage: KeyValueStorage {
-        UserDefaultsKeyValueStorage(sdkConfig: sdkConfig, deviceMetricsGrabber: deviceMetricsGrabber)
+        UserDefaultsKeyValueStorage(deviceMetricsGrabber: deviceMetricsGrabber)
     }
 }
 

--- a/Sources/DataPipeline/Config/SDKConfigBuilder.swift
+++ b/Sources/DataPipeline/Config/SDKConfigBuilder.swift
@@ -124,7 +124,7 @@ public class SDKConfigBuilder {
 
     public func build() -> SDKConfigBuilderResult {
         // create `SdkConfig`` from given configurations
-        var sdkConfig = SdkConfig.Factory.create(siteId: "", apiKey: "", region: .US)
+        var sdkConfig = SdkConfig.Factory.create()
         sdkConfig.logLevel = logLevel
 
         // create `DataPipelineConfigOptions` from given configurations

--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -22,7 +22,7 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
 
     // singleton constructor
     private init() {
-        self.globalDataStore = CioGlobalDataStore.getInstance()
+        self.globalDataStore = DIGraphShared.shared.globalDataStore
         super.init(moduleName: Self.moduleName)
     }
 

--- a/Tests/Common/Extensions/DateExtensionTests.swift
+++ b/Tests/Common/Extensions/DateExtensionTests.swift
@@ -63,7 +63,6 @@ class DateExtensionTest: UnitTest {
     // MARK: formatToIso8601WithMilliseconds
 
     func test_givenDate_formatToIso8601WithMilliseconds_expectString() {
-        let calendar = TimeZone(identifier: "UTC")
         var components = DateComponents()
         components.year = 2024
         components.month = 2

--- a/Tests/Common/Util/KeyValueStorageTest.swift
+++ b/Tests/Common/Util/KeyValueStorageTest.swift
@@ -12,19 +12,23 @@ class KeyValueStorageTests: UnitTest {
     }
 
     private func getSiteStorageInstance(siteId: String, deviceMetricsGrabber: DeviceMetricsGrabber? = nil) -> UserDefaultsKeyValueStorage {
+        let instance = UserDefaultsKeyValueStorage(
+            deviceMetricsGrabber: deviceMetricsGrabber ?? diGraph.deviceMetricsGrabber
+        )
+        instance.siteId = siteId
+        return instance
+    }
+
+    private func getGlobalInstance(deviceMetricsGrabber: DeviceMetricsGrabber? = nil) -> UserDefaultsKeyValueStorage {
         UserDefaultsKeyValueStorage(
-            sdkConfig: SdkConfig.Factory.create(siteId: siteId, apiKey: "", region: .US),
             deviceMetricsGrabber: deviceMetricsGrabber ?? diGraph.deviceMetricsGrabber
         )
     }
 
-    private func getGlobalInstance(deviceMetricsGrabber: DeviceMetricsGrabber? = nil) -> UserDefaultsKeyValueStorage {
-        let instance = UserDefaultsKeyValueStorage(
-            sdkConfig: SdkConfig.Factory.create(siteId: "", apiKey: "", region: .US),
-            deviceMetricsGrabber: deviceMetricsGrabber ?? diGraph.deviceMetricsGrabber
-        )
-        instance.switchToGlobalDataStore()
-        return instance
+    override func setUp() {
+        super.setUp()
+
+        defaultStorage.deleteAll()
     }
 
     // MARK: integration tests

--- a/Tests/Shared/Core/UnitTestBase.swift
+++ b/Tests/Shared/Core/UnitTestBase.swift
@@ -72,7 +72,7 @@ open class UnitTestBase<Component>: XCTestCase {
      @param modifySdkConfig Closure allowing customization of the SDK/Module configuration before the SDK/Module instance is initialized.
      */
     open func setUp(enableLogs: Bool = false, sdkConfig: SdkConfig? = nil) {
-        var newSdkConfig = sdkConfig ?? SdkConfig.Factory.create(siteId: testSiteId, apiKey: "", region: Region.US)
+        var newSdkConfig = sdkConfig ?? SdkConfig.Factory.create()
         if enableLogs {
             newSdkConfig.logLevel = CioLogLevel.debug
         }

--- a/Tests/Tracking/APITest.swift
+++ b/Tests/Tracking/APITest.swift
@@ -45,7 +45,7 @@ class TrackingAPITest: UnitTest {
             "version": sdkWrapperVersion
         ]
 
-        var actual = CioSdkConfig.Factory.create(siteId: "", apiKey: "", region: .US)
+        var actual = CioSdkConfig.Factory.create()
         actual.modify(params: givenParamsFromSdkWrapper)
 
         XCTAssertEqual(actual.logLevel.rawValue, logLevel)
@@ -63,7 +63,7 @@ class TrackingAPITest: UnitTest {
             "versionWrong": sdkWrapperVersion
         ]
 
-        var actual = CioSdkConfig.Factory.create(siteId: "", apiKey: "", region: .US)
+        var actual = CioSdkConfig.Factory.create()
         actual.modify(params: givenParamsFromSdkWrapper)
 
         XCTAssertEqual(actual.logLevel.rawValue, CioLogLevel.error.rawValue)
@@ -71,7 +71,7 @@ class TrackingAPITest: UnitTest {
     }
 
     func test_SdkConfig_givenNoModification_expectDefaults() {
-        let actual = CioSdkConfig.Factory.create(siteId: "", apiKey: "", region: .US)
+        let actual = CioSdkConfig.Factory.create()
 
         XCTAssertEqual(actual.logLevel.rawValue, CioLogLevel.error.rawValue)
         XCTAssertNil(actual._sdkWrapperConfig)


### PR DESCRIPTION
Part of: https://linear.app/customerio/issue/MBL-120/public-api-remove-unused-properties-from-sdkconfig

Some dependencies made this change difficult because they are tightly coupled to SdkConfig. KeyValueStore being the biggest problem.

The `CioProfileStore` is currently broken with this change because now it uses a global data store but it needs to have a siteid sandboxed store. Will be fixing this in next commit.

---

**Stack**:
- #547
- #546 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*