### PR TITLE
docs: [vision-on-sample-app][6/n] AppDelegate

### DIFF
--- a/Apps/VisionOS/VisionOS.xcodeproj/project.pbxproj
+++ b/Apps/VisionOS/VisionOS.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		6023AD352B913708001540EF /* CodeSnippets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6023AD342B913708001540EF /* CodeSnippets.swift */; };
+		6023AD372B9137F0001540EF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6023AD362B9137F0001540EF /* AppDelegate.swift */; };
 		60F967352B9125D000A4E95E /* VisionOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967342B9125D000A4E95E /* VisionOSApp.swift */; };
 		60F967372B9125D000A4E95E /* MainScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967362B9125D000A4E95E /* MainScreen.swift */; };
 		60F967392B9125D100A4E95E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 60F967382B9125D100A4E95E /* Assets.xcassets */; };
@@ -25,6 +26,7 @@
 
 /* Begin PBXFileReference section */
 		6023AD342B913708001540EF /* CodeSnippets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodeSnippets.swift; sourceTree = "<group>"; };
+		6023AD362B9137F0001540EF /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		60F9672D2B9125D000A4E95E /* VisionOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VisionOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		60F967342B9125D000A4E95E /* VisionOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisionOSApp.swift; sourceTree = "<group>"; };
 		60F967362B9125D000A4E95E /* MainScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainScreen.swift; sourceTree = "<group>"; };
@@ -78,6 +80,7 @@
 				60F967562B912C1000A4E95E /* ViewUtils */,
 				60F9674F2B91288400A4E95E /* Storage */,
 				60F967342B9125D000A4E95E /* VisionOSApp.swift */,
+				6023AD362B9137F0001540EF /* AppDelegate.swift */,
 				60F967362B9125D000A4E95E /* MainScreen.swift */,
 				60F967382B9125D100A4E95E /* Assets.xcassets */,
 				60F9673D2B9125D100A4E95E /* Info.plist */,
@@ -208,6 +211,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6023AD372B9137F0001540EF /* AppDelegate.swift in Sources */,
 				60F967602B912E2E00A4E95E /* InlineNavigationLink.swift in Sources */,
 				60F9675C2B912C1000A4E95E /* SplashCodeSyntaxHighlighter.swift in Sources */,
 				60F967542B91288400A4E95E /* Payloads.swift in Sources */,

--- a/Apps/VisionOS/VisionOS/AppDelegate.swift
+++ b/Apps/VisionOS/VisionOS/AppDelegate.swift
@@ -1,0 +1,39 @@
+import CioTracking
+import UIKit
+
+class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication
+            .LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        /*
+
+         How do I get the values for the siteId and apiKy?
+         1- Login or Signup in CustomerIO platform: https://fly.customer.io/
+         2- On the top right section click the
+         Settings Icon >> Workspace Settings >> API and webhook credentials
+         You will see list of one or more workspaces and each has
+         its own pair of siteId and apiKey, these are the ones
+         to use here.
+         */
+
+        let workspaceSettings = AppState.shared.workspaceSettings
+        if workspaceSettings.isSet() {
+            CustomerIO.initialize(
+                siteId: workspaceSettings.siteId,
+                apiKey: workspaceSettings.apiKey,
+                region: workspaceSettings.region
+            ) { config in
+                // Debug config just to make the demo
+                // easier. You can learn more about these configs
+                // here: https://customer.io/docs/sdk/ios/getting-started/#configuration-options
+                config.backgroundQueueMinNumberOfTasks = 1
+                config.backgroundQueueSecondsDelay = 0
+                config.logLevel = .debug
+            }
+        }
+
+        return true
+    }
+}

--- a/Apps/VisionOS/VisionOS/VisionOSApp.swift
+++ b/Apps/VisionOS/VisionOS/VisionOSApp.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 @main
 struct VisionOSApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     var body: some Scene {
         WindowGroup {
             MainScreen()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

## Context

This is a PR in a series of PRs to build sample app that runs Identify and Track in VisionPro
The app is built to be an interactive walk through guidance for developers who are integrating Customer.io Swift SDK in their VisioPro apps.
For more context:

- See the project [one pager](https://www.notion.so/custio/Spacial-Identify-and-Tracking-6587d848bbde494095c0585237326ed3?pvs=4)
- See [Linear Issue](https://linear.app/customerio/issue/MBL-115/sample-app-for-visionpro)

## PR Summary
This PR introduces fthe app delegate which will be used to initialize `CustomerIO`

## Test plan
- Open `VisionOs.xcproject`
- Hit CMD+R to run the project and make sure you have VisionOS simulator installed and selected