### PR TITLE
docs: [vision-on-sample-app][11/n] Identify

### DIFF
--- a/Apps/VisionOS/VisionOS.xcodeproj/project.pbxproj
+++ b/Apps/VisionOS/VisionOS.xcodeproj/project.pbxproj
@@ -19,10 +19,9 @@
 		606F2C212B9B79F3004E7318 /* PropertiesInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606F2C202B9B79F3004E7318 /* PropertiesInputView.swift */; };
 		60A077662B9C8E1D000600CF /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A077652B9C8E1D000600CF /* ViewModel.swift */; };
 		60A077722B9CE8C1000600CF /* SDKInstallationTutorialView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A077712B9CE8C1000600CF /* SDKInstallationTutorialView.swift */; };
-		6023AD482B915391001540EF /* SetupTutorialView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6023AD462B915391001540EF /* SetupTutorialView.swift */; };
-		6023AD4C2B9153EB001540EF /* FloatingTitleTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6023AD4A2B9153EB001540EF /* FloatingTitleTextField.swift */; };
-		6023AD4D2B9153EB001540EF /* LineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6023AD4B2B9153EB001540EF /* LineView.swift */; };
+		60A077762B9D040F000600CF /* CodeSnippetHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A077752B9D040F000600CF /* CodeSnippetHelper.swift */; };
 		60F485152B9157340091A34A /* PostInitializeCustomerIOIntro.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F485142B9157340091A34A /* PostInitializeCustomerIOIntro.swift */; };
+		60F485172B9158CF0091A34A /* IdentifyTutorialView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F485162B9158CF0091A34A /* IdentifyTutorialView.swift */; };
 		60F967352B9125D000A4E95E /* VisionOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967342B9125D000A4E95E /* VisionOSApp.swift */; };
 		60F967372B9125D000A4E95E /* MainScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967362B9125D000A4E95E /* MainScreen.swift */; };
 		60F967392B9125D100A4E95E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 60F967382B9125D100A4E95E /* Assets.xcassets */; };
@@ -51,10 +50,9 @@
 		606F2C202B9B79F3004E7318 /* PropertiesInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertiesInputView.swift; sourceTree = "<group>"; };
 		60A077652B9C8E1D000600CF /* ViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		60A077712B9CE8C1000600CF /* SDKInstallationTutorialView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SDKInstallationTutorialView.swift; sourceTree = "<group>"; };
-		6023AD462B915391001540EF /* SetupTutorialView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SetupTutorialView.swift; sourceTree = "<group>"; };
-		6023AD4A2B9153EB001540EF /* FloatingTitleTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FloatingTitleTextField.swift; sourceTree = "<group>"; };
-		6023AD4B2B9153EB001540EF /* LineView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineView.swift; sourceTree = "<group>"; };
+		60A077752B9D040F000600CF /* CodeSnippetHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeSnippetHelper.swift; sourceTree = "<group>"; };
 		60F485142B9157340091A34A /* PostInitializeCustomerIOIntro.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostInitializeCustomerIOIntro.swift; sourceTree = "<group>"; };
+		60F485162B9158CF0091A34A /* IdentifyTutorialView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentifyTutorialView.swift; sourceTree = "<group>"; };
 		60F9672D2B9125D000A4E95E /* VisionOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VisionOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		60F967342B9125D000A4E95E /* VisionOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisionOSApp.swift; sourceTree = "<group>"; };
 		60F967362B9125D000A4E95E /* MainScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainScreen.swift; sourceTree = "<group>"; };
@@ -104,6 +102,7 @@
 				60A077712B9CE8C1000600CF /* SDKInstallationTutorialView.swift */,
 				6023AD462B915391001540EF /* SetupTutorialView.swift */,
 				60F485142B9157340091A34A /* PostInitializeCustomerIOIntro.swift */,
+				60F485162B9158CF0091A34A /* IdentifyTutorialView.swift */,
 			);
 			path = TutorialViews;
 			sourceTree = "<group>";
