### PR TITLE
fix: rich push image downloading path conflict when its already downloaded

### DIFF
--- a/Sources/Common/Service/HttpRequestRunner.swift
+++ b/Sources/Common/Service/HttpRequestRunner.swift
@@ -55,10 +55,12 @@ class UrlRequestHttpRequestRunner: HttpRequestRunner {
         let directoryURL = fileType.directoryToSaveFiles(fileManager: FileManager.default)
 
         session.downloadTask(with: url) { tempLocation, response, _ in
-            guard let tempLocation = tempLocation, let uniqueFileName = response?.suggestedFilename else {
+            guard let tempLocation = tempLocation, let suggestedFileName = response?.suggestedFilename else {
                 return onComplete(nil)
             }
 
+            // create a unique file name so when trying to move temp file to destination it doesn't give an exception
+            let uniqueFileName = UUID().uuidString + "_" + suggestedFileName
             let destinationURL = directoryURL
                 .appendingPathComponent(uniqueFileName)
 

--- a/Tests/Shared/HttpTest.swift
+++ b/Tests/Shared/HttpTest.swift
@@ -20,10 +20,12 @@ open class HttpTest: UnitTest {
     public var runner: HttpRequestRunner?
     public var userAgentUtil: UserAgentUtil!
     public var session: URLSession?
+    public var publicSession: URLSession = CIOHttpClient.getBasicSession()
 
     override open func setUp() {
         super.setUp()
 
+        runner = UrlRequestHttpRequestRunner()
         userAgentUtil = diGraph.userAgentUtil
 
         /*
@@ -31,12 +33,58 @@ open class HttpTest: UnitTest {
          we see environment variables set in XCode.
          */
         if let siteId = getEnvironmentVariable("SITE_ID"), let apiKey = getEnvironmentVariable("API_KEY") {
-            runner = UrlRequestHttpRequestRunner()
             session = CIOHttpClient.getCIOApiSession(
                 siteId: siteId,
                 apiKey: apiKey,
                 userAgentHeaderValue: userAgentUtil.getUserAgentHeaderValue()
             )
+        }
+    }
+
+    func testParallelDownloadFileCreatesUniquePaths() {
+        let expectation1 = expectation(description: "Parallel download file 1")
+        let expectation2 = expectation(description: "Parallel download file 2")
+
+        let url = URL(string: "https://thumbs.dreamstime.com/b/bee-flower-27533578.jpg")!
+        var path1: URL?
+        var path2: URL?
+
+        XCTAssertNotNil(runner)
+
+        // Initiate the first download
+        runner?.downloadFile(
+            url: url,
+            fileType: .richPushImage,
+            session: publicSession,
+            onComplete: { path in
+                XCTAssertNotNil(path)
+                path1 = path
+                expectation1.fulfill()
+            }
+        )
+
+        // Initiate the second download in parallel
+        runner?.downloadFile(
+            url: url,
+            fileType: .richPushImage,
+            session: publicSession,
+            onComplete: { path in
+                XCTAssertNotNil(path)
+                path2 = path
+                expectation2.fulfill()
+            }
+        )
+
+        // Wait for both downloads to complete
+        waitForExpectations(timeout: 20.0) { error in
+            if let error = error {
+                XCTFail("Test failed with error: \(error)")
+            }
+
+            // Verify that both paths are not nil and unique
+            XCTAssertNotNil(path1, "First path should not be nil")
+            XCTAssertNotNil(path2, "Second path should not be nil")
+            XCTAssertNotEqual(path1, path2, "Expected unique path for each parallel download")
         }
     }
 


### PR DESCRIPTION
more context: https://www.loom.com/share/971cb87f0216460faa0cefbf4fc9591e

and similar merged PR for cdp, where this issue was found : https://github.com/customerio/customerio-ios/pull/551