### PR TITLE
docs: [vision-os-sample-app][3/n] Markdown utils

### DIFF
--- a/Apps/VisionOS/VisionOS.xcodeproj/project.pbxproj
+++ b/Apps/VisionOS/VisionOS.xcodeproj/project.pbxproj
@@ -16,6 +16,9 @@
 		60F967532B91288400A4E95E /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967502B91288400A4E95E /* AppState.swift */; };
 		60F967542B91288400A4E95E /* Payloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967512B91288400A4E95E /* Payloads.swift */; };
 		60F967552B91288400A4E95E /* UserDefaultsCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967522B91288400A4E95E /* UserDefaultsCodable.swift */; };
+		60F9675B2B912C1000A4E95E /* TextOutputFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967582B912C1000A4E95E /* TextOutputFormat.swift */; };
+		60F9675C2B912C1000A4E95E /* SplashCodeSyntaxHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967592B912C1000A4E95E /* SplashCodeSyntaxHighlighter.swift */; };
+		60F9675D2B912C1000A4E95E /* MarkdownTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F9675A2B912C1000A4E95E /* MarkdownTheme.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +31,9 @@
 		60F967502B91288400A4E95E /* AppState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		60F967512B91288400A4E95E /* Payloads.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Payloads.swift; sourceTree = "<group>"; };
 		60F967522B91288400A4E95E /* UserDefaultsCodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDefaultsCodable.swift; sourceTree = "<group>"; };
+		60F967582B912C1000A4E95E /* TextOutputFormat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextOutputFormat.swift; sourceTree = "<group>"; };
+		60F967592B912C1000A4E95E /* SplashCodeSyntaxHighlighter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SplashCodeSyntaxHighlighter.swift; sourceTree = "<group>"; };
+		60F9675A2B912C1000A4E95E /* MarkdownTheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarkdownTheme.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -65,6 +71,7 @@
 		60F9672F2B9125D000A4E95E /* VisionOS */ = {
 			isa = PBXGroup;
 			children = (
+				60F967562B912C1000A4E95E /* ViewUtils */,
 				60F9674F2B91288400A4E95E /* Storage */,
 				60F967342B9125D000A4E95E /* VisionOSApp.swift */,
 				60F967362B9125D000A4E95E /* MainScreen.swift */,
@@ -97,6 +104,24 @@
 				60F967522B91288400A4E95E /* UserDefaultsCodable.swift */,
 			);
 			path = Storage;
+			sourceTree = "<group>";
+		};
+		60F967562B912C1000A4E95E /* ViewUtils */ = {
+			isa = PBXGroup;
+			children = (
+				60F967572B912C1000A4E95E /* SyntaxHighlighting */,
+				60F9675A2B912C1000A4E95E /* MarkdownTheme.swift */,
+			);
+			path = ViewUtils;
+			sourceTree = "<group>";
+		};
+		60F967572B912C1000A4E95E /* SyntaxHighlighting */ = {
+			isa = PBXGroup;
+			children = (
+				60F967582B912C1000A4E95E /* TextOutputFormat.swift */,
+				60F967592B912C1000A4E95E /* SplashCodeSyntaxHighlighter.swift */,
+			);
+			path = SyntaxHighlighting;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -177,8 +202,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				60F9675C2B912C1000A4E95E /* SplashCodeSyntaxHighlighter.swift in Sources */,
 				60F967542B91288400A4E95E /* Payloads.swift in Sources */,
 				60F967372B9125D000A4E95E /* MainScreen.swift in Sources */,
+				60F9675B2B912C1000A4E95E /* TextOutputFormat.swift in Sources */,
+				60F9675D2B912C1000A4E95E /* MarkdownTheme.swift in Sources */,
 				60F967352B9125D000A4E95E /* VisionOSApp.swift in Sources */,
 				60F967532B91288400A4E95E /* AppState.swift in Sources */,
 				60F967552B91288400A4E95E /* UserDefaultsCodable.swift in Sources */,

--- a/Apps/VisionOS/VisionOS/ViewUtils/MarkdownTheme.swift
+++ b/Apps/VisionOS/VisionOS/ViewUtils/MarkdownTheme.swift
@@ -1,0 +1,63 @@
+import MarkdownUI
+import SwiftUI
+
+private extension Color {
+    static let codeBackground = Color(rgba: 0x333336FF)
+    static let blockquoteIcon = Color(rgba: 0xFECD00FF)
+    static let blockquoteBackground = Color(rgba: 0xAF65FFFF)
+    static let linkColor = Color(rgba: 0x04ECBBFF)
+}
+
+extension Theme {
+    static let tutorial = Theme.docC
+        .code {
+            FontFamilyVariant(.monospaced)
+            FontSize(16)
+            FontStyle(.italic)
+            FontWeight(.bold)
+        }
+        .codeBlock { configuration in
+            ScrollView(.horizontal) {
+                configuration.label
+                    .fixedSize(horizontal: false, vertical: true)
+                    .relativeLineSpacing(.em(0.333335))
+                    .markdownTextStyle {
+                        FontFamilyVariant(.monospaced)
+                        FontSize(22)
+                    }
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 16)
+            }
+            .background(Color.codeBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 15, style: .continuous))
+        }
+        .paragraph { configuration in
+            configuration.label
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .text {
+            FontSize(22)
+        }
+        .link {
+            ForegroundColor(Color.linkColor)
+            FontWeight(.semibold)
+            UnderlineStyle(.single)
+        }
+        .blockquote { configuration in
+            HStack(spacing: 0) {
+                Image(systemName: "exclamationmark.warninglight.fill")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 60)
+                    .rotationEffect(.degrees(180))
+                    .foregroundColor(Color.blockquoteIcon)
+                    .padding(.horizontal)
+                configuration.label
+                    .relativePadding(.vertical, length: .em(0.3))
+                    .relativePadding(.trailing, length: .em(1))
+            }
+            .background(Color.blockquoteBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .fixedSize(horizontal: false, vertical: true)
+        }
+}

