### PR TITLE
test: update config tests

### DIFF
--- a/Sources/Common/Store/SdkConfig.swift
+++ b/Sources/Common/Store/SdkConfig.swift
@@ -37,8 +37,6 @@ public struct SdkConfig {
         case logLevel
     }
 
-    /// To help you get setup with the SDK or debug SDK, change the log level of logs you
-    /// wish to view from the SDK.
     public let logLevel: CioLogLevel
 
     // private init to ensure `SdkConfig` can either be created using `SDKConfigBuilder` or `SdkConfig.Factory` only.

--- a/Sources/Common/Store/SdkConfig.swift
+++ b/Sources/Common/Store/SdkConfig.swift
@@ -9,7 +9,7 @@ public struct SdkConfig {
         #if DEBUG
         // Only used for testing purposes.
         public static func create(logLevel: CioLogLevel? = nil) -> SdkConfig {
-            return SdkConfig(logLevel: logLevel)
+            SdkConfig(logLevel: logLevel)
         }
         #endif
 

--- a/Sources/Common/Store/SdkConfig.swift
+++ b/Sources/Common/Store/SdkConfig.swift
@@ -1,51 +1,48 @@
 import Foundation
-#if canImport(UIKit)
-import UIKit
-#endif
 
-/**
- Configuration options for the Customer.io SDK.
- See `CustomerIO.config()` to configurate the SDK.
-
- Example use case:
- ```
- // create a new instance
- let sdkConfigInstance = SdkConfig.Factory.create(region: .US)
- // now, you can modify it
- sdkConfigInstance.trackingApiUrl = "https..."
- sdkConfigInstance.autoTrackPushEvents = false
- ```
- */
+/// Defines configuration options for the Customer.io SDK.
+///
+/// Use `SDKConfigBuilder` for constructing its instances. For detailed usage, see builder class documentation.
 public struct SdkConfig {
-    // Used to create new instance of SdkConfig when the SDK is initialized.
-    // Then, each property of the SdkConfig object can be modified by the user.
+    // Since wrapper SDKs cannot use `SDKConfigBuilder`, we need to provide a way to create `SdkConfig` using a dictionary.
     public enum Factory {
-        public static func create() -> SdkConfig {
-            SdkConfig(
-                logLevel: CioLogLevel.error
-            )
+        #if DEBUG
+        // Only used for testing purposes.
+        public static func create(logLevel: CioLogLevel? = nil) -> SdkConfig {
+            return SdkConfig(logLevel: logLevel)
+        }
+        #endif
+
+        /// Constructs `SdkConfig` by parsing and applying configurations from provided dictionary.
+        public static func create(from dictionary: [String: Any]) -> SdkConfig {
+            // Build config using provided options.
+            // Use each option from `dictionary` if present, otherwise use default value.
+            // Ensure default values align with those in `SDKConfigBuilder`.
+            // We'll later work on adding option to centralize default values in one place, ideally within the `SDKConfig` struct.
+
+            var logLevel: CioLogLevel?
+            if let logLevelStringValue = dictionary[Keys.logLevel.rawValue] as? String,
+               let paramLogLevel = CioLogLevel.getLogLevel(for: logLevelStringValue) {
+                logLevel = paramLogLevel
+            }
+
+            return SdkConfig(logLevel: logLevel)
         }
     }
 
-    public mutating func modify(params: [String: Any]) {
-        // Each SDK config option should be able to be set from `param` map.
-        // If one isn't provided, use the default value instead.
-
-        // If a parameter takes more logic to calculate, perform the logic up here.
-        if let logLevelStringValue = params[Keys.logLevel.rawValue] as? String, let paramLogLevel =
-            CioLogLevel.getLogLevel(for: logLevelStringValue) {
-            logLevel = paramLogLevel
-        }
-    }
-
-    // Constants that SDK wrappers can use with `modify` function for setting configuration options with strings.
-    // It's important to keep these values backwards compatible to avoid breaking SDK wrappers.
-    public enum Keys: String { // Constants used to map each of the options in SdkConfig
+    /// Constants used to map each of the options in SdkConfig.
+    /// It's important to keep these values backwards compatible to avoid breaking SDK wrappers.
+    public enum Keys: String {
         // config features
         case logLevel
     }
 
     /// To help you get setup with the SDK or debug SDK, change the log level of logs you
     /// wish to view from the SDK.
-    public var logLevel: CioLogLevel
+    public let logLevel: CioLogLevel
+
+    // private init to ensure `SdkConfig` can either be created using `SDKConfigBuilder` or `SdkConfig.Factory` only.
+    private init(logLevel: CioLogLevel?) {
+        self.logLevel = logLevel ?? CioLogLevel.error
+    }
 }

--- a/Sources/DataPipeline/Config/DataPipelineConfigOptions.swift
+++ b/Sources/DataPipeline/Config/DataPipelineConfigOptions.swift
@@ -2,7 +2,9 @@ import CioInternalCommon
 import Foundation
 import Segment
 
-/// Configuration options for the Customer.io Data Pipeline module
+/// Defines configuration options for the Customer.io Data Pipeline module.
+///
+/// Use `SDKConfigBuilder` for constructing its instances. For detailed usage, see builder class documentation.
 public struct DataPipelineConfigOptions {
     /// Server key
     public let cdpApiKey: String

--- a/Sources/DataPipeline/Config/SDKConfigBuilder.swift
+++ b/Sources/DataPipeline/Config/SDKConfigBuilder.swift
@@ -7,10 +7,11 @@ import Segment
 /// the SDK, ensuring all required and optional settings are appropriately configured before the
 /// SDK is initialized.
 ///
-/// Usage Example:
+/// **Usage Example:**
+///
 /// ```
 /// let config = SDKConfigBuilder(cdpApiKey: "your_cdp_api_key")
-///   .apiHost("your_api_host")
+///   .logLevel(.debug)
 ///   .flushAt(30)
 ///   // additional configuration as needed...
 ///   .build()
@@ -39,11 +40,15 @@ public class SDKConfigBuilder {
     private var autoTrackDeviceAttributes: Bool = true
     private var siteId: String?
 
-    // allow construction of builder with required configurations only
+    /// Initializes new `SDKConfigBuilder` with required configuration options.
+    /// - Parameters:
+    ///   - cdpApiKey: Customer.io Data Pipeline API Key
     public init(cdpApiKey: String) {
         self.cdpApiKey = cdpApiKey
     }
 
+    /// To help you get setup with the SDK or debug SDK, change the log level of logs you wish to
+    /// view from the SDK.
     @discardableResult
     public func logLevel(_ logLevel: CioLogLevel) -> SDKConfigBuilder {
         self.logLevel = logLevel
@@ -110,6 +115,8 @@ public class SDKConfigBuilder {
         return self
     }
 
+    /// Enable this property if you want SDK to automatic track device attributes such as
+    /// operating system, device locale, device model, app version etc.
     @discardableResult
     public func autoTrackDeviceAttributes(_ autoTrack: Bool) -> SDKConfigBuilder {
         autoTrackDeviceAttributes = autoTrack
@@ -124,8 +131,9 @@ public class SDKConfigBuilder {
 
     public func build() -> SDKConfigBuilderResult {
         // create `SdkConfig`` from given configurations
-        var sdkConfig = SdkConfig.Factory.create()
-        sdkConfig.logLevel = logLevel
+        let sdkConfig = SdkConfig.Factory.create(
+            logLevel: logLevel
+        )
 
         // create `DataPipelineConfigOptions` from given configurations
         let dataPipelineConfig = DataPipelineConfigOptions(

--- a/Sources/MessagingPush/Config/MessagingPushConfigBuilder.swift
+++ b/Sources/MessagingPush/Config/MessagingPushConfigBuilder.swift
@@ -43,7 +43,7 @@ public class MessagingPushConfigBuilder {
     @available(iOSApplicationExtension, introduced: 13.0)
     /// Initializes new `MessagingPushConfigBuilder` with required configuration options.
     /// - Parameters:
-    ///   - cdpApiKey: CDP API Key required for NotificationServiceExtension only to track metrics
+    ///   - cdpApiKey: Customer.io Data Pipeline API Key required for NotificationServiceExtension only to track metrics
     public init(cdpApiKey: String) {
         self.cdpApiKey = cdpApiKey
     }

--- a/Tests/Common/APITest.swift
+++ b/Tests/Common/APITest.swift
@@ -32,33 +32,7 @@ class CommonAPITest: UnitTest {
 
     // SDK wrappers can configure the SDK from a Map.
     // This test is in API tests as the String keys of the Map are public and need to not break for the SDK wrappers.
-    func test_createSdkConfigFromMap() {
-        let logLevel = "info"
-
-        let givenParamsFromSdkWrapper: [String: Any] = [
-            "logLevel": logLevel
-        ]
-
-        let actual = SdkConfig.Factory.create(from: givenParamsFromSdkWrapper)
-
-        XCTAssertEqual(actual.logLevel.rawValue, logLevel)
-    }
-
-    func test_SdkConfigFromMap_givenWrongKeys_expectDefaults() {
-        let logLevel = "info"
-
-        let givenParamsFromSdkWrapper: [String: Any] = [
-            "logLevelWrong": logLevel
-        ]
-
-        let actual = SdkConfig.Factory.create(from: givenParamsFromSdkWrapper)
-
-        XCTAssertEqual(actual.logLevel.rawValue, CioLogLevel.error.rawValue)
-    }
-
-    func test_SdkConfig_givenNoModification_expectDefaults() {
-        let actual = SdkConfig.Factory.create()
-
-        XCTAssertEqual(actual.logLevel.rawValue, CioLogLevel.error.rawValue)
+    func test_createSdkConfigFromDictionary() {
+        _ = SdkConfig.Factory.create(from: [:])
     }
 }

--- a/Tests/Common/APITest.swift
+++ b/Tests/Common/APITest.swift
@@ -10,8 +10,7 @@ import XCTest
  that is a reminder to either fix the compilation and introduce the breaking change or
  fix the mistake and not introduce the breaking change in the code base.
  */
-
-class TrackingAPITest: UnitTest {
+class CommonAPITest: UnitTest {
     // Test that public functions are accessible by mocked instances
     let mock = CustomerIOInstanceMock()
 
@@ -40,20 +39,19 @@ class TrackingAPITest: UnitTest {
             "logLevel": logLevel
         ]
 
-        var actual = SdkConfig.Factory.create()
-        actual.modify(params: givenParamsFromSdkWrapper)
+        let actual = SdkConfig.Factory.create(from: givenParamsFromSdkWrapper)
 
         XCTAssertEqual(actual.logLevel.rawValue, logLevel)
     }
 
     func test_SdkConfigFromMap_givenWrongKeys_expectDefaults() {
         let logLevel = "info"
+
         let givenParamsFromSdkWrapper: [String: Any] = [
             "logLevelWrong": logLevel
         ]
 
-        var actual = SdkConfig.Factory.create()
-        actual.modify(params: givenParamsFromSdkWrapper)
+        let actual = SdkConfig.Factory.create(from: givenParamsFromSdkWrapper)
 
         XCTAssertEqual(actual.logLevel.rawValue, CioLogLevel.error.rawValue)
     }

--- a/Tests/Common/Store/SdkConfigTest.swift
+++ b/Tests/Common/Store/SdkConfigTest.swift
@@ -1,0 +1,58 @@
+@testable import CioInternalCommon
+import SharedTests
+import XCTest
+
+class SdkConfigTest: UnitTest {
+    func test_initializeFromDictionaryWithCustomValues_expectCustomValues() {
+        let givenDict: [String: Any] = [
+            "logLevel": "debug",
+            "source": "ReactNative",
+            "version": "3.0.1"
+        ]
+
+        let config = SdkConfig.Factory.create(from: givenDict)
+
+        XCTAssertEqual(config.logLevel, .debug)
+        XCTAssertNotNil(config._sdkWrapperConfig)
+        XCTAssertSame(config._sdkWrapperConfig, SdkWrapperConfig(source: SdkWrapperConfig.Source.reactNative, version: "3.0.1"))
+    }
+
+    func test_initializeFromEmptyDictionary_expectDefaultValues() {
+        let givenDict: [String: Any] = [:]
+
+        let config = SdkConfig.Factory.create(from: givenDict)
+
+        XCTAssertEqual(config.logLevel, .error)
+        XCTAssertNil(config._sdkWrapperConfig)
+    }
+
+    func test_initializeFromDictionaryWithOnlyLogLevel_expectNoError() {
+        let givenDict: [String: Any] = [
+            "logLevel": "info"
+        ]
+
+        let config = SdkConfig.Factory.create(from: givenDict)
+
+        XCTAssertEqual(config.logLevel, .info)
+        XCTAssertNil(config._sdkWrapperConfig)
+    }
+
+    func test_initializeFromDictionaryWithIncorrectLogLevelType_expectDefaultValues() {
+        let givenDict: [String: Any] = [
+            "logLevel": CioLogLevel.info
+        ]
+
+        let config = SdkConfig.Factory.create(from: givenDict)
+
+        XCTAssertEqual(config.logLevel, .error)
+        XCTAssertNil(config._sdkWrapperConfig)
+    }
+}
+
+/// Helper methods to assert custom types.
+extension SdkConfigTest {
+    func XCTAssertSame(_ actual: SdkWrapperConfig?, _ expected: SdkWrapperConfig, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(actual?.source, expected.source, file: file, line: line)
+        XCTAssertEqual(actual?.version, expected.version, file: file, line: line)
+    }
+}

--- a/Tests/Common/Store/SdkConfigTest.swift
+++ b/Tests/Common/Store/SdkConfigTest.swift
@@ -5,16 +5,12 @@ import XCTest
 class SdkConfigTest: UnitTest {
     func test_initializeFromDictionaryWithCustomValues_expectCustomValues() {
         let givenDict: [String: Any] = [
-            "logLevel": "debug",
-            "source": "ReactNative",
-            "version": "3.0.1"
+            "logLevel": "debug"
         ]
 
         let config = SdkConfig.Factory.create(from: givenDict)
 
         XCTAssertEqual(config.logLevel, .debug)
-        XCTAssertNotNil(config._sdkWrapperConfig)
-        XCTAssertSame(config._sdkWrapperConfig, SdkWrapperConfig(source: SdkWrapperConfig.Source.reactNative, version: "3.0.1"))
     }
 
     func test_initializeFromEmptyDictionary_expectDefaultValues() {
@@ -23,18 +19,16 @@ class SdkConfigTest: UnitTest {
         let config = SdkConfig.Factory.create(from: givenDict)
 
         XCTAssertEqual(config.logLevel, .error)
-        XCTAssertNil(config._sdkWrapperConfig)
     }
 
-    func test_initializeFromDictionaryWithOnlyLogLevel_expectNoError() {
+    func test_initializeFromDictionaryWithIncorrectLogLevelKey_expectDefaultValues() {
         let givenDict: [String: Any] = [
-            "logLevel": "info"
+            "logLevelWrong": "info"
         ]
 
         let config = SdkConfig.Factory.create(from: givenDict)
 
-        XCTAssertEqual(config.logLevel, .info)
-        XCTAssertNil(config._sdkWrapperConfig)
+        XCTAssertEqual(config.logLevel, .error)
     }
 
     func test_initializeFromDictionaryWithIncorrectLogLevelType_expectDefaultValues() {
@@ -45,14 +39,5 @@ class SdkConfigTest: UnitTest {
         let config = SdkConfig.Factory.create(from: givenDict)
 
         XCTAssertEqual(config.logLevel, .error)
-        XCTAssertNil(config._sdkWrapperConfig)
-    }
-}
-
-/// Helper methods to assert custom types.
-extension SdkConfigTest {
-    func XCTAssertSame(_ actual: SdkWrapperConfig?, _ expected: SdkWrapperConfig, file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(actual?.source, expected.source, file: file, line: line)
-        XCTAssertEqual(actual?.version, expected.version, file: file, line: line)
     }
 }

--- a/Tests/DataPipeline/APITest.swift
+++ b/Tests/DataPipeline/APITest.swift
@@ -87,7 +87,9 @@ class DataPipelineAPITest: UnitTest {
 
     func test_allPublicModuleConfigOptions() throws {
         try skipRunningTest()
-        SDKConfigBuilder(cdpApiKey: "")
+
+        _ = SDKConfigBuilder(cdpApiKey: "")
+            .logLevel(.error)
             .apiHost("")
             .cdnHost("")
             .flushAt(10)
@@ -100,6 +102,7 @@ class DataPipelineAPITest: UnitTest {
             .trackApplicationLifecycleEvents(true)
             .autoTrackDeviceAttributes(true)
             .siteId("")
+            .build()
     }
 
     func test_autoTrackingScreenViewsPluginOptions() throws {

--- a/Tests/DataPipeline/Config/SDKConfigBuilderTest.swift
+++ b/Tests/DataPipeline/Config/SDKConfigBuilderTest.swift
@@ -1,0 +1,121 @@
+@testable import CioDataPipelines
+@testable import Segment
+import SharedTests
+import XCTest
+
+class SDKConfigBuilderTest: UnitTest {
+    func test_initializeAndDoNotModify_expectDefaultValues() {
+        let (sdkConfig, dataPipelineConfig) = SDKConfigBuilder(cdpApiKey: "").build()
+
+        XCTAssertEqual(sdkConfig.logLevel, .error)
+
+        XCTAssertEqual(dataPipelineConfig.apiHost, "cdp.customer.io/v1")
+        XCTAssertEqual(dataPipelineConfig.cdnHost, "cdp.customer.io/v1")
+        XCTAssertEqual(dataPipelineConfig.flushAt, 20)
+        XCTAssertEqual(dataPipelineConfig.flushInterval, 30.0)
+        XCTAssertTrue(dataPipelineConfig.autoAddCustomerIODestination)
+        XCTAssertNil(dataPipelineConfig.defaultSettings)
+        XCTAssertSame(dataPipelineConfig.flushPolicies, [CountBasedFlushPolicy(), IntervalBasedFlushPolicy()])
+        XCTAssertSame(dataPipelineConfig.flushQueue, DispatchQueue(label: "com.segment.operatingModeQueue", qos: .utility))
+        XCTAssertEqual(dataPipelineConfig.operatingMode, OperatingMode.asynchronous)
+        XCTAssertTrue(dataPipelineConfig.trackApplicationLifecycleEvents)
+        XCTAssertTrue(dataPipelineConfig.autoTrackDeviceAttributes)
+        XCTAssertNil(dataPipelineConfig.siteId)
+    }
+
+    func test_initializeAndModify_expectCustomValues() {
+        let givenLogLevel = CioLogLevel.info
+
+        let givenCdpApiKey = String.random
+        let givenApiHost = String.random
+        let givenCdnHost = String.random
+        let givenFlushAt = 17
+        let givenFlushInterval = 23.7
+        let givenAutoAddCustomerIODestination = false
+        let givenSettings = Settings(writeKey: givenCdpApiKey)
+        let givenFlushPolicies: [FlushPolicy] = [CountBasedFlushPolicy(), IntervalBasedFlushPolicy()]
+        let givenFlushQueue = DispatchQueue(label: "com.segment.operatingModeQueue", qos: .utility)
+        let givenOperatingMode = OperatingMode.synchronous
+        let givenTrackApplicationLifecycleEvents = false
+        let givenAutoTrackDeviceAttributes = false
+        let givenSiteId = String.random
+
+        let (sdkConfig, dataPipelineConfig) = SDKConfigBuilder(cdpApiKey: givenCdpApiKey)
+            .logLevel(givenLogLevel)
+            .apiHost(givenApiHost)
+            .cdnHost(givenCdnHost)
+            .flushAt(givenFlushAt)
+            .flushInterval(givenFlushInterval)
+            .autoAddCustomerIODestination(givenAutoAddCustomerIODestination)
+            .defaultSettings(givenSettings)
+            .flushPolicies(givenFlushPolicies)
+            .flushQueue(givenFlushQueue)
+            .operatingMode(givenOperatingMode)
+            .trackApplicationLifecycleEvents(givenTrackApplicationLifecycleEvents)
+            .autoTrackDeviceAttributes(givenAutoTrackDeviceAttributes)
+            .siteId(givenSiteId)
+            .build()
+
+        XCTAssertEqual(sdkConfig.logLevel, givenLogLevel)
+
+        XCTAssertEqual(dataPipelineConfig.cdpApiKey, givenCdpApiKey)
+        XCTAssertEqual(dataPipelineConfig.apiHost, givenApiHost)
+        XCTAssertEqual(dataPipelineConfig.cdnHost, givenCdnHost)
+        XCTAssertEqual(dataPipelineConfig.flushAt, givenFlushAt)
+        XCTAssertEqual(dataPipelineConfig.flushInterval, givenFlushInterval)
+        XCTAssertEqual(dataPipelineConfig.autoAddCustomerIODestination, givenAutoAddCustomerIODestination)
+        XCTAssertSame(dataPipelineConfig.defaultSettings, givenSettings)
+        XCTAssertSame(dataPipelineConfig.flushPolicies, givenFlushPolicies)
+        XCTAssertSame(dataPipelineConfig.flushQueue, givenFlushQueue)
+        XCTAssertEqual(dataPipelineConfig.operatingMode, givenOperatingMode)
+        XCTAssertEqual(dataPipelineConfig.trackApplicationLifecycleEvents, givenTrackApplicationLifecycleEvents)
+        XCTAssertEqual(dataPipelineConfig.autoTrackDeviceAttributes, givenAutoTrackDeviceAttributes)
+        XCTAssertEqual(dataPipelineConfig.siteId, givenSiteId)
+    }
+
+    func test_givenDefaults_expectMatchAnalyticsDefaults() {
+        let givenCdpApiKey = String.random
+        let analyticsConfig = Configuration(writeKey: givenCdpApiKey).values
+
+        var analyticsDefaultExpectedSettings = Settings(writeKey: givenCdpApiKey)
+        analyticsDefaultExpectedSettings.integrations = try! JSON(["Segment.io": true])
+
+        let (_, actual) = SDKConfigBuilder(cdpApiKey: "").build()
+
+        // API host and CDN host should match Customer.io's CDP settings.
+        XCTAssertEqual(actual.apiHost, "cdp.customer.io/v1")
+        XCTAssertEqual(actual.cdnHost, "cdp.customer.io/v1")
+        // Remaining values should match the analytics configuration.
+        XCTAssertEqual(actual.flushAt, analyticsConfig.flushAt)
+        XCTAssertEqual(actual.flushInterval, analyticsConfig.flushInterval)
+        XCTAssertEqual(actual.autoAddCustomerIODestination, analyticsConfig.autoAddSegmentDestination)
+        XCTAssertNil(actual.defaultSettings)
+        XCTAssertSame(analyticsConfig.defaultSettings, analyticsDefaultExpectedSettings)
+        XCTAssertSame(actual.flushPolicies, analyticsConfig.flushPolicies)
+        XCTAssertSame(actual.flushQueue, analyticsConfig.flushQueue)
+        XCTAssertEqual(actual.operatingMode, analyticsConfig.operatingMode)
+        XCTAssertEqual(actual.trackApplicationLifecycleEvents, analyticsConfig.trackApplicationLifecycleEvents)
+    }
+}
+
+/// Helper methods to assert custom types.
+extension SDKConfigBuilderTest {
+    func XCTAssertSame(_ actual: Settings?, _ expected: Settings, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(actual?.integrations, expected.integrations, file: file, line: line)
+    }
+
+    func XCTAssertSame(_ actual: [FlushPolicy], _ expected: [FlushPolicy], file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(actual.count, expected.count, file: file, line: line)
+        // This is not the best way to compare arrays, but it's the best we can do for now without complicating the code.
+        for index in actual.indices {
+            // We assume if class types of policies are same, then policies are the same too.
+            XCTAssertTrue(type(of: actual[index]) == type(of: expected[index]), file: file, line: line)
+        }
+    }
+
+    func XCTAssertSame(_ actual: DispatchQueue?, _ expected: DispatchQueue, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertNotNil(actual)
+        XCTAssertEqual(actual?.label, expected.label, file: file, line: line)
+        XCTAssertEqual(actual?.qos, expected.qos, file: file, line: line)
+    }
+}

--- a/Tests/MessagingInApp/Config/MessagingInAppConfigBuilderTest.swift
+++ b/Tests/MessagingInApp/Config/MessagingInAppConfigBuilderTest.swift
@@ -4,7 +4,7 @@ import SharedTests
 import XCTest
 
 class MessagingInAppConfigBuilderTest: UnitTest {
-    func test_modifiedConfiguration_expectCustomValues() {
+    func test_initializeAndModify_expectCustomValues() {
         let givenSiteId = String.random
         let givenRegion = Region.EU
 
@@ -14,7 +14,7 @@ class MessagingInAppConfigBuilderTest: UnitTest {
         XCTAssertEqual(config.region, givenRegion)
     }
 
-    func test_mapInitializationWithCustomValues_expectCustomValues() {
+    func test_initializeFromDictionaryWithCustomValues_expectCustomValues() {
         let givenSiteId = String.random
         let givenRegion = "EU"
 
@@ -30,7 +30,7 @@ class MessagingInAppConfigBuilderTest: UnitTest {
         XCTAssertEqual(config?.region.rawValue, givenRegion)
     }
 
-    func test_initializationWithEmptyDict_expectThrowError() {
+    func test_initializeFromEmptyDictionary_expectThrowError() {
         let givenDict: [String: Any] = [:]
 
         XCTAssertThrowsError(try MessagingInAppConfigBuilder.build(from: givenDict)) { error in
@@ -38,7 +38,7 @@ class MessagingInAppConfigBuilderTest: UnitTest {
         }
     }
 
-    func test_initializationWithOnlySiteId_expectThrowError() {
+    func test_initializeFromDictionaryWithOnlySiteId_expectThrowError() {
         let givenDict: [String: Any] = [
             "siteId": String.random
         ]
@@ -48,7 +48,7 @@ class MessagingInAppConfigBuilderTest: UnitTest {
         }
     }
 
-    func test_mapInitializationWithIncorrectSiteIdType_expectThrowError() {
+    func test_initializeFromDictionaryWithIncorrectSiteIdType_expectThrowError() {
         let givenDict: [String: Any] = [
             "siteId": 100,
             "region": "US"
@@ -59,7 +59,7 @@ class MessagingInAppConfigBuilderTest: UnitTest {
         }
     }
 
-    func test_initializationWithOnlyRegion_expectThrowError() {
+    func test_initializeFromDictionaryWithOnlyRegion_expectThrowError() {
         let givenDict: [String: Any] = [
             "region": String.random
         ]
@@ -69,7 +69,7 @@ class MessagingInAppConfigBuilderTest: UnitTest {
         }
     }
 
-    func test_mapInitializationWithIncorrectRegionType_expectThrowError() {
+    func test_initializeFromDictionaryWithIncorrectRegionType_expectThrowError() {
         let givenSiteId = String.random
         let givenDict: [String: Any] = [
             "siteId": givenSiteId,
@@ -81,7 +81,7 @@ class MessagingInAppConfigBuilderTest: UnitTest {
         }
     }
 
-    func test_mapInitializationWithIncorrectRegionValue_expectDefaultValue() {
+    func test_initializeFromDictionaryWithIncorrectRegionValue_expectDefaultValue() {
         let givenSiteId = String.random
         let givenDict: [String: Any] = [
             "siteId": givenSiteId,

--- a/Tests/MessagingPush/Config/MessagingPushConfigBuilderTest.swift
+++ b/Tests/MessagingPush/Config/MessagingPushConfigBuilderTest.swift
@@ -3,13 +3,13 @@ import SharedTests
 import XCTest
 
 class MessagingPushConfigBuilderTest: UnitTest {
-    func test_defaultInitialization_expectDefaultValues() {
+    func test_initializeAndDoNotModify_expectDefaultValues() {
         let config = MessagingPushConfigBuilder().build()
 
         XCTAssertDefaultValues(config: config)
     }
 
-    func test_modifiedConfiguration_expectCustomValues() {
+    func test_initializeAndModify_expectCustomValues() {
         let givenAutoFetchDeviceToken = false
         let givenAutoTrackPushEvents = false
         let givenShowPushAppInForeground = false
@@ -25,7 +25,7 @@ class MessagingPushConfigBuilderTest: UnitTest {
         XCTAssertEqual(config.showPushAppInForeground, givenShowPushAppInForeground)
     }
 
-    func test_initializationWithEmptyDict_expectDefaultValues() {
+    func test_initializeFromEmptyDictionary_expectDefaultValues() {
         let givenDict: [String: Any] = [:]
 
         let config = MessagingPushConfigBuilder.build(from: givenDict)
@@ -33,7 +33,7 @@ class MessagingPushConfigBuilderTest: UnitTest {
         XCTAssertDefaultValues(config: config)
     }
 
-    func test_mapInitializationWithCustomValues_expectCustomValues() {
+    func test_initializeFromDictionaryWithCustomValues_expectCustomValues() {
         let givenAutoFetchDeviceToken = false
         let givenAutoTrackPushEvents = false
         let givenShowPushAppInForeground = false
@@ -51,7 +51,7 @@ class MessagingPushConfigBuilderTest: UnitTest {
         XCTAssertEqual(config.showPushAppInForeground, givenShowPushAppInForeground)
     }
 
-    func test_mapInitializationWithIncorrectKeys_expectDefaultValues() {
+    func test_initializeFromDictionaryWithIncorrectKeys_expectDefaultValues() {
         let givenDict: [String: Any] = [
             "fetchDeviceToken": false,
             "trackPushEvents": false,
@@ -63,7 +63,7 @@ class MessagingPushConfigBuilderTest: UnitTest {
         XCTAssertDefaultValues(config: config)
     }
 
-    func test_mapInitializationWithIncorrectValues_expectDefaultValues() {
+    func test_initializeFromDictionaryWithIncorrectValues_expectDefaultValues() {
         let givenDict: [String: Any] = [
             "autoFetchDeviceToken": 123,
             "autoTrackPushEvents": "false",
@@ -78,9 +78,9 @@ class MessagingPushConfigBuilderTest: UnitTest {
 
 extension MessagingPushConfigBuilderTest {
     // Extension method to conveniently assert default values.
-    private func XCTAssertDefaultValues(config: MessagingPushConfigOptions) {
-        XCTAssertTrue(config.autoFetchDeviceToken)
-        XCTAssertTrue(config.autoTrackPushEvents)
-        XCTAssertTrue(config.showPushAppInForeground)
+    private func XCTAssertDefaultValues(config: MessagingPushConfigOptions, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertTrue(config.autoFetchDeviceToken, file: file, line: line)
+        XCTAssertTrue(config.autoTrackPushEvents, file: file, line: line)
+        XCTAssertTrue(config.showPushAppInForeground, file: file, line: line)
     }
 }

--- a/Tests/Shared/Core/UnitTestBase.swift
+++ b/Tests/Shared/Core/UnitTestBase.swift
@@ -72,10 +72,7 @@ open class UnitTestBase<Component>: XCTestCase {
      @param modifySdkConfig Closure allowing customization of the SDK/Module configuration before the SDK/Module instance is initialized.
      */
     open func setUp(enableLogs: Bool = false, sdkConfig: SdkConfig? = nil) {
-        var newSdkConfig = sdkConfig ?? SdkConfig.Factory.create()
-        if enableLogs {
-            newSdkConfig.logLevel = CioLogLevel.debug
-        }
+        var newSdkConfig = sdkConfig ?? SdkConfig.Factory.create(logLevel: enableLogs ? .debug : nil)
 
         diGraph = DIGraph(sdkConfig: newSdkConfig)
         // setup and override dependencies before creating SDK instance, as Shared graph may be initialized and used immediately


### PR DESCRIPTION
helps: [MBL-121](https://linear.app/customerio/issue/MBL-121/write-tests-to-validate-datapipelineconfigoptions-behavior)

### Changes

- Simplified `SdkConfig`
- Updated docs for all configs
- Updated a few config test names for clarity
- Added and improved tests for `SdkConfigBuilder` and `SdkConfig`