### PR TITLE
chore: device attributes update

### DIFF
--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -39,6 +39,9 @@ class DataPipelineImplementation: DataPipelineInstance {
             analytics.add(plugin: customerIODestination)
         }
 
+        // plugin to add contextual inforamation to device attributes
+        analytics.add(plugin: DeviceCreateOrUpdate())
+
         // plugin to update context properties for each request
         analytics.add(plugin: contextPlugin)
 

--- a/Sources/DataPipeline/Plugins/Context.swift
+++ b/Sources/DataPipeline/Plugins/Context.swift
@@ -40,12 +40,19 @@ class Context: Plugin {
             // set the user agent
             context["userAgent"] = userAgentUtil.getUserAgentHeaderValue()
 
-            // set the device attributes
-            if let device = context[keyPath: "device"] as? [String: Any], autoTrackDeviceAttributes {
-                context["device"] = device.mergeWith(attributes)
-            } else {
-                context["device"] = attributes
+            // remove library from context
+            context.removeValue(forKey: "library")
+
+            // if autoTrackDeviceAttributes is false, remove all device attributes except token and type which other destination might depend on
+            if let device = context[keyPath: "device"] as? [String: Any] {
+                if !autoTrackDeviceAttributes {
+                    // Keep only device.token and device.type, remove everything else
+                    let token = device["token"]
+                    let type = device["type"]
+                    context["device"] = ["token": token, "type": type]
+                }
             }
+
             workingEvent.context = try JSON(context)
         } catch {
             analytics?.reportInternalError(error)

--- a/Sources/DataPipeline/Plugins/DeviceCreateOrUpdate.swift
+++ b/Sources/DataPipeline/Plugins/DeviceCreateOrUpdate.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Segment
+
+class DeviceCreateOrUpdate: EventPlugin {
+    var type: PluginType = .enrichment
+    var analytics: Analytics?
+
+    func track(event: TrackEvent) -> TrackEvent? {
+        var workingEvent = event
+        let context = event.context?.dictionaryValue
+
+        if workingEvent.event == "Device Created or Updated" {
+            // add selected contextual data to parameters so they end up as device attributes
+            if let networkDictionary = context?["network"] as? [String: Any] {
+                if let bluetoothValue = networkDictionary["bluetooth"] {
+                    workingEvent.properties?[keyPath: "network_bluetooth"] = try? JSON(bluetoothValue)
+                }
+
+                if let cellularValue = networkDictionary["cellular"] {
+                    workingEvent.properties?[keyPath: "network_cellular"] = try? JSON(cellularValue)
+                }
+
+                if let wifiValue = networkDictionary["wifi"] {
+                    workingEvent.properties?[keyPath: "network_wifi"] = try? JSON(wifiValue)
+                }
+            }
+
+            if let screenDictionary = context?["screen"] as? [String: Any] {
+                if let widthValue = screenDictionary["width"] {
+                    workingEvent.properties?[keyPath: "screen_width"] = try? JSON(widthValue)
+                }
+
+                if let heightValue = screenDictionary["height"] {
+                    workingEvent.properties?[keyPath: "screen_height"] = try? JSON(heightValue)
+                }
+            }
+            if let value = context?["ip"] {
+                workingEvent.properties?[keyPath: "ip"] = try? JSON(value)
+            }
+            if let value = context?["timezone"] {
+                workingEvent.properties?[keyPath: "timezone"] = try? JSON(value)
+            }
+        }
+
+        return workingEvent
+    }
+}

--- a/Tests/DataPipeline/DataPipelineCompatibilityTests.swift
+++ b/Tests/DataPipeline/DataPipelineCompatibilityTests.swift
@@ -123,7 +123,7 @@ class DataPipelineCompatibilityTests: IntegrationTest {
     func test_registerDeviceToken_expectFinalJSONHasCorrectKeysAndValues() {
         let givenIdentifier = String.random
         let givenToken = String.random
-        let expectedData = deviceInfoStub.getDefaultAttributes()
+        let givenDefaultAttributes = deviceInfoStub.getDefaultAttributes()
 
         customerIO.identify(userId: givenIdentifier)
         customerIO.registerDeviceToken(givenToken)
@@ -145,7 +145,27 @@ class DataPipelineCompatibilityTests: IntegrationTest {
         XCTAssertFalse(savedEvent.containsKey("last_used"))
         XCTAssertFalse(savedEvent.containsKey("platform"))
 
-        XCTAssertMatches(savedEvent[mapKeyPath: "properties"], expectedData)
+        var expectedData = givenDefaultAttributes
+        expectedData.merge(
+            (savedEvent[keyPath: "context.screen"] as! [String: Any]).flatten(parentKey: "screen"),
+            uniquingKeysWith: { current, _ in current }
+        )
+
+        expectedData.merge(
+            (savedEvent[keyPath: "context.network"] as! [String: Any]).flatten(parentKey: "network"),
+            uniquingKeysWith: { current, _ in current }
+        )
+        expectedData["timezone"] = savedEvent[keyPath: "context.timezone"] as? String
+        expectedData["ip"] = savedEvent[keyPath: "context.ip"] as? String
+
+        XCTAssertMatches(
+            savedEvent[mapKeyPath: "properties"],
+            expectedData,
+            withTypeMap: [
+                ["network_bluetooth", "network_cellular", "network_wifi"]: Bool.self,
+                ["screen_height", "screen_width"]: Int.self
+            ]
+        )
     }
 
     func test_setDeviceAttributes_expectFinalJSONHasCorrectKeysAndValues() {
@@ -155,7 +175,6 @@ class DataPipelineCompatibilityTests: IntegrationTest {
             "source": "test",
             "debugMode": true
         ]
-        let expectedData = deviceInfoStub.getDefaultAttributes().mergeWith(customAttributes)
 
         customerIO.identify(userId: givenIdentifier)
         customerIO.registerDeviceToken(givenToken)
@@ -174,10 +193,27 @@ class DataPipelineCompatibilityTests: IntegrationTest {
         XCTAssertEqual(savedEvent[keyPath: "userId"] as? String, givenIdentifier)
         XCTAssertEqual(savedEvent[keyPath: "context.device.token"] as? String, givenToken)
 
+        var expectedData = deviceInfoStub.getDefaultAttributes().mergeWith(customAttributes)
+
+        expectedData.merge(
+            (savedEvent[keyPath: "context.screen"] as! [String: Any]).flatten(parentKey: "screen"),
+            uniquingKeysWith: { current, _ in current }
+        )
+
+        expectedData.merge(
+            (savedEvent[keyPath: "context.network"] as! [String: Any]).flatten(parentKey: "network"),
+            uniquingKeysWith: { current, _ in current }
+        )
+        expectedData["timezone"] = savedEvent[keyPath: "context.timezone"] as? String
+        expectedData["ip"] = savedEvent[keyPath: "context.ip"] as? String
+
         XCTAssertMatches(
             savedEvent[mapKeyPath: "properties"],
             expectedData,
-            withTypeMap: [["debugMode"]: Bool.self]
+            withTypeMap: [
+                ["network_bluetooth", "network_cellular", "network_wifi", "debugMode"]: Bool.self,
+                ["screen_height", "screen_width"]: Int.self
+            ]
         )
     }
 

--- a/Tests/Shared/extension/DictionaryExtensions.swift
+++ b/Tests/Shared/extension/DictionaryExtensions.swift
@@ -1,0 +1,67 @@
+extension Dictionary where Key == String, Value == Any {
+    /// Flattens a nested dictionary into a single-level dictionary with unique keys.
+    /// Nested dictionaries are merged into the root level, with their keys combined with parent keys using an underscore as a separator.
+    ///
+    /// - Parameters:
+    ///   - parentKey: A string representing the key path leading to the current dictionary. This is primarily for internal use in recursive calls but can be specified to prepend a prefix to all keys in the flattened dictionary. Defaults to an empty string.
+    /// - Returns: A single-level dictionary with combined keys and values from all levels of the original dictionary.
+    ///
+    /// # Example 1: Basic Usage
+    /// ```
+    /// let userProfile: [String: Any] = [
+    ///     "name": "John Doe",
+    ///     "age": 30,
+    ///     "address": [
+    ///         "street": "123 Main St",
+    ///         "city": "Anytown",
+    ///         "zip": "12345"
+    ///     ]
+    /// ]
+    ///
+    /// let flattenedProfile = userProfile.flatten()
+    /// print(flattenedProfile)
+    /// // Output:
+    /// // [
+    /// //     "name": "John Doe",
+    /// //     "age": 30,
+    /// //     "address_street": "123 Main St",
+    /// //     "address_city": "Anytown",
+    /// //     "address_zip": "12345"
+    /// // ]
+    /// ```
+    ///
+    /// # Example 2: Using `parentKey` to Prepend a Prefix
+    /// ```
+    /// let additionalInfo: [String: Any] = [
+    ///     "hobbies": ["reading", "hiking"],
+    ///     "profession": "Software Developer"
+    /// ]
+    ///
+    /// // Using 'userDetails_' as a prefix to all keys
+    /// let flattenedWithPrefix = additionalInfo.flatten(parentKey: "userDetails")
+    /// print(flattenedWithPrefix)
+    /// // Output:
+    /// // [
+    /// //     "userDetails_hobbies": ["reading", "hiking"],
+    /// //     "userDetails_profession": "Software Developer"
+    /// // ]
+    /// ```
+    func flatten(parentKey: String = "") -> [String: Any] {
+        var flattened = [String: Any]()
+
+        for (key, value) in self {
+            let newKey = parentKey.isEmpty ? key : "\(parentKey)_\(key)"
+
+            if let subDictionary = value as? [String: Any] {
+                let flattenedSub = subDictionary.flatten(parentKey: newKey)
+                for (subKey, subValue) in flattenedSub {
+                    flattened[subKey] = subValue
+                }
+            } else {
+                flattened[newKey] = value
+            }
+        }
+
+        return flattened
+    }
+}


### PR DESCRIPTION
closes: https://linear.app/customerio/issue/MBL-168/device-attributes-in-journeys

It does the following:

- Remove CIO device attributes being sent into `context.device` (it was unnecessary)
- if autoTrackDeviceAttributes is false, remove all device attributes (which was happening before) from context except `token` and `type` which other destinations depend on
- Selected context attributes are now part of device attributes by adding an event plugin
- Remove `library` from `context` as part of https://linear.app/customerio/issue/MBL-173/remove-library-value