### PR TITLE
docs: [vision-os-sample-app][2/n] App State Storage

### DIFF
--- a/Apps/VisionOS/VisionOS.xcodeproj/project.pbxproj
+++ b/Apps/VisionOS/VisionOS.xcodeproj/project.pbxproj
@@ -13,6 +13,9 @@
 		60F967472B91264B00A4E95E /* Splash in Frameworks */ = {isa = PBXBuildFile; productRef = 60F967462B91264B00A4E95E /* Splash */; };
 		60F9674A2B91265B00A4E95E /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 60F967492B91265B00A4E95E /* MarkdownUI */; };
 		60F9674E2B91269D00A4E95E /* Tracking in Frameworks */ = {isa = PBXBuildFile; productRef = 60F9674D2B91269D00A4E95E /* Tracking */; };
+		60F967532B91288400A4E95E /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967502B91288400A4E95E /* AppState.swift */; };
+		60F967542B91288400A4E95E /* Payloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967512B91288400A4E95E /* Payloads.swift */; };
+		60F967552B91288400A4E95E /* UserDefaultsCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967522B91288400A4E95E /* UserDefaultsCodable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -21,7 +24,10 @@
 		60F967362B9125D000A4E95E /* MainScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainScreen.swift; sourceTree = "<group>"; };
 		60F967382B9125D100A4E95E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		60F9673D2B9125D100A4E95E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		60F9674B2B91267200A4E95E /* customerio-ios */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "customerio-ios"; path = ../../..; sourceTree = "<group>"; };
+		60F9674B2B91267200A4E95E /* cio-ios-spl */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "customerio-ios"; path = ../../..; sourceTree = "<group>"; };
+		60F967502B91288400A4E95E /* AppState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
+		60F967512B91288400A4E95E /* Payloads.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Payloads.swift; sourceTree = "<group>"; };
+		60F967522B91288400A4E95E /* UserDefaultsCodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDefaultsCodable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,6 +65,7 @@
 		60F9672F2B9125D000A4E95E /* VisionOS */ = {
 			isa = PBXGroup;
 			children = (
+				60F9674F2B91288400A4E95E /* Storage */,
 				60F967342B9125D000A4E95E /* VisionOSApp.swift */,
 				60F967362B9125D000A4E95E /* MainScreen.swift */,
 				60F967382B9125D100A4E95E /* Assets.xcassets */,
@@ -80,6 +87,16 @@
 			children = (
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		60F9674F2B91288400A4E95E /* Storage */ = {
+			isa = PBXGroup;
+			children = (
+				60F967502B91288400A4E95E /* AppState.swift */,
+				60F967512B91288400A4E95E /* Payloads.swift */,
+				60F967522B91288400A4E95E /* UserDefaultsCodable.swift */,
+			);
+			path = Storage;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -160,8 +177,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				60F967542B91288400A4E95E /* Payloads.swift in Sources */,
 				60F967372B9125D000A4E95E /* MainScreen.swift in Sources */,
 				60F967352B9125D000A4E95E /* VisionOSApp.swift in Sources */,
+				60F967532B91288400A4E95E /* AppState.swift in Sources */,
+				60F967552B91288400A4E95E /* UserDefaultsCodable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Apps/VisionOS/VisionOS/Storage/AppState.swift
+++ b/Apps/VisionOS/VisionOS/Storage/AppState.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+class AppState: ObservableObject {
+    static let shared = AppState()
+
+    @Published var profile: Profile = .loadFromStorage() {
+        didSet {
+            UserDefaults.standard.setValue(
+                profile.toJson(),
+                forKey: Profile.storageKey()
+            )
+        }
+    }
+
+    @Published var workspaceSettings: WorkspaceSettings = .loadFromStorage() {
+        didSet {
+            UserDefaults.standard.setValue(
+                workspaceSettings.toJson(),
+                forKey: WorkspaceSettings.storageKey()
+            )
+        }
+    }
+}

--- a/Apps/VisionOS/VisionOS/Storage/Payloads.swift
+++ b/Apps/VisionOS/VisionOS/Storage/Payloads.swift
@@ -1,0 +1,66 @@
+import CioTracking
+import Foundation
+
+extension Region: CaseIterable, Codable {
+    public static var allCases: [Region] = [.EU, .US]
+}
+
+struct WorkspaceSettings: UserDefaultsCodable {
+    var siteId: String
+    var apiKey: String
+    var region: Region = .EU
+
+    static func storageKey() -> String {
+        "UserDefaultsCodable"
+    }
+
+    static func empty() -> Self {
+        WorkspaceSettings(siteId: "", apiKey: "")
+    }
+
+    func isSet() -> Bool {
+        !siteId.isEmpty && !apiKey.isEmpty
+    }
+}
+
+struct Profile: UserDefaultsCodable {
+    var id: String
+    var properties: [Property]
+    var loggedIn: Bool
+
+    static func empty() -> Profile {
+        Profile(id: UUID().uuidString, properties: [], loggedIn: false)
+    }
+
+    static func storageKey() -> String {
+        "Profile"
+    }
+}
+
+struct Property: Codable, Identifiable, Comparable, Equatable {
+    static func < (lhs: Property, rhs: Property) -> Bool {
+        lhs.name == rhs.name
+    }
+
+    let id: String
+    var name: String
+    var value: String
+
+    init(name: String, value: String) {
+        self.id = UUID().uuidString
+        self.name = name
+        self.value = value
+    }
+}
+
+extension [Property] {
+    func toDictionary() -> [String: String] {
+        var res: [String: String] = [:]
+        forEach { p in
+            if !p.name.isEmpty {
+                res[p.name] = p.value
+            }
+        }
+        return res
+    }
+}

--- a/Apps/VisionOS/VisionOS/Storage/UserDefaultsCodable.swift
+++ b/Apps/VisionOS/VisionOS/Storage/UserDefaultsCodable.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+protocol UserDefaultsCodable: Codable {
+    static func storageKey() -> String
+    static func empty() -> Self
+}
+
+extension UserDefaultsCodable {
+    func toJson() -> Data {
+        let encoder = JSONEncoder()
+        return try! encoder.encode(self)
+    }
+
+    static func from(_ data: Data) -> Self? {
+        let decoder = JSONDecoder()
+        return try? decoder.decode(Self.self, from: data)
+    }
+
+    static func loadFromStorage() -> Self {
+        if let data =
+            UserDefaults.standard.object(forKey: storageKey()) as? Data,
+            let storedInstance = from(data) {
+            return storedInstance
+        }
+
+        let content = Self.empty()
+        UserDefaults.standard.setValue(
+            content.toJson(),
+            forKey: Self.storageKey()
+        )
+
+        return content
+    }
+}


### PR DESCRIPTION
This is a PR in a series of PRs to build sample app that runs Identify and Track in VisionPro
The app is built to be an interactive walk through guidance for developers who are integrating Customer.io Swift SDK in their VisioPro apps.
For more context:

- See the project [one pager](https://www.notion.so/custio/Spacial-Identify-and-Tracking-6587d848bbde494095c0585237326ed3?pvs=4)
- See [Linear Issue](https://linear.app/customerio/issue/MBL-115/sample-app-for-visionpro)

In this PR I added storage utilities to persiste/restore the app satate as well as few payloads that will be used for SDK initialization, profile, and events

- Open `VisionOs.xcproject`
- Hit CMD+R to run the project and make sure you have VisionOS simulator installed and selected

---

**Stack**:
- #628
- #627
- #626
- #625
- #624
- #623
- #622
- #621
- #620
- #619
- #618 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*