### PR TITLE
refactor: process push click event before we call 3rd party callback functions

### DIFF
--- a/Sources/MessagingPush/PushHandling/ManualPushHandling+UserNotifications.swift
+++ b/Sources/MessagingPush/PushHandling/ManualPushHandling+UserNotifications.swift
@@ -96,7 +96,9 @@ extension MessagingPushImplementation {
         // A hack to get an instance of pushClickHandler without making it a property of the MessagingPushImplementation class. pushClickHandler is not available to app extensions but MessagingPushImplementation is.
         // We get around this by getting a instance in this function, only.
         if let pushClickHandler = sdkInitializedUtil.postInitializedData?.diGraph.pushClickHandler {
-            pushClickHandler.pushClicked(push)
+            pushClickHandler.trackPushMetrics(for: push)
+            pushClickHandler.cleanupAfterPushInteractedWith(for: push)
+            pushClickHandler.handleDeepLink(for: push)
         }
     }
 }

--- a/Sources/MessagingPush/PushHandling/PushClickHandler.swift
+++ b/Sources/MessagingPush/PushHandling/PushClickHandler.swift
@@ -5,7 +5,11 @@ import UserNotifications
 
 @available(iOSApplicationExtension, unavailable)
 protocol PushClickHandler: AutoMockable {
-    func pushClicked(_ push: PushNotification)
+    // Cleanup files on device that were used when the push was displayed. Files are no longer
+    // needed now that the push is no longer shown.
+    func cleanupAfterPushInteractedWith(for push: PushNotification)
+    func trackPushMetrics(for push: PushNotification)
+    func handleDeepLink(for push: PushNotification)
 }
 
 @available(iOSApplicationExtension, unavailable)
@@ -19,19 +23,15 @@ class PushClickHandlerImpl: PushClickHandler {
         self.customerIO = customerIO
     }
 
