### PR TITLE
docs: [vision-on-sample-app][4/n] InlineNavigationLinks

### DIFF
--- a/Apps/VisionOS/VisionOS.xcodeproj/project.pbxproj
+++ b/Apps/VisionOS/VisionOS.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		60F9675B2B912C1000A4E95E /* TextOutputFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967582B912C1000A4E95E /* TextOutputFormat.swift */; };
 		60F9675C2B912C1000A4E95E /* SplashCodeSyntaxHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967592B912C1000A4E95E /* SplashCodeSyntaxHighlighter.swift */; };
 		60F9675D2B912C1000A4E95E /* MarkdownTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F9675A2B912C1000A4E95E /* MarkdownTheme.swift */; };
+		60F967602B912E2E00A4E95E /* InlineNavigationLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F9675E2B912E2E00A4E95E /* InlineNavigationLink.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +35,7 @@
 		60F967582B912C1000A4E95E /* TextOutputFormat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextOutputFormat.swift; sourceTree = "<group>"; };
 		60F967592B912C1000A4E95E /* SplashCodeSyntaxHighlighter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SplashCodeSyntaxHighlighter.swift; sourceTree = "<group>"; };
 		60F9675A2B912C1000A4E95E /* MarkdownTheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarkdownTheme.swift; sourceTree = "<group>"; };
+		60F9675E2B912E2E00A4E95E /* InlineNavigationLink.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InlineNavigationLink.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -109,6 +111,7 @@
 		60F967562B912C1000A4E95E /* ViewUtils */ = {
 			isa = PBXGroup;
 			children = (
+				60F9675E2B912E2E00A4E95E /* InlineNavigationLink.swift */,
 				60F967572B912C1000A4E95E /* SyntaxHighlighting */,
 				60F9675A2B912C1000A4E95E /* MarkdownTheme.swift */,
 			);
@@ -202,6 +205,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				60F967602B912E2E00A4E95E /* InlineNavigationLink.swift in Sources */,
 				60F9675C2B912C1000A4E95E /* SplashCodeSyntaxHighlighter.swift in Sources */,
 				60F967542B91288400A4E95E /* Payloads.swift in Sources */,
 				60F967372B9125D000A4E95E /* MainScreen.swift in Sources */,

--- a/Apps/VisionOS/VisionOS/MainScreen.swift
+++ b/Apps/VisionOS/VisionOS/MainScreen.swift
@@ -1,11 +1,22 @@
 import SwiftUI
 
 struct MainScreen: View {
+    @ObservedObject var state: AppState = .shared
     var body: some View {
         VStack {
             Text("Hello, world!")
         }
         .padding()
+        .environment(
+            \.openURL,
+            OpenURLAction { url in
+                guard let link = InlineNavigationLink(fromUrl: url) else {
+                    return .systemAction
+                }
+                state.navigationPath.append(link)
+                return .handled
+            }
+        )
     }
 }
 

--- a/Apps/VisionOS/VisionOS/Storage/AppState.swift
+++ b/Apps/VisionOS/VisionOS/Storage/AppState.swift
@@ -1,5 +1,25 @@
 import Foundation
 
+extension [InlineNavigationLink]: UserDefaultsCodable {
+    static func storageKey() -> String {
+        "navigationPath"
+    }
+
+    static func empty() -> [Element] {
+        []
+    }
+}
+
+extension Set<InlineNavigationLink>: UserDefaultsCodable {
+    static func storageKey() -> String {
+        "visitedLinks"
+    }
+
+    static func empty() -> Set<Element> {
+        .init()
+    }
+}
+
 struct ScreenTitleConfig {
     let screenTitle: String
     let menuTitle: String
@@ -33,7 +53,24 @@ class AppState: ObservableObject {
         }
     }
 
-    // MARK: non persistent state
+    @Published var navigationPath: [InlineNavigationLink] = .loadFromStorage() {
+        didSet {
+            UserDefaults.standard.setValue(
+                navigationPath.toJson(),
+                forKey: [InlineNavigationLink].storageKey()
+            )
+            visitedLinks.formUnion(navigationPath)
+        }
+    }
+
+    @Published var visitedLinks: Set<InlineNavigationLink> = .loadFromStorage() {
+        didSet {
+            UserDefaults.standard.setValue(
+                visitedLinks.toJson(),
+                forKey: Set<InlineNavigationLink>.storageKey()
+            )
+        }
+    }
 
     @Published var titleConfig: ScreenTitleConfig = .init("")
     @Published var errorMessage: String = ""

--- a/Apps/VisionOS/VisionOS/ViewUtils/InlineNavigationLink.swift
+++ b/Apps/VisionOS/VisionOS/ViewUtils/InlineNavigationLink.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+enum InlineNavigationLink: String, Codable, CaseIterable {
+    case sampleAppIntro,
+         install,
+         setup,
+         customerIOIntro,
+         identify,
+         howToTestIdentify,
+         profileAttributes,
+         howToTestProfileAttributes,
+         deviceAttributes,
+         howToTestDeviceAttributes,
+         track,
+         howToTestTrack
+
+    init?(fromUrl url: URL) {
+        guard let link = Self(rawValue: url.absoluteString)
+        else {
+            return nil
+        }
+
+        self = link
+    }
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #617
* #613
* #612
* #611
* #610
* #609
* #608
* __->__ #606
* #605
* #604

## Context

This is a PR in a series of PRs to build sample app that runs Identify and Track in VisionPro
The app is built to be an interactive walk through guidance for developers who are integrating Customer.io Swift SDK in their VisioPro apps.
For more context:

- See the project [one pager](https://www.notion.so/custio/Spacial-Identify-and-Tracking-6587d848bbde494095c0585237326ed3?pvs=4)
- See [Linear Issue](https://linear.app/customerio/issue/MBL-115/sample-app-for-visionpro)


## PR Summary
In this PR I added the InlineNavigationLinks enum and its handling. These enum values represent the screens that will be in the app. It will be used within the markdown content to act as links to navigate to different screens and include some associated values for these screens.

For example:
```
To try this out, see the [identify](InlineNavigationLink.identify) tutorial
```

In this content, the "identify" link when clicked:
- Will go through a specialised URL handler (will be introduced later) that will update the navigation path to navigate to the Identify screen.
- Will be stored in the persistent app state so the app starts at that screen next time
- Will be marked as visited, so the user can tell which screens they saw before. This might be handy if we end up with many content. Which would happen when we add push and in-app

Moreover, the enum cases will be used to build the kind of "table of contents" alike menu for easier navigation throughout the app.

## Test plan
- Open `VisionOs.xcproject`
- Hit CMD+R to run the project and make sure you have VisionOS simulator installed and selected

ghstack-source-id: 12dd5f7f2d3b47f5b92501150c956fbcf886a8cd
Pull Request resolved: https://github.com/customerio/customerio-ios/pull/606