### PR TITLE
test: public api tests for DataPipeline

### DIFF
--- a/Sources/DataPipeline/CustomerIO+Plugins.swift
+++ b/Sources/DataPipeline/CustomerIO+Plugins.swift
@@ -2,7 +2,6 @@ import CioInternalCommon
 import Foundation
 import Segment
 
-// TODO: Add APITest for it?
 public extension CustomerIO {
     /**
      Applies the supplied closure to the currently loaded set of plugins.

--- a/Sources/DataPipeline/CustomerIO+Segment.swift
+++ b/Sources/DataPipeline/CustomerIO+Segment.swift
@@ -4,7 +4,6 @@ import Segment
 
 // MARK: - System Modifiers
 
-// TODO: Add APITest for it?
 public extension CustomerIO {
     /// Enable/Disable analytics capture
     var enabled: Bool {

--- a/Tests/DataPipeline/APITest.swift
+++ b/Tests/DataPipeline/APITest.swift
@@ -19,6 +19,7 @@ class DataPipelineAPITest: UnitTest {
     }
 
     let codedData = CodableExample(foo: "")
+    let exampleURL = URL(string: "https://example.com")!
 
     // Test that public functions are accessible by mocked instances
     let mock = CustomerIOInstanceMock()
@@ -72,10 +73,6 @@ class DataPipelineAPITest: UnitTest {
         CustomerIO.shared.trackMetric(deliveryID: "", event: metric, deviceToken: "")
         mock.trackMetric(deliveryID: "", event: metric, deviceToken: "")
 
-        checkDeviceProfileAttributes()
-    }
-
-    func checkDeviceProfileAttributes() {
         // profile attributes
         CustomerIO.shared.profileAttributes = dictionaryData
         mock.profileAttributes = dictionaryData
@@ -83,6 +80,44 @@ class DataPipelineAPITest: UnitTest {
         // device attributes
         CustomerIO.shared.deviceAttributes = dictionaryData
         mock.deviceAttributes = dictionaryData
+
+        // extensions
+        CustomerIO.shared.setDebugLogsEnabled()
+        CustomerIO.shared.setDebugLogsEnabled(false)
+
+        // plugins
+        CustomerIO.shared.apply { (_: Plugin) in }
+        CustomerIO.shared.add(plugin: UtilityPluginMock())
+        CustomerIO.shared.add { (_: RawEvent?) in nil }
+        CustomerIO.shared.add { (_: RawEvent?) in TrackEvent(event: String.random, properties: nil) }
+        CustomerIO.shared.remove(plugin: UtilityPluginMock())
+        let _: UtilityPluginMock? = CustomerIO.shared.find(pluginType: UtilityPluginMock.self)
+        let _: [UtilityPluginMock]? = CustomerIO.shared.findAll(pluginType: UtilityPluginMock.self)
+        let _: DestinationPlugin? = CustomerIO.shared.find(key: String.random)
+
+        // segment
+        let _: Bool = CustomerIO.shared.enabled
+        let _: String = CustomerIO.shared.anonymousId
+        let _: String? = CustomerIO.shared.userId
+        let _: OperatingMode = CustomerIO.shared.operatingMode
+        let _: TimeInterval = CustomerIO.shared.flushInterval
+        let _: Int = CustomerIO.shared.flushAt
+        let _: [FlushPolicy] = CustomerIO.shared.flushPolicies
+        let _: CodableExample? = CustomerIO.shared.traits()
+        let _: [String: Any]? = CustomerIO.shared.traits()
+        CustomerIO.shared.flush {}
+        CustomerIO.shared.reset()
+        let _: String = CustomerIO.shared.version()
+        let _: Settings? = CustomerIO.shared.settings()
+        CustomerIO.shared.manuallyEnableDestination(plugin: DestinationPluginMock())
+        let _: Bool = CustomerIO.shared.hasUnsentEvents
+        let _: [URL]? = CustomerIO.shared.pendingUploads
+        CustomerIO.shared.purgeStorage()
+        CustomerIO.shared.purgeStorage(fileURL: exampleURL)
+        CustomerIO.shared.waitUntilStarted()
+        CustomerIO.shared.openURL(exampleURL)
+        CustomerIO.shared.openURL(exampleURL, options: codedData)
+        CustomerIO.shared.openURL(exampleURL, options: dictionaryData)
     }
 
     func test_allPublicModuleConfigOptions() throws {

--- a/Tests/DataPipeline/Support/MockPlugins.swift
+++ b/Tests/DataPipeline/Support/MockPlugins.swift
@@ -2,6 +2,9 @@ import CioDataPipelines
 import Foundation
 import Segment
 
+// This file contains mock plugins for testing purposes.
+// These plugins can be used as placeholders for testing APIs that use plugins.
+
 class UtilityPluginMock: Plugin {
     let type: Segment.PluginType = .utility
     var analytics: Segment.Analytics?

--- a/Tests/DataPipeline/Support/MockPlugins.swift
+++ b/Tests/DataPipeline/Support/MockPlugins.swift
@@ -1,0 +1,15 @@
+import CioDataPipelines
+import Foundation
+import Segment
+
+class UtilityPluginMock: Plugin {
+    let type: Segment.PluginType = .utility
+    var analytics: Segment.Analytics?
+}
+
+class DestinationPluginMock: DestinationPlugin {
+    let key: String = "Mock"
+    let timeline: Segment.Timeline = .init()
+    let type: Segment.PluginType = .destination
+    var analytics: Segment.Analytics?
+}


### PR DESCRIPTION
closes: [MBL-144](https://linear.app/customerio/issue/MBL-144/write-apitest-cases-to-remove-todos-in-source-code)

### Changes

- Removed completed TODOs
- Added API tests for public APIs exposed in `CustomerIO+Plugins` and `CustomerIO+Segment`
- Added mock plugins to help in testing