### PR TITLE
chore: fcm sample app using autoFetchDeviceToken

### DIFF
--- a/Apps/CocoaPods-FCM/src/AppDelegate.swift
+++ b/Apps/CocoaPods-FCM/src/AppDelegate.swift
@@ -34,10 +34,6 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         MessagingPushFCM.initialize { config in
             config.autoFetchDeviceToken = true
         }
-
-        // Manually get FCM device token. Swizzling hasn't been working for me.
-        Messaging.messaging().delegate = self
-
         /**
          Registers the `AppDelegate` class to handle when a push notification gets clicked.
          This line of code is optional and only required if you have custom code that needs to run when a push notification gets clicked on.
@@ -50,7 +46,12 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         return true
     }
 
+    // Because this is a SwiftUI app, we need to add this function to inform FCM about an APN token being registered.
+    // Without this function, the FCM delegate will not be called with a FCM token registered.
+    // Docs: https://firebase.google.com/docs/cloud-messaging/ios/client#token-swizzle-disabled
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        // You may or may not set apnsToken here
+        // Adding this method will also serve the purpose
         Messaging.messaging().apnsToken = deviceToken
     }
 }

--- a/Sources/Common/Service/Request/MetricRequest.swift
+++ b/Sources/Common/Service/Request/MetricRequest.swift
@@ -1,4 +1,3 @@
-
 import Foundation
 
 // https://customer.io/docs/api/#operation/pushMetrics


### PR DESCRIPTION
### About the PR

Based on our recent discussion, concerns were raised about the functionality of the `autoFetchDeviceToken` property within SwiftUI applications. While there haven't been any reported user issues, but it was assumed that the feature does not work as expected in SwiftUI.

While being on-call and working on SwiftUI Sample app, I also investigated `autoFetchDeviceToken` propert. The feature functions as intended when implemented correctly. Successful tests were done with both APN and FCM on SwiftUI app. However, this pull request focuses solely on FCM integration, as the SwiftUI iOS Sample app utilizes FCM and CocoaPods.

### About the fix
The fix to make the feature work in SwiftUI apps required some tweaks in AppDelegate file. There have been no major changes but few implementation changes. After the tweaks made, the feature worked smoothly with SwiftUI sample app. 

### Tests
[This user's device ](https://fly.customer.io/workspaces/111525/journeys/people/a5e70600fa01fb01) on fly has been registered after making the updates. 
 