### PR TITLE
docs: Skeleton VisionOS app

### DIFF
--- a/Apps/visionos/visionos.xcodeproj/project.pbxproj
+++ b/Apps/visionos/visionos.xcodeproj/project.pbxproj
@@ -1,0 +1,414 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		60F259332B8FDD4B00A6745A /* visionosApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F259322B8FDD4B00A6745A /* visionosApp.swift */; };
+		60F259352B8FDD4B00A6745A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F259342B8FDD4B00A6745A /* ContentView.swift */; };
+		60F259372B8FDD4D00A6745A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 60F259362B8FDD4D00A6745A /* Assets.xcassets */; };
+		60F2593A2B8FDD4D00A6745A /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 60F259392B8FDD4D00A6745A /* Preview Assets.xcassets */; };
+		60F259432B8FDD9200A6745A /* Splash in Frameworks */ = {isa = PBXBuildFile; productRef = 60F259422B8FDD9200A6745A /* Splash */; };
+		60F259462B8FDDAE00A6745A /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 60F259452B8FDDAE00A6745A /* MarkdownUI */; };
+		60F2594A2B8FDEA000A6745A /* Tracking in Frameworks */ = {isa = PBXBuildFile; productRef = 60F259492B8FDEA000A6745A /* Tracking */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		60F2592B2B8FDD4B00A6745A /* visionos.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = visionos.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		60F259322B8FDD4B00A6745A /* visionosApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = visionosApp.swift; sourceTree = "<group>"; };
+		60F259342B8FDD4B00A6745A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		60F259362B8FDD4D00A6745A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		60F259392B8FDD4D00A6745A /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		60F2593B2B8FDD4D00A6745A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		60F259472B8FDE1900A6745A /* customerio-swift */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "customerio-swift"; path = ../../..; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		60F259282B8FDD4B00A6745A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				60F259432B8FDD9200A6745A /* Splash in Frameworks */,
+				60F259462B8FDDAE00A6745A /* MarkdownUI in Frameworks */,
+				60F2594A2B8FDEA000A6745A /* Tracking in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		60F259222B8FDD4B00A6745A = {
+			isa = PBXGroup;
+			children = (
+				60F2592D2B8FDD4B00A6745A /* visionos */,
+				60F2592E2B8FDD4B00A6745A /* Packages */,
+				60F2592C2B8FDD4B00A6745A /* Products */,
+				60F259482B8FDEA000A6745A /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		60F2592C2B8FDD4B00A6745A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				60F2592B2B8FDD4B00A6745A /* visionos.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		60F2592D2B8FDD4B00A6745A /* visionos */ = {
+			isa = PBXGroup;
+			children = (
+				60F259322B8FDD4B00A6745A /* visionosApp.swift */,
+				60F259342B8FDD4B00A6745A /* ContentView.swift */,
+				60F259362B8FDD4D00A6745A /* Assets.xcassets */,
+				60F2593B2B8FDD4D00A6745A /* Info.plist */,
+				60F259382B8FDD4D00A6745A /* Preview Content */,
+			);
+			path = visionos;
+			sourceTree = "<group>";
+		};
+		60F2592E2B8FDD4B00A6745A /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				60F259472B8FDE1900A6745A /* customerio-swift */,
+			);
+			path = Packages;
+			sourceTree = "<group>";
+		};
+		60F259382B8FDD4D00A6745A /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				60F259392B8FDD4D00A6745A /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		60F259482B8FDEA000A6745A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		60F2592A2B8FDD4B00A6745A /* visionos */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 60F2593E2B8FDD4D00A6745A /* Build configuration list for PBXNativeTarget "visionos" */;
+			buildPhases = (
+				60F259272B8FDD4B00A6745A /* Sources */,
+				60F259282B8FDD4B00A6745A /* Frameworks */,
+				60F259292B8FDD4B00A6745A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = visionos;
+			packageProductDependencies = (
+				60F259422B8FDD9200A6745A /* Splash */,
+				60F259452B8FDDAE00A6745A /* MarkdownUI */,
+				60F259492B8FDEA000A6745A /* Tracking */,
+			);
+			productName = visionos;
+			productReference = 60F2592B2B8FDD4B00A6745A /* visionos.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		60F259232B8FDD4B00A6745A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1520;
+				LastUpgradeCheck = 1520;
+				TargetAttributes = {
+					60F2592A2B8FDD4B00A6745A = {
+						CreatedOnToolsVersion = 15.2;
+					};
+				};
+			};
+			buildConfigurationList = 60F259262B8FDD4B00A6745A /* Build configuration list for PBXProject "visionos" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 60F259222B8FDD4B00A6745A;
+			packageReferences = (
+				60F259412B8FDD9200A6745A /* XCRemoteSwiftPackageReference "Splash" */,
+				60F259442B8FDDAE00A6745A /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
+			);
+			productRefGroup = 60F2592C2B8FDD4B00A6745A /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				60F2592A2B8FDD4B00A6745A /* visionos */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		60F259292B8FDD4B00A6745A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				60F2593A2B8FDD4D00A6745A /* Preview Assets.xcassets in Resources */,
+				60F259372B8FDD4D00A6745A /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		60F259272B8FDD4B00A6745A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				60F259352B8FDD4B00A6745A /* ContentView.swift in Sources */,
+				60F259332B8FDD4B00A6745A /* visionosApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		60F2593C2B8FDD4D00A6745A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = xros;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				XROS_DEPLOYMENT_TARGET = 1.0;
+			};
+			name = Debug;
+		};
+		60F2593D2B8FDD4D00A6745A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = xros;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+				XROS_DEPLOYMENT_TARGET = 1.0;
+			};
+			name = Release;
+		};
+		60F2593F2B8FDD4D00A6745A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"visionos/Preview Content\"";
+				DEVELOPMENT_TEAM = 2YC97BQN3N;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "$(TARGET_NAME)/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.customer.visionos-sample-app.visionos";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+			};
+			name = Debug;
+		};
+		60F259402B8FDD4D00A6745A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"visionos/Preview Content\"";
+				DEVELOPMENT_TEAM = 2YC97BQN3N;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "$(TARGET_NAME)/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.customer.visionos-sample-app.visionos";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		60F259262B8FDD4B00A6745A /* Build configuration list for PBXProject "visionos" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				60F2593C2B8FDD4D00A6745A /* Debug */,
+				60F2593D2B8FDD4D00A6745A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		60F2593E2B8FDD4D00A6745A /* Build configuration list for PBXNativeTarget "visionos" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				60F2593F2B8FDD4D00A6745A /* Debug */,
+				60F259402B8FDD4D00A6745A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		60F259412B8FDD9200A6745A /* XCRemoteSwiftPackageReference "Splash" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Ahmed-Ali/Splash";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.17.0;
+			};
+		};
+		60F259442B8FDDAE00A6745A /* XCRemoteSwiftPackageReference "swift-markdown-ui" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/gonzalezreal/swift-markdown-ui";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.3.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		60F259422B8FDD9200A6745A /* Splash */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 60F259412B8FDD9200A6745A /* XCRemoteSwiftPackageReference "Splash" */;
+			productName = Splash;
+		};
+		60F259452B8FDDAE00A6745A /* MarkdownUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 60F259442B8FDDAE00A6745A /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
+			productName = MarkdownUI;
+		};
+		60F259492B8FDEA000A6745A /* Tracking */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Tracking;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 60F259232B8FDD4B00A6745A /* Project object */;
+}

