### PR TITLE
test: remove flakiness in HttpTest

### DIFF
--- a/Tests/Common/Service/HttpRequestRunnerTest.swift
+++ b/Tests/Common/Service/HttpRequestRunnerTest.swift
@@ -39,4 +39,44 @@ class HttpRequestRunnerTest: HttpTest {
 
         waitForExpectations()
     }
+
+    func testParallelDownloadFileCreatesUniquePaths() {
+        let expectation1 = expectation(description: "Parallel download file 1")
+        let expectation2 = expectation(description: "Parallel download file 2")
+
+        // Got URL from: https://picsum.photos/
+        // Try to find file with a small file size and from a CDN that the CI can download from.
+        let url = URL(string: "https://picsum.photos/200/300.jpg")!
+        var path1: URL?
+        var path2: URL?
+
+        // Initiate the first download
+        runner?.downloadFile(
+            url: url,
+            fileType: .richPushImage,
+            session: publicSession,
+            onComplete: { path in
+                path1 = path
+                expectation1.fulfill()
+            }
+        )
+
+        // Initiate the second download in parallel
+        runner?.downloadFile(
+            url: url,
+            fileType: .richPushImage,
+            session: publicSession,
+            onComplete: { path in
+                path2 = path
+                expectation2.fulfill()
+            }
+        )
+
+        waitForExpectations()
+
+        XCTAssertNotNil(path1)
+        XCTAssertNotNil(path2)
+
+        XCTAssertNotEqual(path1, path2, "Expected unique path for each parallel download")
+    }
 }

--- a/Tests/Shared/HttpTest.swift
+++ b/Tests/Shared/HttpTest.swift
@@ -17,7 +17,7 @@ import XCTest
  3. Manually run the tests below. Use the XCode debug console to see the log output for debugging.
  */
 open class HttpTest: UnitTest {
-    public var runner: HttpRequestRunner?
+    public var runner: HttpRequestRunner!
     public var userAgentUtil: UserAgentUtil!
     public var session: URLSession?
     public var publicSession: URLSession = CIOHttpClient.getBasicSession()
@@ -38,53 +38,6 @@ open class HttpTest: UnitTest {
                 apiKey: apiKey,
                 userAgentHeaderValue: userAgentUtil.getUserAgentHeaderValue()
             )
-        }
-    }
-
-    func testParallelDownloadFileCreatesUniquePaths() {
-        let expectation1 = expectation(description: "Parallel download file 1")
-        let expectation2 = expectation(description: "Parallel download file 2")
-
-        let url = URL(string: "https://thumbs.dreamstime.com/b/bee-flower-27533578.jpg")!
-        var path1: URL?
-        var path2: URL?
-
-        XCTAssertNotNil(runner)
-
-        // Initiate the first download
-        runner?.downloadFile(
-            url: url,
-            fileType: .richPushImage,
-            session: publicSession,
-            onComplete: { path in
-                XCTAssertNotNil(path)
-                path1 = path
-                expectation1.fulfill()
-            }
-        )
-
-        // Initiate the second download in parallel
-        runner?.downloadFile(
-            url: url,
-            fileType: .richPushImage,
-            session: publicSession,
-            onComplete: { path in
-                XCTAssertNotNil(path)
-                path2 = path
-                expectation2.fulfill()
-            }
-        )
-
-        // Wait for both downloads to complete
-        waitForExpectations(timeout: 20.0) { error in
-            if let error = error {
-                XCTFail("Test failed with error: \(error)")
-            }
-
-            // Verify that both paths are not nil and unique
-            XCTAssertNotNil(path1, "First path should not be nil")
-            XCTAssertNotNil(path2, "Second path should not be nil")
-            XCTAssertNotEqual(path1, path2, "Expected unique path for each parallel download")
         }
     }
 


### PR DESCRIPTION
Part of: https://linear.app/customerio/issue/MBL-164/cdp-branch-flaky-tests-on-ci

An attempt at reducing flakiness of HttpTest tests.

The changes done thus far to try and fix issue:
* Chose a different remote image. Maybe the web server we were using blocks github actions?
* Moved the test out of /Shared/ directory and into /Common/. The test suite assumes that test functions are not written in /Shared/ so maybe that was causing issues?

How did I test this change? 
* Ran test 100 times on local dev machine with success. 

commit-id:0467ebc9