### PR TITLE
fix: forward push response events to 3rd party callback functions, for CIO push

### DIFF
--- a/Tests/MessagingPush/PushHandling/PushEventHandlerProxyTest.swift
+++ b/Tests/MessagingPush/PushHandling/PushEventHandlerProxyTest.swift
@@ -1,0 +1,59 @@
+@testable import CioMessagingPush
+@testable import CioTracking
+import Foundation
+import SharedTests
+import XCTest
+
+class PushEventHandlerProxyTest: UnitTest {
+    var pushEventHandlerProxy: PushEventHandlerProxy!
+
+    private let deepLinkUtilMock = DeepLinkUtilMock()
+    private let customerIOMock = CustomerIOInstanceMock()
+
+    override func setUp() {
+        super.setUp()
+
+        pushEventHandlerProxy = PushEventHandlerProxyImpl()
+    }
+
+    // MARK: thread safety
+
+    func test_onPushAction_ensureThreadSafetyCallingDelegates() {
+        runTest(numberOfTimes: 100) { // Ensure no race conditions by running test many times.
+            let delegate1 = PushEventHandlerMock()
+            class PushEventHandlerMock2: PushEventHandlerMock {}
+            let delegate2 = PushEventHandlerMock2()
+
+            let expectDelegatesReceiveEvent = expectation(description: "delegate1 received event")
+            expectDelegatesReceiveEvent.expectedFulfillmentCount = 2 // 1 for each delegate. We do not care what order the delegates get called as long as all get called.
+            let expectCompleteCallingAllDelegates = expectation(description: "complete calling all delegates")
+
+            // When each delegate gets called, have them call the completion handler on different threads to test the proxy is thread safe.
+            delegate1.onPushActionClosure = { _, completion in
+                expectDelegatesReceiveEvent.fulfill()
+
+                self.runOnMain {
+                    completion()
+                }
+            }
+            delegate2.onPushActionClosure = { _, completion in
+                expectDelegatesReceiveEvent.fulfill()
+
+                self.runOnBackground {
+                    completion()
+                }
+            }
+            pushEventHandlerProxy.addPushEventHandler(delegate1)
+            pushEventHandlerProxy.addPushEventHandler(delegate2)
+
+            pushEventHandlerProxy.onPushAction(PushNotificationActionStub(push: PushNotificationStub.getPushSentFromCIO(), didClickOnPush: true)) {
+                expectCompleteCallingAllDelegates.fulfill()
+            }
+
+            wait(for: [
+                expectDelegatesReceiveEvent,
+                expectCompleteCallingAllDelegates
+            ], enforceOrder: true)
+        }
+    }
+}

--- a/Tests/Shared/UnitTest.swift
+++ b/Tests/Shared/UnitTest.swift
@@ -179,4 +179,10 @@ public extension UnitTest {
             block()
         }
     }
+
+    func runOnMain(_ block: @escaping () -> Void) {
+        CioThreadUtil().runMain {
+            block()
+        }
+    }
 }


### PR DESCRIPTION
Part of: https://linear.app/customerio/issue/MBL-138/[bug]-ios-customers-receive-callbacks-from-3rd-party-sdks-for-pushes

When a push response event (push clicked or swiped away) happens, send the push event to other push event handlers in host app. Giving customers the opportunity to process the push. Previously, only non-CIO pushes would be sent to other push event handlers.

Notes:

* Scenario where CIO pushes are not handled (opened metric not tracked, deep link not opened):

See new test function `test_givenMultiplePushHandlers_givenClickedOnCioPush_givenOtherPushHandlerDoesNotCallCompletionHandler_expectCompletionHandlerDoesNotGetCalled` that reproduces scenario.

When the push event is sent to other push event handlers in the app, this is an async operation. The CIO SDK waits until all of the other push handlers call the async completion handler indicating that they are done processing the push. If 1 of those push handlers does not call the completion handler, the CIO SDK will not process the push (track opened metric, open deep link).

If we do not wait for other push handlers to call the async completion handler, there is a risk that customers push processing logic could get terminated early by iOS.

Waiting for other push handlers aligns with Apple's recommendations. Apple notes in their documentation that you need to call the completion handler after you're done processing a push event. https://developer.apple.com/documentation/usernotifications/unusernotificationcenterdelegate/usernotificationcenter(_:didreceive:withcompletionhandler:)

---

**Stack**:
- #634
- #633
- #601
- #590
- #584
- #583 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*