### PR TITLE
test: fix flaky tests on CI that timeout on async operations

### DIFF
--- a/Tests/Common/Module/ModuleTopLevelObjectTest.swift
+++ b/Tests/Common/Module/ModuleTopLevelObjectTest.swift
@@ -33,7 +33,7 @@ class ModuleTopLevelObjectTest: UnitTest {
             }
         }
 
-        waitForExpectations()
+        waitForExpectations(timeout: longTimeout)
 
         // Even though we call initialize multiple times, the initialize count should only be 1.
         XCTAssertEqual(ModuleTopLevelObjectStub.shared.initializeCount, 1)

--- a/Tests/MessagingPush/PushHandling/PushEventHandlerProxyTest.swift
+++ b/Tests/MessagingPush/PushHandling/PushEventHandlerProxyTest.swift
@@ -48,7 +48,7 @@ class PushEventHandlerProxyTest: UnitTest {
         wait(for: [
             expectDelegatesReceiveEvent,
             expectCompleteCallingAllDelegates
-        ], enforceOrder: true)
+        ], timeout: longTimeout, enforceOrder: true)
     }
 
     func test_shouldDisplayPushAppInForeground_ensureThreadSafetyCallingDelegates() {
@@ -90,7 +90,7 @@ class PushEventHandlerProxyTest: UnitTest {
         wait(for: [
             expectDelegatesReceiveEvent,
             expectCompleteCallingAllDelegates
-        ], enforceOrder: true)
+        ], timeout: longTimeout, enforceOrder: true)
     }
 
     // MARK: shouldDisplayPushAppInForeground

--- a/Tests/MessagingPush/Store/PushHistoryTest.swift
+++ b/Tests/MessagingPush/Store/PushHistoryTest.swift
@@ -97,6 +97,6 @@ class PushHistoryTest: IntegrationTest {
             expectBackgroundThreadCheckToComplete.fulfill()
         }
 
-        waitForExpectations()
+        waitForExpectations(timeout: longTimeout)
     }
 }

--- a/Tests/Shared/XCTestCaseExtensions.swift
+++ b/Tests/Shared/XCTestCaseExtensions.swift
@@ -2,6 +2,19 @@ import Foundation
 import XCTest
 
 public extension XCTestCase {
+    var shortTimeout: Double {
+        0.5
+    }
+
+    // Some wait operations are flaky when running on the CI server. This is a workaround to make the tests more reliable.
+    var longTimeout: Double {
+        2.0
+    }
+
+    var defaultTimeout: Double {
+        shortTimeout
+    }
+
     func waitForExpectations(_ timeout: Double, file _: StaticString = #file, line _: UInt = #line) {
         waitForExpectations(timeout: timeout, handler: nil)
     }
@@ -12,7 +25,7 @@ public extension XCTestCase {
         file _: StaticString = #file,
         line _: UInt = #line
     ) {
-        wait(for: expectations, timeout: 0.5, enforceOrder: enforceOrder)
+        wait(for: expectations, timeout: defaultTimeout, enforceOrder: enforceOrder)
     }
 
     func getEnvironmentVariable(_ key: String) -> String? {


### PR DESCRIPTION
Part of: https://linear.app/customerio/issue/MBL-164/cdp-branch-flaky-tests-on-ci

not ready for review yet. Running on CI to see if problem has been fixed.

---

**Stack**:
- #638 ⬅
- #637
- #636
- #635


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*