### PR TITLE
docs: [vision-on-sample-app][4/n] InlineNavigationLinks

### DIFF
--- a/Apps/VisionOS/VisionOS.xcodeproj/project.pbxproj
+++ b/Apps/VisionOS/VisionOS.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		60F9675B2B912C1000A4E95E /* TextOutputFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967582B912C1000A4E95E /* TextOutputFormat.swift */; };
 		60F9675C2B912C1000A4E95E /* SplashCodeSyntaxHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967592B912C1000A4E95E /* SplashCodeSyntaxHighlighter.swift */; };
 		60F9675D2B912C1000A4E95E /* MarkdownTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F9675A2B912C1000A4E95E /* MarkdownTheme.swift */; };
+		60F967602B912E2E00A4E95E /* InlineNavigationLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F9675E2B912E2E00A4E95E /* InlineNavigationLink.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +35,7 @@
 		60F967582B912C1000A4E95E /* TextOutputFormat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextOutputFormat.swift; sourceTree = "<group>"; };
 		60F967592B912C1000A4E95E /* SplashCodeSyntaxHighlighter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SplashCodeSyntaxHighlighter.swift; sourceTree = "<group>"; };
 		60F9675A2B912C1000A4E95E /* MarkdownTheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarkdownTheme.swift; sourceTree = "<group>"; };
+		60F9675E2B912E2E00A4E95E /* InlineNavigationLink.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InlineNavigationLink.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -109,6 +111,7 @@
 		60F967562B912C1000A4E95E /* ViewUtils */ = {
 			isa = PBXGroup;
 			children = (
+				60F9675E2B912E2E00A4E95E /* InlineNavigationLink.swift */,
 				60F967572B912C1000A4E95E /* SyntaxHighlighting */,
 				60F9675A2B912C1000A4E95E /* MarkdownTheme.swift */,
 			);
@@ -202,6 +205,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				60F967602B912E2E00A4E95E /* InlineNavigationLink.swift in Sources */,
 				60F9675C2B912C1000A4E95E /* SplashCodeSyntaxHighlighter.swift in Sources */,
 				60F967542B91288400A4E95E /* Payloads.swift in Sources */,
 				60F967372B9125D000A4E95E /* MainScreen.swift in Sources */,

--- a/Apps/VisionOS/VisionOS.xcodeproj/project.pbxproj
+++ b/Apps/VisionOS/VisionOS.xcodeproj/project.pbxproj
@@ -16,6 +16,9 @@
 		60F967532B91288400A4E95E /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967502B91288400A4E95E /* AppState.swift */; };
 		60F967542B91288400A4E95E /* Payloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967512B91288400A4E95E /* Payloads.swift */; };
 		60F967552B91288400A4E95E /* UserDefaultsCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967522B91288400A4E95E /* UserDefaultsCodable.swift */; };