--- a/Apps/VisionOS/VisionOS/ViewUtils/SyntaxHighlighting/SplashCodeSyntaxHighlighter.swift
+++ b/Apps/VisionOS/VisionOS/ViewUtils/SyntaxHighlighting/SplashCodeSyntaxHighlighter.swift
@@ -1,0 +1,25 @@
+import MarkdownUI
+import Splash
+import SwiftUI
+
+struct SplashCodeSyntaxHighlighter: CodeSyntaxHighlighter {
+    private let syntaxHighlighter: SyntaxHighlighter<TextOutputFormat>
+
+    init(theme: Splash.Theme) {
+        self.syntaxHighlighter = SyntaxHighlighter(format: TextOutputFormat(theme: theme))
+    }
+
+    func highlightCode(_ content: String, language: String?) -> Text {
+        guard language?.lowercased() == "swift" else {
+            return Text(content)
+        }
+
+        return syntaxHighlighter.highlight(content)
+    }
+}
+
+extension CodeSyntaxHighlighter where Self == SplashCodeSyntaxHighlighter {
+    static var splash: Self {
+        SplashCodeSyntaxHighlighter(theme: .wwdc17(withFont: .init(size: 18)))
+    }
+}

--- a/Apps/VisionOS/VisionOS/ViewUtils/SyntaxHighlighting/TextOutputFormat.swift
+++ b/Apps/VisionOS/VisionOS/ViewUtils/SyntaxHighlighting/TextOutputFormat.swift
@@ -1,0 +1,45 @@
+import Splash
+import SwiftUI
+
+struct TextOutputFormat: OutputFormat {
+    private let theme: Theme
+
+    init(theme: Theme) {
+        self.theme = theme
+    }
+
+    func makeBuilder() -> Builder {
+        Builder(theme: theme)
+    }
+}
+
+extension TextOutputFormat {
+    struct Builder: OutputBuilder {
+        private let theme: Theme
+        private var accumulatedText: [Text]
+
+        fileprivate init(theme: Theme) {
+            self.theme = theme
+            self.accumulatedText = []
+        }
+
+        mutating func addToken(_ token: String, ofType type: TokenType) {
+            let color = theme.tokenColors[type] ?? theme.plainTextColor
+            accumulatedText.append(Text(token).foregroundColor(.init(uiColor: color)))
+        }
+
+        mutating func addPlainText(_ text: String) {
+            accumulatedText.append(
+                Text(text).foregroundColor(.init(uiColor: theme.plainTextColor))
+            )
+        }
+
+        mutating func addWhitespace(_ whitespace: String) {
+            accumulatedText.append(Text(whitespace))
+        }
+
+        func build() -> Text {
+            accumulatedText.reduce(Text(""), +)
+        }
+    }
+}


### PR DESCRIPTION
This is a PR in a series of PRs to build sample app that runs Identify and Track in VisionPro
The app is built to be an interactive walk through guidance for developers who are integrating Customer.io Swift SDK in their VisioPro apps.
For more context:

- See the project [one pager](https://www.notion.so/custio/Spacial-Identify-and-Tracking-6587d848bbde494095c0585237326ed3?pvs=4)
- See [Linear Issue](https://linear.app/customerio/issue/MBL-115/sample-app-for-visionpro)

In this PR I added few utils for code syntax highlighting and the Markdown theme that will use it

- Open `VisionOs.xcproject`
- Hit CMD+R to run the project and make sure you have VisionOS simulator installed and selected

---

**Stack**:
- #628
- #627
- #626
- #625
- #624
- #623
- #622
- #621
- #620
- #619 ⬅
- #618


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*