### PR TITLE
chore: auto screen tracking plugin using config

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
@@ -57,11 +57,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if let cdnHost = storage.cdnHost, !cdnHost.isEmpty {
             config.cdnHost(cdnHost)
         }
-        CustomerIO.initialize(withConfig: config.build())
-        let autoScreenTrack = storage.isTrackScreenEnabled ?? true
-        if autoScreenTrack {
-            CustomerIO.shared.add(plugin: AutoTrackingScreenViews(filterAutoScreenViewEvents: nil, autoScreenViewBody: nil))
+        if storage.isTrackScreenEnabled == true {
+            config.autoTrackScreenViews()
         }
+        CustomerIO.initialize(withConfig: config.build())
 
         // Initialize messaging features after initializing Customer.io SDK
         MessagingInApp

--- a/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
@@ -58,7 +58,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             config.cdnHost(cdnHost)
         }
         if storage.isTrackScreenEnabled == true {
-            config.autoTrackScreenViews()
+            config.autoTrackUIKitScreenViews()
         }
         CustomerIO.initialize(withConfig: config.build())
 

--- a/Sources/DataPipeline/Config/DataPipelineConfigOptions.swift
+++ b/Sources/DataPipeline/Config/DataPipelineConfigOptions.swift
@@ -30,4 +30,7 @@ public struct DataPipelineConfigOptions {
 
     /// Configuration options required for migration from earlier versions
     public let migrationSiteId: String?
+
+    /// Plugins identified based on configuration provided by the user
+    let autoConfiguredPlugins: [Plugin]
 }

--- a/Sources/DataPipeline/Config/SDKConfigBuilder.swift
+++ b/Sources/DataPipeline/Config/SDKConfigBuilder.swift
@@ -164,8 +164,9 @@ public class SDKConfigBuilder {
         return self
     }
 
