### PR TITLE
test: fix flaky tests that use convenient function `runTest(numberOfTimes)`

### DIFF
--- a/Tests/MessagingPush/PushHandling/PushEventHandlerProxyTest.swift
+++ b/Tests/MessagingPush/PushHandling/PushEventHandlerProxyTest.swift
@@ -15,86 +15,82 @@ class PushEventHandlerProxyTest: UnitTest {
     // MARK: thread safety
 
     func test_onPushAction_ensureThreadSafetyCallingDelegates() {
-        runTest(numberOfTimes: 100) { // Ensure no race conditions by running test many times.
-            let delegate1 = PushEventHandlerMock()
-            class PushEventHandlerMock2: PushEventHandlerMock {}
-            let delegate2 = PushEventHandlerMock2()
+        let delegate1 = PushEventHandlerMock()
+        class PushEventHandlerMock2: PushEventHandlerMock {}
+        let delegate2 = PushEventHandlerMock2()
 
-            let expectDelegatesReceiveEvent = expectation(description: "delegate1 received event")
-            expectDelegatesReceiveEvent.expectedFulfillmentCount = 2 // 1 for each delegate. We do not care what order the delegates get called as long as all get called.
-            let expectCompleteCallingAllDelegates = expectation(description: "complete calling all delegates")
+        let expectDelegatesReceiveEvent = expectation(description: "delegate1 received event")
+        expectDelegatesReceiveEvent.expectedFulfillmentCount = 2 // 1 for each delegate. We do not care what order the delegates get called as long as all get called.
+        let expectCompleteCallingAllDelegates = expectation(description: "complete calling all delegates")
 
-            // When each delegate gets called, have them call the completion handler on different threads to test the proxy is thread safe.
-            delegate1.onPushActionClosure = { _, completion in
-                expectDelegatesReceiveEvent.fulfill()
+        // When each delegate gets called, have them call the completion handler on different threads to test the proxy is thread safe.
+        delegate1.onPushActionClosure = { _, completion in
+            expectDelegatesReceiveEvent.fulfill()
 
-                self.runOnMain {
-                    completion()
-                }
+            self.runOnMain {
+                completion()
             }
-            delegate2.onPushActionClosure = { _, completion in
-                expectDelegatesReceiveEvent.fulfill()
-
-                self.runOnBackground {
-                    completion()
-                }
-            }
-            proxy.addPushEventHandler(delegate1)
-            proxy.addPushEventHandler(delegate2)
-
-            proxy.onPushAction(PushNotificationActionStub(push: PushNotificationStub.getPushSentFromCIO(), didClickOnPush: true)) {
-                expectCompleteCallingAllDelegates.fulfill()
-            }
-
-            wait(for: [
-                expectDelegatesReceiveEvent,
-                expectCompleteCallingAllDelegates
-            ], enforceOrder: true)
         }
+        delegate2.onPushActionClosure = { _, completion in
+            expectDelegatesReceiveEvent.fulfill()
+
+            self.runOnBackground {
+                completion()
+            }
+        }
+        proxy.addPushEventHandler(delegate1)
+        proxy.addPushEventHandler(delegate2)
+
+        proxy.onPushAction(PushNotificationActionStub(push: PushNotificationStub.getPushSentFromCIO(), didClickOnPush: true)) {
+            expectCompleteCallingAllDelegates.fulfill()
+        }
+
+        wait(for: [
+            expectDelegatesReceiveEvent,
+            expectCompleteCallingAllDelegates
+        ], enforceOrder: true)
     }
 
     func test_shouldDisplayPushAppInForeground_ensureThreadSafetyCallingDelegates() {
-        runTest(numberOfTimes: 100) { // Ensure no race conditions by running test many times.
-            let givenPush = PushNotificationStub.getPushSentFromCIO()
+        let givenPush = PushNotificationStub.getPushSentFromCIO()
 
-            let delegate1 = PushEventHandlerMock()
-            class PushEventHandlerMock2: PushEventHandlerMock {}
-            let delegate2 = PushEventHandlerMock2()
+        let delegate1 = PushEventHandlerMock()
+        class PushEventHandlerMock2: PushEventHandlerMock {}
+        let delegate2 = PushEventHandlerMock2()
 
-            let expectDelegatesReceiveEvent = expectation(description: "delegate1 received event")
-            expectDelegatesReceiveEvent.expectedFulfillmentCount = 2 // 1 for each delegate. We do not care what order the delegates get called as long as all get called.
-            let expectCompleteCallingAllDelegates = expectation(description: "complete calling all delegates")
+        let expectDelegatesReceiveEvent = expectation(description: "delegate1 received event")
+        expectDelegatesReceiveEvent.expectedFulfillmentCount = 2 // 1 for each delegate. We do not care what order the delegates get called as long as all get called.
+        let expectCompleteCallingAllDelegates = expectation(description: "complete calling all delegates")
 
-            // When each delegate gets called, have them call the completion handler on different threads to test the proxy is thread safe.
-            delegate1.shouldDisplayPushAppInForegroundClosure = { _, completion in
-                expectDelegatesReceiveEvent.fulfill()
+        // When each delegate gets called, have them call the completion handler on different threads to test the proxy is thread safe.
+        delegate1.shouldDisplayPushAppInForegroundClosure = { _, completion in
+            expectDelegatesReceiveEvent.fulfill()
 
-                self.runOnMain {
-                    completion(false)
-                }
+            self.runOnMain {
+                completion(false)
             }
-            delegate2.shouldDisplayPushAppInForegroundClosure = { _, completion in
-                expectDelegatesReceiveEvent.fulfill()
-
-                self.runOnBackground {
-                    completion(true)
-                }
-            }
-            proxy.addPushEventHandler(delegate1)
-            proxy.addPushEventHandler(delegate2)
-
-            proxy.shouldDisplayPushAppInForeground(givenPush, completionHandler: { actualShouldDisplayPush in
-                // Assert that the 1 delegate that returns `true` is the return result.
-                XCTAssertTrue(actualShouldDisplayPush)
-
-                expectCompleteCallingAllDelegates.fulfill()
-            })
-
-            wait(for: [
-                expectDelegatesReceiveEvent,
-                expectCompleteCallingAllDelegates
-            ], enforceOrder: true)
         }
+        delegate2.shouldDisplayPushAppInForegroundClosure = { _, completion in
+            expectDelegatesReceiveEvent.fulfill()
+
+            self.runOnBackground {
+                completion(true)
+            }
+        }
+        proxy.addPushEventHandler(delegate1)
+        proxy.addPushEventHandler(delegate2)
+
+        proxy.shouldDisplayPushAppInForeground(givenPush, completionHandler: { actualShouldDisplayPush in
+            // Assert that the 1 delegate that returns `true` is the return result.
+            XCTAssertTrue(actualShouldDisplayPush)
+
+            expectCompleteCallingAllDelegates.fulfill()
+        })
+
+        wait(for: [
+            expectDelegatesReceiveEvent,
+            expectCompleteCallingAllDelegates
+        ], enforceOrder: true)
     }
 
     // MARK: shouldDisplayPushAppInForeground

--- a/Tests/MessagingPush/Store/PushHistoryTest.swift
+++ b/Tests/MessagingPush/Store/PushHistoryTest.swift
@@ -82,23 +82,21 @@ class PushHistoryTest: IntegrationTest {
     }
 
     func test_hasHandledPush_expectThreadSafe() {
-        runTest(numberOfTimes: 100) {
-            let givenPushId = String.random
-            let givenDate = Date().subtract(10, .minute)
+        let givenPushId = String.random
+        let givenDate = Date().subtract(10, .minute)
 
-            let expectBackgroundThreadCheckToComplete = expectation(description: "Background thread check should complete")
+        let expectBackgroundThreadCheckToComplete = expectation(description: "Background thread check should complete")
 
-            // Handle push
-            XCTAssertFalse(self.pushHistory.hasHandledPush(pushEvent: .didReceive, pushId: givenPushId, pushDeliveryDate: givenDate))
+        // Handle push
+        XCTAssertFalse(pushHistory.hasHandledPush(pushEvent: .didReceive, pushId: givenPushId, pushDeliveryDate: givenDate))
 
-            // Assert that the push was handled when accessing from a different thread.
-            runOnBackground {
-                XCTAssertTrue(self.pushHistory.hasHandledPush(pushEvent: .didReceive, pushId: givenPushId, pushDeliveryDate: givenDate))
+        // Assert that the push was handled when accessing from a different thread.
+        runOnBackground {
+            XCTAssertTrue(self.pushHistory.hasHandledPush(pushEvent: .didReceive, pushId: givenPushId, pushDeliveryDate: givenDate))
 
-                expectBackgroundThreadCheckToComplete.fulfill()
-            }
-
-            waitForExpectations()
+            expectBackgroundThreadCheckToComplete.fulfill()
         }
+
+        waitForExpectations()
     }
 }

--- a/Tests/Shared/Core/UnitTestBase.swift
+++ b/Tests/Shared/Core/UnitTestBase.swift
@@ -154,14 +154,6 @@ open class UnitTestBase<Component>: XCTestCase {
         await fulfillment(of: expectations, timeout: 0.5)
     }
 
-    public func runTest(numberOfTimes: Int, test: () -> Void) {
-        for _ in 0 ..< numberOfTimes {
-            setUp()
-            test()
-            tearDown()
-        }
-    }
-
     public func runOnBackground(_ block: @escaping () -> Void) {
         CioThreadUtil().runBackground {
             block()


### PR DESCRIPTION
Part of: https://linear.app/customerio/issue/MBL-164/cdp-branch-flaky-tests-on-ci

I have noticed a pattern where test functions that use the convenient function, runTest(numberOfTimes:), are flaky on CI. `runTest` was introduced as a way to try and catch race conditions by running a test many times.

While doing deeper research to running test functions multiple times, the solutions I found were either (1) working for older versions of Xcode but not the latest versions or (2) identical solution as `runTest(numberOfTimes:)` but with an additional `sleep` function after setup and teardown.

I could not find a solution that was reliable and up-to-date. Therefore, I think the best solution is remove `runTest`.

If you want to run a test multiple times, you can inside of Xcode: https://stackoverflow.com/a/67963997

---

**Stack**:
- #638
- #637 ⬅
- #636
- #635


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*