### PR TITLE
chore: add region to sdk config builder

### DIFF
--- a/Sources/Common/Service/CIOApiEndpoint.swift
+++ b/Sources/Common/Service/CIOApiEndpoint.swift
@@ -34,16 +34,3 @@ public extension CIOApiEndpoint {
         return fullPath
     }
 }
-
-/**
- Collection of the different base URLs for all the APIs of Customer.io.
- Each endpoint in `HttpEndpoint` knows what base API that it needs. That is where
- the full URL including path is constructed.
- */
-public struct HttpBaseUrls: Equatable {
-    let trackingApi: String
-
-    static func getProduction(region: Region) -> HttpBaseUrls {
-        HttpBaseUrls(trackingApi: region.productionTrackingUrl)
-    }
-}

--- a/Sources/Common/Type/Region.swift
+++ b/Sources/Common/Type/Region.swift
@@ -12,16 +12,6 @@ public enum Region: String, Equatable {
     case US
     /// The European Union (EU) data center
     case EU
-
-    // Note: These URLs are meant to be used specifically by the official
-    // mobile SDKs. View our API docs: https://customer.io/docs/api/
-    // to find the correct hostname for what you're trying to do.
-    public var productionTrackingUrl: String {
-        switch self {
-        case .US: return "https://track-sdk.customer.io"
-        case .EU: return "https://track-sdk-eu.customer.io"
-        }
-    }
 }
 
 public extension Region {

--- a/Sources/DataPipeline/Config/SDKConfigBuilder.swift
+++ b/Sources/DataPipeline/Config/SDKConfigBuilder.swift
@@ -18,17 +18,16 @@ import Segment
 /// // Use `config` for initializing the SDK...
 /// ```
 public class SDKConfigBuilder {
-    // default static values for configuration options
-    private static let defaultAPIHost = "cdp.customer.io/v1"
-    private static let defaultCDNHost = "cdp.customer.io/v1"
+    // helper configuration options to ease setting up other configurations such as `apiHost` and `cdnHost`
+    private var region: Region = .US
 
     // configuration options for SdkConfig
     private var logLevel: CioLogLevel = .error
 
     // configuration options for DataPipelineConfigOptions
     private let cdpApiKey: String
-    private var apiHost: String = SDKConfigBuilder.defaultAPIHost
-    private var cdnHost: String = SDKConfigBuilder.defaultCDNHost
+    private var apiHost: String?
+    private var cdnHost: String?
     private var flushAt: Int = 20
     private var flushInterval: Seconds = 30
     private var autoAddCustomerIODestination: Bool = true
@@ -45,6 +44,15 @@ public class SDKConfigBuilder {
     ///   - cdpApiKey: Customer.io Data Pipeline API Key
     public init(cdpApiKey: String) {
         self.cdpApiKey = cdpApiKey
+    }
+
+    /// Specifies the workspace region to ensure CDP requests are routed to the correct regional endpoint.
+    /// Default values for apiHost and cdnHost are determined by the region.
+    /// However, if apiHost or cdnHost are manually specified, those values override region-based defaults.
+    @discardableResult
+    public func region(_ region: Region) -> SDKConfigBuilder {
+        self.region = region
+        return self
     }
 
     /// To help you get setup with the SDK or debug SDK, change the log level of logs you wish to
@@ -138,8 +146,8 @@ public class SDKConfigBuilder {
         // create `DataPipelineConfigOptions` from given configurations
         let dataPipelineConfig = DataPipelineConfigOptions(
             cdpApiKey: cdpApiKey,
-            apiHost: apiHost,
-            cdnHost: cdnHost,
+            apiHost: apiHost ?? region.apiHost,
+            cdnHost: cdnHost ?? region.cdnHost,
             flushAt: flushAt,
             flushInterval: flushInterval,
             autoAddCustomerIODestination: autoAddCustomerIODestination,

--- a/Sources/DataPipeline/Type/Region.swift
+++ b/Sources/DataPipeline/Type/Region.swift
@@ -1,0 +1,18 @@
+import CioInternalCommon
+
+// These URLs are for requesting CDP settings from the CDP API, and must align with server's CDP regional configuration.
+extension Region {
+    var apiHost: String {
+        switch self {
+        case .US: return "cdp.customer.io/v1"
+        case .EU: return "cdp-eu.customer.io/v1"
+        }
+    }
+
+    var cdnHost: String {
+        switch self {
+        case .US: return "cdp.customer.io/v1"
+        case .EU: return "cdp-eu.customer.io/v1"
+        }
+    }
+}

--- a/Tests/DataPipeline/Config/SDKConfigBuilderTest.swift
+++ b/Tests/DataPipeline/Config/SDKConfigBuilderTest.swift
@@ -42,6 +42,8 @@ class SDKConfigBuilderTest: UnitTest {
 
         let (sdkConfig, dataPipelineConfig) = SDKConfigBuilder(cdpApiKey: givenCdpApiKey)
             .logLevel(givenLogLevel)
+            // Region should be ignored because we are setting the API host and CDN host directly.
+            .region(.US)
             .apiHost(givenApiHost)
             .cdnHost(givenCdnHost)
             .flushAt(givenFlushAt)
@@ -95,6 +97,48 @@ class SDKConfigBuilderTest: UnitTest {
         XCTAssertSame(actual.flushQueue, analyticsConfig.flushQueue)
         XCTAssertEqual(actual.operatingMode, analyticsConfig.operatingMode)
         XCTAssertEqual(actual.trackApplicationLifecycleEvents, analyticsConfig.trackApplicationLifecycleEvents)
+    }
+
+    func test_givenRegionUS_expectRegionDefaults() {
+        let (_, dataPipelineConfig) = SDKConfigBuilder(cdpApiKey: .random)
+            .region(.US)
+            .build()
+
+        XCTAssertEqual(dataPipelineConfig.apiHost, "cdp.customer.io/v1")
+        XCTAssertEqual(dataPipelineConfig.cdnHost, "cdp.customer.io/v1")
+    }
+
+    func test_givenRegionEU_expectRegionDefaults() {
+        let (_, dataPipelineConfig) = SDKConfigBuilder(cdpApiKey: .random)
+            .region(.EU)
+            .build()
+
+        XCTAssertEqual(dataPipelineConfig.apiHost, "cdp-eu.customer.io/v1")
+        XCTAssertEqual(dataPipelineConfig.cdnHost, "cdp-eu.customer.io/v1")
+    }
+
+    func test_givenApiHostModified_expectIgnoreRegionDefaultsForApiHost() {
+        let givenApiHost = String.random
+
+        let (_, dataPipelineConfig) = SDKConfigBuilder(cdpApiKey: .random)
+            .region(.US)
+            .apiHost(givenApiHost)
+            .build()
+
+        XCTAssertEqual(dataPipelineConfig.apiHost, givenApiHost)
+        XCTAssertEqual(dataPipelineConfig.cdnHost, "cdp.customer.io/v1")
+    }
+
+    func test_givenCdnHostModified_expectIgnoreRegionDefaultsForCdnHost() {
+        let givenCdnHost = String.random
+
+        let (_, dataPipelineConfig) = SDKConfigBuilder(cdpApiKey: .random)
+            .region(.US)
+            .cdnHost(givenCdnHost)
+            .build()
+
+        XCTAssertEqual(dataPipelineConfig.apiHost, "cdp.customer.io/v1")
+        XCTAssertEqual(dataPipelineConfig.cdnHost, givenCdnHost)
     }
 }
 


### PR DESCRIPTION
closes: [MBL-152](https://linear.app/customerio/issue/MBL-152/add-region-support-to-cdp-config)

### Changes

- Exposes `Region` option in `SDKConfigBuilder` for conveniently setting `apiHost` and `cdnHost` for `US` and `EU` regions
- Updated tests for `Region` changes
- Remove old API url and relevant code from `Region`