### PR TITLE
chore: fix data pipeline tests

### DIFF
--- a/Sources/DataPipeline/CustomerIO.swift
+++ b/Sources/DataPipeline/CustomerIO.swift
@@ -12,9 +12,10 @@ public extension CustomerIO {
         // can introduce an option to store and retrieve it.
         let (sdkConfig, cdpConfig) = config
 
-        let implementation = DataPipeline.initialize(moduleConfig: cdpConfig)
-        // set the logLevel for ConsoleLogger
+        // set the logLevel for ConsoleLogger before initializing any module
         DIGraphShared.shared.logger.setLogLevel(sdkConfig.logLevel)
+        // initialize DataPipeline module with the provided configuration
+        let implementation = DataPipeline.initialize(moduleConfig: cdpConfig)
         // enable Analytics logs accordingly to logLevel
         CustomerIO.shared.setDebugLogsEnabled(sdkConfig.logLevel == CioLogLevel.debug)
         initialize(implementation: implementation)

--- a/Tests/DataPipeline/APITest.swift
+++ b/Tests/DataPipeline/APITest.swift
@@ -30,7 +30,7 @@ class DataPipelineAPITest: UnitTest {
         try skipRunningTest()
 
         // Initialize
-        CustomerIO.initialize(withConfig: SDKConfigBuilder(cdpApiKey: "").build())
+        CustomerIO.initialize(withConfig: SDKConfigBuilder(cdpApiKey: .random).build())
 
         // Identify
         CustomerIO.shared.identify(userId: "")
@@ -125,7 +125,7 @@ class DataPipelineAPITest: UnitTest {
     func test_allPublicModuleConfigOptions() throws {
         try skipRunningTest()
 
-        _ = SDKConfigBuilder(cdpApiKey: "")
+        _ = SDKConfigBuilder(cdpApiKey: .random)
             .logLevel(.info)
             .apiHost("")
             .cdnHost("")

--- a/Tests/DataPipeline/Config/SDKConfigBuilderTest.swift
+++ b/Tests/DataPipeline/Config/SDKConfigBuilderTest.swift
@@ -5,7 +5,7 @@ import XCTest
 
 class SDKConfigBuilderTest: UnitTest {
     func test_initializeAndDoNotModify_expectDefaultValues() {
-        let (sdkConfig, dataPipelineConfig) = SDKConfigBuilder(cdpApiKey: "").build()
+        let (sdkConfig, dataPipelineConfig) = SDKConfigBuilder(cdpApiKey: .random).build()
 
         XCTAssertEqual(sdkConfig.logLevel, .error)
 
@@ -86,7 +86,7 @@ class SDKConfigBuilderTest: UnitTest {
             XCTFail("Failed to setup test integrations with error: \(error)")
         }
 
-        let (_, actual) = SDKConfigBuilder(cdpApiKey: "").build()
+        let (_, actual) = SDKConfigBuilder(cdpApiKey: .random).build()
 
         // API host and CDN host should match Customer.io's CDP settings.
         XCTAssertEqual(actual.apiHost, "cdp.customer.io/v1")

--- a/Tests/DataPipeline/Core/UnitTest.swift
+++ b/Tests/DataPipeline/Core/UnitTest.swift
@@ -76,5 +76,6 @@ open class UnitTest: SharedTests.UnitTestBase<CustomerIO> {
     override open func cleanupTestEnvironment() {
         super.cleanupTestEnvironment()
         CustomerIO.resetTestEnvironment()
+        Analytics.removeActiveWriteKey(dataPipelineConfigOptions.cdpApiKey)
     }
 }

--- a/Tests/DataPipeline/Core/UnitTest.swift
+++ b/Tests/DataPipeline/Core/UnitTest.swift
@@ -75,7 +75,7 @@ open class UnitTest: SharedTests.UnitTestBase<CustomerIO> {
 
     override open func cleanupTestEnvironment() {
         super.cleanupTestEnvironment()
-        CustomerIO.resetTestEnvironment()
         Analytics.removeActiveWriteKey(dataPipelineConfigOptions.cdpApiKey)
+        CustomerIO.resetTestEnvironment()
     }
 }

--- a/Tests/DataPipeline/DataPipelineInteractionTests.swift
+++ b/Tests/DataPipeline/DataPipelineInteractionTests.swift
@@ -23,7 +23,7 @@ open class DataPipelineInteractionTests: IntegrationTest {
     }
 }
 
-class DataPipelineInteractionDefaultConfigTests: DataPipelineInteractionTests {
+class CDPInteractionDefaultConfigTests: DataPipelineInteractionTests {
     override open func setUp() {
         super.setUp()
 
@@ -566,7 +566,7 @@ class DataPipelineInteractionDefaultConfigTests: DataPipelineInteractionTests {
     }
 }
 
-class DataPipelineInteractionCustomConfigTest: DataPipelineInteractionTests {
+class CDPInteractionCustomConfigTests: DataPipelineInteractionTests {
     override func setUp() {
         // keep setUp empty to prevent default setUp so we can test with custom configurations for each test.
     }

--- a/Tests/MessagingPushAPN/APITest.swift
+++ b/Tests/MessagingPushAPN/APITest.swift
@@ -31,8 +31,8 @@ class MessagingPushAPNAPITest: UnitTest {
         // to other targets (such as iOS).
         // You should be able to uncomment the initialize() function below and should get compile errors saying that the
         // function is not available to iOS.
-        // MessagingPush.initialize(withConfig: MessagingPushConfigBuilder(cdpApiKey: "").build())
-        // MessagingPushAPN.initialize(withConfig: MessagingPushConfigBuilder(cdpApiKey: "").build())
+        // MessagingPush.initialize(withConfig: MessagingPushConfigBuilder(cdpApiKey: .random).build())
+        // MessagingPushAPN.initialize(withConfig: MessagingPushConfigBuilder(cdpApiKey: .random).build())
 
         // `moduleConfig` is not really meant to be accessed by customers, so it is okay to not have it in the mock.
         // However, it is public so we should make sure it does not change.
@@ -73,7 +73,7 @@ class MessagingPushAPNAPITest: UnitTest {
         // to other targets (such as iOS).
         // You should be able to uncomment the initialize() function below and should get compile errors saying that the
         // function is not available to iOS.
-        // _ = MessagingPushConfigBuilder(cdpApiKey: "").build()
+        // _ = MessagingPushConfigBuilder(cdpApiKey: .random).build()
 
         let configOptions: [String: Any] = [:]
         _ = MessagingPushConfigBuilder.build(from: configOptions)

--- a/Tests/MessagingPushFCM/APITest.swift
+++ b/Tests/MessagingPushFCM/APITest.swift
@@ -31,8 +31,8 @@ class MessagingPushFCMAPITest: UnitTest {
         // to other targets (such as iOS).
         // You should be able to uncomment the initialize() function below and should get compile errors saying that the
         // function is not available to iOS.
-        // MessagingPush.initialize(withConfig: MessagingPushConfigBuilder(cdpApiKey: "").build())
-        // MessagingPushFCM.initialize(withConfig: MessagingPushConfigBuilder(cdpApiKey: "").build())
+        // MessagingPush.initialize(withConfig: MessagingPushConfigBuilder(cdpApiKey: .random).build())
+        // MessagingPushFCM.initialize(withConfig: MessagingPushConfigBuilder(cdpApiKey: .random).build())
 
         // `moduleConfig` is not really meant to be accessed by customers, so it is okay to not have it in the mock.
         // However, it is public so we should make sure it does not change.
@@ -73,7 +73,7 @@ class MessagingPushFCMAPITest: UnitTest {
         // to other targets (such as iOS).
         // You should be able to uncomment the initialize() function below and should get compile errors saying that the
         // function is not available to iOS.
-        // _ = MessagingPushConfigBuilder(cdpApiKey: "").build()
+        // _ = MessagingPushConfigBuilder(cdpApiKey: .random).build()
 
         let configOptions: [String: Any] = [:]
         _ = MessagingPushConfigBuilder.build(from: configOptions)


### PR DESCRIPTION
### Changes

- Fixed tests breaking due to reinitialization of `analytics` with same `writeKey`
- Fixed `logLevel` for `DataPipeline` module