+		60F9675B2B912C1000A4E95E /* TextOutputFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967582B912C1000A4E95E /* TextOutputFormat.swift */; };
+		60F9675C2B912C1000A4E95E /* SplashCodeSyntaxHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967592B912C1000A4E95E /* SplashCodeSyntaxHighlighter.swift */; };
+		60F9675D2B912C1000A4E95E /* MarkdownTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F9675A2B912C1000A4E95E /* MarkdownTheme.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +31,9 @@
 		60F967502B91288400A4E95E /* AppState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		60F967512B91288400A4E95E /* Payloads.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Payloads.swift; sourceTree = "<group>"; };
 		60F967522B91288400A4E95E /* UserDefaultsCodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDefaultsCodable.swift; sourceTree = "<group>"; };
+		60F967582B912C1000A4E95E /* TextOutputFormat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextOutputFormat.swift; sourceTree = "<group>"; };
+		60F967592B912C1000A4E95E /* SplashCodeSyntaxHighlighter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SplashCodeSyntaxHighlighter.swift; sourceTree = "<group>"; };
+		60F9675A2B912C1000A4E95E /* MarkdownTheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarkdownTheme.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -65,6 +71,7 @@
 		60F9672F2B9125D000A4E95E /* VisionOS */ = {
 			isa = PBXGroup;
 			children = (
+				60F967562B912C1000A4E95E /* ViewUtils */,
 				60F9674F2B91288400A4E95E /* Storage */,
 				60F967342B9125D000A4E95E /* VisionOSApp.swift */,
 				60F967362B9125D000A4E95E /* MainScreen.swift */,
@@ -97,6 +104,24 @@
 				60F967522B91288400A4E95E /* UserDefaultsCodable.swift */,
 			);
 			path = Storage;
+			sourceTree = "<group>";
+		};
+		60F967562B912C1000A4E95E /* ViewUtils */ = {
+			isa = PBXGroup;
+			children = (
+				60F967572B912C1000A4E95E /* SyntaxHighlighting */,
+				60F9675A2B912C1000A4E95E /* MarkdownTheme.swift */,
+			);
+			path = ViewUtils;
+			sourceTree = "<group>";
+		};
+		60F967572B912C1000A4E95E /* SyntaxHighlighting */ = {
+			isa = PBXGroup;
+			children = (
+				60F967582B912C1000A4E95E /* TextOutputFormat.swift */,
+				60F967592B912C1000A4E95E /* SplashCodeSyntaxHighlighter.swift */,
+			);
+			path = SyntaxHighlighting;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -177,8 +202,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				60F9675C2B912C1000A4E95E /* SplashCodeSyntaxHighlighter.swift in Sources */,
 				60F967542B91288400A4E95E /* Payloads.swift in Sources */,
 				60F967372B9125D000A4E95E /* MainScreen.swift in Sources */,
+				60F9675B2B912C1000A4E95E /* TextOutputFormat.swift in Sources */,
+				60F9675D2B912C1000A4E95E /* MarkdownTheme.swift in Sources */,
 				60F967352B9125D000A4E95E /* VisionOSApp.swift in Sources */,
 				60F967532B91288400A4E95E /* AppState.swift in Sources */,
 				60F967552B91288400A4E95E /* UserDefaultsCodable.swift in Sources */,

--- a/Apps/VisionOS/VisionOS.xcodeproj/project.pbxproj
+++ b/Apps/VisionOS/VisionOS.xcodeproj/project.pbxproj
@@ -13,6 +13,9 @@
 		60F967472B91264B00A4E95E /* Splash in Frameworks */ = {isa = PBXBuildFile; productRef = 60F967462B91264B00A4E95E /* Splash */; };
 		60F9674A2B91265B00A4E95E /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 60F967492B91265B00A4E95E /* MarkdownUI */; };
 		60F9674E2B91269D00A4E95E /* Tracking in Frameworks */ = {isa = PBXBuildFile; productRef = 60F9674D2B91269D00A4E95E /* Tracking */; };
+		60F967532B91288400A4E95E /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967502B91288400A4E95E /* AppState.swift */; };
+		60F967542B91288400A4E95E /* Payloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967512B91288400A4E95E /* Payloads.swift */; };
+		60F967552B91288400A4E95E /* UserDefaultsCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967522B91288400A4E95E /* UserDefaultsCodable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -21,7 +24,10 @@
 		60F967362B9125D000A4E95E /* MainScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainScreen.swift; sourceTree = "<group>"; };
 		60F967382B9125D100A4E95E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		60F9673D2B9125D100A4E95E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		60F9674B2B91267200A4E95E /* customerio-ios */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "customerio-ios"; path = ../../..; sourceTree = "<group>"; };
