### PR TITLE
fix: expo users reported app crash on didFailToRegisterForRemoteNotificationsWithError

### DIFF
--- a/Sources/MessagingPushAPN/MessagingPushAPN+PushConfigs.swift
+++ b/Sources/MessagingPushAPN/MessagingPushAPN+PushConfigs.swift
@@ -45,6 +45,6 @@ extension MessagingPushAPN {
     // Swizzled method for `didFailToRegisterForRemoteNotificationsWithError'
     @objc
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
-        messagingPush.deleteDeviceToken()
+        Self.shared.deleteDeviceToken()
     }
 }


### PR DESCRIPTION
part of: https://linear.app/customerio/issue/MBL-141/expo-50-with-version-100-beta15-crash-startup-app-on-ios

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After code reviews are approved and you determine this PR is ready to merge, select *Squash and Merge* button on this screen, leave the title and description to the default values, then merge the PR.