-    // Note: This function is called from automatic and manual push click handlers.
-    func pushClicked(_ push: PushNotification) {
+    func trackPushMetrics(for push: PushNotification) {
         guard let cioDelivery = push.cioDelivery else {
             return
         }
 
         customerIO.trackMetric(deliveryID: cioDelivery.id, event: .opened, deviceToken: cioDelivery.token)
+    }
 
-        // Cleanup files on device that were used when the push was displayed. Files are no longer
-        // needed now that the push is no longer shown.
-        cleanupAfterPushInteractedWith(push: push)
-
-        // Handle deep link, if there is one attached to push.
+    func handleDeepLink(for push: PushNotification) {
         if let deepLinkUrl = push.cioDeepLink?.url {
             deepLinkUtil.handleDeepLink(deepLinkUrl)
         }
@@ -40,7 +40,7 @@ class PushClickHandlerImpl: PushClickHandler {
     // There are files that are created just for displaying a rich push. After a push is interacted with, those files
     // are no longer needed.
     // This function's job is to cleanup after a push is no longer being displayed.
-    func cleanupAfterPushInteractedWith(push: PushNotification) {
+    func cleanupAfterPushInteractedWith(for push: PushNotification) {
         push.cioAttachments.forEach { attachment in
             let localFilePath = attachment.localFileUrl
 

--- a/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
@@ -449,38 +449,102 @@ class PushClickHandlerMock: PushClickHandler, Mock {
     }
 
     public func resetMock() {
-        pushClickedCallsCount = 0
-        pushClickedReceivedArguments = nil
-        pushClickedReceivedInvocations = []
+        cleanupAfterPushInteractedWithCallsCount = 0
+        cleanupAfterPushInteractedWithReceivedArguments = nil
+        cleanupAfterPushInteractedWithReceivedInvocations = []
+
+        mockCalled = false // do last as resetting properties above can make this true
+        trackPushMetricsCallsCount = 0
+        trackPushMetricsReceivedArguments = nil
+        trackPushMetricsReceivedInvocations = []
+
+        mockCalled = false // do last as resetting properties above can make this true
+        handleDeepLinkCallsCount = 0
+        handleDeepLinkReceivedArguments = nil
+        handleDeepLinkReceivedInvocations = []
 
         mockCalled = false // do last as resetting properties above can make this true
     }
 
-    // MARK: - pushClicked
+    // MARK: - cleanupAfterPushInteractedWith
 
     /// Number of times the function was called.
-    private(set) var pushClickedCallsCount = 0
+    private(set) var cleanupAfterPushInteractedWithCallsCount = 0
     /// `true` if the function was ever called.
-    var pushClickedCalled: Bool {
-        pushClickedCallsCount > 0
+    var cleanupAfterPushInteractedWithCalled: Bool {
+        cleanupAfterPushInteractedWithCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    private(set) var pushClickedReceivedArguments: PushNotification?
+    private(set) var cleanupAfterPushInteractedWithReceivedArguments: PushNotification?
     /// Arguments from *all* of the times that the function was called.
-    private(set) var pushClickedReceivedInvocations: [PushNotification] = []
+    private(set) var cleanupAfterPushInteractedWithReceivedInvocations: [PushNotification] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    var pushClickedClosure: ((PushNotification) -> Void)?
+    var cleanupAfterPushInteractedWithClosure: ((PushNotification) -> Void)?
 
-    /// Mocked function for `pushClicked(_ push: PushNotification)`. Your opportunity to return a mocked value and check result of mock in test code.
-    func pushClicked(_ push: PushNotification) {
+    /// Mocked function for `cleanupAfterPushInteractedWith(for push: PushNotification)`. Your opportunity to return a mocked value and check result of mock in test code.
+    func cleanupAfterPushInteractedWith(for push: PushNotification) {
         mockCalled = true
-        pushClickedCallsCount += 1
-        pushClickedReceivedArguments = push
-        pushClickedReceivedInvocations.append(push)
-        pushClickedClosure?(push)
+        cleanupAfterPushInteractedWithCallsCount += 1
+        cleanupAfterPushInteractedWithReceivedArguments = push
+        cleanupAfterPushInteractedWithReceivedInvocations.append(push)
+        cleanupAfterPushInteractedWithClosure?(push)
+    }
+
+    // MARK: - trackPushMetrics
+
+    /// Number of times the function was called.
+    private(set) var trackPushMetricsCallsCount = 0
+    /// `true` if the function was ever called.
+    var trackPushMetricsCalled: Bool {
+        trackPushMetricsCallsCount > 0
+    }
+
+    /// The arguments from the *last* time the function was called.
+    private(set) var trackPushMetricsReceivedArguments: PushNotification?
+    /// Arguments from *all* of the times that the function was called.
+    private(set) var trackPushMetricsReceivedInvocations: [PushNotification] = []
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     */
+    var trackPushMetricsClosure: ((PushNotification) -> Void)?
+
+    /// Mocked function for `trackPushMetrics(for push: PushNotification)`. Your opportunity to return a mocked value and check result of mock in test code.
+    func trackPushMetrics(for push: PushNotification) {
+        mockCalled = true
+        trackPushMetricsCallsCount += 1
+        trackPushMetricsReceivedArguments = push
+        trackPushMetricsReceivedInvocations.append(push)
+        trackPushMetricsClosure?(push)
+    }
+
+    // MARK: - handleDeepLink
+
+    /// Number of times the function was called.
+    private(set) var handleDeepLinkCallsCount = 0
+    /// `true` if the function was ever called.
+    var handleDeepLinkCalled: Bool {
+        handleDeepLinkCallsCount > 0
+    }
+
+    /// The arguments from the *last* time the function was called.
+    private(set) var handleDeepLinkReceivedArguments: PushNotification?
+    /// Arguments from *all* of the times that the function was called.
+    private(set) var handleDeepLinkReceivedInvocations: [PushNotification] = []
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     */
+    var handleDeepLinkClosure: ((PushNotification) -> Void)?
+
+    /// Mocked function for `handleDeepLink(for push: PushNotification)`. Your opportunity to return a mocked value and check result of mock in test code.
+    func handleDeepLink(for push: PushNotification) {
+        mockCalled = true
+        handleDeepLinkCallsCount += 1
+        handleDeepLinkReceivedArguments = push
+        handleDeepLinkReceivedInvocations.append(push)
+        handleDeepLinkClosure?(push)
     }
 }
 

--- a/Tests/MessagingPush/Extension/PushClickHandlerMockExtension.swift
+++ b/Tests/MessagingPush/Extension/PushClickHandlerMockExtension.swift
@@ -1,0 +1,56 @@
+@testable import CioMessagingPush
+import Foundation
+import XCTest
+
+/*
+ Set of test utilities for testing when a push notification is clicked.
+
+ It's recommended to use these functions in your test functions when you're using `PushClickHandlerMock`.
+ */
+
+// MARK: Assertions
+
+extension PushClickHandlerMock {
+    // It's important that when we process a push click, we open the deep link last. This is because when opening a deep link, the device browser could open and the app could be put into the background.
+    // Before the app potentially goes into the background, perform all other push click handling.
+    func assertWillHandleDeepLinkLast(for push: PushNotification) {
+        // When deep link is handled, we expect all other click handling to have already been done.
+        handleDeepLinkClosure = { _ in
+            // We expect all other push click handling to have already happened.
+            self.assertHandledPushClick(for: push)
+
+            // XXX: This would be a good place to call: mock.verifyNoMoreInteractions(), like in Mockito, to be more confident that we are calling deep link last.
+        }
+    }
+
+    // When a push click is handled in the SDK, we expect *all* of these steps are performed.
+    func assertHandledPushClick(for push: PushNotification) {
+        XCTAssertEqual(cleanupAfterPushInteractedWithCallsCount, 1)
+
+        assertTrackedOpenPushMetric(for: push)
+        assertOpenedDeepLink(for: push)
+    }
+
+    func assertTrackedOpenPushMetric(for push: PushNotification, _ didTrackMetric: Bool = true, expectedNumberOfCalls: Int = 1) {
+        XCTAssertEqual(trackPushMetricsCalled, didTrackMetric)
+
+        if didTrackMetric {
+            XCTAssertEqual(trackPushMetricsCallsCount, expectedNumberOfCalls)
+            XCTAssertEqual(trackPushMetricsReceivedArguments!.pushId, push.pushId)
+        }
+    }
+
+    func assertOpenedDeepLink(for push: PushNotification, _ didOpenDeepLink: Bool = true, expectedNumberOfCalls: Int = 1) {
+        XCTAssertEqual(handleDeepLinkCalled, didOpenDeepLink)
+
+        if didOpenDeepLink {
+            XCTAssertEqual(handleDeepLinkCallsCount, expectedNumberOfCalls)
+            XCTAssertEqual(handleDeepLinkReceivedArguments?.cioDeepLink, push.cioDeepLink)
+        }
+    }
+
+    func assertDidNotHandlePushClick() {
+        XCTAssertFalse(trackPushMetricsCalled)
+        XCTAssertFalse(handleDeepLinkCalled)
+    }
+}

--- a/Tests/MessagingPush/PushHandling/PushClickHandlerTest.swift
+++ b/Tests/MessagingPush/PushHandling/PushClickHandlerTest.swift
@@ -18,30 +18,32 @@ class PushClickHandlerTest: IntegrationTest {
         pushClickHandler = PushClickHandlerImpl(deepLinkUtil: deepLinkUtilMock, customerIO: customerIOMock)
     }
 
-    // MARK: pushClicked
+    // MARK: handleDeepLink
 
-    func test_pushClicked_givenNoDeepLinkAttached_expectDoNotHandleDeepLink() {
+    func test_handleDeepLink_givenNoDeepLinkAttached_expectDoNotHandleDeepLink() {
         let givenPush = PushNotificationStub.getPushSentFromCIO(imageUrl: "https://example.com/image.png")
 
-        pushClickHandler.pushClicked(givenPush)
+        pushClickHandler.handleDeepLink(for: givenPush)
 
         XCTAssertFalse(deepLinkUtilMock.mockCalled)
     }
 
-    func test_pushClicked_givenDeepLinkAttached_expectHandleDeepLink() {
+    func test_handleDeepLink_givenDeepLinkAttached_expectHandleDeepLink() {
         let givenDeepLink = "https://example.com/\(String.random)"
         let givenPush = PushNotificationStub.getPushSentFromCIO(deepLink: givenDeepLink, imageUrl: "https://example.com/image.png")
 
-        pushClickHandler.pushClicked(givenPush)
+        pushClickHandler.handleDeepLink(for: givenPush)
 
         XCTAssertEqual(deepLinkUtilMock.handleDeepLinkCallsCount, 1)
         XCTAssertEqual(deepLinkUtilMock.handleDeepLinkReceivedArguments, URL(string: givenDeepLink))
     }
 
-    func test_pushClicked_expectTrackOpenedEvent() {
+    // MARK: trackPushMetrics
+
+    func test_trackPushMetrics_expectTrackOpenedEvent() {
         let givenPush = PushNotificationStub.getPushSentFromCIO(imageUrl: "https://example.com/image.png")
 
-        pushClickHandler.pushClicked(givenPush)
+        pushClickHandler.trackPushMetrics(for: givenPush)
 
         XCTAssertEqual(customerIOMock.trackMetricCallsCount, 1)
     }


### PR DESCRIPTION
Closes: https://linear.app/customerio/issue/MBL-154/process-push-event-before-we-call-3rd-party-callback-functions

If a 3rd party callback function does not call the async `completionHandler`, there is a risk that we will not be able to process the push click event.

Knowing there is always a risk of this happening, we decided to do as much push processing as possible before allowing 3rd party callback functions to process the push. Making this feature more reliable for customers, even if they forget to call the `completionHandler`.

---

**Stack**:
- #634
- #633
- #601
- #590 ⬅
- #584
- #583


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*