### PR TITLE
refactor: reduce tearDown flakiness in test suite

### DIFF
--- a/Sources/Common/Communication/EventBusHandler.swift
+++ b/Sources/Common/Communication/EventBusHandler.swift
@@ -6,6 +6,7 @@ public protocol EventBusHandler {
     func addObserver<E: EventRepresentable>(_ eventType: E.Type, action: @escaping (E) -> Void)
     func removeObserver<E: EventRepresentable>(for eventType: E.Type)
     func postEvent<E: EventRepresentable>(_ event: E)
+    func postEventAndWait<E: EventRepresentable>(_ event: E) async
     func removeFromStorage<E: EventRepresentable>(_ event: E) async
     func reset() async
 }
@@ -19,8 +20,10 @@ public protocol EventBusHandler {
 public class CioEventBusHandler: EventBusHandler {
     private let eventBus: EventBus
     private let eventCache: EventCache
-    private let eventStorage: EventStorage
-    private let logger: Logger
+    let eventStorage: EventStorage
+    let logger: Logger
+
+    @Atomic private var taskBag: TaskBag = []
 
     /// Initializes the EventBusHandler with dependencies for event bus and storage.
     /// - Parameters:
@@ -38,7 +41,11 @@ public class CioEventBusHandler: EventBusHandler {
         self.eventCache = eventCache
         self.eventStorage = eventStorage
         self.logger = logger
-        Task { await loadEventsFromStorage() }
+        taskBag += Task { await loadEventsFromStorage() }
+    }
+
+    deinit {
+        taskBag.cancelAll()
     }
 
     /// Loads events from persistent storage into in-memory storage for quick access and event replay.
@@ -69,7 +76,7 @@ public class CioEventBusHandler: EventBusHandler {
             }
         }
 
-        Task {
+        taskBag += Task {
             await eventBus.addObserver(eventType.key, action: adaptedAction)
             await replayEvents(forType: eventType, action: adaptedAction)
         }
@@ -78,7 +85,7 @@ public class CioEventBusHandler: EventBusHandler {
     /// Removes an observer for a specific event type.
     /// - Parameter eventType: The event type for which to remove the observer.
     public func removeObserver<E: EventRepresentable>(for eventType: E.Type) {
-        Task { await eventBus.removeObserver(for: E.key) }
+        taskBag += Task { await eventBus.removeObserver(for: E.key) }
     }
 
     /// Replays events of a specific type to any new observers, ensuring they receive past events.
@@ -101,14 +108,21 @@ public class CioEventBusHandler: EventBusHandler {
     /// Posts an event to the EventBus and stores it if there are no observers.
     /// - Parameter event: The event to post.
     public func postEvent<E: EventRepresentable>(_ event: E) {
+        taskBag += Task {
+            await postEventAndWait(event)
+        }
+    }
+
+    /// Version of `postEvent` that returns when the event has been posted.
+    public func postEventAndWait<E: EventRepresentable>(_ event: E) async {
         logger.debug("EventBusHandler: Posting event - \(event)")
-        Task {
-            let hasObservers = await eventBus.post(event)
-            await eventCache.addEvent(event: event)
-            if !hasObservers {
-                logger.debug("EventBusHandler: Storing event in memory - \(event)")
-                await storeEvent(event)
-            }
+
+        let hasObservers = await eventBus.post(event)
+        await eventCache.addEvent(event: event)
+
+        if !hasObservers {
+            logger.debug("EventBusHandler: Storing event in memory - \(event)")
+            await storeEvent(event)
         }
     }
 

--- a/Sources/Common/Util/TaskBag.swift
+++ b/Sources/Common/Util/TaskBag.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/*
+ A convenient data type to easily keep track of Swift async Tasks and be able to cancel them all when the class is deinitialized.
+
+ - Create instance: let taskBag: TaskBag = []
+ - Add new Tasks: taskBag += Task { ... }
+ - Cancel all tasks:
+ ```
+ deinit {
+   taskBag.cancelAll()
+ }
+ ```
+ */
+public typealias TaskBag = [Task<Void, Error>]
+
+extension TaskBag {
+    static func += (left: inout [Task<Void, Error>], right: Task<Void, Error>) {
+        left.append(right)
+    }
+
+    func cancelAll() {
+        forEach { task in
+            task.cancel()
+        }
+    }
+}

--- a/Sources/Common/autogenerated/AutoMockable.generated.swift
+++ b/Sources/Common/autogenerated/AutoMockable.generated.swift
@@ -258,16 +258,16 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
     // MARK: - identify
 
     /// Number of times the function was called.
-    public private(set) var identifyCallsCount = 0
+    @Atomic public private(set) var identifyCallsCount = 0
     /// `true` if the function was ever called.
     public var identifyCalled: Bool {
         identifyCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var identifyReceivedArguments: (userId: String, traits: [String: Any]?)?
+    @Atomic public private(set) var identifyReceivedArguments: (userId: String, traits: [String: Any]?)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var identifyReceivedInvocations: [(userId: String, traits: [String: Any]?)] = []
+    @Atomic public private(set) var identifyReceivedInvocations: [(userId: String, traits: [String: Any]?)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -285,9 +285,9 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
     // MARK: - identify<RequestBody: Codable>
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var identifyEncodableReceivedArguments: (userId: String, traits: AnyEncodable)?
+    @Atomic public private(set) var identifyEncodableReceivedArguments: (userId: String, traits: AnyEncodable)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var identifyEncodableReceivedInvocations: [(userId: String, traits: AnyEncodable)] = []
+    @Atomic public private(set) var identifyEncodableReceivedInvocations: [(userId: String, traits: AnyEncodable)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -305,7 +305,7 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
     // MARK: - clearIdentify
 
     /// Number of times the function was called.
-    public private(set) var clearIdentifyCallsCount = 0
+    @Atomic public private(set) var clearIdentifyCallsCount = 0
     /// `true` if the function was ever called.
     public var clearIdentifyCalled: Bool {
         clearIdentifyCallsCount > 0
@@ -326,16 +326,16 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
     // MARK: - registerDeviceToken
 
     /// Number of times the function was called.
-    public private(set) var registerDeviceTokenCallsCount = 0
+    @Atomic public private(set) var registerDeviceTokenCallsCount = 0
     /// `true` if the function was ever called.
     public var registerDeviceTokenCalled: Bool {
         registerDeviceTokenCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var registerDeviceTokenReceivedArguments: String?
+    @Atomic public private(set) var registerDeviceTokenReceivedArguments: String?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var registerDeviceTokenReceivedInvocations: [String] = []
+    @Atomic public private(set) var registerDeviceTokenReceivedInvocations: [String] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -353,7 +353,7 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
     // MARK: - deleteDeviceToken
 
     /// Number of times the function was called.
-    public private(set) var deleteDeviceTokenCallsCount = 0
+    @Atomic public private(set) var deleteDeviceTokenCallsCount = 0
     /// `true` if the function was ever called.
     public var deleteDeviceTokenCalled: Bool {
         deleteDeviceTokenCallsCount > 0
@@ -374,16 +374,16 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
     // MARK: - track
 
     /// Number of times the function was called.
-    public private(set) var trackCallsCount = 0
+    @Atomic public private(set) var trackCallsCount = 0
     /// `true` if the function was ever called.
     public var trackCalled: Bool {
         trackCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var trackReceivedArguments: (name: String, properties: [String: Any]?)?
+    @Atomic public private(set) var trackReceivedArguments: (name: String, properties: [String: Any]?)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var trackReceivedInvocations: [(name: String, properties: [String: Any]?)] = []
+    @Atomic public private(set) var trackReceivedInvocations: [(name: String, properties: [String: Any]?)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -401,9 +401,9 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
     // MARK: - track<RequestBody: Codable>
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var trackEncodableReceivedArguments: (name: String, properties: AnyEncodable)?
+    @Atomic public private(set) var trackEncodableReceivedArguments: (name: String, properties: AnyEncodable)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var trackEncodableReceivedInvocations: [(name: String, properties: AnyEncodable)] = []
+    @Atomic public private(set) var trackEncodableReceivedInvocations: [(name: String, properties: AnyEncodable)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -421,16 +421,16 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
     // MARK: - screen
 
     /// Number of times the function was called.
-    public private(set) var screenCallsCount = 0
+    @Atomic public private(set) var screenCallsCount = 0
     /// `true` if the function was ever called.
     public var screenCalled: Bool {
         screenCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var screenReceivedArguments: (title: String, properties: [String: Any]?)?
+    @Atomic public private(set) var screenReceivedArguments: (title: String, properties: [String: Any]?)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var screenReceivedInvocations: [(title: String, properties: [String: Any]?)] = []
+    @Atomic public private(set) var screenReceivedInvocations: [(title: String, properties: [String: Any]?)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -448,9 +448,9 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
     // MARK: - screen<RequestBody: Codable>
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var screenEncodableReceivedArguments: (title: String, properties: AnyEncodable)?
+    @Atomic public private(set) var screenEncodableReceivedArguments: (title: String, properties: AnyEncodable)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var screenEncodableReceivedInvocations: [(title: String, properties: AnyEncodable)] = []
+    @Atomic public private(set) var screenEncodableReceivedInvocations: [(title: String, properties: AnyEncodable)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -468,16 +468,16 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
     // MARK: - trackMetric
 
     /// Number of times the function was called.
-    public private(set) var trackMetricCallsCount = 0
+    @Atomic public private(set) var trackMetricCallsCount = 0
     /// `true` if the function was ever called.
     public var trackMetricCalled: Bool {
         trackMetricCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var trackMetricReceivedArguments: (deliveryID: String, event: Metric, deviceToken: String)?
+    @Atomic public private(set) var trackMetricReceivedArguments: (deliveryID: String, event: Metric, deviceToken: String)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var trackMetricReceivedInvocations: [(deliveryID: String, event: Metric, deviceToken: String)] = []
+    @Atomic public private(set) var trackMetricReceivedInvocations: [(deliveryID: String, event: Metric, deviceToken: String)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -864,16 +864,16 @@ public class DeviceInfoMock: DeviceInfo, Mock {
     // MARK: - isPushSubscribed
 
     /// Number of times the function was called.
-    public private(set) var isPushSubscribedCallsCount = 0
+    @Atomic public private(set) var isPushSubscribedCallsCount = 0
     /// `true` if the function was ever called.
     public var isPushSubscribedCalled: Bool {
         isPushSubscribedCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var isPushSubscribedReceivedArguments: ((Bool) -> Void)?
+    @Atomic public private(set) var isPushSubscribedReceivedArguments: ((Bool) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var isPushSubscribedReceivedInvocations: [(Bool) -> Void] = []
+    @Atomic public private(set) var isPushSubscribedReceivedInvocations: [(Bool) -> Void] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -986,16 +986,16 @@ public class EventBusMock: EventBus, Mock {
     // MARK: - post
 
     /// Number of times the function was called.
-    public private(set) var postCallsCount = 0
+    @Atomic public private(set) var postCallsCount = 0
     /// `true` if the function was ever called.
     public var postCalled: Bool {
         postCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var postReceivedArguments: AnyEventRepresentable?
+    @Atomic public private(set) var postReceivedArguments: AnyEventRepresentable?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var postReceivedInvocations: [AnyEventRepresentable] = []
+    @Atomic public private(set) var postReceivedInvocations: [AnyEventRepresentable] = []
     /// Value to return from the mocked function.
     public var postReturnValue: Bool!
     /**
@@ -1018,16 +1018,16 @@ public class EventBusMock: EventBus, Mock {
     // MARK: - addObserver
 
     /// Number of times the function was called.
-    public private(set) var addObserverCallsCount = 0
+    @Atomic public private(set) var addObserverCallsCount = 0
     /// `true` if the function was ever called.
     public var addObserverCalled: Bool {
         addObserverCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var addObserverReceivedArguments: (eventType: String, action: (AnyEventRepresentable) -> Void)?
+    @Atomic public private(set) var addObserverReceivedArguments: (eventType: String, action: (AnyEventRepresentable) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var addObserverReceivedInvocations: [(eventType: String, action: (AnyEventRepresentable) -> Void)] = []
+    @Atomic public private(set) var addObserverReceivedInvocations: [(eventType: String, action: (AnyEventRepresentable) -> Void)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -1045,16 +1045,16 @@ public class EventBusMock: EventBus, Mock {
     // MARK: - removeObserver
 
     /// Number of times the function was called.
-    public private(set) var removeObserverCallsCount = 0
+    @Atomic public private(set) var removeObserverCallsCount = 0
     /// `true` if the function was ever called.
     public var removeObserverCalled: Bool {
         removeObserverCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var removeObserverReceivedArguments: String?
+    @Atomic public private(set) var removeObserverReceivedArguments: String?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var removeObserverReceivedInvocations: [String] = []
+    @Atomic public private(set) var removeObserverReceivedInvocations: [String] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -1072,7 +1072,7 @@ public class EventBusMock: EventBus, Mock {
     // MARK: - removeAllObservers
 
     /// Number of times the function was called.
-    public private(set) var removeAllObserversCallsCount = 0
+    @Atomic public private(set) var removeAllObserversCallsCount = 0
     /// `true` if the function was ever called.
     public var removeAllObserversCalled: Bool {
         removeAllObserversCallsCount > 0
@@ -1132,16 +1132,16 @@ public class EventCacheMock: EventCache, Mock {
     // MARK: - addEvent
 
     /// Number of times the function was called.
-    public private(set) var addEventCallsCount = 0
+    @Atomic public private(set) var addEventCallsCount = 0
     /// `true` if the function was ever called.
     public var addEventCalled: Bool {
         addEventCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var addEventReceivedArguments: AnyEventRepresentable?
+    @Atomic public private(set) var addEventReceivedArguments: AnyEventRepresentable?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var addEventReceivedInvocations: [AnyEventRepresentable] = []
+    @Atomic public private(set) var addEventReceivedInvocations: [AnyEventRepresentable] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -1159,16 +1159,16 @@ public class EventCacheMock: EventCache, Mock {
     // MARK: - storeEvents
 
     /// Number of times the function was called.
-    public private(set) var storeEventsCallsCount = 0
+    @Atomic public private(set) var storeEventsCallsCount = 0
     /// `true` if the function was ever called.
     public var storeEventsCalled: Bool {
         storeEventsCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var storeEventsReceivedArguments: (events: [AnyEventRepresentable], key: String)?
+    @Atomic public private(set) var storeEventsReceivedArguments: (events: [AnyEventRepresentable], key: String)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var storeEventsReceivedInvocations: [(events: [AnyEventRepresentable], key: String)] = []
+    @Atomic public private(set) var storeEventsReceivedInvocations: [(events: [AnyEventRepresentable], key: String)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -1186,16 +1186,16 @@ public class EventCacheMock: EventCache, Mock {
     // MARK: - getEvent
 
     /// Number of times the function was called.
-    public private(set) var getEventCallsCount = 0
+    @Atomic public private(set) var getEventCallsCount = 0
     /// `true` if the function was ever called.
     public var getEventCalled: Bool {
         getEventCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var getEventReceivedArguments: String?
+    @Atomic public private(set) var getEventReceivedArguments: String?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var getEventReceivedInvocations: [String] = []
+    @Atomic public private(set) var getEventReceivedInvocations: [String] = []
     /// Value to return from the mocked function.
     public var getEventReturnValue: [AnyEventRepresentable]!
     /**
@@ -1217,16 +1217,16 @@ public class EventCacheMock: EventCache, Mock {
     // MARK: - removeAllEventsForKey
 
     /// Number of times the function was called.
-    public private(set) var removeAllEventsForKeyCallsCount = 0
+    @Atomic public private(set) var removeAllEventsForKeyCallsCount = 0
     /// `true` if the function was ever called.
     public var removeAllEventsForKeyCalled: Bool {
         removeAllEventsForKeyCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var removeAllEventsForKeyReceivedArguments: String?
+    @Atomic public private(set) var removeAllEventsForKeyReceivedArguments: String?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var removeAllEventsForKeyReceivedInvocations: [String] = []
+    @Atomic public private(set) var removeAllEventsForKeyReceivedInvocations: [String] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -1287,16 +1287,16 @@ public class EventStorageMock: EventStorage, Mock {
 
     var storeThrowableError: Error?
     /// Number of times the function was called.
-    public private(set) var storeCallsCount = 0
+    @Atomic public private(set) var storeCallsCount = 0
     /// `true` if the function was ever called.
     public var storeCalled: Bool {
         storeCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var storeReceivedArguments: AnyEventRepresentable?
+    @Atomic public private(set) var storeReceivedArguments: AnyEventRepresentable?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var storeReceivedInvocations: [AnyEventRepresentable] = []
+    @Atomic public private(set) var storeReceivedInvocations: [AnyEventRepresentable] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -1318,16 +1318,16 @@ public class EventStorageMock: EventStorage, Mock {
 
     var retrieveThrowableError: Error?
     /// Number of times the function was called.
-    public private(set) var retrieveCallsCount = 0
+    @Atomic public private(set) var retrieveCallsCount = 0
     /// `true` if the function was ever called.
     public var retrieveCalled: Bool {
         retrieveCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var retrieveReceivedArguments: (eventType: String, storageId: String)?
+    @Atomic public private(set) var retrieveReceivedArguments: (eventType: String, storageId: String)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var retrieveReceivedInvocations: [(eventType: String, storageId: String)] = []
+    @Atomic public private(set) var retrieveReceivedInvocations: [(eventType: String, storageId: String)] = []
     /// Value to return from the mocked function.
     public var retrieveReturnValue: AnyEventRepresentable?
     /**
@@ -1353,16 +1353,16 @@ public class EventStorageMock: EventStorage, Mock {
 
     var loadEventsThrowableError: Error?
     /// Number of times the function was called.
-    public private(set) var loadEventsCallsCount = 0
+    @Atomic public private(set) var loadEventsCallsCount = 0
     /// `true` if the function was ever called.
     public var loadEventsCalled: Bool {
         loadEventsCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var loadEventsReceivedArguments: String?
+    @Atomic public private(set) var loadEventsReceivedArguments: String?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var loadEventsReceivedInvocations: [String] = []
+    @Atomic public private(set) var loadEventsReceivedInvocations: [String] = []
     /// Value to return from the mocked function.
     public var loadEventsReturnValue: [AnyEventRepresentable]!
     /**
@@ -1387,16 +1387,16 @@ public class EventStorageMock: EventStorage, Mock {
     // MARK: - remove
 
     /// Number of times the function was called.
-    public private(set) var removeCallsCount = 0
+    @Atomic public private(set) var removeCallsCount = 0
     /// `true` if the function was ever called.
     public var removeCalled: Bool {
         removeCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var removeReceivedArguments: (eventType: String, storageId: String)?
+    @Atomic public private(set) var removeReceivedArguments: (eventType: String, storageId: String)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var removeReceivedInvocations: [(eventType: String, storageId: String)] = []
+    @Atomic public private(set) var removeReceivedInvocations: [(eventType: String, storageId: String)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -1414,7 +1414,7 @@ public class EventStorageMock: EventStorage, Mock {
     // MARK: - removeAll
 
     /// Number of times the function was called.
-    public private(set) var removeAllCallsCount = 0
+    @Atomic public private(set) var removeAllCallsCount = 0
     /// `true` if the function was ever called.
     public var removeAllCalled: Bool {
         removeAllCallsCount > 0
@@ -1469,16 +1469,16 @@ public class FileStorageMock: FileStorage, Mock {
     // MARK: - save
 
     /// Number of times the function was called.
-    public private(set) var saveCallsCount = 0
+    @Atomic public private(set) var saveCallsCount = 0
     /// `true` if the function was ever called.
     public var saveCalled: Bool {
         saveCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var saveReceivedArguments: (siteId: String, type: FileType, contents: Data, fileId: String?)?
+    @Atomic public private(set) var saveReceivedArguments: (siteId: String, type: FileType, contents: Data, fileId: String?)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var saveReceivedInvocations: [(siteId: String, type: FileType, contents: Data, fileId: String?)] = []
+    @Atomic public private(set) var saveReceivedInvocations: [(siteId: String, type: FileType, contents: Data, fileId: String?)] = []
     /// Value to return from the mocked function.
     public var saveReturnValue: Bool!
     /**
@@ -1500,16 +1500,16 @@ public class FileStorageMock: FileStorage, Mock {
     // MARK: - get
 
     /// Number of times the function was called.
-    public private(set) var getCallsCount = 0
+    @Atomic public private(set) var getCallsCount = 0
     /// `true` if the function was ever called.
     public var getCalled: Bool {
         getCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var getReceivedArguments: (siteId: String, type: FileType, fileId: String?)?
+    @Atomic public private(set) var getReceivedArguments: (siteId: String, type: FileType, fileId: String?)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var getReceivedInvocations: [(siteId: String, type: FileType, fileId: String?)] = []
+    @Atomic public private(set) var getReceivedInvocations: [(siteId: String, type: FileType, fileId: String?)] = []
     /// Value to return from the mocked function.
     public var getReturnValue: Data?
     /**
@@ -1531,16 +1531,16 @@ public class FileStorageMock: FileStorage, Mock {
     // MARK: - delete
 
     /// Number of times the function was called.
-    public private(set) var deleteCallsCount = 0
+    @Atomic public private(set) var deleteCallsCount = 0
     /// `true` if the function was ever called.
     public var deleteCalled: Bool {
         deleteCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var deleteReceivedArguments: (siteId: String, type: FileType, fileId: String)?
+    @Atomic public private(set) var deleteReceivedArguments: (siteId: String, type: FileType, fileId: String)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var deleteReceivedInvocations: [(siteId: String, type: FileType, fileId: String)] = []
+    @Atomic public private(set) var deleteReceivedInvocations: [(siteId: String, type: FileType, fileId: String)] = []
     /// Value to return from the mocked function.
     public var deleteReturnValue: Bool!
     /**
@@ -1623,7 +1623,7 @@ public class GlobalDataStoreMock: GlobalDataStore, Mock {
     // MARK: - deleteAll
 
     /// Number of times the function was called.
-    public private(set) var deleteAllCallsCount = 0
+    @Atomic public private(set) var deleteAllCallsCount = 0
     /// `true` if the function was ever called.
     public var deleteAllCalled: Bool {
         deleteAllCallsCount > 0
@@ -1678,16 +1678,16 @@ public class HttpClientMock: HttpClient, Mock {
     // MARK: - request
 
     /// Number of times the function was called.
-    public private(set) var requestCallsCount = 0
+    @Atomic public private(set) var requestCallsCount = 0
     /// `true` if the function was ever called.
     public var requestCalled: Bool {
         requestCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var requestReceivedArguments: (params: HttpRequestParams, onComplete: (Result<Data, HttpRequestError>) -> Void)?
+    @Atomic public private(set) var requestReceivedArguments: (params: HttpRequestParams, onComplete: (Result<Data, HttpRequestError>) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var requestReceivedInvocations: [(params: HttpRequestParams, onComplete: (Result<Data, HttpRequestError>) -> Void)] = []
+    @Atomic public private(set) var requestReceivedInvocations: [(params: HttpRequestParams, onComplete: (Result<Data, HttpRequestError>) -> Void)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -1705,16 +1705,16 @@ public class HttpClientMock: HttpClient, Mock {
     // MARK: - downloadFile
 
     /// Number of times the function was called.
-    public private(set) var downloadFileCallsCount = 0
+    @Atomic public private(set) var downloadFileCallsCount = 0
     /// `true` if the function was ever called.
     public var downloadFileCalled: Bool {
         downloadFileCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var downloadFileReceivedArguments: (url: URL, fileType: DownloadFileType, onComplete: (URL?) -> Void)?
+    @Atomic public private(set) var downloadFileReceivedArguments: (url: URL, fileType: DownloadFileType, onComplete: (URL?) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var downloadFileReceivedInvocations: [(url: URL, fileType: DownloadFileType, onComplete: (URL?) -> Void)] = []
+    @Atomic public private(set) var downloadFileReceivedInvocations: [(url: URL, fileType: DownloadFileType, onComplete: (URL?) -> Void)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -1732,16 +1732,16 @@ public class HttpClientMock: HttpClient, Mock {
     // MARK: - cancel
 
     /// Number of times the function was called.
-    public private(set) var cancelCallsCount = 0
+    @Atomic public private(set) var cancelCallsCount = 0
     /// `true` if the function was ever called.
     public var cancelCalled: Bool {
         cancelCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var cancelReceivedArguments: Bool?
+    @Atomic public private(set) var cancelReceivedArguments: Bool?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var cancelReceivedInvocations: [Bool] = []
+    @Atomic public private(set) var cancelReceivedInvocations: [Bool] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -1788,16 +1788,16 @@ public class HttpRequestRunnerMock: HttpRequestRunner, Mock {
     // MARK: - request
 
     /// Number of times the function was called.
-    public private(set) var requestCallsCount = 0
+    @Atomic public private(set) var requestCallsCount = 0
     /// `true` if the function was ever called.
     public var requestCalled: Bool {
         requestCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var requestReceivedArguments: (params: HttpRequestParams, session: URLSession, onComplete: (Data?, HTTPURLResponse?, Error?) -> Void)?
+    @Atomic public private(set) var requestReceivedArguments: (params: HttpRequestParams, session: URLSession, onComplete: (Data?, HTTPURLResponse?, Error?) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var requestReceivedInvocations: [(params: HttpRequestParams, session: URLSession, onComplete: (Data?, HTTPURLResponse?, Error?) -> Void)] = []
+    @Atomic public private(set) var requestReceivedInvocations: [(params: HttpRequestParams, session: URLSession, onComplete: (Data?, HTTPURLResponse?, Error?) -> Void)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -1815,16 +1815,16 @@ public class HttpRequestRunnerMock: HttpRequestRunner, Mock {
     // MARK: - downloadFile
 
     /// Number of times the function was called.
-    public private(set) var downloadFileCallsCount = 0
+    @Atomic public private(set) var downloadFileCallsCount = 0
     /// `true` if the function was ever called.
     public var downloadFileCalled: Bool {
         downloadFileCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var downloadFileReceivedArguments: (url: URL, fileType: DownloadFileType, session: URLSession, onComplete: (URL?) -> Void)?
+    @Atomic public private(set) var downloadFileReceivedArguments: (url: URL, fileType: DownloadFileType, session: URLSession, onComplete: (URL?) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var downloadFileReceivedInvocations: [(url: URL, fileType: DownloadFileType, session: URLSession, onComplete: (URL?) -> Void)] = []
+    @Atomic public private(set) var downloadFileReceivedInvocations: [(url: URL, fileType: DownloadFileType, session: URLSession, onComplete: (URL?) -> Void)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -1919,16 +1919,16 @@ public class LoggerMock: Logger, Mock {
     // MARK: - setLogLevel
 
     /// Number of times the function was called.
-    public private(set) var setLogLevelCallsCount = 0
+    @Atomic public private(set) var setLogLevelCallsCount = 0
     /// `true` if the function was ever called.
     public var setLogLevelCalled: Bool {
         setLogLevelCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var setLogLevelReceivedArguments: CioLogLevel?
+    @Atomic public private(set) var setLogLevelReceivedArguments: CioLogLevel?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var setLogLevelReceivedInvocations: [CioLogLevel] = []
+    @Atomic public private(set) var setLogLevelReceivedInvocations: [CioLogLevel] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -1946,16 +1946,16 @@ public class LoggerMock: Logger, Mock {
     // MARK: - debug
 
     /// Number of times the function was called.
-    public private(set) var debugCallsCount = 0
+    @Atomic public private(set) var debugCallsCount = 0
     /// `true` if the function was ever called.
     public var debugCalled: Bool {
         debugCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var debugReceivedArguments: String?
+    @Atomic public private(set) var debugReceivedArguments: String?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var debugReceivedInvocations: [String] = []
+    @Atomic public private(set) var debugReceivedInvocations: [String] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -1973,16 +1973,16 @@ public class LoggerMock: Logger, Mock {
     // MARK: - info
 
     /// Number of times the function was called.
-    public private(set) var infoCallsCount = 0
+    @Atomic public private(set) var infoCallsCount = 0
     /// `true` if the function was ever called.
     public var infoCalled: Bool {
         infoCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var infoReceivedArguments: String?
+    @Atomic public private(set) var infoReceivedArguments: String?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var infoReceivedInvocations: [String] = []
+    @Atomic public private(set) var infoReceivedInvocations: [String] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -2000,16 +2000,16 @@ public class LoggerMock: Logger, Mock {
     // MARK: - error
 
     /// Number of times the function was called.
-    public private(set) var errorCallsCount = 0
+    @Atomic public private(set) var errorCallsCount = 0
     /// `true` if the function was ever called.
     public var errorCalled: Bool {
         errorCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var errorReceivedArguments: String?
+    @Atomic public private(set) var errorReceivedArguments: String?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var errorReceivedInvocations: [String] = []
+    @Atomic public private(set) var errorReceivedInvocations: [String] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -2056,16 +2056,16 @@ public class ProfileStoreMock: ProfileStore, Mock {
     // MARK: - getProfileId
 
     /// Number of times the function was called.
-    public private(set) var getProfileIdCallsCount = 0
+    @Atomic public private(set) var getProfileIdCallsCount = 0
     /// `true` if the function was ever called.
     public var getProfileIdCalled: Bool {
         getProfileIdCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var getProfileIdReceivedArguments: String?
+    @Atomic public private(set) var getProfileIdReceivedArguments: String?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var getProfileIdReceivedInvocations: [String] = []
+    @Atomic public private(set) var getProfileIdReceivedInvocations: [String] = []
     /// Value to return from the mocked function.
     public var getProfileIdReturnValue: String?
     /**
@@ -2087,16 +2087,16 @@ public class ProfileStoreMock: ProfileStore, Mock {
     // MARK: - deleteProfileId
 
     /// Number of times the function was called.
-    public private(set) var deleteProfileIdCallsCount = 0
+    @Atomic public private(set) var deleteProfileIdCallsCount = 0
     /// `true` if the function was ever called.
     public var deleteProfileIdCalled: Bool {
         deleteProfileIdCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var deleteProfileIdReceivedArguments: String?
+    @Atomic public private(set) var deleteProfileIdReceivedArguments: String?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var deleteProfileIdReceivedInvocations: [String] = []
+    @Atomic public private(set) var deleteProfileIdReceivedInvocations: [String] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -2148,16 +2148,16 @@ public class QueueMock: Queue, Mock {
     // MARK: - getAllStoredTasks
 
     /// Number of times the function was called.
-    public private(set) var getAllStoredTasksCallsCount = 0
+    @Atomic public private(set) var getAllStoredTasksCallsCount = 0
     /// `true` if the function was ever called.
     public var getAllStoredTasksCalled: Bool {
         getAllStoredTasksCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var getAllStoredTasksReceivedArguments: String?
+    @Atomic public private(set) var getAllStoredTasksReceivedArguments: String?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var getAllStoredTasksReceivedInvocations: [String] = []
+    @Atomic public private(set) var getAllStoredTasksReceivedInvocations: [String] = []
     /// Value to return from the mocked function.
     public var getAllStoredTasksReturnValue: [QueueTaskMetadata]!
     /**
@@ -2179,16 +2179,16 @@ public class QueueMock: Queue, Mock {
     // MARK: - getTaskDetail
 
     /// Number of times the function was called.
-    public private(set) var getTaskDetailCallsCount = 0
+    @Atomic public private(set) var getTaskDetailCallsCount = 0
     /// `true` if the function was ever called.
     public var getTaskDetailCalled: Bool {
         getTaskDetailCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var getTaskDetailReceivedArguments: (task: QueueTaskMetadata, siteId: String)?
+    @Atomic public private(set) var getTaskDetailReceivedArguments: (task: QueueTaskMetadata, siteId: String)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var getTaskDetailReceivedInvocations: [(task: QueueTaskMetadata, siteId: String)] = []
+    @Atomic public private(set) var getTaskDetailReceivedInvocations: [(task: QueueTaskMetadata, siteId: String)] = []
     /// Value to return from the mocked function.
     public var getTaskDetailReturnValue: TaskDetail?
     /**
@@ -2210,16 +2210,16 @@ public class QueueMock: Queue, Mock {
     // MARK: - deleteProcessedTask
 
     /// Number of times the function was called.
-    public private(set) var deleteProcessedTaskCallsCount = 0
+    @Atomic public private(set) var deleteProcessedTaskCallsCount = 0
     /// `true` if the function was ever called.
     public var deleteProcessedTaskCalled: Bool {
         deleteProcessedTaskCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var deleteProcessedTaskReceivedArguments: (task: QueueTaskMetadata, siteId: String)?
+    @Atomic public private(set) var deleteProcessedTaskReceivedArguments: (task: QueueTaskMetadata, siteId: String)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var deleteProcessedTaskReceivedInvocations: [(task: QueueTaskMetadata, siteId: String)] = []
+    @Atomic public private(set) var deleteProcessedTaskReceivedInvocations: [(task: QueueTaskMetadata, siteId: String)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -2271,16 +2271,16 @@ public class QueueStorageMock: QueueStorage, Mock {
     // MARK: - getInventory
 
     /// Number of times the function was called.
-    public private(set) var getInventoryCallsCount = 0
+    @Atomic public private(set) var getInventoryCallsCount = 0
     /// `true` if the function was ever called.
     public var getInventoryCalled: Bool {
         getInventoryCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var getInventoryReceivedArguments: String?
+    @Atomic public private(set) var getInventoryReceivedArguments: String?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var getInventoryReceivedInvocations: [String] = []
+    @Atomic public private(set) var getInventoryReceivedInvocations: [String] = []
     /// Value to return from the mocked function.
     public var getInventoryReturnValue: [QueueTaskMetadata]!
     /**
@@ -2302,16 +2302,16 @@ public class QueueStorageMock: QueueStorage, Mock {
     // MARK: - get
 
     /// Number of times the function was called.
-    public private(set) var getCallsCount = 0
+    @Atomic public private(set) var getCallsCount = 0
     /// `true` if the function was ever called.
     public var getCalled: Bool {
         getCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var getReceivedArguments: (storageId: String, siteId: String)?
+    @Atomic public private(set) var getReceivedArguments: (storageId: String, siteId: String)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var getReceivedInvocations: [(storageId: String, siteId: String)] = []
+    @Atomic public private(set) var getReceivedInvocations: [(storageId: String, siteId: String)] = []
     /// Value to return from the mocked function.
     public var getReturnValue: QueueTask?
     /**
@@ -2333,16 +2333,16 @@ public class QueueStorageMock: QueueStorage, Mock {
     // MARK: - delete
 
     /// Number of times the function was called.
-    public private(set) var deleteCallsCount = 0
+    @Atomic public private(set) var deleteCallsCount = 0
     /// `true` if the function was ever called.
     public var deleteCalled: Bool {
         deleteCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var deleteReceivedArguments: (storageId: String, siteId: String)?
+    @Atomic public private(set) var deleteReceivedArguments: (storageId: String, siteId: String)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var deleteReceivedInvocations: [(storageId: String, siteId: String)] = []
+    @Atomic public private(set) var deleteReceivedInvocations: [(storageId: String, siteId: String)] = []
     /// Value to return from the mocked function.
     public var deleteReturnValue: Bool!
     /**
@@ -2396,16 +2396,16 @@ class SimpleTimerMock: SimpleTimer, Mock {
     // MARK: - scheduleAndCancelPrevious
 
     /// Number of times the function was called.
-    private(set) var scheduleAndCancelPreviousCallsCount = 0
+    @Atomic private(set) var scheduleAndCancelPreviousCallsCount = 0
     /// `true` if the function was ever called.
     var scheduleAndCancelPreviousCalled: Bool {
         scheduleAndCancelPreviousCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    private(set) var scheduleAndCancelPreviousReceivedArguments: (seconds: Seconds, block: () -> Void)?
+    @Atomic private(set) var scheduleAndCancelPreviousReceivedArguments: (seconds: Seconds, block: () -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    private(set) var scheduleAndCancelPreviousReceivedInvocations: [(seconds: Seconds, block: () -> Void)] = []
+    @Atomic private(set) var scheduleAndCancelPreviousReceivedInvocations: [(seconds: Seconds, block: () -> Void)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -2423,16 +2423,16 @@ class SimpleTimerMock: SimpleTimer, Mock {
     // MARK: - scheduleIfNotAlready
 
     /// Number of times the function was called.
-    private(set) var scheduleIfNotAlreadyCallsCount = 0
+    @Atomic private(set) var scheduleIfNotAlreadyCallsCount = 0
     /// `true` if the function was ever called.
     var scheduleIfNotAlreadyCalled: Bool {
         scheduleIfNotAlreadyCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    private(set) var scheduleIfNotAlreadyReceivedArguments: (seconds: Seconds, block: () -> Void)?
+    @Atomic private(set) var scheduleIfNotAlreadyReceivedArguments: (seconds: Seconds, block: () -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    private(set) var scheduleIfNotAlreadyReceivedInvocations: [(seconds: Seconds, block: () -> Void)] = []
+    @Atomic private(set) var scheduleIfNotAlreadyReceivedInvocations: [(seconds: Seconds, block: () -> Void)] = []
     /// Value to return from the mocked function.
     var scheduleIfNotAlreadyReturnValue: Bool!
     /**
@@ -2454,7 +2454,7 @@ class SimpleTimerMock: SimpleTimer, Mock {
     // MARK: - cancel
 
     /// Number of times the function was called.
-    private(set) var cancelCallsCount = 0
+    @Atomic private(set) var cancelCallsCount = 0
     /// `true` if the function was ever called.
     var cancelCalled: Bool {
         cancelCallsCount > 0
@@ -2502,16 +2502,16 @@ class SingleScheduleTimerMock: SingleScheduleTimer, Mock {
     // MARK: - scheduleIfNotAlready
 
     /// Number of times the function was called.
-    private(set) var scheduleIfNotAlreadyCallsCount = 0
+    @Atomic private(set) var scheduleIfNotAlreadyCallsCount = 0
     /// `true` if the function was ever called.
     var scheduleIfNotAlreadyCalled: Bool {
         scheduleIfNotAlreadyCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    private(set) var scheduleIfNotAlreadyReceivedArguments: (seconds: Seconds, block: () -> Void)?
+    @Atomic private(set) var scheduleIfNotAlreadyReceivedArguments: (seconds: Seconds, block: () -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    private(set) var scheduleIfNotAlreadyReceivedInvocations: [(seconds: Seconds, block: () -> Void)] = []
+    @Atomic private(set) var scheduleIfNotAlreadyReceivedInvocations: [(seconds: Seconds, block: () -> Void)] = []
     /// Value to return from the mocked function.
     var scheduleIfNotAlreadyReturnValue: Bool!
     /**
@@ -2533,7 +2533,7 @@ class SingleScheduleTimerMock: SingleScheduleTimer, Mock {
     // MARK: - cancel
 
     /// Number of times the function was called.
-    private(set) var cancelCallsCount = 0
+    @Atomic private(set) var cancelCallsCount = 0
     /// `true` if the function was ever called.
     var cancelCalled: Bool {
         cancelCallsCount > 0
@@ -2584,16 +2584,16 @@ public class UIKitWrapperMock: UIKitWrapper, Mock {
     // MARK: - open
 
     /// Number of times the function was called.
-    public private(set) var openCallsCount = 0
+    @Atomic public private(set) var openCallsCount = 0
     /// `true` if the function was ever called.
     public var openCalled: Bool {
         openCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var openReceivedArguments: URL?
+    @Atomic public private(set) var openReceivedArguments: URL?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var openReceivedInvocations: [URL] = []
+    @Atomic public private(set) var openReceivedInvocations: [URL] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -2611,16 +2611,16 @@ public class UIKitWrapperMock: UIKitWrapper, Mock {
     // MARK: - continueNSUserActivity
 
     /// Number of times the function was called.
-    public private(set) var continueNSUserActivityCallsCount = 0
+    @Atomic public private(set) var continueNSUserActivityCallsCount = 0
     /// `true` if the function was ever called.
     public var continueNSUserActivityCalled: Bool {
         continueNSUserActivityCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var continueNSUserActivityReceivedArguments: URL?
+    @Atomic public private(set) var continueNSUserActivityReceivedArguments: URL?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var continueNSUserActivityReceivedInvocations: [URL] = []
+    @Atomic public private(set) var continueNSUserActivityReceivedInvocations: [URL] = []
     /// Value to return from the mocked function.
     public var continueNSUserActivityReturnValue: Bool!
     /**
@@ -2664,7 +2664,7 @@ public class UserAgentUtilMock: UserAgentUtil, Mock {
     // MARK: - getUserAgentHeaderValue
 
     /// Number of times the function was called.
-    public private(set) var getUserAgentHeaderValueCallsCount = 0
+    @Atomic public private(set) var getUserAgentHeaderValueCallsCount = 0
     /// `true` if the function was ever called.
     public var getUserAgentHeaderValueCalled: Bool {
         getUserAgentHeaderValueCallsCount > 0

--- a/Sources/DataPipeline/autogenerated/AutoMockable.generated.swift
+++ b/Sources/DataPipeline/autogenerated/AutoMockable.generated.swift
@@ -106,16 +106,16 @@ class DeviceAttributesProviderMock: DeviceAttributesProvider, Mock {
     // MARK: - getDefaultDeviceAttributes
 
     /// Number of times the function was called.
-    private(set) var getDefaultDeviceAttributesCallsCount = 0
+    @Atomic private(set) var getDefaultDeviceAttributesCallsCount = 0
     /// `true` if the function was ever called.
     var getDefaultDeviceAttributesCalled: Bool {
         getDefaultDeviceAttributesCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    private(set) var getDefaultDeviceAttributesReceivedArguments: (([String: Any]) -> Void)?
+    @Atomic private(set) var getDefaultDeviceAttributesReceivedArguments: (([String: Any]) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    private(set) var getDefaultDeviceAttributesReceivedInvocations: [([String: Any]) -> Void] = []
+    @Atomic private(set) var getDefaultDeviceAttributesReceivedInvocations: [([String: Any]) -> Void] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */

--- a/Sources/MessagingInApp/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingInApp/autogenerated/AutoMockable.generated.swift
@@ -121,16 +121,16 @@ public class InAppEventListenerMock: InAppEventListener, Mock {
     // MARK: - messageShown
 
     /// Number of times the function was called.
-    public private(set) var messageShownCallsCount = 0
+    @Atomic public private(set) var messageShownCallsCount = 0
     /// `true` if the function was ever called.
     public var messageShownCalled: Bool {
         messageShownCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var messageShownReceivedArguments: InAppMessage?
+    @Atomic public private(set) var messageShownReceivedArguments: InAppMessage?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var messageShownReceivedInvocations: [InAppMessage] = []
+    @Atomic public private(set) var messageShownReceivedInvocations: [InAppMessage] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -148,16 +148,16 @@ public class InAppEventListenerMock: InAppEventListener, Mock {
     // MARK: - messageDismissed
 
     /// Number of times the function was called.
-    public private(set) var messageDismissedCallsCount = 0
+    @Atomic public private(set) var messageDismissedCallsCount = 0
     /// `true` if the function was ever called.
     public var messageDismissedCalled: Bool {
         messageDismissedCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var messageDismissedReceivedArguments: InAppMessage?
+    @Atomic public private(set) var messageDismissedReceivedArguments: InAppMessage?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var messageDismissedReceivedInvocations: [InAppMessage] = []
+    @Atomic public private(set) var messageDismissedReceivedInvocations: [InAppMessage] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -175,16 +175,16 @@ public class InAppEventListenerMock: InAppEventListener, Mock {
     // MARK: - errorWithMessage
 
     /// Number of times the function was called.
-    public private(set) var errorWithMessageCallsCount = 0
+    @Atomic public private(set) var errorWithMessageCallsCount = 0
     /// `true` if the function was ever called.
     public var errorWithMessageCalled: Bool {
         errorWithMessageCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var errorWithMessageReceivedArguments: InAppMessage?
+    @Atomic public private(set) var errorWithMessageReceivedArguments: InAppMessage?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var errorWithMessageReceivedInvocations: [InAppMessage] = []
+    @Atomic public private(set) var errorWithMessageReceivedInvocations: [InAppMessage] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -202,16 +202,16 @@ public class InAppEventListenerMock: InAppEventListener, Mock {
     // MARK: - messageActionTaken
 
     /// Number of times the function was called.
-    public private(set) var messageActionTakenCallsCount = 0
+    @Atomic public private(set) var messageActionTakenCallsCount = 0
     /// `true` if the function was ever called.
     public var messageActionTakenCalled: Bool {
         messageActionTakenCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var messageActionTakenReceivedArguments: (message: InAppMessage, actionValue: String, actionName: String)?
+    @Atomic public private(set) var messageActionTakenReceivedArguments: (message: InAppMessage, actionValue: String, actionName: String)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var messageActionTakenReceivedInvocations: [(message: InAppMessage, actionValue: String, actionName: String)] = []
+    @Atomic public private(set) var messageActionTakenReceivedInvocations: [(message: InAppMessage, actionValue: String, actionName: String)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -269,16 +269,16 @@ class InAppProviderMock: InAppProvider, Mock {
     // MARK: - initialize
 
     /// Number of times the function was called.
-    private(set) var initializeCallsCount = 0
+    @Atomic private(set) var initializeCallsCount = 0
     /// `true` if the function was ever called.
     var initializeCalled: Bool {
         initializeCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    private(set) var initializeReceivedArguments: (siteId: String, region: Region, delegate: GistDelegate, enableLogging: Bool)?
+    @Atomic private(set) var initializeReceivedArguments: (siteId: String, region: Region, delegate: GistDelegate, enableLogging: Bool)?
     /// Arguments from *all* of the times that the function was called.
-    private(set) var initializeReceivedInvocations: [(siteId: String, region: Region, delegate: GistDelegate, enableLogging: Bool)] = []
+    @Atomic private(set) var initializeReceivedInvocations: [(siteId: String, region: Region, delegate: GistDelegate, enableLogging: Bool)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -296,16 +296,16 @@ class InAppProviderMock: InAppProvider, Mock {
     // MARK: - setProfileIdentifier
 
     /// Number of times the function was called.
-    private(set) var setProfileIdentifierCallsCount = 0
+    @Atomic private(set) var setProfileIdentifierCallsCount = 0
     /// `true` if the function was ever called.
     var setProfileIdentifierCalled: Bool {
         setProfileIdentifierCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    private(set) var setProfileIdentifierReceivedArguments: String?
+    @Atomic private(set) var setProfileIdentifierReceivedArguments: String?
     /// Arguments from *all* of the times that the function was called.
-    private(set) var setProfileIdentifierReceivedInvocations: [String] = []
+    @Atomic private(set) var setProfileIdentifierReceivedInvocations: [String] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -323,7 +323,7 @@ class InAppProviderMock: InAppProvider, Mock {
     // MARK: - clearIdentify
 
     /// Number of times the function was called.
-    private(set) var clearIdentifyCallsCount = 0
+    @Atomic private(set) var clearIdentifyCallsCount = 0
     /// `true` if the function was ever called.
     var clearIdentifyCalled: Bool {
         clearIdentifyCallsCount > 0
@@ -344,16 +344,16 @@ class InAppProviderMock: InAppProvider, Mock {
     // MARK: - setRoute
 
     /// Number of times the function was called.
-    private(set) var setRouteCallsCount = 0
+    @Atomic private(set) var setRouteCallsCount = 0
     /// `true` if the function was ever called.
     var setRouteCalled: Bool {
         setRouteCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    private(set) var setRouteReceivedArguments: String?
+    @Atomic private(set) var setRouteReceivedArguments: String?
     /// Arguments from *all* of the times that the function was called.
-    private(set) var setRouteReceivedInvocations: [String] = []
+    @Atomic private(set) var setRouteReceivedInvocations: [String] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -371,7 +371,7 @@ class InAppProviderMock: InAppProvider, Mock {
     // MARK: - dismissMessage
 
     /// Number of times the function was called.
-    private(set) var dismissMessageCallsCount = 0
+    @Atomic private(set) var dismissMessageCallsCount = 0
     /// `true` if the function was ever called.
     var dismissMessageCalled: Bool {
         dismissMessageCallsCount > 0
@@ -419,16 +419,16 @@ public class MessagingInAppInstanceMock: MessagingInAppInstance, Mock {
     // MARK: - setEventListener
 
     /// Number of times the function was called.
-    public private(set) var setEventListenerCallsCount = 0
+    @Atomic public private(set) var setEventListenerCallsCount = 0
     /// `true` if the function was ever called.
     public var setEventListenerCalled: Bool {
         setEventListenerCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var setEventListenerReceivedArguments: InAppEventListener??
+    @Atomic public private(set) var setEventListenerReceivedArguments: InAppEventListener??
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var setEventListenerReceivedInvocations: [InAppEventListener?] = []
+    @Atomic public private(set) var setEventListenerReceivedInvocations: [InAppEventListener?] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -446,7 +446,7 @@ public class MessagingInAppInstanceMock: MessagingInAppInstance, Mock {
     // MARK: - dismissMessage
 
     /// Number of times the function was called.
-    public private(set) var dismissMessageCallsCount = 0
+    @Atomic public private(set) var dismissMessageCallsCount = 0
     /// `true` if the function was ever called.
     public var dismissMessageCalled: Bool {
         dismissMessageCallsCount > 0

--- a/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
@@ -105,7 +105,7 @@ class AutomaticPushClickHandlingMock: AutomaticPushClickHandling, Mock {
     // MARK: - start
 
     /// Number of times the function was called.
-    private(set) var startCallsCount = 0
+    @Atomic private(set) var startCallsCount = 0
     /// `true` if the function was ever called.
     var startCalled: Bool {
         startCallsCount > 0
@@ -150,16 +150,16 @@ class DeepLinkUtilMock: DeepLinkUtil, Mock {
     // MARK: - handleDeepLink
 
     /// Number of times the function was called.
-    private(set) var handleDeepLinkCallsCount = 0
+    @Atomic private(set) var handleDeepLinkCallsCount = 0
     /// `true` if the function was ever called.
     var handleDeepLinkCalled: Bool {
         handleDeepLinkCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    private(set) var handleDeepLinkReceivedArguments: URL?
+    @Atomic private(set) var handleDeepLinkReceivedArguments: URL?
     /// Arguments from *all* of the times that the function was called.
-    private(set) var handleDeepLinkReceivedInvocations: [URL] = []
+    @Atomic private(set) var handleDeepLinkReceivedInvocations: [URL] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -273,16 +273,16 @@ public class MessagingPushInstanceMock: MessagingPushInstance, Mock {
     // MARK: - registerDeviceToken
 
     /// Number of times the function was called.
-    public private(set) var registerDeviceTokenCallsCount = 0
+    @Atomic public private(set) var registerDeviceTokenCallsCount = 0
     /// `true` if the function was ever called.
     public var registerDeviceTokenCalled: Bool {
         registerDeviceTokenCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var registerDeviceTokenReceivedArguments: String?
+    @Atomic public private(set) var registerDeviceTokenReceivedArguments: String?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var registerDeviceTokenReceivedInvocations: [String] = []
+    @Atomic public private(set) var registerDeviceTokenReceivedInvocations: [String] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -300,7 +300,7 @@ public class MessagingPushInstanceMock: MessagingPushInstance, Mock {
     // MARK: - deleteDeviceToken
 
     /// Number of times the function was called.
-    public private(set) var deleteDeviceTokenCallsCount = 0
+    @Atomic public private(set) var deleteDeviceTokenCallsCount = 0
     /// `true` if the function was ever called.
     public var deleteDeviceTokenCalled: Bool {
         deleteDeviceTokenCallsCount > 0
@@ -321,16 +321,16 @@ public class MessagingPushInstanceMock: MessagingPushInstance, Mock {
     // MARK: - trackMetric
 
     /// Number of times the function was called.
-    public private(set) var trackMetricCallsCount = 0
+    @Atomic public private(set) var trackMetricCallsCount = 0
     /// `true` if the function was ever called.
     public var trackMetricCalled: Bool {
         trackMetricCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var trackMetricReceivedArguments: (deliveryID: String, event: Metric, deviceToken: String)?
+    @Atomic public private(set) var trackMetricReceivedArguments: (deliveryID: String, event: Metric, deviceToken: String)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var trackMetricReceivedInvocations: [(deliveryID: String, event: Metric, deviceToken: String)] = []
+    @Atomic public private(set) var trackMetricReceivedInvocations: [(deliveryID: String, event: Metric, deviceToken: String)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -349,16 +349,16 @@ public class MessagingPushInstanceMock: MessagingPushInstance, Mock {
 
     #if canImport(UserNotifications)
     /// Number of times the function was called.
-    public private(set) var didReceiveNotificationRequestCallsCount = 0
+    @Atomic public private(set) var didReceiveNotificationRequestCallsCount = 0
     /// `true` if the function was ever called.
     public var didReceiveNotificationRequestCalled: Bool {
         didReceiveNotificationRequestCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var didReceiveNotificationRequestReceivedArguments: (request: UNNotificationRequest, contentHandler: (UNNotificationContent) -> Void)?
+    @Atomic public private(set) var didReceiveNotificationRequestReceivedArguments: (request: UNNotificationRequest, contentHandler: (UNNotificationContent) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var didReceiveNotificationRequestReceivedInvocations: [(request: UNNotificationRequest, contentHandler: (UNNotificationContent) -> Void)] = []
+    @Atomic public private(set) var didReceiveNotificationRequestReceivedInvocations: [(request: UNNotificationRequest, contentHandler: (UNNotificationContent) -> Void)] = []
     /// Value to return from the mocked function.
     public var didReceiveNotificationRequestReturnValue: Bool!
     /**
@@ -383,7 +383,7 @@ public class MessagingPushInstanceMock: MessagingPushInstance, Mock {
 
     #if canImport(UserNotifications)
     /// Number of times the function was called.
-    public private(set) var serviceExtensionTimeWillExpireCallsCount = 0
+    @Atomic public private(set) var serviceExtensionTimeWillExpireCallsCount = 0
     /// `true` if the function was ever called.
     public var serviceExtensionTimeWillExpireCalled: Bool {
         serviceExtensionTimeWillExpireCallsCount > 0
@@ -406,16 +406,16 @@ public class MessagingPushInstanceMock: MessagingPushInstance, Mock {
 
     #if canImport(UserNotifications)
     /// Number of times the function was called.
-    public private(set) var userNotificationCenter_withCompletionCallsCount = 0
+    @Atomic public private(set) var userNotificationCenter_withCompletionCallsCount = 0
     /// `true` if the function was ever called.
     public var userNotificationCenter_withCompletionCalled: Bool {
         userNotificationCenter_withCompletionCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var userNotificationCenter_withCompletionReceivedArguments: (center: UNUserNotificationCenter, response: UNNotificationResponse, completionHandler: () -> Void)?
+    @Atomic public private(set) var userNotificationCenter_withCompletionReceivedArguments: (center: UNUserNotificationCenter, response: UNNotificationResponse, completionHandler: () -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var userNotificationCenter_withCompletionReceivedInvocations: [(center: UNUserNotificationCenter, response: UNNotificationResponse, completionHandler: () -> Void)] = []
+    @Atomic public private(set) var userNotificationCenter_withCompletionReceivedInvocations: [(center: UNUserNotificationCenter, response: UNNotificationResponse, completionHandler: () -> Void)] = []
     /// Value to return from the mocked function.
     public var userNotificationCenter_withCompletionReturnValue: Bool!
     /**
@@ -439,16 +439,16 @@ public class MessagingPushInstanceMock: MessagingPushInstance, Mock {
 
     #if canImport(UserNotifications)
     /// Number of times the function was called.
-    public private(set) var userNotificationCenterCallsCount = 0
+    @Atomic public private(set) var userNotificationCenterCallsCount = 0
     /// `true` if the function was ever called.
     public var userNotificationCenterCalled: Bool {
         userNotificationCenterCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var userNotificationCenterReceivedArguments: (center: UNUserNotificationCenter, response: UNNotificationResponse)?
+    @Atomic public private(set) var userNotificationCenterReceivedArguments: (center: UNUserNotificationCenter, response: UNNotificationResponse)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var userNotificationCenterReceivedInvocations: [(center: UNUserNotificationCenter, response: UNNotificationResponse)] = []
+    @Atomic public private(set) var userNotificationCenterReceivedInvocations: [(center: UNUserNotificationCenter, response: UNNotificationResponse)] = []
     /// Value to return from the mocked function.
     public var userNotificationCenterReturnValue: CustomerIOParsedPushPayload?
     /**
@@ -496,16 +496,16 @@ class PushClickHandlerMock: PushClickHandler, Mock {
     // MARK: - pushClicked
 
     /// Number of times the function was called.
-    private(set) var pushClickedCallsCount = 0
+    @Atomic private(set) var pushClickedCallsCount = 0
     /// `true` if the function was ever called.
     var pushClickedCalled: Bool {
         pushClickedCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    private(set) var pushClickedReceivedArguments: PushNotification?
+    @Atomic private(set) var pushClickedReceivedArguments: PushNotification?
     /// Arguments from *all* of the times that the function was called.
-    private(set) var pushClickedReceivedInvocations: [PushNotification] = []
+    @Atomic private(set) var pushClickedReceivedInvocations: [PushNotification] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -552,16 +552,16 @@ class PushEventHandlerMock: PushEventHandler, Mock {
     // MARK: - onPushAction
 
     /// Number of times the function was called.
-    private(set) var onPushActionCallsCount = 0
+    @Atomic private(set) var onPushActionCallsCount = 0
     /// `true` if the function was ever called.
     var onPushActionCalled: Bool {
         onPushActionCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    private(set) var onPushActionReceivedArguments: (pushAction: PushNotificationAction, completionHandler: () -> Void)?
+    @Atomic private(set) var onPushActionReceivedArguments: (pushAction: PushNotificationAction, completionHandler: () -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    private(set) var onPushActionReceivedInvocations: [(pushAction: PushNotificationAction, completionHandler: () -> Void)] = []
+    @Atomic private(set) var onPushActionReceivedInvocations: [(pushAction: PushNotificationAction, completionHandler: () -> Void)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -579,16 +579,16 @@ class PushEventHandlerMock: PushEventHandler, Mock {
     // MARK: - shouldDisplayPushAppInForeground
 
     /// Number of times the function was called.
-    private(set) var shouldDisplayPushAppInForegroundCallsCount = 0
+    @Atomic private(set) var shouldDisplayPushAppInForegroundCallsCount = 0
     /// `true` if the function was ever called.
     var shouldDisplayPushAppInForegroundCalled: Bool {
         shouldDisplayPushAppInForegroundCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    private(set) var shouldDisplayPushAppInForegroundReceivedArguments: (push: PushNotification, completionHandler: (Bool) -> Void)?
+    @Atomic private(set) var shouldDisplayPushAppInForegroundReceivedArguments: (push: PushNotification, completionHandler: (Bool) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    private(set) var shouldDisplayPushAppInForegroundReceivedInvocations: [(push: PushNotification, completionHandler: (Bool) -> Void)] = []
+    @Atomic private(set) var shouldDisplayPushAppInForegroundReceivedInvocations: [(push: PushNotification, completionHandler: (Bool) -> Void)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -641,16 +641,16 @@ class PushEventHandlerProxyMock: PushEventHandlerProxy, Mock {
     // MARK: - addPushEventHandler
 
     /// Number of times the function was called.
-    private(set) var addPushEventHandlerCallsCount = 0
+    @Atomic private(set) var addPushEventHandlerCallsCount = 0
     /// `true` if the function was ever called.
     var addPushEventHandlerCalled: Bool {
         addPushEventHandlerCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    private(set) var addPushEventHandlerReceivedArguments: PushEventHandler?
+    @Atomic private(set) var addPushEventHandlerReceivedArguments: PushEventHandler?
     /// Arguments from *all* of the times that the function was called.
-    private(set) var addPushEventHandlerReceivedInvocations: [PushEventHandler] = []
+    @Atomic private(set) var addPushEventHandlerReceivedInvocations: [PushEventHandler] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -668,16 +668,16 @@ class PushEventHandlerProxyMock: PushEventHandlerProxy, Mock {
     // MARK: - onPushAction
 
     /// Number of times the function was called.
-    private(set) var onPushActionCallsCount = 0
+    @Atomic private(set) var onPushActionCallsCount = 0
     /// `true` if the function was ever called.
     var onPushActionCalled: Bool {
         onPushActionCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    private(set) var onPushActionReceivedArguments: (pushAction: PushNotificationAction, completionHandler: () -> Void)?
+    @Atomic private(set) var onPushActionReceivedArguments: (pushAction: PushNotificationAction, completionHandler: () -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    private(set) var onPushActionReceivedInvocations: [(pushAction: PushNotificationAction, completionHandler: () -> Void)] = []
+    @Atomic private(set) var onPushActionReceivedInvocations: [(pushAction: PushNotificationAction, completionHandler: () -> Void)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -695,16 +695,16 @@ class PushEventHandlerProxyMock: PushEventHandlerProxy, Mock {
     // MARK: - shouldDisplayPushAppInForeground
 
     /// Number of times the function was called.
-    private(set) var shouldDisplayPushAppInForegroundCallsCount = 0
+    @Atomic private(set) var shouldDisplayPushAppInForegroundCallsCount = 0
     /// `true` if the function was ever called.
     var shouldDisplayPushAppInForegroundCalled: Bool {
         shouldDisplayPushAppInForegroundCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    private(set) var shouldDisplayPushAppInForegroundReceivedArguments: (push: PushNotification, completionHandler: (Bool) -> Void)?
+    @Atomic private(set) var shouldDisplayPushAppInForegroundReceivedArguments: (push: PushNotification, completionHandler: (Bool) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    private(set) var shouldDisplayPushAppInForegroundReceivedInvocations: [(push: PushNotification, completionHandler: (Bool) -> Void)] = []
+    @Atomic private(set) var shouldDisplayPushAppInForegroundReceivedInvocations: [(push: PushNotification, completionHandler: (Bool) -> Void)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -746,16 +746,16 @@ class PushHistoryMock: PushHistory, Mock {
     // MARK: - hasHandledPush
 
     /// Number of times the function was called.
-    private(set) var hasHandledPushCallsCount = 0
+    @Atomic private(set) var hasHandledPushCallsCount = 0
     /// `true` if the function was ever called.
     var hasHandledPushCalled: Bool {
         hasHandledPushCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    private(set) var hasHandledPushReceivedArguments: (pushEvent: PushHistoryEvent, pushId: String, pushDeliveryDate: Date)?
+    @Atomic private(set) var hasHandledPushReceivedArguments: (pushEvent: PushHistoryEvent, pushId: String, pushDeliveryDate: Date)?
     /// Arguments from *all* of the times that the function was called.
-    private(set) var hasHandledPushReceivedInvocations: [(pushEvent: PushHistoryEvent, pushId: String, pushDeliveryDate: Date)] = []
+    @Atomic private(set) var hasHandledPushReceivedInvocations: [(pushEvent: PushHistoryEvent, pushId: String, pushDeliveryDate: Date)] = []
     /// Value to return from the mocked function.
     var hasHandledPushReturnValue: Bool!
     /**

--- a/Sources/MessagingPushAPN/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingPushAPN/autogenerated/AutoMockable.generated.swift
@@ -137,16 +137,16 @@ public class MessagingPushAPNInstanceMock: MessagingPushAPNInstance, Mock {
     // MARK: - registerDeviceToken
 
     /// Number of times the function was called.
-    public private(set) var registerDeviceTokenCallsCount = 0
+    @Atomic public private(set) var registerDeviceTokenCallsCount = 0
     /// `true` if the function was ever called.
     public var registerDeviceTokenCalled: Bool {
         registerDeviceTokenCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var registerDeviceTokenReceivedArguments: Data?
+    @Atomic public private(set) var registerDeviceTokenReceivedArguments: Data?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var registerDeviceTokenReceivedInvocations: [Data] = []
+    @Atomic public private(set) var registerDeviceTokenReceivedInvocations: [Data] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -164,16 +164,16 @@ public class MessagingPushAPNInstanceMock: MessagingPushAPNInstance, Mock {
     // MARK: - application
 
     /// Number of times the function was called.
-    public private(set) var didRegisterForRemoteNotificationsCallsCount = 0
+    @Atomic public private(set) var didRegisterForRemoteNotificationsCallsCount = 0
     /// `true` if the function was ever called.
     public var didRegisterForRemoteNotificationsCalled: Bool {
         didRegisterForRemoteNotificationsCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var didRegisterForRemoteNotificationsReceivedArguments: (application: Any, deviceToken: Data)?
+    @Atomic public private(set) var didRegisterForRemoteNotificationsReceivedArguments: (application: Any, deviceToken: Data)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var didRegisterForRemoteNotificationsReceivedInvocations: [(application: Any, deviceToken: Data)] = []
+    @Atomic public private(set) var didRegisterForRemoteNotificationsReceivedInvocations: [(application: Any, deviceToken: Data)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -191,16 +191,16 @@ public class MessagingPushAPNInstanceMock: MessagingPushAPNInstance, Mock {
     // MARK: - application
 
     /// Number of times the function was called.
-    public private(set) var didFailToRegisterForRemoteNotificationsCallsCount = 0
+    @Atomic public private(set) var didFailToRegisterForRemoteNotificationsCallsCount = 0
     /// `true` if the function was ever called.
     public var didFailToRegisterForRemoteNotificationsCalled: Bool {
         didFailToRegisterForRemoteNotificationsCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var didFailToRegisterForRemoteNotificationsReceivedArguments: (application: Any, error: Error)?
+    @Atomic public private(set) var didFailToRegisterForRemoteNotificationsReceivedArguments: (application: Any, error: Error)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var didFailToRegisterForRemoteNotificationsReceivedInvocations: [(application: Any, error: Error)] = []
+    @Atomic public private(set) var didFailToRegisterForRemoteNotificationsReceivedInvocations: [(application: Any, error: Error)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -218,7 +218,7 @@ public class MessagingPushAPNInstanceMock: MessagingPushAPNInstance, Mock {
     // MARK: - deleteDeviceToken
 
     /// Number of times the function was called.
-    public private(set) var deleteDeviceTokenCallsCount = 0
+    @Atomic public private(set) var deleteDeviceTokenCallsCount = 0
     /// `true` if the function was ever called.
     public var deleteDeviceTokenCalled: Bool {
         deleteDeviceTokenCallsCount > 0
@@ -239,16 +239,16 @@ public class MessagingPushAPNInstanceMock: MessagingPushAPNInstance, Mock {
     // MARK: - trackMetric
 
     /// Number of times the function was called.
-    public private(set) var trackMetricCallsCount = 0
+    @Atomic public private(set) var trackMetricCallsCount = 0
     /// `true` if the function was ever called.
     public var trackMetricCalled: Bool {
         trackMetricCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var trackMetricReceivedArguments: (deliveryID: String, event: Metric, deviceToken: String)?
+    @Atomic public private(set) var trackMetricReceivedArguments: (deliveryID: String, event: Metric, deviceToken: String)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var trackMetricReceivedInvocations: [(deliveryID: String, event: Metric, deviceToken: String)] = []
+    @Atomic public private(set) var trackMetricReceivedInvocations: [(deliveryID: String, event: Metric, deviceToken: String)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -267,16 +267,16 @@ public class MessagingPushAPNInstanceMock: MessagingPushAPNInstance, Mock {
 
     #if canImport(UserNotifications)
     /// Number of times the function was called.
-    public private(set) var didReceiveNotificationRequestCallsCount = 0
+    @Atomic public private(set) var didReceiveNotificationRequestCallsCount = 0
     /// `true` if the function was ever called.
     public var didReceiveNotificationRequestCalled: Bool {
         didReceiveNotificationRequestCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var didReceiveNotificationRequestReceivedArguments: (request: UNNotificationRequest, contentHandler: (UNNotificationContent) -> Void)?
+    @Atomic public private(set) var didReceiveNotificationRequestReceivedArguments: (request: UNNotificationRequest, contentHandler: (UNNotificationContent) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var didReceiveNotificationRequestReceivedInvocations: [(request: UNNotificationRequest, contentHandler: (UNNotificationContent) -> Void)] = []
+    @Atomic public private(set) var didReceiveNotificationRequestReceivedInvocations: [(request: UNNotificationRequest, contentHandler: (UNNotificationContent) -> Void)] = []
     /// Value to return from the mocked function.
     public var didReceiveNotificationRequestReturnValue: Bool!
     /**
@@ -301,7 +301,7 @@ public class MessagingPushAPNInstanceMock: MessagingPushAPNInstance, Mock {
 
     #if canImport(UserNotifications)
     /// Number of times the function was called.
-    public private(set) var serviceExtensionTimeWillExpireCallsCount = 0
+    @Atomic public private(set) var serviceExtensionTimeWillExpireCallsCount = 0
     /// `true` if the function was ever called.
     public var serviceExtensionTimeWillExpireCalled: Bool {
         serviceExtensionTimeWillExpireCallsCount > 0

--- a/Sources/MessagingPushFCM/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingPushFCM/autogenerated/AutoMockable.generated.swift
@@ -137,16 +137,16 @@ public class MessagingPushFCMInstanceMock: MessagingPushFCMInstance, Mock {
     // MARK: - registerDeviceToken
 
     /// Number of times the function was called.
-    public private(set) var registerDeviceTokenCallsCount = 0
+    @Atomic public private(set) var registerDeviceTokenCallsCount = 0
     /// `true` if the function was ever called.
     public var registerDeviceTokenCalled: Bool {
         registerDeviceTokenCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var registerDeviceTokenReceivedArguments: String??
+    @Atomic public private(set) var registerDeviceTokenReceivedArguments: String??
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var registerDeviceTokenReceivedInvocations: [String?] = []
+    @Atomic public private(set) var registerDeviceTokenReceivedInvocations: [String?] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -164,16 +164,16 @@ public class MessagingPushFCMInstanceMock: MessagingPushFCMInstance, Mock {
     // MARK: - messaging
 
     /// Number of times the function was called.
-    public private(set) var didReceiveRegistrationTokenCallsCount = 0
+    @Atomic public private(set) var didReceiveRegistrationTokenCallsCount = 0
     /// `true` if the function was ever called.
     public var didReceiveRegistrationTokenCalled: Bool {
         didReceiveRegistrationTokenCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var didReceiveRegistrationTokenReceivedArguments: (messaging: Any, fcmToken: String?)?
+    @Atomic public private(set) var didReceiveRegistrationTokenReceivedArguments: (messaging: Any, fcmToken: String?)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var didReceiveRegistrationTokenReceivedInvocations: [(messaging: Any, fcmToken: String?)] = []
+    @Atomic public private(set) var didReceiveRegistrationTokenReceivedInvocations: [(messaging: Any, fcmToken: String?)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -191,16 +191,16 @@ public class MessagingPushFCMInstanceMock: MessagingPushFCMInstance, Mock {
     // MARK: - application
 
     /// Number of times the function was called.
-    public private(set) var didFailToRegisterForRemoteNotificationsCallsCount = 0
+    @Atomic public private(set) var didFailToRegisterForRemoteNotificationsCallsCount = 0
     /// `true` if the function was ever called.
     public var didFailToRegisterForRemoteNotificationsCalled: Bool {
         didFailToRegisterForRemoteNotificationsCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var didFailToRegisterForRemoteNotificationsReceivedArguments: (application: Any, error: Error)?
+    @Atomic public private(set) var didFailToRegisterForRemoteNotificationsReceivedArguments: (application: Any, error: Error)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var didFailToRegisterForRemoteNotificationsReceivedInvocations: [(application: Any, error: Error)] = []
+    @Atomic public private(set) var didFailToRegisterForRemoteNotificationsReceivedInvocations: [(application: Any, error: Error)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -218,7 +218,7 @@ public class MessagingPushFCMInstanceMock: MessagingPushFCMInstance, Mock {
     // MARK: - deleteDeviceToken
 
     /// Number of times the function was called.
-    public private(set) var deleteDeviceTokenCallsCount = 0
+    @Atomic public private(set) var deleteDeviceTokenCallsCount = 0
     /// `true` if the function was ever called.
     public var deleteDeviceTokenCalled: Bool {
         deleteDeviceTokenCallsCount > 0
@@ -239,16 +239,16 @@ public class MessagingPushFCMInstanceMock: MessagingPushFCMInstance, Mock {
     // MARK: - trackMetric
 
     /// Number of times the function was called.
-    public private(set) var trackMetricCallsCount = 0
+    @Atomic public private(set) var trackMetricCallsCount = 0
     /// `true` if the function was ever called.
     public var trackMetricCalled: Bool {
         trackMetricCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var trackMetricReceivedArguments: (deliveryID: String, event: Metric, deviceToken: String)?
+    @Atomic public private(set) var trackMetricReceivedArguments: (deliveryID: String, event: Metric, deviceToken: String)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var trackMetricReceivedInvocations: [(deliveryID: String, event: Metric, deviceToken: String)] = []
+    @Atomic public private(set) var trackMetricReceivedInvocations: [(deliveryID: String, event: Metric, deviceToken: String)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -267,16 +267,16 @@ public class MessagingPushFCMInstanceMock: MessagingPushFCMInstance, Mock {
 
     #if canImport(UserNotifications)
     /// Number of times the function was called.
-    public private(set) var didReceiveNotificationRequestCallsCount = 0
+    @Atomic public private(set) var didReceiveNotificationRequestCallsCount = 0
     /// `true` if the function was ever called.
     public var didReceiveNotificationRequestCalled: Bool {
         didReceiveNotificationRequestCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var didReceiveNotificationRequestReceivedArguments: (request: UNNotificationRequest, contentHandler: (UNNotificationContent) -> Void)?
+    @Atomic public private(set) var didReceiveNotificationRequestReceivedArguments: (request: UNNotificationRequest, contentHandler: (UNNotificationContent) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var didReceiveNotificationRequestReceivedInvocations: [(request: UNNotificationRequest, contentHandler: (UNNotificationContent) -> Void)] = []
+    @Atomic public private(set) var didReceiveNotificationRequestReceivedInvocations: [(request: UNNotificationRequest, contentHandler: (UNNotificationContent) -> Void)] = []
     /// Value to return from the mocked function.
     public var didReceiveNotificationRequestReturnValue: Bool!
     /**
@@ -301,7 +301,7 @@ public class MessagingPushFCMInstanceMock: MessagingPushFCMInstance, Mock {
 
     #if canImport(UserNotifications)
     /// Number of times the function was called.
-    public private(set) var serviceExtensionTimeWillExpireCallsCount = 0
+    @Atomic public private(set) var serviceExtensionTimeWillExpireCallsCount = 0
     /// `true` if the function was ever called.
     public var serviceExtensionTimeWillExpireCalled: Bool {
         serviceExtensionTimeWillExpireCallsCount > 0

--- a/Sources/Migration/autogenerated/AutoMockable.generated.swift
+++ b/Sources/Migration/autogenerated/AutoMockable.generated.swift
@@ -136,16 +136,16 @@ public class DataPipelineMigrationActionMock: DataPipelineMigrationAction, Mock 
     // MARK: - processAlreadyIdentifiedUser
 
     /// Number of times the function was called.
-    public private(set) var processAlreadyIdentifiedUserCallsCount = 0
+    @Atomic public private(set) var processAlreadyIdentifiedUserCallsCount = 0
     /// `true` if the function was ever called.
     public var processAlreadyIdentifiedUserCalled: Bool {
         processAlreadyIdentifiedUserCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var processAlreadyIdentifiedUserReceivedArguments: String?
+    @Atomic public private(set) var processAlreadyIdentifiedUserReceivedArguments: String?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var processAlreadyIdentifiedUserReceivedInvocations: [String] = []
+    @Atomic public private(set) var processAlreadyIdentifiedUserReceivedInvocations: [String] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -163,16 +163,16 @@ public class DataPipelineMigrationActionMock: DataPipelineMigrationAction, Mock 
     // MARK: - processIdentifyFromBGQ
 
     /// Number of times the function was called.
-    public private(set) var processIdentifyFromBGQCallsCount = 0
+    @Atomic public private(set) var processIdentifyFromBGQCallsCount = 0
     /// `true` if the function was ever called.
     public var processIdentifyFromBGQCalled: Bool {
         processIdentifyFromBGQCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var processIdentifyFromBGQReceivedArguments: (identifier: String, timestamp: String, body: [String: Any]?)?
+    @Atomic public private(set) var processIdentifyFromBGQReceivedArguments: (identifier: String, timestamp: String, body: [String: Any]?)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var processIdentifyFromBGQReceivedInvocations: [(identifier: String, timestamp: String, body: [String: Any]?)] = []
+    @Atomic public private(set) var processIdentifyFromBGQReceivedInvocations: [(identifier: String, timestamp: String, body: [String: Any]?)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -190,16 +190,16 @@ public class DataPipelineMigrationActionMock: DataPipelineMigrationAction, Mock 
     // MARK: - processScreenEventFromBGQ
 
     /// Number of times the function was called.
-    public private(set) var processScreenEventFromBGQCallsCount = 0
+    @Atomic public private(set) var processScreenEventFromBGQCallsCount = 0
     /// `true` if the function was ever called.
     public var processScreenEventFromBGQCalled: Bool {
         processScreenEventFromBGQCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var processScreenEventFromBGQReceivedArguments: (identifier: String, name: String, timestamp: String?, properties: [String: Any])?
+    @Atomic public private(set) var processScreenEventFromBGQReceivedArguments: (identifier: String, name: String, timestamp: String?, properties: [String: Any])?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var processScreenEventFromBGQReceivedInvocations: [(identifier: String, name: String, timestamp: String?, properties: [String: Any])] = []
+    @Atomic public private(set) var processScreenEventFromBGQReceivedInvocations: [(identifier: String, name: String, timestamp: String?, properties: [String: Any])] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -217,16 +217,16 @@ public class DataPipelineMigrationActionMock: DataPipelineMigrationAction, Mock 
     // MARK: - processEventFromBGQ
 
     /// Number of times the function was called.
-    public private(set) var processEventFromBGQCallsCount = 0
+    @Atomic public private(set) var processEventFromBGQCallsCount = 0
     /// `true` if the function was ever called.
     public var processEventFromBGQCalled: Bool {
         processEventFromBGQCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var processEventFromBGQReceivedArguments: (identifier: String, name: String, timestamp: String?, properties: [String: Any])?
+    @Atomic public private(set) var processEventFromBGQReceivedArguments: (identifier: String, name: String, timestamp: String?, properties: [String: Any])?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var processEventFromBGQReceivedInvocations: [(identifier: String, name: String, timestamp: String?, properties: [String: Any])] = []
+    @Atomic public private(set) var processEventFromBGQReceivedInvocations: [(identifier: String, name: String, timestamp: String?, properties: [String: Any])] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -244,16 +244,16 @@ public class DataPipelineMigrationActionMock: DataPipelineMigrationAction, Mock 
     // MARK: - processDeleteTokenFromBGQ
 
     /// Number of times the function was called.
-    public private(set) var processDeleteTokenFromBGQCallsCount = 0
+    @Atomic public private(set) var processDeleteTokenFromBGQCallsCount = 0
     /// `true` if the function was ever called.
     public var processDeleteTokenFromBGQCalled: Bool {
         processDeleteTokenFromBGQCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var processDeleteTokenFromBGQReceivedArguments: (identifier: String, token: String, timestamp: String)?
+    @Atomic public private(set) var processDeleteTokenFromBGQReceivedArguments: (identifier: String, token: String, timestamp: String)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var processDeleteTokenFromBGQReceivedInvocations: [(identifier: String, token: String, timestamp: String)] = []
+    @Atomic public private(set) var processDeleteTokenFromBGQReceivedInvocations: [(identifier: String, token: String, timestamp: String)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -271,16 +271,16 @@ public class DataPipelineMigrationActionMock: DataPipelineMigrationAction, Mock 
     // MARK: - processRegisterDeviceFromBGQ
 
     /// Number of times the function was called.
-    public private(set) var processRegisterDeviceFromBGQCallsCount = 0
+    @Atomic public private(set) var processRegisterDeviceFromBGQCallsCount = 0
     /// `true` if the function was ever called.
     public var processRegisterDeviceFromBGQCalled: Bool {
         processRegisterDeviceFromBGQCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var processRegisterDeviceFromBGQReceivedArguments: (identifier: String, token: String, timestamp: String, attributes: [String: Any]?)?
+    @Atomic public private(set) var processRegisterDeviceFromBGQReceivedArguments: (identifier: String, token: String, timestamp: String, attributes: [String: Any]?)?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var processRegisterDeviceFromBGQReceivedInvocations: [(identifier: String, token: String, timestamp: String, attributes: [String: Any]?)] = []
+    @Atomic public private(set) var processRegisterDeviceFromBGQReceivedInvocations: [(identifier: String, token: String, timestamp: String, attributes: [String: Any]?)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
@@ -298,16 +298,16 @@ public class DataPipelineMigrationActionMock: DataPipelineMigrationAction, Mock 
     // MARK: - processMetricsFromBGQ
 
     /// Number of times the function was called.
-    public private(set) var processMetricsFromBGQCallsCount = 0
+    @Atomic public private(set) var processMetricsFromBGQCallsCount = 0
     /// `true` if the function was ever called.
     public var processMetricsFromBGQCalled: Bool {
         processMetricsFromBGQCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    public private(set) var processMetricsFromBGQReceivedArguments: (token: String?, event: String, deliveryId: String, timestamp: String, metaData: [String: Any])?
+    @Atomic public private(set) var processMetricsFromBGQReceivedArguments: (token: String?, event: String, deliveryId: String, timestamp: String, metaData: [String: Any])?
     /// Arguments from *all* of the times that the function was called.
-    public private(set) var processMetricsFromBGQReceivedInvocations: [(token: String?, event: String, deliveryId: String, timestamp: String, metaData: [String: Any])] = []
+    @Atomic public private(set) var processMetricsFromBGQReceivedInvocations: [(token: String?, event: String, deliveryId: String, timestamp: String, metaData: [String: Any])] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */

--- a/Sources/Templates/AutoMockable.stencil
+++ b/Sources/Templates/AutoMockable.stencil
@@ -150,7 +150,7 @@ class ExampleTest: XCTestCase {
     {% if not method|annotated:"DuplicateMethod" %}
     {% if not method.isInitializer %}
     /// Number of times the function was called.  
-    {{ type.accessLevel }} private(set) var {% call swiftifyMethodName method %}CallsCount = 0
+    @Atomic {{ type.accessLevel }} private(set) var {% call swiftifyMethodName method %}CallsCount = 0
     /// `true` if the function was ever called. 
     {{ type.accessLevel }} var {% call swiftifyMethodName method %}Called: Bool {
         return {% call swiftifyMethodName method %}CallsCount > 0
@@ -159,14 +159,14 @@ class ExampleTest: XCTestCase {
     {% endif %} {# endif DuplicateMethod #}
     {% if method.parameters.count == 1 %}
     /// The arguments from the *last* time the function was called. 
-    {{ type.accessLevel }} private(set) var {% call swiftifyMethodName method %}ReceivedArguments: ({% for param in method.parameters %}{%if not param|annotated:"SkipParamCapture" %}{{ param.unwrappedTypeName if param.typeAttributes.escaping else param.typeName }}{{ ', ' if not forloop.last }}{% endif %}{% endfor %})?
+    @Atomic {{ type.accessLevel }} private(set) var {% call swiftifyMethodName method %}ReceivedArguments: ({% for param in method.parameters %}{%if not param|annotated:"SkipParamCapture" %}{{ param.unwrappedTypeName if param.typeAttributes.escaping else param.typeName }}{{ ', ' if not forloop.last }}{% endif %}{% endfor %})?
     /// Arguments from *all* of the times that the function was called. 
-    {{ type.accessLevel }} private(set) var {% call swiftifyMethodName method %}ReceivedInvocations: [({% for param in method.parameters %}{%if not param|annotated:"SkipParamCapture" %}{{ param.unwrappedTypeName if param.typeAttributes.escaping else param.typeName }}{{ ', ' if not forloop.last }}{% endif %}{% endfor %})] = []
+    @Atomic {{ type.accessLevel }} private(set) var {% call swiftifyMethodName method %}ReceivedInvocations: [({% for param in method.parameters %}{%if not param|annotated:"SkipParamCapture" %}{{ param.unwrappedTypeName if param.typeAttributes.escaping else param.typeName }}{{ ', ' if not forloop.last }}{% endif %}{% endfor %})] = []
     {% elif not method.parameters.count == 0 %}
     /// The arguments from the *last* time the function was called. 
-    {{ type.accessLevel }} private(set) var {% call swiftifyMethodName method %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% call parameterTypeName param true %}{{ ', ' if not forloop.last }}{% endfor %})?
+    @Atomic {{ type.accessLevel }} private(set) var {% call swiftifyMethodName method %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% call parameterTypeName param true %}{{ ', ' if not forloop.last }}{% endfor %})?
     /// Arguments from *all* of the times that the function was called. 
-    {{ type.accessLevel }} private(set) var {% call swiftifyMethodName method %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {% call parameterTypeName param true %}{{ ', ' if not forloop.last }}{% endfor %})] = []
+    @Atomic {{ type.accessLevel }} private(set) var {% call swiftifyMethodName method %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {% call parameterTypeName param true %}{{ ', ' if not forloop.last }}{% endfor %})] = []
     {% endif %}
     {% if not method.returnTypeName.isVoid and not method.isInitializer %}
     /// Value to return from the mocked function. 

--- a/Tests/Shared/Mocks/EventBusHandler.swift
+++ b/Tests/Shared/Mocks/EventBusHandler.swift
@@ -52,6 +52,12 @@ public class EventBusHandlerMock: EventBusHandler, Mock {
         postEventArguments = event
     }
 
+    public func postEventAndWait<E>(_ event: E) async where E: EventRepresentable {
+        mockCalled = true
+        postEventCallsCount += 1
+        postEventArguments = event
+    }
+
     public private(set) var removeFromStorageCallsCount = 0
     public var removeFromStorageCalled: Bool { removeFromStorageCallsCount > 0 }
 

--- a/Tests/Shared/extension/EventBusExtensions.swift
+++ b/Tests/Shared/extension/EventBusExtensions.swift
@@ -1,0 +1,32 @@
+@testable import CioInternalCommon
+import Foundation
+
+/*
+ Collection of EventBus functions only meant to be used for tests, not in SDK code.
+ */
+
+// MARK: wait for events to finish replaying.
+
+// Replaying eventbus events is an async operation in the SDK. Some test functions may need to wait to proceed until after these async operations are complete.
+
+public extension EventBusHandler {
+    func waitForReplayEventsToFinish<E>(_ eventType: E.Type) async where E: EventRepresentable {
+        await(self as? CioEventBusHandler)?.waitForReplayEventsToFinish(eventType)
+    }
+}
+
+public extension CioEventBusHandler {
+    func waitForReplayEventsToFinish<E>(_ eventType: E.Type) async where E: EventRepresentable {
+        do {
+            while true {
+                let key = eventType.key
+                let storedEvents = try await eventStorage.loadEvents(ofType: key)
+                if storedEvents.isEmpty {
+                    return
+                }
+            }
+        } catch {
+            logger.debug("Error waiting for relay events to finish: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
Part of: https://linear.app/customerio/issue/MBL-95/improve-test-suite-compatibility-with-async-eventbus-operations

As part of improving test suite compatibility with the EventBus, this refactor reduces flakiness by replacing the async operations in tearDown() with synchronous operations. The async code (`Task {}`) in the synchronous function (`deleteAllPersistentData`) is not guaranteed to complete by the time tearDown() is complete. This can create flaky test results where, for example, the EventBus does not reset before the next test function runs. 

This synchronous solution was chosen because it has another benefit for us: by using this more generic solution, we do not need to reset the data store for just the EventBus, we reset the data stores for all objects. Making the test suite easier to maintain. 

As an alternative solution, we could convert all test classes in the test suite to use `tearDown() async` instead of `tearDown()`. Then, we would guarantee that all async operations would complete before `tearDown()` is complete. 

commit-id:42b484a0

---

**Stack**:
- #615 ⬅
- #614


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*