### PR TITLE
fix: call completionHandler if push handler does not implement option…

### DIFF
--- a/Apps/CocoaPods-FCM/src/AppDelegate.swift
+++ b/Apps/CocoaPods-FCM/src/AppDelegate.swift
@@ -73,9 +73,9 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         completionHandler()
     }
 
-    // For testing purposes, it's suggested to not include the willPresent function in the AppDelegate.
-    // The automatic push click handling feature uses swizzling. A good edge case to test with swizzling is when
-    // there is an optional function of UNUserNotificationCenterDelegate not implemented. By not including willPresent, we are able to test this case.
+    // For QA testing, it's suggested to not implement this optional function.
+    // The SDK contains logic that handles when this optional function is implemented in a host iOS app, or not. Do not implement it to test the use case.
+    //
 //    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
 }
 

--- a/Sources/MessagingPush/PushHandling/ManualPushHandling+UserNotifications.swift
+++ b/Sources/MessagingPush/PushHandling/ManualPushHandling+UserNotifications.swift
@@ -96,7 +96,9 @@ extension MessagingPushImplementation {
         // A hack to get an instance of pushClickHandler without making it a property of the MessagingPushImplementation class. pushClickHandler is not available to app extensions but MessagingPushImplementation is.
         // We get around this by getting a instance in this function, only.
         if let pushClickHandler = sdkInitializedUtil.postInitializedData?.diGraph.pushClickHandler {
-            pushClickHandler.pushClicked(push)
+            pushClickHandler.trackPushMetrics(for: push)
+            pushClickHandler.cleanupAfterPushInteractedWith(for: push)
+            pushClickHandler.handleDeepLink(for: push)
         }
     }
 }

--- a/Sources/MessagingPush/PushHandling/PushClickHandler.swift
+++ b/Sources/MessagingPush/PushHandling/PushClickHandler.swift
@@ -5,7 +5,11 @@ import UserNotifications
 
 @available(iOSApplicationExtension, unavailable)
 protocol PushClickHandler: AutoMockable {
-    func pushClicked(_ push: PushNotification)
+    // Cleanup files on device that were used when the push was displayed. Files are no longer
+    // needed now that the push is no longer shown.
+    func cleanupAfterPushInteractedWith(for push: PushNotification)
+    func trackPushMetrics(for push: PushNotification)
+    func handleDeepLink(for push: PushNotification)
 }
 
 @available(iOSApplicationExtension, unavailable)
@@ -19,19 +23,15 @@ class PushClickHandlerImpl: PushClickHandler {
         self.customerIO = customerIO
     }
 
