### PR TITLE
refactor: use cdpApiKey in iOS SDK remaining test cases

### DIFF
--- a/Tests/DataPipeline/Core/UnitTest.swift
+++ b/Tests/DataPipeline/Core/UnitTest.swift
@@ -24,10 +24,10 @@ open class UnitTest: SharedTests.UnitTestBase<CustomerIO> {
 
     open func setUp(
         enableLogs: Bool = false,
-        writeKey: String? = nil,
+        cdpApiKey: String? = nil,
         modifySdkConfig: ((SDKConfigBuilder) -> Void)?
     ) {
-        let sdkConfigBuilder = SDKConfigBuilder(writeKey: writeKey ?? testWriteKey)
+        let sdkConfigBuilder = SDKConfigBuilder(cdpApiKey: cdpApiKey ?? testCdpApiKey)
         // set sdk log level to debug if logs are enabled
         if enableLogs {
             sdkConfigBuilder.logLevel(.debug)

--- a/Tests/DataPipeline/DataPipelineInteractionTests.swift
+++ b/Tests/DataPipeline/DataPipelineInteractionTests.swift
@@ -27,8 +27,8 @@ class DataPipelineInteractionTests: IntegrationTest {
         outputReader = (customerIO.add(plugin: OutputReaderPlugin()) as? OutputReaderPlugin)
     }
 
-    override func setUp(enableLogs: Bool = false, writeKey: String? = nil, modifySdkConfig: ((SDKConfigBuilder) -> Void)?) {
-        super.setUp(enableLogs: enableLogs, writeKey: writeKey, modifySdkConfig: modifySdkConfig)
+    override func setUp(enableLogs: Bool = false, cdpApiKey: String? = nil, modifySdkConfig: ((SDKConfigBuilder) -> Void)?) {
+        super.setUp(enableLogs: enableLogs, cdpApiKey: cdpApiKey, modifySdkConfig: modifySdkConfig)
         // OutputReaderPlugin helps validating interactions with analytics
         outputReader = (customerIO.add(plugin: OutputReaderPlugin()) as? OutputReaderPlugin)
     }

--- a/Tests/MessagingPush/HttpTest.swift
+++ b/Tests/MessagingPush/HttpTest.swift
@@ -13,7 +13,7 @@ import XCTest
 
  In order to *run* tests on your local machine, follow these setup steps:
  1. In XCode, go to: Edit Scheme > Run
- 2. Create an environment variables: `WRITE_KEY`. Populate the values with  test credentials from a source that you control.
+ 2. Create an environment variables: `CDP_API_KEY`. Populate the values with  test credentials from a source that you control.
  3. Manually run the tests below. Use the XCode debug console to see the log output for debugging.
  */
 open class HttpTest: UnitTest {
@@ -33,7 +33,7 @@ open class HttpTest: UnitTest {
          We don't want to run these tests on a CI server (flaky!) so, only populate the runner if
          we see environment variables set in XCode.
          */
-        if let writeKey = getEnvironmentVariable("CDP_API_KEY") {
+        if let cdpApiKey = getEnvironmentVariable("CDP_API_KEY") {
             cioSession = RichPushHttpClient.getCIOApiSession(
                 key: cdpApiKey,
                 userAgentHeaderValue: deviceInfo.getUserAgentHeaderValue()

--- a/Tests/Tracking/Core/UnitTest.swift
+++ b/Tests/Tracking/Core/UnitTest.swift
@@ -22,7 +22,7 @@ open class UnitTest: SharedTests.UnitTestBase<CustomerIO> {
     }
 
     override open func initializeSDKComponents() -> CustomerIO? {
-        let (_, dataPipelineConfig) = SDKConfigBuilder(writeKey: "")
+        let (_, dataPipelineConfig) = SDKConfigBuilder(cdpApiKey: "")
             // disable auto add destination to prevent tests from sending data to server
             .autoAddCustomerIODestination(false)
             .build()


### PR DESCRIPTION
part of: https://linear.app/customerio/issue/MBL-101/ensure-initilization-key-match-ui

Some PRs were merged after completing above ticket and were added/modified or for some reason were using `writeKey` instead of `cdpApiKey`. This PR caters to it and makes the use of  `cdpApiKey` in all test cases.

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After code reviews are approved and you determine this PR is ready to merge, select *Squash and Merge* button on this screen, leave the title and description to the default values, then merge the PR.