--- a/Apps/visionos/visionos.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Apps/visionos/visionos.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Apps/visionos/visionos/Assets.xcassets/AppIcon.solidimagestack/Back.solidimagestacklayer/Content.imageset/Contents.json
+++ b/Apps/visionos/visionos/Assets.xcassets/AppIcon.solidimagestack/Back.solidimagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "idiom" : "vision",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Apps/visionos/visionos/Assets.xcassets/AppIcon.solidimagestack/Back.solidimagestacklayer/Contents.json
+++ b/Apps/visionos/visionos/Assets.xcassets/AppIcon.solidimagestack/Back.solidimagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Apps/visionos/visionos/Assets.xcassets/AppIcon.solidimagestack/Contents.json
+++ b/Apps/visionos/visionos/Assets.xcassets/AppIcon.solidimagestack/Contents.json
@@ -1,0 +1,17 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "layers" : [
+    {
+      "filename" : "Front.solidimagestacklayer"
+    },
+    {
+      "filename" : "Middle.solidimagestacklayer"
+    },
+    {
+      "filename" : "Back.solidimagestacklayer"
+    }
+  ]
+}

--- a/Apps/visionos/visionos/Assets.xcassets/AppIcon.solidimagestack/Front.solidimagestacklayer/Content.imageset/Contents.json
+++ b/Apps/visionos/visionos/Assets.xcassets/AppIcon.solidimagestack/Front.solidimagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "idiom" : "vision",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Apps/visionos/visionos/Assets.xcassets/AppIcon.solidimagestack/Front.solidimagestacklayer/Contents.json
+++ b/Apps/visionos/visionos/Assets.xcassets/AppIcon.solidimagestack/Front.solidimagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Apps/visionos/visionos/Assets.xcassets/AppIcon.solidimagestack/Middle.solidimagestacklayer/Content.imageset/Contents.json
+++ b/Apps/visionos/visionos/Assets.xcassets/AppIcon.solidimagestack/Middle.solidimagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "idiom" : "vision",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Apps/visionos/visionos/Assets.xcassets/AppIcon.solidimagestack/Middle.solidimagestacklayer/Contents.json
+++ b/Apps/visionos/visionos/Assets.xcassets/AppIcon.solidimagestack/Middle.solidimagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Apps/visionos/visionos/Assets.xcassets/Contents.json
+++ b/Apps/visionos/visionos/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Apps/visionos/visionos/ContentView.swift
+++ b/Apps/visionos/visionos/ContentView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+
+            Text("Hello, world!")
+        }
+        .padding()
+    }
+}
+
+#Preview(windowStyle: .automatic) {
+    ContentView()
+}

--- a/Apps/visionos/visionos/Info.plist
+++ b/Apps/visionos/visionos/Info.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationPreferredDefaultSceneSessionRole</key>
+		<string>UIWindowSceneSessionRoleApplication</string>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict/>
+	</dict>
+</dict>
+</plist>

--- a/Apps/visionos/visionos/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Apps/visionos/visionos/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Apps/visionos/visionos/visionosApp.swift
+++ b/Apps/visionos/visionos/visionosApp.swift
@@ -1,0 +1,17 @@
+//
+//  visionosApp.swift
+//  visionos
+//
+//  Created by Ahmed Ali on 29/02/2024.
+//
+
+import SwiftUI
+
+@main
+struct visionosApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
docs: Skeleton VisionOS app

## Context
We are building a sample app for VisionOS to demonstrate the usage of CustomerIO SwiftSDK in VisionOS.

## In this PR
In this PR we are introducing a new empty VisionOS app, with a single `Hello World` screen and the Swift Package Manger dependencies that will be used. Namely:
- `swift-markdown-ui`: which will be used for imarkdown rendering.
- `'splash`: dependency to create custom code syntax highlighting themes.
- `customerio-swift`: local dependency on the CIO Swift SDK

## Test Plan:
- Open visionos.xcproject in Xcode
- Make sure you have VisionOS simulator installed and selected
- CMD+R to run the app and see the `Hello World` screen
