### PR TITLE
test: fix flaky tests when running on CI

### DIFF
--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -62,7 +62,7 @@ jobs:
           - sample-app: "CocoaPods-FCM"
             apn-or-fcm: FCM
 
-    runs-on: macos-13
+    runs-on: macos-14
     name: Building app...${{ matrix.sample-app }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -144,7 +144,7 @@ jobs:
     if: ${{ needs.deploy-git-tag.outputs.new_release_published == 'true' || github.event_name == 'workflow_dispatch' }}
     env:
       COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Checkout git tag that got created in previous step
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ concurrency: # cancel previous workflow run if one exists.
 
 jobs:
   automated-tests:
-    runs-on: macos-13
+    runs-on: macos-14
     permissions:
       checks: write # Need write permission to add test result check.
     steps:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,6 +211,8 @@ GEM
       xcpretty (~> 0.2, >= 0.0.7)
 
 PLATFORMS
+  arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-22
@@ -220,4 +222,4 @@ DEPENDENCIES
   fastlane-plugin-firebase_app_distribution
 
 BUNDLED WITH
-   2.2.18
+   2.5.3


### PR DESCRIPTION
Part of: https://linear.app/customerio/issue/MBL-164/cdp-branch-flaky-tests-on-ci

We have been experiencing some flaky tests, only when running on our CI. After reviewing the test functions and the error messages thrown on CI, I think that the issue is because of slow performance when running the test suite on the CI. After doing some research online, others were sharing similar issues, specifically when running tests on Xcode 15.0 and 15.1. Xcode release notes also share known issues when running tests on CI and slow performance.

By updating our CI to macos 14 github action runners, we are installing Xcode 15.2 which has better test performance.

---

**Stack**:
- #636
- #635 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*