### PR TITLE
fix: decoupled autoTrackPushEvents config

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
@@ -49,7 +49,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             config.backgroundQueueMinNumberOfTasks = Int(self.storage.bgNumOfTasks ?? "10") ?? 10
             config.autoTrackScreenViews = self.storage.isTrackScreenEnabled ?? true
 
-            config.autoTrackPushEvents = true
+            config.autoTrackPushMetricEvents = [.delivered, .opened]
 
             if let trackUrl = self.storage.trackUrl, !trackUrl.isEmpty {
                 config.trackingApiUrl = trackUrl

--- a/Apps/APN-UIKit/NotificationServiceExtension/NotificationService.swift
+++ b/Apps/APN-UIKit/NotificationServiceExtension/NotificationService.swift
@@ -8,7 +8,7 @@ class NotificationService: UNNotificationServiceExtension {
 
     override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
         CustomerIO.initialize(siteId: BuildEnvironment.CustomerIO.siteId, apiKey: BuildEnvironment.CustomerIO.apiKey, region: Region.US) { config in
-            config.autoTrackPushEvents = true
+            config.autoTrackPushMetricEvents = [.delivered, .opened]
         }
 
         MessagingPush.shared.didReceive(request, withContentHandler: contentHandler)

--- a/Apps/CocoaPods-FCM/src/AppDelegate.swift
+++ b/Apps/CocoaPods-FCM/src/AppDelegate.swift
@@ -23,7 +23,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         // Initialize the Customer.io SDK
         CustomerIO.initialize(siteId: siteId, apiKey: apiKey, region: .US) { config in
             // Modify properties in the config object to configure the Customer.io SDK.
-            config.autoTrackPushEvents = true
+            config.autoTrackPushMetricEvents = [.delivered, .opened]
             // config.logLevel = .debug // Uncomment this line to enable debug logging.
 
             // This line of code is internal to Customer.io for testing purposes. Do not add this code to your app.

--- a/Sources/Common/Service/Request/MetricRequest.swift
+++ b/Sources/Common/Service/Request/MetricRequest.swift
@@ -1,4 +1,3 @@
-
 import Foundation
 
 // https://customer.io/docs/api/#operation/pushMetrics

--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -66,7 +66,7 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
         let logger = diGraph.logger
         logger.debug("Setting up MessagingPush module...")
 
-        if diGraph.sdkConfig.autoTrackPushEvents {
+        if diGraph.sdkConfig.autoTrackPushMetricEvents.isOpenedEnabled {
             diGraph.automaticPushClickHandling.start()
         }
 

--- a/Sources/MessagingPush/RichPush/MessagingPush+RichPush.swift
+++ b/Sources/MessagingPush/RichPush/MessagingPush+RichPush.swift
@@ -60,7 +60,7 @@ extension MessagingPushImplementation {
 
         logger.info("push was sent from Customer.io. Processing the request...")
 
-        if sdkConfig.autoTrackPushEvents {
+        if sdkConfig.autoTrackPushMetricEvents.isDeliveredEnabled {
             logger.info("automatically tracking push metric: delivered")
             logger.debug("parsed deliveryId \(pushCioDeliveryInfo.id), deviceToken: \(pushCioDeliveryInfo.token)")
 

--- a/Sources/Tracking/CustomerIO.swift
+++ b/Sources/Tracking/CustomerIO.swift
@@ -202,7 +202,18 @@ public class CustomerIO: CustomerIOInstance {
     private static func initialize(
         config: SdkConfig
     ) {
-        let newDiGraph = DIGraph(sdkConfig: config)
+        var sdkConfig = config
+
+        // temporary handling for backward compatibility with `autoTrackPushEvents`.
+        // if `autoTrackPushEvents` is false (disabled) and `autoTrackPushMetricEvents` is set to track all events (default),
+        // we adjust to track only `delivered`. This approach aims to avoid missing `delivered` events for customers
+        // transitioning from the old setting/or who wanted to suppress opened, especially when explicit disabling of `delivered`
+        // tracking isn't distinguishable in the current setup. This is a conservative choice to ensure event tracking continuity.
+        if !sdkConfig.autoTrackPushEvents, sdkConfig.autoTrackPushMetricEvents.isTrackingAllEvents {
+            sdkConfig.autoTrackPushMetricEvents = [.delivered]
+        }
+
+        let newDiGraph = DIGraph(sdkConfig: sdkConfig)
 
         shared.diGraph = newDiGraph
         shared.implementation = CustomerIOImplementation(diGraph: newDiGraph)

--- a/Tests/MessagingPush/MessagingPushTest.swift
+++ b/Tests/MessagingPush/MessagingPushTest.swift
@@ -49,7 +49,7 @@ class MessagignPushTest: IntegrationTest {
 
     func test_initialize_givenCustomerDisabledAutoPushClickHandling_expectDoNotEnableFeature() {
         setupTest { config in
-            config.autoTrackPushEvents = false
+            config.autoTrackPushMetricEvents = .delivered // could be empty too
         }
 
         MessagingPush.initialize()

--- a/Tests/MessagingPush/PushHandling/ManualPushHandlingTest.swift
+++ b/Tests/MessagingPush/PushHandling/ManualPushHandlingTest.swift
@@ -14,7 +14,7 @@ class ManualPushHandlingIntegrationTests: IntegrationTest {
 
     override func setUp() {
         super.setUp { config in
-            config.autoTrackPushEvents = false // we are testing manual push tracking. Disable automatic push tracking feature.
+            config.autoTrackPushMetricEvents = .delivered // we are testing manual push tracking. Disable opened automatic push tracking feature.
         }
 
         diGraph.override(value: customerIOMock, forType: CustomerIOInstance.self)

--- a/Tests/Tracking/APITest.swift
+++ b/Tests/Tracking/APITest.swift
@@ -35,6 +35,7 @@ class TrackingAPITest: UnitTest {
         // Initialize
         CustomerIO.initialize(siteId: "", apiKey: "", region: .EU) { (config: inout CioSdkConfig) in
             config.autoTrackPushEvents = false
+            config.autoTrackPushMetricEvents = []
         }
         // There is another `initialize()` function that's available to Notification Service Extension and not available
         // to other targets (such as iOS).
@@ -110,10 +111,10 @@ class TrackingAPITest: UnitTest {
         CustomerIO.initialize(siteId: "", apiKey: "", region: .EU) { config in
             config.trackingApiUrl = ""
             config.autoTrackPushEvents = true
+            config.autoTrackPushMetricEvents = [.delivered, .opened]
             config.backgroundQueueMinNumberOfTasks = 10
             config.backgroundQueueSecondsDelay = 10
             config.logLevel = .error
-            config.autoTrackPushEvents = false
             config.autoScreenViewBody = { [:] }
             config.filterAutoScreenViewEvents = { viewController in
                 class MyViewController: UIViewController {}


### PR DESCRIPTION
- Provide users with the flexibility to only disable opened.
- Deprecation of  autoTrackPushEvents
- Handle case for legacy user autoTrackPushEvents with false

closes: https://linear.app/customerio/issue/MBL-138/[bug]-decouple-autotrack-config