+    @available(iOSApplicationExtension, unavailable)
     public func build() -> SDKConfigBuilderResult {
-        // create `SdkConfig`` from given configurations
+        // create `SdkConfig` from given configurations
         let sdkConfig = SdkConfig.Factory.create(
             logLevel: logLevel
         )

--- a/Sources/DataPipeline/Config/SDKConfigBuilder.swift
+++ b/Sources/DataPipeline/Config/SDKConfigBuilder.swift
@@ -23,7 +23,7 @@ import UIKit
 public class SDKConfigBuilder {
     // helper configuration options to ease setting up other configurations such as `apiHost` and `cdnHost`
     private var region: Region = .US
-    private var autoTrackScreenViews: Bool = false
+    private var autoTrackUIKitScreenViews: Bool = false
     private var autoScreenViewBody: (() -> [String: Any])?
     #if canImport(UIKit)
     private var filterAutoScreenViewEvents: ((UIViewController) -> Bool)?
@@ -71,11 +71,12 @@ public class SDKConfigBuilder {
     ///     Return `true` from function if you would like the screenview event to be tracked. Default: `nil`,
     ///     which uses the default filter function packaged by the SDK. Provide a non-nil value to not call the SDK's filtering.
     @discardableResult
-    public func autoTrackScreenViews(
+    public func autoTrackUIKitScreenViews(
+        enabled: Bool = true,
         autoScreenViewBody: (() -> [String: Any])? = nil,
         filterAutoScreenViewEvents: ((UIViewController) -> Bool)? = nil
     ) -> SDKConfigBuilder {
-        autoTrackScreenViews = true
+        autoTrackUIKitScreenViews = enabled
         self.autoScreenViewBody = autoScreenViewBody
         self.filterAutoScreenViewEvents = filterAutoScreenViewEvents
         return self
@@ -171,7 +172,7 @@ public class SDKConfigBuilder {
 
         // create plugins based on given configurations
         var configuredPlugins: [Plugin] = []
-        if autoTrackScreenViews {
+        if autoTrackUIKitScreenViews {
             configuredPlugins.append(AutoTrackingScreenViews(
                 filterAutoScreenViewEvents: filterAutoScreenViewEvents,
                 autoScreenViewBody: autoScreenViewBody

--- a/Sources/DataPipeline/Config/SDKConfigBuilder.swift
+++ b/Sources/DataPipeline/Config/SDKConfigBuilder.swift
@@ -63,13 +63,17 @@ public class SDKConfigBuilder {
         return self
     }
 
-    /// Automatic tracking of screen views will generate `screen` type events on every screen transition within your application.
+    /// Enable this property if you want SDK to automatically track screen views for UIKit based apps.
     /// - Parameters:
-    ///     - autoScreenViewBody: Handler to be called by our automatic screen tracker to generate `screen` event body variables.
-    ///     You can use this to override our defaults and pass custom values in the body of the `screen` event.
-    ///     - filterAutoScreenViewEvents: Filter automatic screenview events to remove events that are irrelevant to your app.
-    ///     Return `true` from function if you would like the screenview event to be tracked. Default: `nil`,
-    ///     which uses the default filter function packaged by the SDK. Provide a non-nil value to not call the SDK's filtering.
+    ///   - enabled: `true` to enable auto tracking of screen views, `false` to disable.
+    ///   - autoScreenViewBody: Closure that returns a dictionary of properties to be sent with the
+    ///     screen view event. This closure is called every time a screen view event is sent and can be used
+    ///     to override our defaults and provide custom values in the body of the `screen` event..
+    ///   - filterAutoScreenViewEvents: Closure that returns a boolean value indicating whether
+    ///     the screen view event should be sent. Return `true` from function if you would like the screen
+    ///     view event to be tracked. This closure is called every time a screen view event is about to be
+    ///     tracked. Default value is `nil`, which uses the default filter function packaged by the SDK.
+    ///     Provide a non-nil value to not call the SDK's filtering.
     @discardableResult
     public func autoTrackUIKitScreenViews(
         enabled: Bool = true,

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -39,6 +39,11 @@ class DataPipelineImplementation: DataPipelineInstance {
             analytics.add(plugin: customerIODestination)
         }
 
+        // add configured plugins to analytics
+        for plugin in moduleConfig.autoConfiguredPlugins {
+            analytics.add(plugin: plugin)
+        }
+
         // plugin to update context properties for each request
         analytics.add(plugin: contextPlugin)
 

--- a/Tests/DataPipeline/Config/SDKConfigBuilderTest.swift
+++ b/Tests/DataPipeline/Config/SDKConfigBuilderTest.swift
@@ -170,13 +170,13 @@ class SDKConfigBuilderTest: UnitTest {
             .build()
 
         let autoConfiguredPlugins = dataPipelineConfig.autoConfiguredPlugins
-        let screenPlugin = autoConfiguredPlugins.first
+        let configuredPlugins = autoConfiguredPlugins.first
         // track screen to verify handlers are attached to the plugin.
-        (screenPlugin as? AutoTrackingScreenViews)?.performScreenTracking(onViewController: UIAlertController())
+        (configuredPlugins as? AutoTrackingScreenViews)?.performScreenTracking(onViewController: UIAlertController())
 
         XCTAssertEqual(autoConfiguredPlugins.count, 1)
-        XCTAssertNotNil(screenPlugin)
-        XCTAssertTrue(screenPlugin is AutoTrackingScreenViews)
+        XCTAssertNotNil(configuredPlugins)
+        XCTAssertTrue(configuredPlugins is AutoTrackingScreenViews)
         waitForExpectations()
     }
 }

--- a/Tests/DataPipeline/Config/SDKConfigBuilderTest.swift
+++ b/Tests/DataPipeline/Config/SDKConfigBuilderTest.swift
@@ -56,6 +56,7 @@ class SDKConfigBuilderTest: UnitTest {
             .operatingMode(givenOperatingMode)
             .trackApplicationLifecycleEvents(givenTrackApplicationLifecycleEvents)
             .autoTrackDeviceAttributes(givenAutoTrackDeviceAttributes)
+            .autoTrackUIKitScreenViews(enabled: false)
             .migrationSiteId(givenSiteId)
             .build()
 
@@ -74,6 +75,7 @@ class SDKConfigBuilderTest: UnitTest {
         XCTAssertEqual(dataPipelineConfig.trackApplicationLifecycleEvents, givenTrackApplicationLifecycleEvents)
         XCTAssertEqual(dataPipelineConfig.autoTrackDeviceAttributes, givenAutoTrackDeviceAttributes)
         XCTAssertEqual(dataPipelineConfig.migrationSiteId, givenSiteId)
+        XCTAssertEqual(dataPipelineConfig.autoConfiguredPlugins.count, 0)
     }
 
     func test_givenDefaults_expectMatchAnalyticsDefaults() {
@@ -160,7 +162,8 @@ class SDKConfigBuilderTest: UnitTest {
         }
 
         let (_, dataPipelineConfig) = SDKConfigBuilder(cdpApiKey: .random)
-            .autoTrackScreenViews(
+            .autoTrackUIKitScreenViews(
+                enabled: true,
                 autoScreenViewBody: givenAutoScreenViewBody,
                 filterAutoScreenViewEvents: givenFilterAutoScreenViewEvents
             )

--- a/Tests/DataPipeline/Config/SDKConfigBuilderTest.swift
+++ b/Tests/DataPipeline/Config/SDKConfigBuilderTest.swift
@@ -148,7 +148,7 @@ class SDKConfigBuilderTest: UnitTest {
         XCTAssertEqual(dataPipelineConfig.cdnHost, givenCdnHost)
     }
 
-    func test_autoScreenTrackingEnabled_expectScreenPluginAttached() {
+    func test_autoScreenTrackingEnabled_expectScreenPluginAttachedWithGivenHandlers() {
         let autoScreenViewBodyExpectation = expectation(description: "Waiting for autoScreenViewBody to be invoked")
         let givenAutoScreenViewBody: (() -> [String: Any]) = {
             autoScreenViewBodyExpectation.fulfill()
@@ -171,6 +171,7 @@ class SDKConfigBuilderTest: UnitTest {
 
         let autoConfiguredPlugins = dataPipelineConfig.autoConfiguredPlugins
         let screenPlugin = autoConfiguredPlugins.first
+        // track screen to verify handlers are attached to the plugin.
         (screenPlugin as? AutoTrackingScreenViews)?.performScreenTracking(onViewController: UIAlertController())
 
         XCTAssertEqual(autoConfiguredPlugins.count, 1)

--- a/Tests/DataPipeline/Config/SDKConfigBuilderTest.swift
+++ b/Tests/DataPipeline/Config/SDKConfigBuilderTest.swift
@@ -170,13 +170,13 @@ class SDKConfigBuilderTest: UnitTest {
             .build()
 
         let autoConfiguredPlugins = dataPipelineConfig.autoConfiguredPlugins
-        let configuredPlugins = autoConfiguredPlugins.first
+        let configuredPlugin = autoConfiguredPlugins.first
         // track screen to verify handlers are attached to the plugin.
-        (configuredPlugins as? AutoTrackingScreenViews)?.performScreenTracking(onViewController: UIAlertController())
+        (configuredPlugin as? AutoTrackingScreenViews)?.performScreenTracking(onViewController: UIAlertController())
 
         XCTAssertEqual(autoConfiguredPlugins.count, 1)
-        XCTAssertNotNil(configuredPlugins)
-        XCTAssertTrue(configuredPlugins is AutoTrackingScreenViews)
+        XCTAssertNotNil(configuredPlugin)
+        XCTAssertTrue(configuredPlugin is AutoTrackingScreenViews)
         waitForExpectations()
     }
 }


### PR DESCRIPTION
closes: https://linear.app/customerio/issue/MBL-166/update-autotrack-screen-view-config

### Changes

- Added `autoTrackScreenViews` to `SDKConfigBuilder` so customers can attach screen plugin using config
- Added `autoConfiguredPlugins` to `DataPipelineConfigOptions` so builder can provide finals plugins using convenient config options for customers