@@ -172,9 +171,10 @@
 		60F967562B912C1000A4E95E /* ViewUtils */ = {
 			isa = PBXGroup;
 			children = (
-				60F9675E2B912E2E00A4E95E /* InlineNavigationLink.swift */,
 				60F967572B912C1000A4E95E /* SyntaxHighlighting */,
 				60F9675A2B912C1000A4E95E /* MarkdownTheme.swift */,
+				60F9675E2B912E2E00A4E95E /* InlineNavigationLink.swift */,
+				60A077752B9D040F000600CF /* CodeSnippetHelper.swift */,
 			);
 			path = ViewUtils;
 			sourceTree = "<group>";
@@ -266,6 +266,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				60F485172B9158CF0091A34A /* IdentifyTutorialView.swift in Sources */,
 				6023AD482B915391001540EF /* SetupTutorialView.swift in Sources */,
 				6023AD372B9137F0001540EF /* AppDelegate.swift in Sources */,
 				60A077722B9CE8C1000600CF /* SDKInstallationTutorialView.swift in Sources */,
@@ -278,12 +279,12 @@
 				60F967542B91288400A4E95E /* Payloads.swift in Sources */,
 				6023AD4C2B9153EB001540EF /* FloatingTitleTextField.swift in Sources */,
 				60F967372B9125D000A4E95E /* MainScreen.swift in Sources */,
-				6023AD352B913708001540EF /* CodeSnippets.swift in Sources */,
 				60F485152B9157340091A34A /* PostInitializeCustomerIOIntro.swift in Sources */,
 				60F9675B2B912C1000A4E95E /* TextOutputFormat.swift in Sources */,
 				60A077662B9C8E1D000600CF /* ViewModel.swift in Sources */,
 				6023AD3E2B913954001540EF /* ToastView.swift in Sources */,
 				60F9675D2B912C1000A4E95E /* MarkdownTheme.swift in Sources */,
+				60A077762B9D040F000600CF /* CodeSnippetHelper.swift in Sources */,
 				60F967352B9125D000A4E95E /* VisionOSApp.swift in Sources */,
 				60F967532B91288400A4E95E /* AppState.swift in Sources */,
 				6023AD3D2B913954001540EF /* Logo.swift in Sources */,

--- a/Apps/VisionOS/VisionOS/AppDelegate.swift
+++ b/Apps/VisionOS/VisionOS/AppDelegate.swift
@@ -33,6 +33,15 @@ class AppDelegate: NSObject, UIApplicationDelegate {
                 config.logLevel = .debug
             }
         }
+        
+        // If user already logged in, let's
+        // call identify
+        let profile = AppState.shared.profile
+        if profile.loggedIn {
+            CustomerIO.shared.identify(
+                identifier: profile.id,
+                body: profile.properties.toDictionary())
+        }
 
         return true
     }

--- a/Apps/VisionOS/VisionOS/MainScreen.swift
+++ b/Apps/VisionOS/VisionOS/MainScreen.swift
@@ -37,6 +37,14 @@ import SwiftUI
     case .customerIOIntro:
         PostInitializeCustomerIOIntro()
 
+    case .identify:
+        IdentifyTutorialView { _ in
+            CustomerIO.shared.identify(
+                identifier: state.profile.id,
+                body: state.profile.properties.toDictionary()
+            )
+            state.navigationPath = [.howToTestIdentify]
+        }
     default:
         Text("Not implemented")
     }

