### PR TITLE
fix: open deep link from main thread as required by UIKit

### DIFF
--- a/Sources/MessagingPush/PushHandling/PushEventHandlerProxy.swift
+++ b/Sources/MessagingPush/PushHandling/PushEventHandlerProxy.swift
@@ -49,7 +49,10 @@ class PushEventHandlerProxyImpl: PushEventHandlerProxy {
             return
         }
 
-        Task {
+        // UserNotification runs this event on the main thread.
+        // Run this async task on the main thread to match that behavior. Otherwise, we run the risk of warnings or crashes by trying to call UIKit
+        // functions from a background thread.
+        Task { @MainActor in
             // Wait for all other push event handlers to finish before calling the completion handler.
             // Each iteration of the loop waits for the push event to be processed by the delegate.
             for delegate in nestedDelegates.values {
@@ -81,7 +84,10 @@ class PushEventHandlerProxyImpl: PushEventHandlerProxy {
             return
         }
 
-        Task {
+        // UserNotification runs this event on the main thread.
+        // Run this async task on the main thread to match that behavior. Otherwise, we run the risk of warnings or crashes by trying to call UIKit
+        // functions from a background thread.
+        Task { @MainActor in
             // 2+ other push event handlers may exist in app. We need to decide if a push should be displayed or not, by combining all the results from all other push handlers.
             // To do that, we start with Apple's default value of: do not display.
             // If any of the handlers return result indicating push should be displayed, we return true.


### PR DESCRIPTION
While QA testing https://linear.app/customerio/issue/MBL-138/[bug]-ios-customers-receive-callbacks-from-3rd-party-sdks-for-pushes, I noticed Xcode give a warning that we were opening deep links from a background thread instead of main thread. UIKit operations must be executed on a main thread.

Because our proxy is creating a new async Task that by default runs on a background thread, the proxy will forward all push handling events on a background thread which is what causes this issue. We can fix this by telling Swift to run the async block on the main thread.

---

**Stack**:
- #632 ⬅
- #601
- #590
- #584
- #583


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*