### PR TITLE
fix: prevent duplicate automatic screenview events from being tracked

### DIFF
--- a/Sources/Common/Util/LockManager.swift
+++ b/Sources/Common/Util/LockManager.swift
@@ -32,6 +32,7 @@ public class LockManager {
 public enum LockReference: String {
     case queueStorage
     case pushHistory
+    case autoTrackScreenViewStore
 }
 
 // Dependency needs to be accessed by multiple graphs.

--- a/Sources/DataPipeline/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/DataPipeline/autogenerated/AutoDependencyInjection.generated.swift
@@ -78,6 +78,9 @@ extension DIGraphShared {
     func testDependenciesAbleToResolve() -> Int {
         var countDependenciesResolved = 0
 
+        _ = autoTrackingScreenViewStore
+        countDependenciesResolved += 1
+
         _ = deviceAttributesProvider
         countDependenciesResolved += 1
 
@@ -85,6 +88,30 @@ extension DIGraphShared {
     }
 
     // Handle classes annotated with InjectRegisterShared
+    // AutoTrackingScreenViewStore (singleton)
+    var autoTrackingScreenViewStore: AutoTrackingScreenViewStore {
+        getOverriddenInstance() ??
+            sharedAutoTrackingScreenViewStore
+    }
+
+    var sharedAutoTrackingScreenViewStore: AutoTrackingScreenViewStore {
+        // Use a DispatchQueue to make singleton thread safe. You must create unique dispatchqueues instead of using 1 shared one or you will get a crash when trying
+        // to call DispatchQueue.sync{} while already inside another DispatchQueue.sync{} call.
+        DispatchQueue(label: "DIGraphShared_AutoTrackingScreenViewStore_singleton_access").sync {
+            if let overridenDep: AutoTrackingScreenViewStore = getOverriddenInstance() {
+                return overridenDep
+            }
+            let existingSingletonInstance = self.singletons[String(describing: AutoTrackingScreenViewStore.self)] as? AutoTrackingScreenViewStore
+            let instance = existingSingletonInstance ?? _get_autoTrackingScreenViewStore()
+            self.singletons[String(describing: AutoTrackingScreenViewStore.self)] = instance
+            return instance
+        }
+    }
+
+    private func _get_autoTrackingScreenViewStore() -> AutoTrackingScreenViewStore {
+        InMemoryAutoTrackingScreenViewStore(lockManager: lockManager)
+    }
+
     // DeviceAttributesProvider
     var deviceAttributesProvider: DeviceAttributesProvider {
         getOverriddenInstance() ??


### PR DESCRIPTION
Closes: https://linear.app/customerio/issue/MBL-130/automatic-screen-view-feature-causing-multiple-events-tracked

The SDK keeps track of the last screen automatically tracked. If the new screenview event is equal to this last screen tracked, ignore the request.

The linear ticket gives context on why this solution was chosen over alternative approaches.

commit-id:336b0aff