-    // Note: This function is called from automatic and manual push click handlers.
-    func pushClicked(_ push: PushNotification) {
+    func trackPushMetrics(for push: PushNotification) {
         guard let cioDelivery = push.cioDelivery else {
             return
         }
 
         customerIO.trackMetric(deliveryID: cioDelivery.id, event: .opened, deviceToken: cioDelivery.token)
+    }
 
-        // Cleanup files on device that were used when the push was displayed. Files are no longer
-        // needed now that the push is no longer shown.
-        cleanupAfterPushInteractedWith(push: push)
-
-        // Handle deep link, if there is one attached to push.
+    func handleDeepLink(for push: PushNotification) {
         if let deepLinkUrl = push.cioDeepLink?.url {
             deepLinkUtil.handleDeepLink(deepLinkUrl)
         }
@@ -40,7 +40,7 @@ class PushClickHandlerImpl: PushClickHandler {
     // There are files that are created just for displaying a rich push. After a push is interacted with, those files
     // are no longer needed.
     // This function's job is to cleanup after a push is no longer being displayed.
-    func cleanupAfterPushInteractedWith(push: PushNotification) {
+    func cleanupAfterPushInteractedWith(for push: PushNotification) {
         push.cioAttachments.forEach { attachment in
             let localFilePath = attachment.localFileUrl
 

--- a/Sources/MessagingPush/PushHandling/PushEventHandlerProxy.swift
+++ b/Sources/MessagingPush/PushHandling/PushEventHandlerProxy.swift
@@ -49,7 +49,10 @@ class PushEventHandlerProxyImpl: PushEventHandlerProxy {
             return
         }
 
-        Task {
+        // UserNotification runs this event on the main thread.
+        // Run this async task on the main thread to match that behavior. Otherwise, we run the risk of warnings or crashes by trying to call UIKit
+        // functions from a background thread.
+        Task { @MainActor in
             // Wait for all other push event handlers to finish before calling the completion handler.
             // Each iteration of the loop waits for the push event to be processed by the delegate.
             for delegate in nestedDelegates.values {
@@ -81,7 +84,10 @@ class PushEventHandlerProxyImpl: PushEventHandlerProxy {
             return
         }
 
-        Task {
+        // UserNotification runs this event on the main thread.
+        // Run this async task on the main thread to match that behavior. Otherwise, we run the risk of warnings or crashes by trying to call UIKit
+        // functions from a background thread.
+        Task { @MainActor in
             // 2+ other push event handlers may exist in app. We need to decide if a push should be displayed or not, by combining all the results from all other push handlers.
             // To do that, we start with Apple's default value of: do not display.
             // If any of the handlers return result indicating push should be displayed, we return true.

--- a/Sources/MessagingPush/PushHandling/iOSPushEventListener.swift
+++ b/Sources/MessagingPush/PushHandling/iOSPushEventListener.swift
@@ -83,9 +83,17 @@ class IOSPushEventListener: PushEventHandler {
 
         logger.debug("Push came from CIO. Handle the willPresent event on behalf of the customer.")
 
-        let shouldShowPush = moduleConfig.showPushAppInForeground
+        // Forward event to other push handlers so they can receive a callback about this push event.
+        pushEventHandlerProxy.shouldDisplayPushAppInForeground(push, completionHandler: { _ in
+            // When this block of code executes, the customer is done processing the push event.
 
-        // Call the completionHandler so customer does not need to. The push came from CIO, so it gets handled by the CIO SDK.
-        completionHandler(shouldShowPush)
+            // Because push came from CIO, ignore the return result of other push handlers.
+            // Determine if CIO push should be shown from SDK config
+            let shouldShowPush = self.moduleConfig.showPushAppInForeground
+
+            // The push came from CIO, so it gets handled by the CIO SDK.
+            // Calling the completion handler indicates to the OS that we are done processing the push.
+            completionHandler(shouldShowPush)
+        })
     }
 }

--- a/Sources/MessagingPush/UserNotificationsFramework/Wrappers.swift
+++ b/Sources/MessagingPush/UserNotificationsFramework/Wrappers.swift
@@ -129,7 +129,11 @@ class UNUserNotificationCenterDelegateWrapper: PushEventHandler {
             return
         }
 
-        delegate.userNotificationCenter?(UNUserNotificationCenter.current(), didReceive: userNotificationsWrapperInstance.response, withCompletionHandler: completionHandler)
+        let delegateGotCalled: Void? = delegate.userNotificationCenter?(UNUserNotificationCenter.current(), didReceive: userNotificationsWrapperInstance.response, withCompletionHandler: completionHandler)
+
+        if delegateGotCalled == nil { // delegate did not implement this optional method. Call the completionHandler for them.
+            completionHandler()
+        }
     }
 
     func shouldDisplayPushAppInForeground(_ push: PushNotification, completionHandler: @escaping (Bool) -> Void) {
@@ -137,10 +141,14 @@ class UNUserNotificationCenterDelegateWrapper: PushEventHandler {
             return
         }
 
-        delegate.userNotificationCenter?(UNUserNotificationCenter.current(), willPresent: unnotification) { displayPushInForegroundOptions in
+        let delegateGotCalled: Void? = delegate.userNotificationCenter?(UNUserNotificationCenter.current(), willPresent: unnotification) { displayPushInForegroundOptions in
             let shouldShowPush = !displayPushInForegroundOptions.isEmpty
 
             completionHandler(shouldShowPush)
+        }
+
+        if delegateGotCalled == nil { // delegate did not implement this optional method. Call the completionHandler for them.
+            completionHandler(false)
         }
     }
 }

--- a/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
@@ -449,38 +449,102 @@ class PushClickHandlerMock: PushClickHandler, Mock {
     }
 
     public func resetMock() {
-        pushClickedCallsCount = 0
-        pushClickedReceivedArguments = nil
-        pushClickedReceivedInvocations = []
+        cleanupAfterPushInteractedWithCallsCount = 0
+        cleanupAfterPushInteractedWithReceivedArguments = nil
+        cleanupAfterPushInteractedWithReceivedInvocations = []
+
+        mockCalled = false // do last as resetting properties above can make this true
+        trackPushMetricsCallsCount = 0
+        trackPushMetricsReceivedArguments = nil
+        trackPushMetricsReceivedInvocations = []
+
+        mockCalled = false // do last as resetting properties above can make this true
+        handleDeepLinkCallsCount = 0
+        handleDeepLinkReceivedArguments = nil
+        handleDeepLinkReceivedInvocations = []
 
         mockCalled = false // do last as resetting properties above can make this true
     }
 
-    // MARK: - pushClicked
+    // MARK: - cleanupAfterPushInteractedWith
 
     /// Number of times the function was called.
-    private(set) var pushClickedCallsCount = 0
+    private(set) var cleanupAfterPushInteractedWithCallsCount = 0
     /// `true` if the function was ever called.
-    var pushClickedCalled: Bool {
-        pushClickedCallsCount > 0
+    var cleanupAfterPushInteractedWithCalled: Bool {
+        cleanupAfterPushInteractedWithCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    private(set) var pushClickedReceivedArguments: PushNotification?
+    private(set) var cleanupAfterPushInteractedWithReceivedArguments: PushNotification?
     /// Arguments from *all* of the times that the function was called.
-    private(set) var pushClickedReceivedInvocations: [PushNotification] = []
+    private(set) var cleanupAfterPushInteractedWithReceivedInvocations: [PushNotification] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    var pushClickedClosure: ((PushNotification) -> Void)?
+    var cleanupAfterPushInteractedWithClosure: ((PushNotification) -> Void)?
 
-    /// Mocked function for `pushClicked(_ push: PushNotification)`. Your opportunity to return a mocked value and check result of mock in test code.
-    func pushClicked(_ push: PushNotification) {
+    /// Mocked function for `cleanupAfterPushInteractedWith(for push: PushNotification)`. Your opportunity to return a mocked value and check result of mock in test code.
+    func cleanupAfterPushInteractedWith(for push: PushNotification) {
         mockCalled = true
-        pushClickedCallsCount += 1
-        pushClickedReceivedArguments = push
-        pushClickedReceivedInvocations.append(push)
-        pushClickedClosure?(push)
+        cleanupAfterPushInteractedWithCallsCount += 1
+        cleanupAfterPushInteractedWithReceivedArguments = push
+        cleanupAfterPushInteractedWithReceivedInvocations.append(push)
+        cleanupAfterPushInteractedWithClosure?(push)
+    }
+
+    // MARK: - trackPushMetrics
+
+    /// Number of times the function was called.
+    private(set) var trackPushMetricsCallsCount = 0
+    /// `true` if the function was ever called.
+    var trackPushMetricsCalled: Bool {
+        trackPushMetricsCallsCount > 0
+    }
+
+    /// The arguments from the *last* time the function was called.
+    private(set) var trackPushMetricsReceivedArguments: PushNotification?
+    /// Arguments from *all* of the times that the function was called.
+    private(set) var trackPushMetricsReceivedInvocations: [PushNotification] = []
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     */
+    var trackPushMetricsClosure: ((PushNotification) -> Void)?
+
+    /// Mocked function for `trackPushMetrics(for push: PushNotification)`. Your opportunity to return a mocked value and check result of mock in test code.
+    func trackPushMetrics(for push: PushNotification) {
+        mockCalled = true
+        trackPushMetricsCallsCount += 1
+        trackPushMetricsReceivedArguments = push
+        trackPushMetricsReceivedInvocations.append(push)
+        trackPushMetricsClosure?(push)
+    }
+
+    // MARK: - handleDeepLink
+
+    /// Number of times the function was called.
+    private(set) var handleDeepLinkCallsCount = 0
+    /// `true` if the function was ever called.
+    var handleDeepLinkCalled: Bool {
+        handleDeepLinkCallsCount > 0
+    }
+
+    /// The arguments from the *last* time the function was called.
+    private(set) var handleDeepLinkReceivedArguments: PushNotification?
+    /// Arguments from *all* of the times that the function was called.
+    private(set) var handleDeepLinkReceivedInvocations: [PushNotification] = []
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     */
+    var handleDeepLinkClosure: ((PushNotification) -> Void)?
+
+    /// Mocked function for `handleDeepLink(for push: PushNotification)`. Your opportunity to return a mocked value and check result of mock in test code.
+    func handleDeepLink(for push: PushNotification) {
+        mockCalled = true
+        handleDeepLinkCallsCount += 1
+        handleDeepLinkReceivedArguments = push
+        handleDeepLinkReceivedInvocations.append(push)
+        handleDeepLinkClosure?(push)
     }
 }
 

--- a/Tests/MessagingPush/Extension/PushClickHandlerMockExtension.swift
+++ b/Tests/MessagingPush/Extension/PushClickHandlerMockExtension.swift
@@ -1,0 +1,56 @@
+@testable import CioMessagingPush
+import Foundation
+import XCTest
+
+/*
+ Set of test utilities for testing when a push notification is clicked.
+
+ It's recommended to use these functions in your test functions when you're using `PushClickHandlerMock`.
+ */
+
+// MARK: Assertions
+
+extension PushClickHandlerMock {
+    // It's important that when we process a push click, we open the deep link last. This is because when opening a deep link, the device browser could open and the app could be put into the background.
+    // Before the app potentially goes into the background, perform all other push click handling.
+    func assertWillHandleDeepLinkLast(for push: PushNotification) {
+        // When deep link is handled, we expect all other click handling to have already been done.
+        handleDeepLinkClosure = { _ in
+            // We expect all other push click handling to have already happened.
+            self.assertHandledPushClick(for: push)
+
+            // XXX: This would be a good place to call: mock.verifyNoMoreInteractions(), like in Mockito, to be more confident that we are calling deep link last.
+        }
+    }
+
+    // When a push click is handled in the SDK, we expect *all* of these steps are performed.
+    func assertHandledPushClick(for push: PushNotification) {
+        XCTAssertEqual(cleanupAfterPushInteractedWithCallsCount, 1)
+
+        assertTrackedOpenPushMetric(for: push)
+        assertOpenedDeepLink(for: push)
+    }
+
+    func assertTrackedOpenPushMetric(for push: PushNotification, _ didTrackMetric: Bool = true, expectedNumberOfCalls: Int = 1) {
+        XCTAssertEqual(trackPushMetricsCalled, didTrackMetric)
+
+        if didTrackMetric {
+            XCTAssertEqual(trackPushMetricsCallsCount, expectedNumberOfCalls)
+            XCTAssertEqual(trackPushMetricsReceivedArguments!.pushId, push.pushId)
+        }
+    }
+
+    func assertOpenedDeepLink(for push: PushNotification, _ didOpenDeepLink: Bool = true, expectedNumberOfCalls: Int = 1) {
+        XCTAssertEqual(handleDeepLinkCalled, didOpenDeepLink)
+
+        if didOpenDeepLink {
+            XCTAssertEqual(handleDeepLinkCallsCount, expectedNumberOfCalls)
+            XCTAssertEqual(handleDeepLinkReceivedArguments?.cioDeepLink, push.cioDeepLink)
+        }
+    }
+
+    func assertDidNotHandlePushClick() {
+        XCTAssertFalse(trackPushMetricsCalled)
+        XCTAssertFalse(handleDeepLinkCalled)
+    }
+}

--- a/Tests/MessagingPush/PushHandling/AutomaticPushDeliveredAppInForegroundTest.swift
+++ b/Tests/MessagingPush/PushHandling/AutomaticPushDeliveredAppInForegroundTest.swift
@@ -4,15 +4,14 @@ import Foundation
 import SharedTests
 import XCTest
 
+// When a push is delivered to an iOS device and the app is in the foreground, iOS gives the app the option to either display that push or to not display that push.
 class AutomaticPushDeliveredAppInForegrondTest: IntegrationTest {
     private var pushEventHandler: PushEventHandler!
 
     private let pushClickHandler = PushClickHandlerMock()
     private let pushEventHandlerProxy = PushEventHandlerProxyImpl()
 
-    // MARK: test handling when push delivered, app in foreground
-
-    // When a push is delivered to an iOS device and the app is in the foreground, iOS gives the app the option to either display that push or to not display that push.
+    // MARK: SDK configuration behavior
 
     func test_givenCioPushDelivered_givenSdkConfigDisplayPush_expectPushDisplayed() {
         configureSdk(shouldDisplayPushAppInForeground: true)
@@ -21,7 +20,7 @@ class AutomaticPushDeliveredAppInForegrondTest: IntegrationTest {
 
         let didPushGetDisplayed = deliverPush(givenPush)
 
-        XCTAssertTrue(didPushGetDisplayed)
+        XCTAssertEqual(didPushGetDisplayed, true)
     }
 
     func test_givenCioPushDelivered_givenSdkConfigDoNotDisplayPush_expectPushNotDisplayed() {
@@ -31,10 +30,24 @@ class AutomaticPushDeliveredAppInForegrondTest: IntegrationTest {
 
         let didPushGetDisplayed = deliverPush(givenPush)
 
-        XCTAssertFalse(didPushGetDisplayed)
+        XCTAssertEqual(didPushGetDisplayed, false)
     }
 
-    func test_givenMultiplePushHandlers_givenNonCioPushDelivered_expectHandleEvent() {
+    // MARK: cio SDK only push event handler in app
+
+    func test_givenCioOnlyPushHandler_givenNonCioPushDelivered_expectHandleEvent() {
+        configureSdk(shouldDisplayPushAppInForeground: true)
+
+        let givenPush = PushNotificationStub.getPushNotSentFromCIO()
+
+        let didPushGetDisplayed = deliverPush(givenPush)
+
+        XCTAssertEqual(didPushGetDisplayed, true)
+    }
+
+    // MARK: multiple push handlers in app
+
+    func test_givenOtherPushHandlers_givenNonCioPushDelivered_expectHandleEvent() {
         configureSdk(shouldDisplayPushAppInForeground: false)
         let givenPush = PushNotificationStub.getPushNotSentFromCIO()
         var otherPushHandlerCalled = false
@@ -52,14 +65,81 @@ class AutomaticPushDeliveredAppInForegrondTest: IntegrationTest {
         XCTAssertTrue(otherPushHandlerCalled)
     }
 
-    func test_givenCioOnlyPushHandler_givenNonCioPushDelivered_expectHandleEvent() {
+    func test_givenOtherPushHandlers_givenCioPushDelivered_expectOtherPushHandlerGetsCallback_expectIgnoreResultOfOtherHandler() {
         configureSdk(shouldDisplayPushAppInForeground: true)
+        let givenPush = PushNotificationStub.getPushSentFromCIO()
+        let expectOtherPushHandlerCallbackCalled = expectation(description: "Expect other push handler callback called")
 
-        let givenPush = PushNotificationStub.getPushNotSentFromCIO()
+        let givenOtherPushHandler = PushEventHandlerMock()
+        givenOtherPushHandler.shouldDisplayPushAppInForegroundClosure = { _, onComplete in
+            // We expect that other push handler gets callback of push event from CIO push
+            expectOtherPushHandlerCallbackCalled.fulfill()
+
+            // We expect that this return result is ignored. The CIO SDK config setting is used instead.
+            onComplete(false)
+        }
+        addOtherPushEventHandler(givenOtherPushHandler)
 
         let didPushGetDisplayed = deliverPush(givenPush)
 
-        XCTAssertTrue(didPushGetDisplayed)
+        waitForExpectations()
+
+        // Check that the decision to display push was determined by SDK config and not from the return result of 3rd party callback.
+        XCTAssertEqual(didPushGetDisplayed, true)
+    }
+
+    // Important to test that 2+ 3rd party push handlers for some use cases.
+    func test_givenMultiplePushHandlers_givenCioPushDelivered_expectOtherPushHandlersGetCallback() {
+        configureSdk(shouldDisplayPushAppInForeground: true)
+        let givenPush = PushNotificationStub.getPushSentFromCIO()
+        let expectOtherPushHandlerCallbackCalled = expectation(description: "Expect other push handler callback called")
+        expectOtherPushHandlerCallbackCalled.expectedFulfillmentCount = 2
+
+        // In order to add 2+ push handlers to SDK, each class needs to have a unique name.
+        // The SDK only accepts unique push event handlers. Creating this class makes each push handler unique.
+        class PushEventHandlerMock2: PushEventHandlerMock {}
+
+        let givenOtherPushHandler1 = PushEventHandlerMock()
+        let givenOtherPushHandler2 = PushEventHandlerMock2()
+        givenOtherPushHandler1.shouldDisplayPushAppInForegroundClosure = { _, onComplete in
+            expectOtherPushHandlerCallbackCalled.fulfill()
+
+            onComplete(true)
+        }
+        givenOtherPushHandler2.shouldDisplayPushAppInForegroundClosure = { _, onComplete in
+            expectOtherPushHandlerCallbackCalled.fulfill()
+
+            onComplete(true)
+        }
+        addOtherPushEventHandler(givenOtherPushHandler1)
+        addOtherPushEventHandler(givenOtherPushHandler2)
+
+        _ = deliverPush(givenPush)
+
+        waitForExpectations()
+    }
+
+    // MARK: completion handler
+
+    func test_givenMultiplePushHandlers_givenCioPushDelivered_givenOtherPushHandlerDoesNotCallCompletionHandler_expectCompletionHandlerDoesNotGetCalled() {
+        configureSdk(shouldDisplayPushAppInForeground: true)
+
+        let expectOtherClickHandlerToGetCallback = expectation(description: "Receive a callback")
+        let givenPush = PushNotificationStub.getPushSentFromCIO()
+        let givenOtherPushHandler = PushEventHandlerMock()
+
+        givenOtherPushHandler.shouldDisplayPushAppInForegroundClosure = { _, _ in
+            // Do not call completion handler.
+            expectOtherClickHandlerToGetCallback.fulfill()
+        }
+        addOtherPushEventHandler(givenOtherPushHandler)
+
+        let didPushGetDisplayed = deliverPush(givenPush, expectToCallCompletionHandler: false)
+
+        waitForExpectations(for: [expectOtherClickHandlerToGetCallback])
+
+        // nil result means that completionHandler never got called and returned a result.
+        XCTAssertNil(didPushGetDisplayed)
     }
 }
 
@@ -78,12 +158,16 @@ extension AutomaticPushDeliveredAppInForegrondTest {
         )
     }
 
-    func deliverPush(_ push: PushNotification) -> Bool {
+    func deliverPush(_ push: PushNotification, expectToCallCompletionHandler: Bool = true) -> Bool? {
         // Note: It's important that we test that the `withContentHandler` callback function gets called either by our SDK (when we handle it), or the 3rd party handler.
         let expectCompletionHandlerCalled = expectation(description: "Expect completion handler called by a handler")
-        expectCompletionHandlerCalled.expectedFulfillmentCount = 1 // Test will fail if called 2+ times which could indicate a bug because only 1 push click handler should be calling it.
+        if expectToCallCompletionHandler {
+            expectCompletionHandlerCalled.expectedFulfillmentCount = 1 // Test will fail if called 2+ times which could indicate a bug because only 1 push click handler should be calling it.
+        } else {
+            expectCompletionHandlerCalled.isInverted = true
+        }
 
-        var returnValueFromPushHandler = false
+        var returnValueFromPushHandler: Bool?
 
         pushEventHandler.shouldDisplayPushAppInForeground(push) { shouldDisplayPush in
             returnValueFromPushHandler = shouldDisplayPush

--- a/Tests/MessagingPush/PushHandling/PushClickHandlerTest.swift
+++ b/Tests/MessagingPush/PushHandling/PushClickHandlerTest.swift
@@ -18,30 +18,32 @@ class PushClickHandlerTest: IntegrationTest {
         pushClickHandler = PushClickHandlerImpl(deepLinkUtil: deepLinkUtilMock, customerIO: customerIOMock)
     }
 
-    // MARK: pushClicked
+    // MARK: handleDeepLink
 
-    func test_pushClicked_givenNoDeepLinkAttached_expectDoNotHandleDeepLink() {
+    func test_handleDeepLink_givenNoDeepLinkAttached_expectDoNotHandleDeepLink() {
         let givenPush = PushNotificationStub.getPushSentFromCIO(imageUrl: "https://example.com/image.png")
 
-        pushClickHandler.pushClicked(givenPush)
+        pushClickHandler.handleDeepLink(for: givenPush)
 
         XCTAssertFalse(deepLinkUtilMock.mockCalled)
     }
 
-    func test_pushClicked_givenDeepLinkAttached_expectHandleDeepLink() {
+    func test_handleDeepLink_givenDeepLinkAttached_expectHandleDeepLink() {
         let givenDeepLink = "https://example.com/\(String.random)"
         let givenPush = PushNotificationStub.getPushSentFromCIO(deepLink: givenDeepLink, imageUrl: "https://example.com/image.png")
 
-        pushClickHandler.pushClicked(givenPush)
+        pushClickHandler.handleDeepLink(for: givenPush)
 
         XCTAssertEqual(deepLinkUtilMock.handleDeepLinkCallsCount, 1)
         XCTAssertEqual(deepLinkUtilMock.handleDeepLinkReceivedArguments, URL(string: givenDeepLink))
     }
 
-    func test_pushClicked_expectTrackOpenedEvent() {
+    // MARK: trackPushMetrics
+
+    func test_trackPushMetrics_expectTrackOpenedEvent() {
         let givenPush = PushNotificationStub.getPushSentFromCIO(imageUrl: "https://example.com/image.png")
 
-        pushClickHandler.pushClicked(givenPush)
+        pushClickHandler.trackPushMetrics(for: givenPush)
 
         XCTAssertEqual(customerIOMock.trackMetricCallsCount, 1)
     }

--- a/Tests/MessagingPush/PushHandling/PushEventHandlerProxyTest.swift
+++ b/Tests/MessagingPush/PushHandling/PushEventHandlerProxyTest.swift
@@ -1,0 +1,59 @@
+@testable import CioMessagingPush
+@testable import CioTracking
+import Foundation
+import SharedTests
+import XCTest
+
+class PushEventHandlerProxyTest: UnitTest {
+    var pushEventHandlerProxy: PushEventHandlerProxy!
+
+    private let deepLinkUtilMock = DeepLinkUtilMock()
+    private let customerIOMock = CustomerIOInstanceMock()
+
+    override func setUp() {
+        super.setUp()
+
+        pushEventHandlerProxy = PushEventHandlerProxyImpl()
+    }
+
+    // MARK: thread safety
+
+    func test_onPushAction_ensureThreadSafetyCallingDelegates() {
+        runTest(numberOfTimes: 100) { // Ensure no race conditions by running test many times.
+            let delegate1 = PushEventHandlerMock()
+            class PushEventHandlerMock2: PushEventHandlerMock {}
+            let delegate2 = PushEventHandlerMock2()
+
+            let expectDelegatesReceiveEvent = expectation(description: "delegate1 received event")
+            expectDelegatesReceiveEvent.expectedFulfillmentCount = 2 // 1 for each delegate. We do not care what order the delegates get called as long as all get called.
+            let expectCompleteCallingAllDelegates = expectation(description: "complete calling all delegates")
+
+            // When each delegate gets called, have them call the completion handler on different threads to test the proxy is thread safe.
+            delegate1.onPushActionClosure = { _, completion in
+                expectDelegatesReceiveEvent.fulfill()
+
+                self.runOnMain {
+                    completion()
+                }
+            }
+            delegate2.onPushActionClosure = { _, completion in
+                expectDelegatesReceiveEvent.fulfill()
+
+                self.runOnBackground {
+                    completion()
+                }
+            }
+            pushEventHandlerProxy.addPushEventHandler(delegate1)
+            pushEventHandlerProxy.addPushEventHandler(delegate2)
+
+            pushEventHandlerProxy.onPushAction(PushNotificationActionStub(push: PushNotificationStub.getPushSentFromCIO(), didClickOnPush: true)) {
+                expectCompleteCallingAllDelegates.fulfill()
+            }
+
+            wait(for: [
+                expectDelegatesReceiveEvent,
+                expectCompleteCallingAllDelegates
+            ], enforceOrder: true)
+        }
+    }
+}

--- a/Tests/MessagingPush/PushHandling/PushEventHandlerProxyTest.swift
+++ b/Tests/MessagingPush/PushHandling/PushEventHandlerProxyTest.swift
@@ -1,19 +1,15 @@
 @testable import CioMessagingPush
-@testable import CioTracking
 import Foundation
 import SharedTests
 import XCTest
 
 class PushEventHandlerProxyTest: UnitTest {
-    var pushEventHandlerProxy: PushEventHandlerProxy!
-
-    private let deepLinkUtilMock = DeepLinkUtilMock()
-    private let customerIOMock = CustomerIOInstanceMock()
+    private var proxy: PushEventHandlerProxyImpl!
 
     override func setUp() {
         super.setUp()
 
-        pushEventHandlerProxy = PushEventHandlerProxyImpl()
+        proxy = PushEventHandlerProxyImpl()
     }
 
     // MARK: thread safety
@@ -43,10 +39,10 @@ class PushEventHandlerProxyTest: UnitTest {
                     completion()
                 }
             }
-            pushEventHandlerProxy.addPushEventHandler(delegate1)
-            pushEventHandlerProxy.addPushEventHandler(delegate2)
+            proxy.addPushEventHandler(delegate1)
+            proxy.addPushEventHandler(delegate2)
 
-            pushEventHandlerProxy.onPushAction(PushNotificationActionStub(push: PushNotificationStub.getPushSentFromCIO(), didClickOnPush: true)) {
+            proxy.onPushAction(PushNotificationActionStub(push: PushNotificationStub.getPushSentFromCIO(), didClickOnPush: true)) {
                 expectCompleteCallingAllDelegates.fulfill()
             }
 
@@ -55,5 +51,139 @@ class PushEventHandlerProxyTest: UnitTest {
                 expectCompleteCallingAllDelegates
             ], enforceOrder: true)
         }
+    }
+
+    func test_shouldDisplayPushAppInForeground_ensureThreadSafetyCallingDelegates() {
+        runTest(numberOfTimes: 100) { // Ensure no race conditions by running test many times.
+            let givenPush = PushNotificationStub.getPushSentFromCIO()
+
+            let delegate1 = PushEventHandlerMock()
+            class PushEventHandlerMock2: PushEventHandlerMock {}
+            let delegate2 = PushEventHandlerMock2()
+
+            let expectDelegatesReceiveEvent = expectation(description: "delegate1 received event")
+            expectDelegatesReceiveEvent.expectedFulfillmentCount = 2 // 1 for each delegate. We do not care what order the delegates get called as long as all get called.
+            let expectCompleteCallingAllDelegates = expectation(description: "complete calling all delegates")
+
+            // When each delegate gets called, have them call the completion handler on different threads to test the proxy is thread safe.
+            delegate1.shouldDisplayPushAppInForegroundClosure = { _, completion in
+                expectDelegatesReceiveEvent.fulfill()
+
+                self.runOnMain {
+                    completion(false)
+                }
+            }
+            delegate2.shouldDisplayPushAppInForegroundClosure = { _, completion in
+                expectDelegatesReceiveEvent.fulfill()
+
+                self.runOnBackground {
+                    completion(true)
+                }
+            }
+            proxy.addPushEventHandler(delegate1)
+            proxy.addPushEventHandler(delegate2)
+
+            proxy.shouldDisplayPushAppInForeground(givenPush, completionHandler: { actualShouldDisplayPush in
+                // Assert that the 1 delegate that returns `true` is the return result.
+                XCTAssertTrue(actualShouldDisplayPush)
+
+                expectCompleteCallingAllDelegates.fulfill()
+            })
+
+            wait(for: [
+                expectDelegatesReceiveEvent,
+                expectCompleteCallingAllDelegates
+            ], enforceOrder: true)
+        }
+    }
+
+    // MARK: shouldDisplayPushAppInForeground
+
+    func test_shouldDisplayPushAppInForeground_givenNoHandlers_expectTrue() {
+        let push = PushNotificationStub.getPushSentFromCIO()
+        var actual: Bool!
+
+        proxy.shouldDisplayPushAppInForeground(push) { value in
+            actual = value
+        }
+
+        XCTAssertTrue(actual)
+    }
+
+    func test_shouldDisplayPushAppInForeground_givenOneHandler_expectReturnResultFromHandler() async throws {
+        let push = PushNotificationStub.getPushSentFromCIO()
+        var actual: Bool!
+
+        let handler = PushEventHandlerMock()
+        handler.shouldDisplayPushAppInForegroundClosure = { _, onComplete in
+            onComplete(true)
+        }
+        proxy.addPushEventHandler(handler)
+
+        await waitForAsyncOperation { asyncComplete in
+            self.proxy.shouldDisplayPushAppInForeground(push) { value in
+                actual = value
+                asyncComplete()
+            }
+        }
+
+        XCTAssertTrue(actual)
+    }
+
+    // The SDK's logic to combine the return results is: return `false`, unless at least 1 push handler returns `true`.
+    // To test that, we will perform multiple checks in the test function and watch the results change after each check.
+    func test_shouldDisplayPushAppInForeground_givenMultipleHandlers_expectCombineReturnResults() async throws {
+        let push = PushNotificationStub.getPushSentFromCIO()
+        var actual: Bool!
+
+        // First, test that `false` is the default return result.
+
+        let handler1 = PushEventHandlerMock()
+        handler1.shouldDisplayPushAppInForegroundClosure = { _, onComplete in
+            onComplete(false)
+        }
+        proxy.addPushEventHandler(handler1)
+
+        await waitForAsyncOperation { asyncComplete in
+            self.proxy.shouldDisplayPushAppInForeground(push) { value in
+                actual = value
+                asyncComplete()
+            }
+        }
+
+        XCTAssertFalse(actual)
+
+        // Next, add another push handler that's return result is `true`.
+        // We expect return result to now be `true`, since 1 handler returned `true`.
+        class PushEventHandlerMock2: PushEventHandlerMock {}
+        let handler2 = PushEventHandlerMock2()
+        handler2.shouldDisplayPushAppInForegroundClosure = { _, onComplete in
+            onComplete(true)
+        }
+        proxy.addPushEventHandler(handler2)
+
+        await waitForAsyncOperation { asyncComplete in
+            self.proxy.shouldDisplayPushAppInForeground(push) { value in
+                actual = value
+                asyncComplete()
+            }
+        }
+        XCTAssertTrue(actual)
+
+        // Finally, check that once 1 handler returns `true`, the return result is always `true`.
+        class PushEventHandlerMock3: PushEventHandlerMock {}
+        let handler3 = PushEventHandlerMock3()
+        handler3.shouldDisplayPushAppInForegroundClosure = { _, onComplete in
+            onComplete(false)
+        }
+        proxy.addPushEventHandler(handler3)
+
+        await waitForAsyncOperation { asyncComplete in
+            self.proxy.shouldDisplayPushAppInForeground(push) { value in
+                actual = value
+                asyncComplete()
+            }
+        }
+        XCTAssertTrue(actual)
     }
 }

--- a/Tests/Shared/UnitTest.swift
+++ b/Tests/Shared/UnitTest.swift
@@ -185,4 +185,27 @@ public extension UnitTest {
             block()
         }
     }
+
+    /*
+     Run an async operation with a completion handler in a more convenient way.
+
+     Example:
+     ```
+     await waitForAsyncOperation { asyncComplete in
+        callCode {
+            // when this code runs, callCode's completion handler was called.
+            asyncComplete()
+        }
+     }
+     ```
+
+     This is an alternative to boilerplate `expectation()`, `expectation.fulfill()` API.
+     */
+    func waitForAsyncOperation(_ block: @escaping (@escaping () -> Void) -> Void) async {
+        await withCheckedContinuation { continuation in
+            block {
+                continuation.resume()
+            }
+        }
+    }
 }

--- a/Tests/Shared/UnitTest.swift
+++ b/Tests/Shared/UnitTest.swift
@@ -179,4 +179,10 @@ public extension UnitTest {
             block()
         }
     }
+
+    func runOnMain(_ block: @escaping () -> Void) {
+        CioThreadUtil().runMain {
+            block()
+        }
+    }
 }


### PR DESCRIPTION
…al function

While QA testing https://linear.app/customerio/issue/MBL-138/[bug]-ios-customers-receive-callbacks-from-3rd-party-sdks-for-pushes, I noticed the 3rd party push handler was not calling the completionHandler, which resulted in our SDK not able to finish processing the push event.

The reason this issue can occur is because the UserNotificationCenterDelegate functions are optional. So, customers do not need to implement functions in their app, if they do not want to. Check the FCM sample app AppDelegate for an example where we only implement 1 of the 2 functions for push event handling.

This commit fixes the issue by checking if the push handler implements the optional function or not. If not, we call the completion handler for you.

Testing performed:
* manual QA testing iOS sample apps. Checked the value of `delegateGotCalled` when the optional function is and is not implemented in host iOS app. 

Note: Because UserNotification center functions are not able to execute in test suite, the code in this PR can only be QA tested and automated tests cannot be written for it. 

commit-id:c6506c76

---

**Stack**:
- #634 ⬅
- #633
- #601
- #590
- #584
- #583


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*