--- a/Apps/VisionOS/VisionOS/TutorialViews/IdentifyTutorialView.swift
+++ b/Apps/VisionOS/VisionOS/TutorialViews/IdentifyTutorialView.swift
@@ -1,0 +1,87 @@
+import MarkdownUI
+import Splash
+import SwiftUI
+
+private func identifyCodeSnippet(_ profile: Profile) -> String {
+    let propertiesStr = propertiesToTutorialString(profile.properties,
+    linePrefix: "\t\t")
+    if propertiesStr.isEmpty {
+        return
+"""
+CustomerIO.shared.identify(
+    identifier: "\(profile.id)"
+)
+"""
+    } else {
+        return
+"""
+CustomerIO.shared.identify(
+    identifier: "\(profile.id)",
+    data: \(propertiesStr)
+)
+"""
+    }
+}
+
+struct IdentifyTutorialView: View {
+    @ObservedObject var state = AppState.shared
+    @State private var profile = AppState.shared.profile
+    @EnvironmentObject private var viewModel: ViewModel
+    
+    static let title = ScreenTitleConfig("Identify")
+
+    let onSuccess: (Profile) -> Void
+
+    var body: some View {
+        ScrollView(.vertical) {
+            VStack(alignment: .leading) {
+                Markdown {
+"""
+In CustomerIO many things revolve around People. What actions
+(tracked events) they do, what we know about them (their attributes),
+what devices they use and what are the capabilities of thess devices
+(device attributes). All starts with by **Identify**ing the customer.
+Learn more about [identifying people](https://customer.io/docs/journeys/identifying-people/#identifiers)
+
+```swift
+\(identifyCodeSnippet(profile))
+```
+
+`identifier` is the only mandatory parameter. However,
+you can also add any encodable data. Use the input below to add
+key/value pairs. Try it with a property name `email` and any value.
+"Email" is another way you can use to identify people in Customer.io.
+
+"""
+                }
+
+                PropertiesInputView(
+                    properties: $profile.properties,
+                    addPropertiesLabel: "Fill the name and value for a property and tap the **+** button to add a property before calling `Customer.shared.identify`"
+                )
+
+                Divider()
+                HStack {
+                    Button("Identify") {
+                        profile.loggedIn = true
+                        state.profile = profile
+                        onSuccess(state.profile)
+                    }
+                }
+            }
+            .onAppear {
+                viewModel.titleConfig = Self.title
+        }
+        }
+    }
+}
+
+// MARK: Utilities
+
+#Preview {
+    AppState.shared.profile = Profile.empty()
+    return CommonLayoutView {
+        IdentifyTutorialView { _ in
+        }
+    }
+}

--- a/Apps/VisionOS/VisionOS/ViewUtils/CodeSnippetHelper.swift
+++ b/Apps/VisionOS/VisionOS/ViewUtils/CodeSnippetHelper.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+extension String {
+    func escapeQuotes() -> String {
+        return self.replacingOccurrences(of: "\"", with: "\"\"")
+    }
+}
+
+func propertiesToTutorialString(_ properties: [Property],
+                                linePrefix: String = "") -> String {
+    let senatizedProperties = properties.filter { p in
+        !p.name.isEmpty && !p.value.isEmpty
+    }.map { p in
+        Property(
+            name: p.name
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .escapeQuotes(),
+            value: p.value
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .escapeQuotes())
+    }
+    if (senatizedProperties.isEmpty) {
+        return ""
+    }
+    
+    var res = "["
+    var sep = ""
+    senatizedProperties.forEach { p in
+        res += """
+        \(sep)"\(p.name)": "\(p.value)"
+        """
+        sep = ", "
+    }
+    res += "]"
+    return res
+}

--- a/Apps/VisionOS/VisionOS/ViewUtils/InlineNavigationLink.swift
+++ b/Apps/VisionOS/VisionOS/ViewUtils/InlineNavigationLink.swift
@@ -35,7 +35,7 @@ enum InlineNavigationLink: String, Codable, CaseIterable {
         case .customerIOIntro:
             PostInitializeCustomerIOIntro.title.menuTitle
         case .identify:
-            ""
+            IdentifyTutorialView.title.menuTitle
         case .howToTestIdentify:
             ""
         case .profileAttributes:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #617
* #613
* #612
* #611
* #610
* #609
* #608
* #606
* #605
* #604

## Context

This is a PR in a series of PRs to build sample app that runs Identify and Track in VisionPro
The app is built to be an interactive walk through guidance for developers who are integrating Customer.io Swift SDK in their VisioPro apps.
For more context:

- See the project [one pager](https://www.notion.so/custio/Spacial-Identify-and-Tracking-6587d848bbde494095c0585237326ed3?pvs=4)
- See [Linear Issue](https://linear.app/customerio/issue/MBL-115/sample-app-for-visionpro)

## PR Summary
This PR introduces a the "Identify" tutorial screen. It demonstrates the requirements of the API, allows the user to enter profile attributes to be send alongside the identify call.
Once the user hits the "Identify" button:
- The app will navigate to the "how to test identify" screen that's still blank.
- The identify details will be saved in the AppState and used to call idenfity
- Next app run will use the persisted data to call idenfity on app start

## Test plan
**UI:**
- Add/remove profile attributes and make sure they reflect in the code snippet

**Persistence**
- Ensure the "Initialize" button indeed calls `CustomerIO.shared.identify`
- Ensure next app start does call identify after initializing the SDK

https://github.com/customerio/customerio-ios/assets/142905621/97a8a07c-755c-41f3-984f-21954daded30


