### PR TITLE
fix: all sdk modules can only be initialized once

### DIFF
--- a/Sources/DataPipeline/DataPipeline.swift
+++ b/Sources/DataPipeline/DataPipeline.swift
@@ -37,8 +37,8 @@ public class DataPipeline: ModuleTopLevelObject<DataPipelineInstance>, DataPipel
     public static func setUpSharedInstanceForUnitTest(implementation: DataPipelineInstance, config: DataPipelineConfigOptions) -> DataPipelineInstance {
         // initialize static properties before implementation creation, as they may be directly used by other classes
         moduleConfig = config
+        shared._implementation = implementation
 
-        shared.setImplementationInstance(implementation: implementation)
         return implementation
     }
 
@@ -61,22 +61,13 @@ public class DataPipeline: ModuleTopLevelObject<DataPipelineInstance>, DataPipel
      */
     @discardableResult
     public static func initialize(moduleConfig: DataPipelineConfigOptions) -> DataPipelineInstance {
-        Self.moduleConfig = moduleConfig
-        shared.initializeModule()
-        return shared
-    }
+        shared.initializeModuleIfNotAlready {
+            Self.moduleConfig = moduleConfig
 
-    private func initializeModule() {
-        guard getImplementationInstance() == nil else {
-            logger.info("\(moduleName) module is already initialized. Ignoring redundant initialization request.")
-            return
+            return DataPipelineImplementation(diGraph: DIGraphShared.shared, moduleConfig: moduleConfig)
         }
 
-        logger.debug("Setting up \(moduleName) module...")
-        let cdpImplementation = DataPipelineImplementation(diGraph: DIGraphShared.shared, moduleConfig: Self.moduleConfig)
-        setImplementationInstance(implementation: cdpImplementation)
-
-        logger.info("\(moduleName) module successfully set up with SDK")
+        return shared
     }
 
     // MARK: - DataPipelineInstance implementation

--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -8,17 +8,10 @@ import Foundation
 public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, MessagingPushInstance {
     @Atomic public private(set) static var shared = MessagingPush()
     @Atomic public private(set) static var moduleConfig: MessagingPushConfigOptions = .Factory.create()
+
     private static let moduleName = "MessagingPush"
 
     private var globalDataStore: GlobalDataStore
-
-    /*
-     It's preferred to get a lock from lockmanager. Because this is a top-level class where the digraph may be nil, it's more difficult to get a lock from lockmanager.
-
-     Because this class is a singleton, we can create a lock instance that will be shared in all calls to this class.
-     */
-    private let lock = Lock.unsafeInit()
-    @Atomic private var hasSetupModule = false
 
     // singleton constructor
     private init() {
@@ -35,8 +28,8 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
         // initialize static properties before implementation creation, as they may be directly used by other classes
         shared.globalDataStore = diGraphShared.globalDataStore
         moduleConfig = config
+        shared._implementation = implementation
 
-        shared.setImplementationInstance(implementation: implementation)
         return implementation
     }
 
@@ -61,21 +54,19 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
     public static func initialize(
         configure configureHandler: ((inout MessagingPushConfigOptions) -> Void)? = nil
     ) -> MessagingPushInstance {
-        if let configureHandler = configureHandler {
-            // pass current config reference to update it without needing to recreate
-            configureHandler(&moduleConfig)
-        }
+        shared.initializeModuleIfNotAlready {
+            if let configureHandler = configureHandler {
+                // pass current config reference to update it without needing to recreate
+                configureHandler(&moduleConfig)
+            }
 
-        let moduleInitializedFirstTime = shared.initializeModuleIfNotAlready()
+            // Some part of the initialize is specific only to non-NSE targets.
+            // Put those parts in this non-NSE initialize method.
+            if Self.moduleConfig.autoTrackPushEvents {
+                DIGraphShared.shared.automaticPushClickHandling.start()
+            }
 
-        guard moduleInitializedFirstTime else {
-            return shared
-        }
-
-        // Some part of the initialize is specific only to non-NSE targets.
-        // Put those parts in this non-NSE initialize method.
-        if Self.moduleConfig.autoTrackPushEvents {
-            DIGraphShared.shared.automaticPushClickHandling.start()
+            return shared.getImplementation()
         }
 
         return shared
@@ -89,38 +80,20 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
         cdpApiKey: String,
         configure configureHandler: ((inout MessagingPushConfigOptions) -> Void)? = nil
     ) -> MessagingPushInstance {
-        if let configureHandler = configureHandler {
-            configureHandler(&moduleConfig)
-        }
-        moduleConfig.cdpApiKey = cdpApiKey
+        shared.initializeModuleIfNotAlready {
+            if let configureHandler = configureHandler {
+                configureHandler(&moduleConfig)
+            }
+            moduleConfig.cdpApiKey = cdpApiKey
 
-        shared.initializeModuleIfNotAlready()
+            return shared.getImplementation()
+        }
 
         return shared
     }
 
-    @discardableResult
-    private func initializeModuleIfNotAlready() -> Bool {
-        // Make this function thread-safe by immediately locking it.
-        lock.lock()
-        defer {
-            lock.unlock()
-        }
-
-        // Make sure this function is only called 1 time.
-        if hasSetupModule {
-            logger.info("\(moduleName) module is already initialized. Ignoring redundant initialization request.")
-            return false
-        }
-        hasSetupModule = true
-
-        logger.debug("Setting up \(moduleName) module...")
-        let pushImplementation = MessagingPushImplementation(diGraph: DIGraphShared.shared, moduleConfig: Self.moduleConfig)
-        setImplementationInstance(implementation: pushImplementation)
-
-        logger.info("\(moduleName) module successfully set up with SDK")
-
-        return true
+    private func getImplementation() -> MessagingPushInstance {
+        MessagingPushImplementation(diGraph: DIGraphShared.shared, moduleConfig: Self.moduleConfig)
     }
 
     /**

--- a/Tests/Common/Module/ModuleTopLevelObjectTest.swift
+++ b/Tests/Common/Module/ModuleTopLevelObjectTest.swift
@@ -1,0 +1,72 @@
+@testable import CioInternalCommon
+import Foundation
+import SharedTests
+import XCTest
+
+class ModuleTopLevelObjectTest: UnitTest {
+    override func setUp() {
+        super.setUp()
+
+        ModuleTopLevelObjectStub.reset()
+    }
+
+    // MARK: initialize
+
+    func test_initialize_expectOnlyAbleToInitializeOnce_expectInitializeThreadSafe() {
+        // Run test multiple times to ensure thread safety. To try and catch a race condition, if one will exist.
+        // I do not suggest running test < 100 times. When bugs existed because of not being thread safe, the test may have to run 50 times until it fails.
+        runTest(numberOfTimes: 100) {
+            let expectAllThreadsToComplete = expectation(description: "All threads should complete")
+            expectAllThreadsToComplete.expectedFulfillmentCount = 2
+
+            XCTAssertEqual(ModuleTopLevelObjectStub.shared.initializeCount, 0)
+
+            // Initialize the module twice, on different threads.
+            // This tests:
+            // 1. Only able to initialize the module once.
+            // 2. Initialize is thread-safe.
+            runOnBackground {
+                ModuleTopLevelObjectStub.initialize()
+
+                expectAllThreadsToComplete.fulfill()
+            }
+
+            runOnBackground {
+                ModuleTopLevelObjectStub.initialize()
+
+                expectAllThreadsToComplete.fulfill()
+            }
+
+            waitForExpectations(1) // test may take up to 1 second to finish because it is running so many times. CI server is a less powerful machine and this test is flaky when we set wait() for < 1 second.
+
+            // Even though we call initialize twice, the initialize count should only be 1.
+            XCTAssertEqual(ModuleTopLevelObjectStub.shared.initializeCount, 1)
+        }
+    }
+}
+
+protocol ModuleTopLevelObjectStubInstance {}
+
+// Simple stub that has the same public API as SDK module subclasses.
+class ModuleTopLevelObjectStub: ModuleTopLevelObject<ModuleTopLevelObjectStubInstance>, ModuleTopLevelObjectStubInstance {
+    @Atomic static var shared = ModuleTopLevelObjectStub()
+
+    public private(set) var initializeCount = 0
+
+    static func reset() {
+        shared = ModuleTopLevelObjectStub()
+    }
+
+    init() {
+        super.init(moduleName: "Stub")
+    }
+
+    static func initialize() {
+        // This is a public function that customers can call to initialize the module.
+        shared.initializeModuleIfNotAlready {
+            shared.initializeCount += 1
+
+            return shared
+        }
+    }
+}

--- a/Tests/MessagingPush/MessagingPushTest.swift
+++ b/Tests/MessagingPush/MessagingPushTest.swift
@@ -5,38 +5,20 @@ import SharedTests
 import XCTest
 
 class MessagingPushTest: IntegrationTest {
+    override func initializeSDKComponents() -> MessagingPushInstance? {
+        // We want to manually initialize the module in test functions. So, override this function to disable automatic module initialization.
+        nil
+    }
+
     private let automaticPushClickHandlingMock = AutomaticPushClickHandlingMock()
 
     override func setUp() {
-        setupTest()
+        super.setUp()
+
+        DIGraphShared.shared.override(value: automaticPushClickHandlingMock, forType: AutomaticPushClickHandling.self)
     }
 
     // MARK: initialize
-
-    func test_initialize_expectOnlyAbleToInitializeOnce_expectInitializeThreadSafe() {
-        // Run test multiple times to ensure thread safety. To try and catch a race condition, if one will exist.
-        // I do not suggest running test < 100 times. When bugs existed because of not being thread safe, the test may have to run 50 times until it fails.
-        runTest(numberOfTimes: 100) {
-            let expectAllThreadsToComplete = expectation(description: "All threads should complete")
-            expectAllThreadsToComplete.expectedFulfillmentCount = 2
-
-            runOnBackground {
-                MessagingPush.initialize()
-
-                expectAllThreadsToComplete.fulfill()
-            }
-
-            runOnBackground {
-                MessagingPush.initialize()
-
-                expectAllThreadsToComplete.fulfill()
-            }
-
-            waitForExpectations(1) // test may take up to 1 second to finish because it is running so many times. CI server is a less powerful machine and this test is flaky when we set wait() for < 1 second.
-
-            XCTAssertEqual(automaticPushClickHandlingMock.startCallsCount, 1)
-        }
-    }
 
     func test_initialize_givenDefaultModuleConfigOptions_expectStartAutoPushClickHandling() {
         MessagingPush.initialize()
@@ -45,20 +27,10 @@ class MessagingPushTest: IntegrationTest {
     }
 
     func test_initialize_givenCustomerDisabledAutoPushClickHandling_expectDoNotEnableFeature() {
-        setupTest { config in
-            config.autoTrackPushEvents = false
+        MessagingPush.initialize {
+            $0.autoTrackPushEvents = false
         }
 
-        MessagingPush.initialize()
-
         XCTAssertFalse(automaticPushClickHandlingMock.startCalled)
-    }
-}
-
-extension MessagingPushTest {
-    func setupTest(modifyModuleConfig: ((inout MessagingPushConfigOptions) -> Void)? = nil) {
-        super.setUp(modifyModuleConfig: modifyModuleConfig)
-
-        DIGraphShared.shared.override(value: automaticPushClickHandlingMock, forType: AutomaticPushClickHandling.self)
     }
 }


### PR DESCRIPTION
Closes: https://linear.app/customerio/issue/MBL-129/sdk-modules-can-only-be-initialized-1-time

All SDK modules have a top-level `ModuleName.initialize()` function. We have a SDK requirement that this function is only executed one time and ignore all future calls.

This change brings a few improvements to this requirement:
1. Move implementation into base class, `ModuleTopLevelObject`, to encapsulate the logic and allow re-use by all SDK modules.
2. Adds automated tests for `ModuleTopLevelObjectTest` super class to assert that our code only allows initializing modules one time. Note: These tests were originally written in `MessagingPushTest` and were moved to new `ModuleTopLevelObjectTest` class.

commit-id:63854a04