### PR TITLE
ci: disable CI status checks that we are letting fail during CDP development

### DIFF
--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -54,13 +54,17 @@ jobs:
         sample-app: 
         # List all sample apps you want to have compiled. 
         # List item is name of directory inside of "Apps" directory for the corresponding app to compile. 
-        - "CocoaPods-FCM"
+
+  # Note: During CDP development, we have allowed the cocoapods app to fail to build.
+  # When we get it fixed, uncomment this line to make the CI build it again. 
+
+        #- "CocoaPods-FCM"
         - "APN-UIKit"
         include: # Add additional variables to each sample app build: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude
           - sample-app: "APN-UIKit"
             apn-or-fcm: APN
-          - sample-app: "CocoaPods-FCM"
-            apn-or-fcm: FCM
+          # - sample-app: "CocoaPods-FCM"
+          #   apn-or-fcm: FCM
 
     runs-on: macos-13
     name: Building app...${{ matrix.sample-app }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,18 +1,21 @@
-name: Lint
+# During development of CDP, we have allowed the lint check on CI to fail before merging PRs. 
+# File commented out until we get lint fixed on this branch. 
 
-on: [pull_request]
+# name: Lint
 
-jobs:
-  assert-formatted:
-    name: Assert that code has been linted and formatted before merging
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install binny to run lint tools 
-        run: |
-          curl -L --output binny https://github.com/customerio/binny/releases/download/latest/binny-macos-x86_64
-          chmod +x binny 
-      - name: Run swiftformat. Fail if any errors. 
-        run: make format && git diff --exit-code
-      - name: Run swiftlint. Fail if any errors. 
-        run: make lint
+# on: [pull_request]
+
+# jobs:
+#   assert-formatted:
+#     name: Assert that code has been linted and formatted before merging
+#     runs-on: macos-latest
+#     steps:
+#       - uses: actions/checkout@v4
+#       - name: Install binny to run lint tools 
+#         run: |
+#           curl -L --output binny https://github.com/customerio/binny/releases/download/latest/binny-macos-x86_64
+#           chmod +x binny 
+#       - name: Run swiftformat. Fail if any errors. 
+#         run: make format && git diff --exit-code
+#       - name: Run swiftlint. Fail if any errors. 
+#         run: make lint


### PR DESCRIPTION
During CDP development, we have been OK with letting some of the CI status checks fail before we merge a PR. Instead of merging with some status checks be red (fail), this change disables CI running the checks that we currently let fail. This way, we can get back in the habit of not merging a PR until all CI status checks are green. Making it less likely we will break the main-cdp branch by accident.