### PR TITLE
chore: rename siteId

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
@@ -49,7 +49,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             .flushAt(Int(storage.bgNumOfTasks ?? "10") ?? 10)
             .flushInterval(Double(storage.bgQDelay ?? "30") ?? 30)
             .autoTrackDeviceAttributes(storage.isTrackDeviceAttrEnabled ?? true)
-            .siteId(siteId)
+            .migrationSiteId(siteId)
 
         if let apiHost = storage.apiHost, !apiHost.isEmpty {
             config.apiHost(apiHost)

--- a/Apps/CocoaPods-FCM/src/AppDelegate.swift
+++ b/Apps/CocoaPods-FCM/src/AppDelegate.swift
@@ -22,7 +22,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
         // Configure and initialize the Customer.io SDK
         let config = SDKConfigBuilder(cdpApiKey: cdpApiKey)
-            .siteId(siteId)
+            .migrationSiteId(siteId)
             .flushAt(appSetSettings?.flushAt ?? 10)
             .flushInterval(Double(appSetSettings?.flushInterval ?? 30))
             .autoTrackDeviceAttributes(appSetSettings?.trackDeviceAttributes ?? true)

--- a/Apps/Common/Source/Model/CioSettings.swift
+++ b/Apps/Common/Source/Model/CioSettings.swift
@@ -19,7 +19,7 @@ public struct CioSettings: Codable {
         let sdkConfig = DataPipeline.moduleConfig
         let logLevel = DIGraphShared.shared.logger.logLevel
         return CioSettings(
-            siteId: sdkConfig?.siteId ?? "",
+            siteId: sdkConfig?.migrationSiteId ?? "",
             cdpApiKey: sdkConfig?.cdpApiKey ?? "",
             apiHost: sdkConfig?.apiHost ?? "",
             cdnHost: sdkConfig?.cdnHost ?? "",

--- a/Sources/DataPipeline/Config/DataPipelineConfigOptions.swift
+++ b/Sources/DataPipeline/Config/DataPipelineConfigOptions.swift
@@ -29,5 +29,5 @@ public struct DataPipelineConfigOptions {
     public let autoTrackDeviceAttributes: Bool
 
     /// Configuration options required for migration from earlier versions
-    public let siteId: String?
+    public let migrationSiteId: String?
 }

--- a/Sources/DataPipeline/Config/SDKConfigBuilder.swift
+++ b/Sources/DataPipeline/Config/SDKConfigBuilder.swift
@@ -37,7 +37,7 @@ public class SDKConfigBuilder {
     private var operatingMode: OperatingMode = .asynchronous
     private var trackApplicationLifecycleEvents: Bool = true
     private var autoTrackDeviceAttributes: Bool = true
-    private var siteId: String?
+    private var migrationSiteId: String?
 
     /// Initializes new `SDKConfigBuilder` with required configuration options.
     /// - Parameters:
@@ -132,8 +132,8 @@ public class SDKConfigBuilder {
     }
 
     @discardableResult
-    public func siteId(_ siteId: String) -> SDKConfigBuilder {
-        self.siteId = siteId
+    public func migrationSiteId(_ siteId: String) -> SDKConfigBuilder {
+        migrationSiteId = siteId
         return self
     }
 
@@ -157,7 +157,7 @@ public class SDKConfigBuilder {
             operatingMode: operatingMode,
             trackApplicationLifecycleEvents: trackApplicationLifecycleEvents,
             autoTrackDeviceAttributes: autoTrackDeviceAttributes,
-            siteId: siteId
+            migrationSiteId: migrationSiteId
         )
 
         return (sdkConfig: sdkConfig, dataPipelineConfig: dataPipelineConfig)

--- a/Sources/DataPipeline/CustomerIO.swift
+++ b/Sources/DataPipeline/CustomerIO.swift
@@ -22,7 +22,7 @@ public extension CustomerIO {
 
         // Handle logged-in user from Journeys to CDP and check
         // if any unprocessed tasks are pending in the background queue.
-        if let siteId = cdpConfig.siteId {
+        if let siteId = cdpConfig.migrationSiteId {
             let migrationAssistant = DataPipelineMigrationAssistant(handler: implementation)
             migrationAssistant.performMigration(siteId: siteId)
         }

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -51,7 +51,7 @@ class DataPipelineImplementation: DataPipelineInstance {
     }
 
     private func postProfileAlreadyIdentified() {
-        if let siteId = moduleConfig.siteId, let identifier = profileStore.getProfileId(siteId: siteId) {
+        if let siteId = moduleConfig.migrationSiteId, let identifier = profileStore.getProfileId(siteId: siteId) {
             eventBusHandler.postEvent(ProfileIdentifiedEvent(identifier: identifier))
         } else if let identifier = analytics.userId {
             eventBusHandler.postEvent(ProfileIdentifiedEvent(identifier: identifier))

--- a/Tests/DataPipeline/APITest.swift
+++ b/Tests/DataPipeline/APITest.swift
@@ -138,7 +138,7 @@ class DataPipelineAPITest: UnitTest {
             .operatingMode(OperatingMode.asynchronous)
             .trackApplicationLifecycleEvents(true)
             .autoTrackDeviceAttributes(true)
-            .siteId("")
+            .migrationSiteId("")
             .build()
     }
 

--- a/Tests/DataPipeline/Config/SDKConfigBuilderTest.swift
+++ b/Tests/DataPipeline/Config/SDKConfigBuilderTest.swift
@@ -20,7 +20,7 @@ class SDKConfigBuilderTest: UnitTest {
         XCTAssertEqual(dataPipelineConfig.operatingMode, OperatingMode.asynchronous)
         XCTAssertTrue(dataPipelineConfig.trackApplicationLifecycleEvents)
         XCTAssertTrue(dataPipelineConfig.autoTrackDeviceAttributes)
-        XCTAssertNil(dataPipelineConfig.siteId)
+        XCTAssertNil(dataPipelineConfig.migrationSiteId)
     }
 
     func test_initializeAndModify_expectCustomValues() {
@@ -55,7 +55,7 @@ class SDKConfigBuilderTest: UnitTest {
             .operatingMode(givenOperatingMode)
             .trackApplicationLifecycleEvents(givenTrackApplicationLifecycleEvents)
             .autoTrackDeviceAttributes(givenAutoTrackDeviceAttributes)
-            .siteId(givenSiteId)
+            .migrationSiteId(givenSiteId)
             .build()
 
         XCTAssertEqual(sdkConfig.logLevel, givenLogLevel)
@@ -72,7 +72,7 @@ class SDKConfigBuilderTest: UnitTest {
         XCTAssertEqual(dataPipelineConfig.operatingMode, givenOperatingMode)
         XCTAssertEqual(dataPipelineConfig.trackApplicationLifecycleEvents, givenTrackApplicationLifecycleEvents)
         XCTAssertEqual(dataPipelineConfig.autoTrackDeviceAttributes, givenAutoTrackDeviceAttributes)
-        XCTAssertEqual(dataPipelineConfig.siteId, givenSiteId)
+        XCTAssertEqual(dataPipelineConfig.migrationSiteId, givenSiteId)
     }
 
     func test_givenDefaults_expectMatchAnalyticsDefaults() {


### PR DESCRIPTION
closes: https://linear.app/customerio/issue/MBL-162/change-siteid-to-migrationsiteid-in-datapipelineconfigoptions

Renamed siteId to migrationSiteId in following areas:

- DataPipelineConfigOptions
- SDK config build
- Sample apps