### PR TITLE
test: reduce flaky test results on CI

### DIFF
--- a/Tests/MessagingInApp/MessagingInAppImplementationTest.swift
+++ b/Tests/MessagingInApp/MessagingInAppImplementationTest.swift
@@ -264,6 +264,7 @@ extension MessagingInAppImplementationTest {
             expectation.fulfill()
         }
         // Wait for the expectations to be fulfilled, with a timeout slightly longer than given timeout
-        wait(for: [expectation], timeout: timeoutInSeconds + 0.1)
+        // Note: On CI, we experienced flakiness if the timeout value was only 0.1 seconds longer then the given timeout value.
+        wait(for: [expectation], timeout: timeoutInSeconds + 0.5)
     }
 }


### PR DESCRIPTION
On CI, we have been getting flaky failed test functions because of expectation timeouts in this block of code. This is happening because the performance of CI machines is slower and processes could take longer to execute on CI.

We have a [ticket](https://linear.app/customerio/issue/MBL-95/reduce-time-it-takes-for-test-suite-to-execute-by-replacing-sleep#comment-ef5545d3) to try and replace the timeout functionality altogether, but until then, this change fixes flaky failed tests by bumping the timeout.