### PR TITLE
docs: [vision-on-sample-app][5/n] Code Snippets

### DIFF
--- a/Apps/VisionOS/VisionOS.xcodeproj/project.pbxproj
+++ b/Apps/VisionOS/VisionOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6023AD352B913708001540EF /* CodeSnippets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6023AD342B913708001540EF /* CodeSnippets.swift */; };
 		60F967352B9125D000A4E95E /* VisionOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967342B9125D000A4E95E /* VisionOSApp.swift */; };
 		60F967372B9125D000A4E95E /* MainScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967362B9125D000A4E95E /* MainScreen.swift */; };
 		60F967392B9125D100A4E95E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 60F967382B9125D100A4E95E /* Assets.xcassets */; };
@@ -23,12 +24,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		6023AD342B913708001540EF /* CodeSnippets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodeSnippets.swift; sourceTree = "<group>"; };
 		60F9672D2B9125D000A4E95E /* VisionOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VisionOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		60F967342B9125D000A4E95E /* VisionOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisionOSApp.swift; sourceTree = "<group>"; };
 		60F967362B9125D000A4E95E /* MainScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainScreen.swift; sourceTree = "<group>"; };
 		60F967382B9125D100A4E95E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		60F9673D2B9125D100A4E95E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		60F9674B2B91267200A4E95E /* cio-ios-spl */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "customerio-ios"; path = ../../..; sourceTree = "<group>"; };
+		60F9674B2B91267200A4E95E /* customerio-ios */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "customerio-ios"; path = ../../..; sourceTree = "<group>"; };
 		60F967502B91288400A4E95E /* AppState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		60F967512B91288400A4E95E /* Payloads.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Payloads.swift; sourceTree = "<group>"; };
 		60F967522B91288400A4E95E /* UserDefaultsCodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDefaultsCodable.swift; sourceTree = "<group>"; };
@@ -111,9 +113,10 @@
 		60F967562B912C1000A4E95E /* ViewUtils */ = {
 			isa = PBXGroup;
 			children = (
+				6023AD342B913708001540EF /* CodeSnippets.swift */,
 				60F9675E2B912E2E00A4E95E /* InlineNavigationLink.swift */,
-				60F967572B912C1000A4E95E /* SyntaxHighlighting */,
 				60F9675A2B912C1000A4E95E /* MarkdownTheme.swift */,
+				60F967572B912C1000A4E95E /* SyntaxHighlighting */,
 			);
 			path = ViewUtils;
 			sourceTree = "<group>";
@@ -209,6 +212,7 @@
 				60F9675C2B912C1000A4E95E /* SplashCodeSyntaxHighlighter.swift in Sources */,
 				60F967542B91288400A4E95E /* Payloads.swift in Sources */,
 				60F967372B9125D000A4E95E /* MainScreen.swift in Sources */,
+				6023AD352B913708001540EF /* CodeSnippets.swift in Sources */,
 				60F9675B2B912C1000A4E95E /* TextOutputFormat.swift in Sources */,
 				60F9675D2B912C1000A4E95E /* MarkdownTheme.swift in Sources */,
 				60F967352B9125D000A4E95E /* VisionOSApp.swift in Sources */,

--- a/Apps/VisionOS/VisionOS/Storage/AppState.swift
+++ b/Apps/VisionOS/VisionOS/Storage/AppState.swift
@@ -72,6 +72,8 @@ class AppState: ObservableObject {
         }
     }
 
+    // MARK: non persistent state
+
     @Published var titleConfig: ScreenTitleConfig = .init("")
     @Published var errorMessage: String = ""
     @Published var successMessage: String = ""

--- a/Apps/VisionOS/VisionOS/ViewUtils/CodeSnippets.swift
+++ b/Apps/VisionOS/VisionOS/ViewUtils/CodeSnippets.swift
@@ -1,0 +1,67 @@
+import Foundation
+import MarkdownUI
+
+func dataToTutorialString(_ data: [String: String], linePrefix: String = "") -> String {
+    let keys = data.keys.sorted().reversed()
+
+    if keys.isEmpty {
+        return "[:]"
+    }
+
+    var res = "["
+    var sep = ""
+    keys.forEach { key in
+        let propertyName = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        let propertyValue = data[key]!
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        res += """
+        \(sep)"\(propertyName)": "\(propertyValue)"
+        """
+        sep = ", "
+    }
+    res += "]"
+    return res
+}
+
+func initializeCodeSnippet(withWorkspaceSettings settings: WorkspaceSettings)
+    -> String {
+    """
+    CustomerIO.initialize(
+                siteId: "\(settings.siteId)",
+                apiKey: "\(settings.apiKey)",
+                region: .\(settings.region),
+                configure: nil)
+    """
+}
+
+func identifyAsText(withProfile profile: Profile) -> String {
+    if profile.email.isEmpty, profile.name.isEmpty {
+        return
+            """
+            CustomerIO.shared.identify(
+              identifier: "\(profile.id)"
+            )
+            """
+    }
+    return """
+    CustomerIO.shared.identify(
+      identifier: "\(profile.id)",
+      data: \(dataToTutorialString(profile.fieldsToDictionay(), linePrefix: "\t\t")))
+    """
+}
+
+func trackAsText(withEvent event: Event) -> String {
+    if event.propertyName.isEmpty, event.propertyValue.isEmpty {
+        return
+            """
+            CustomerIO.shared.track(
+              name: "\(event.name)"
+            )
+            """
+    }
+    return """
+    CustomerIO.shared.track(
+      name: "\(event.name)",
+      data: \(dataToTutorialString(event.fieldsToDictionay(), linePrefix: "\t\t")))
+    """
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #613
* #612
* #611
* #610
* #609
* #608
* __->__ #607
* #606
* #605
* #604

## Context

This is a PR in a series of PRs to build sample app that runs Identify and Track in VisionPro
The app is built to be an interactive walk through guidance for developers who are integrating Customer.io Swift SDK in their VisioPro apps.
For more context:

- See the project [one pager](https://www.notion.so/custio/Spacial-Identify-and-Tracking-6587d848bbde494095c0585237326ed3?pvs=4)
- See [Linear Issue](https://linear.app/customerio/issue/MBL-115/sample-app-for-visionpro)

## PR Summary
This PR introduces few small utils that will be used for code snippets in the app

## Test plan
- Open `VisionOs.xcproject`
- Hit CMD+R to run the project and make sure you have VisionOS simulator installed and selected