+		60F9674B2B91267200A4E95E /* cio-ios-spl */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "customerio-ios"; path = ../../..; sourceTree = "<group>"; };
+		60F967502B91288400A4E95E /* AppState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
+		60F967512B91288400A4E95E /* Payloads.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Payloads.swift; sourceTree = "<group>"; };
+		60F967522B91288400A4E95E /* UserDefaultsCodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDefaultsCodable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,6 +65,7 @@
 		60F9672F2B9125D000A4E95E /* VisionOS */ = {
 			isa = PBXGroup;
 			children = (
+				60F9674F2B91288400A4E95E /* Storage */,
 				60F967342B9125D000A4E95E /* VisionOSApp.swift */,
 				60F967362B9125D000A4E95E /* MainScreen.swift */,
 				60F967382B9125D100A4E95E /* Assets.xcassets */,
@@ -80,6 +87,16 @@
 			children = (
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		60F9674F2B91288400A4E95E /* Storage */ = {
+			isa = PBXGroup;
+			children = (
+				60F967502B91288400A4E95E /* AppState.swift */,
+				60F967512B91288400A4E95E /* Payloads.swift */,
+				60F967522B91288400A4E95E /* UserDefaultsCodable.swift */,
+			);
+			path = Storage;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -160,8 +177,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				60F967542B91288400A4E95E /* Payloads.swift in Sources */,
 				60F967372B9125D000A4E95E /* MainScreen.swift in Sources */,
 				60F967352B9125D000A4E95E /* VisionOSApp.swift in Sources */,
+				60F967532B91288400A4E95E /* AppState.swift in Sources */,
+				60F967552B91288400A4E95E /* UserDefaultsCodable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Apps/VisionOS/VisionOS/MainScreen.swift
+++ b/Apps/VisionOS/VisionOS/MainScreen.swift
@@ -1,11 +1,22 @@
 import SwiftUI
 
 struct MainScreen: View {
+    @ObservedObject var state: AppState = .shared
     var body: some View {
         VStack {
             Text("Hello, world!")
         }
         .padding()
+        .environment(
+            \.openURL,
+            OpenURLAction { url in
+                guard let link = InlineNavigationLink(fromUrl: url) else {
+                    return .systemAction
+                }
+                state.navigationPath.append(link)
+                return .handled
+            }
+        )
     }
 }
 

--- a/Apps/VisionOS/VisionOS/Storage/AppState.swift
+++ b/Apps/VisionOS/VisionOS/Storage/AppState.swift
@@ -1,5 +1,25 @@
 import Foundation
 
+extension [InlineNavigationLink]: UserDefaultsCodable {
+    static func storageKey() -> String {
+        "navigationPath"
+    }
+
+    static func empty() -> [Element] {
+        []
+    }
+}
+
+extension Set<InlineNavigationLink>: UserDefaultsCodable {
+    static func storageKey() -> String {
+        "visitedLinks"
+    }
+
+    static func empty() -> Set<Element> {
+        .init()
+    }
+}
+
 struct ScreenTitleConfig {
     let screenTitle: String
     let menuTitle: String
@@ -33,7 +53,24 @@ class AppState: ObservableObject {
         }
     }
 
-    // MARK: non persistent state
+    @Published var navigationPath: [InlineNavigationLink] = .loadFromStorage() {
+        didSet {
+            UserDefaults.standard.setValue(
+                navigationPath.toJson(),
+                forKey: [InlineNavigationLink].storageKey()
+            )
+            visitedLinks.formUnion(navigationPath)
+        }
+    }
+
+    @Published var visitedLinks: Set<InlineNavigationLink> = .loadFromStorage() {
+        didSet {
+            UserDefaults.standard.setValue(
+                visitedLinks.toJson(),
+                forKey: Set<InlineNavigationLink>.storageKey()
+            )
+        }
+    }
 
     @Published var titleConfig: ScreenTitleConfig = .init("")
     @Published var errorMessage: String = ""

--- a/Apps/VisionOS/VisionOS/Storage/AppState.swift
+++ b/Apps/VisionOS/VisionOS/Storage/AppState.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+struct ScreenTitleConfig {
+    let screenTitle: String
+    let menuTitle: String
+    let showVisionProLogo: Bool
+
+    init(_ screenTitle: String, menuTitle: String? = nil, showVisionProLogo: Bool = false) {
+        self.screenTitle = screenTitle
+        self.menuTitle = menuTitle ?? screenTitle
+        self.showVisionProLogo = showVisionProLogo
+    }
+}
+
+class AppState: ObservableObject {
+    static let shared = AppState()
+
+    @Published var profile: Profile = .loadFromStorage() {
+        didSet {
+            UserDefaults.standard.setValue(
+                profile.toJson(),
+                forKey: Profile.storageKey()
+            )
+        }
+    }
+
+    @Published var workspaceSettings: WorkspaceSettings = .loadFromStorage() {
+        didSet {
+            UserDefaults.standard.setValue(
+                workspaceSettings.toJson(),
+                forKey: WorkspaceSettings.storageKey()
+            )
+        }
+    }
+
+    // MARK: non persistent state
+
+    @Published var titleConfig: ScreenTitleConfig = .init("")
+    @Published var errorMessage: String = ""
+    @Published var successMessage: String = ""
+}

--- a/Apps/VisionOS/VisionOS/Storage/Payloads.swift
+++ b/Apps/VisionOS/VisionOS/Storage/Payloads.swift
@@ -1,0 +1,85 @@
+import CioTracking
+import Foundation
+
+extension Region: CaseIterable, Codable {
+    public static var allCases: [Region] = [.EU, .US]
+}
+
+struct WorkspaceSettings: UserDefaultsCodable {
+    var siteId: String
+    var apiKey: String
+    var region: Region = .EU
+
+    static func storageKey() -> String {
+        "UserDefaultsCodable"
+    }
+
+    static func empty() -> Self {
+        WorkspaceSettings(siteId: "", apiKey: "")
+    }
+
+    func isSet() -> Bool {
+        !siteId.isEmpty && !apiKey.isEmpty
+    }
+}
+
+struct Profile: UserDefaultsCodable {
+    var id: String
+    var name: String
+    var email: String
+    var loggedIn: Bool
+
+    static func empty() -> Profile {
+        Profile(id: UUID().uuidString, name: "", email: "", loggedIn: false)
+    }
+
+    static func storageKey() -> String {
+        "Profile"
+    }
+}
+
+struct Event {
+    var name: String = ""
+    var propertyName: String = ""
+    var propertyValue: String = ""
+}
+
+struct ProfileAttribute {
+    var name: String
+    var value: String
+}
+
+struct DeviceAttribute {
+    var name: String
+    var value: String
+}
+
+extension Profile {
+    func fieldsToDictionay() -> [String: String] {
+        var dic: [String: String] = [:]
+        if !name.isEmpty {
+            dic["name"] = name
+        }
+
+        if !email.isEmpty {
+            dic["email"] = email
+        }
+
+        return dic
+    }
+}
+
+extension Event {
+    func fieldsToDictionay() -> [String: String] {
+        var dic: [String: String] = [:]
+        if !name.isEmpty {
+            dic["name"] = name
+        }
+
+        if !propertyName.isEmpty {
+            dic[propertyName] = propertyValue
+        }
+
+        return dic
+    }
+}

--- a/Apps/VisionOS/VisionOS/Storage/UserDefaultsCodable.swift
+++ b/Apps/VisionOS/VisionOS/Storage/UserDefaultsCodable.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+protocol UserDefaultsCodable: Codable {
+    static func storageKey() -> String
+    static func empty() -> Self
+}
+
+extension UserDefaultsCodable {
+    func toJson() -> Data {
+        let encoder = JSONEncoder()
+        return try! encoder.encode(self)
+    }
+
+    static func from(_ data: Data) -> Self? {
+        let decoder = JSONDecoder()
+        return try? decoder.decode(Self.self, from: data)
+    }
+
+    static func loadFromStorage() -> Self {
+        if let data =
+            UserDefaults.standard.object(forKey: storageKey()) as? Data,
+            let storedInstance = from(data) {
+            return storedInstance
+        }
+
+        let content = Self.empty()
+        UserDefaults.standard.setValue(
+            content.toJson(),
+            forKey: Self.storageKey()
+        )
+
+        return content
+    }
+}

--- a/Apps/VisionOS/VisionOS/ViewUtils/InlineNavigationLink.swift
+++ b/Apps/VisionOS/VisionOS/ViewUtils/InlineNavigationLink.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+enum InlineNavigationLink: String, Codable, CaseIterable {
+    case sampleAppIntro,
+         install,
+         setup,
+         customerIOIntro,
+         identify,
+         howToTestIdentify,
+         profileAttributes,
+         howToTestProfileAttributes,
+         deviceAttributes,
+         howToTestDeviceAttributes,
+         track,
+         howToTestTrack
+
+    init?(fromUrl url: URL) {
+        guard let link = Self(rawValue: url.absoluteString)
+        else {
+            return nil
+        }
+
+        self = link
+    }
+}

--- a/Apps/VisionOS/VisionOS/ViewUtils/MarkdownTheme.swift
+++ b/Apps/VisionOS/VisionOS/ViewUtils/MarkdownTheme.swift
@@ -1,0 +1,63 @@
+import MarkdownUI
+import SwiftUI
+
+private extension Color {
+    static let codeBackground = Color(rgba: 0x333336FF)
+    static let blockquoteIcon = Color(rgba: 0xFECD00FF)
+    static let blockquoteBackground = Color(rgba: 0xAF65FFFF)
+    static let linkColor = Color(rgba: 0x04ECBBFF)
+}
+
+extension Theme {
+    static let tutorial = Theme.docC
+        .code {
+            FontFamilyVariant(.monospaced)
+            FontSize(16)
+            FontStyle(.italic)
+            FontWeight(.bold)
+        }
+        .codeBlock { configuration in
+            ScrollView(.horizontal) {
+                configuration.label
+                    .fixedSize(horizontal: false, vertical: true)
+                    .relativeLineSpacing(.em(0.333335))
+                    .markdownTextStyle {
+                        FontFamilyVariant(.monospaced)
+                        FontSize(22)
+                    }
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 16)
+            }
+            .background(Color.codeBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 15, style: .continuous))
+        }
+        .paragraph { configuration in
+            configuration.label
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .text {
+            FontSize(22)
+        }
+        .link {
+            ForegroundColor(Color.linkColor)
+            FontWeight(.semibold)
+            UnderlineStyle(.single)
+        }
+        .blockquote { configuration in
+            HStack(spacing: 0) {
+                Image(systemName: "exclamationmark.warninglight.fill")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 60)
+                    .rotationEffect(.degrees(180))
+                    .foregroundColor(Color.blockquoteIcon)
+                    .padding(.horizontal)
+                configuration.label
+                    .relativePadding(.vertical, length: .em(0.3))
+                    .relativePadding(.trailing, length: .em(1))
+            }
+            .background(Color.blockquoteBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .fixedSize(horizontal: false, vertical: true)
+        }
+}

--- a/Apps/VisionOS/VisionOS/ViewUtils/SyntaxHighlighting/SplashCodeSyntaxHighlighter.swift
+++ b/Apps/VisionOS/VisionOS/ViewUtils/SyntaxHighlighting/SplashCodeSyntaxHighlighter.swift
@@ -1,0 +1,25 @@
+import MarkdownUI
+import Splash
+import SwiftUI
+
+struct SplashCodeSyntaxHighlighter: CodeSyntaxHighlighter {
+    private let syntaxHighlighter: SyntaxHighlighter<TextOutputFormat>
+
+    init(theme: Splash.Theme) {
+        self.syntaxHighlighter = SyntaxHighlighter(format: TextOutputFormat(theme: theme))
+    }
+
+    func highlightCode(_ content: String, language: String?) -> Text {
+        guard language?.lowercased() == "swift" else {
+            return Text(content)
+        }
+
+        return syntaxHighlighter.highlight(content)
+    }
+}
+
+extension CodeSyntaxHighlighter where Self == SplashCodeSyntaxHighlighter {
+    static var splash: Self {
+        SplashCodeSyntaxHighlighter(theme: .wwdc17(withFont: .init(size: 18)))
+    }
+}

--- a/Apps/VisionOS/VisionOS/ViewUtils/SyntaxHighlighting/TextOutputFormat.swift
+++ b/Apps/VisionOS/VisionOS/ViewUtils/SyntaxHighlighting/TextOutputFormat.swift
@@ -1,0 +1,45 @@
+import Splash
+import SwiftUI
+
+struct TextOutputFormat: OutputFormat {
+    private let theme: Theme
+
+    init(theme: Theme) {
+        self.theme = theme
+    }
+
+    func makeBuilder() -> Builder {
+        Builder(theme: theme)
+    }
+}
+
+extension TextOutputFormat {
+    struct Builder: OutputBuilder {
+        private let theme: Theme
+        private var accumulatedText: [Text]
+
+        fileprivate init(theme: Theme) {
+            self.theme = theme
+            self.accumulatedText = []
+        }
+
+        mutating func addToken(_ token: String, ofType type: TokenType) {
+            let color = theme.tokenColors[type] ?? theme.plainTextColor
+            accumulatedText.append(Text(token).foregroundColor(.init(uiColor: color)))
+        }
+
+        mutating func addPlainText(_ text: String) {
+            accumulatedText.append(
+                Text(text).foregroundColor(.init(uiColor: theme.plainTextColor))
+            )
+        }
+
+        mutating func addWhitespace(_ whitespace: String) {
+            accumulatedText.append(Text(whitespace))
+        }
+
+        func build() -> Text {
+            accumulatedText.reduce(Text(""), +)
+        }
+    }
+}


### PR DESCRIPTION
docs: [vision-on-sample-app][4/n] InlineNavigationLinks

## Context

This is a PR in a series of PRs to build sample app that runs Identify and Track in VisionPro
The app is built to be an interactive walk through guidance for developers who are integrating Customer.io Swift SDK in their VisioPro apps.
For more context:

- See the project [one pager](https://www.notion.so/custio/Spacial-Identify-and-Tracking-6587d848bbde494095c0585237326ed3?pvs=4)
- See [Linear Issue](https://linear.app/customerio/issue/MBL-115/sample-app-for-visionpro)


## PR Summary
In this PR I added the InlineNavigationLinks enum and its handling. These enum values represent the screens that will be in the app. It will be used within the markdown content to act as links; the its handler will route the app to the correct screen based on the link.

## Test plan
- Open `VisionOs.xcproject`
- Hit CMD+R to run the project and make sure you have VisionOS simulator installed and selected

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/customerio/customerio-ios/pull/580).
* #602
* #598
* #597
* #596
* #586
* #585
* #581
* __->__ #580
* #579
* #578