### PR TITLE
chore: logger fixes and improvements

### DIFF
--- a/Apps/APN-UIKit/NotificationServiceExtension/NotificationService.swift
+++ b/Apps/APN-UIKit/NotificationServiceExtension/NotificationService.swift
@@ -8,6 +8,7 @@ class NotificationService: UNNotificationServiceExtension {
     override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
         MessagingPushAPN.initializeForExtension(
             withConfig: MessagingPushConfigBuilder(cdpApiKey: BuildEnvironment.CustomerIO.cdpApiKey)
+                .logLevel(.debug)
                 .build()
         )
 

--- a/Apps/CocoaPods-FCM/Rich Push Notification Service Extension/NotificationService.swift
+++ b/Apps/CocoaPods-FCM/Rich Push Notification Service Extension/NotificationService.swift
@@ -5,6 +5,7 @@ class NotificationService: UNNotificationServiceExtension {
     override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
         MessagingPushFCM.initializeForExtension(
             withConfig: MessagingPushConfigBuilder(cdpApiKey: BuildEnvironment.CustomerIO.cdpApiKey)
+                .logLevel(.debug)
                 .build()
         )
 

--- a/Sources/Common/Util/Log.swift
+++ b/Sources/Common/Util/Log.swift
@@ -61,6 +61,7 @@ public enum CioLogLevel: String, CaseIterable {
 
 // log messages to console.
 // sourcery: InjectRegisterShared = "Logger"
+// sourcery: InjectSingleton
 public class ConsoleLogger: Logger {
     public var logLevel: CioLogLevel = .error
 

--- a/Sources/DataPipeline/Config/SDKConfigBuilder.swift
+++ b/Sources/DataPipeline/Config/SDKConfigBuilder.swift
@@ -177,6 +177,9 @@ public class SDKConfigBuilder {
 
         // create plugins based on given configurations
         var configuredPlugins: [Plugin] = []
+        if logLevel == CioLogLevel.debug {
+            configuredPlugins.append(ConsoleLogger(diGraph: DIGraphShared.shared))
+        }
         if autoTrackUIKitScreenViews {
             configuredPlugins.append(AutoTrackingScreenViews(
                 filterAutoScreenViewEvents: filterAutoScreenViewEvents,

--- a/Sources/DataPipeline/CustomerIO+Plugins.swift
+++ b/Sources/DataPipeline/CustomerIO+Plugins.swift
@@ -57,21 +57,4 @@ public extension CustomerIO {
     func find(key: String) -> DestinationPlugin? {
         DataPipeline.shared.analytics.find(key: key)
     }
-
-    func setDebugLogsEnabled(_ enabled: Bool = true) {
-        // enable debug logs in analytics
-        Analytics.debugLogsEnabled = enabled
-
-        let analytics = DataPipeline.shared.analytics
-        let loggerPlugin = analytics.find(pluginType: ConsoleLogger.self)
-        if enabled {
-            // if logs are enabled but plugin is not added, add it to enable logs
-            if loggerPlugin == nil {
-                analytics.add(plugin: ConsoleLogger(diGraph: DIGraphShared.shared))
-            }
-            // else if logs are disabled, remove plugin if added already
-        } else if let loggerPlugin = loggerPlugin {
-            analytics.remove(plugin: loggerPlugin)
-        }
-    }
 }

--- a/Sources/DataPipeline/CustomerIO.swift
+++ b/Sources/DataPipeline/CustomerIO.swift
@@ -16,8 +16,6 @@ public extension CustomerIO {
         DIGraphShared.shared.logger.setLogLevel(sdkConfig.logLevel)
         // initialize DataPipeline module with the provided configuration
         let implementation = DataPipeline.initialize(moduleConfig: cdpConfig)
-        // enable Analytics logs accordingly to logLevel
-        CustomerIO.shared.setDebugLogsEnabled(sdkConfig.logLevel == CioLogLevel.debug)
         initialize(implementation: implementation)
 
         // Handle logged-in user from Journeys to CDP and check

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -33,7 +33,7 @@ class DataPipelineImplementation: DataPipelineInstance {
 
     private func initialize(diGraph: DIGraphShared) {
         // enable Analytics logs accordingly to logLevel
-        Analytics.debugLogsEnabled = diGraph.logger.logLevel == .debug
+        Analytics.debugLogsEnabled = logger.logLevel == .debug
 
         // add CustomerIO destination plugin
         if moduleConfig.autoAddCustomerIODestination {

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -32,6 +32,9 @@ class DataPipelineImplementation: DataPipelineInstance {
     }
 
     private func initialize(diGraph: DIGraphShared) {
+        // enable Analytics logs accordingly to logLevel
+        Analytics.debugLogsEnabled = diGraph.logger.logLevel == .debug
+
         // add CustomerIO destination plugin
         if moduleConfig.autoAddCustomerIODestination {
             let customerIODestination = CustomerIODestination()

--- a/Sources/MessagingPush/Config/MessagingPushConfigBuilder.swift
+++ b/Sources/MessagingPush/Config/MessagingPushConfigBuilder.swift
@@ -28,6 +28,9 @@ import Foundation
 /// // Use `config` for initializing the push module in NotificationServiceExtension...
 /// ```
 public class MessagingPushConfigBuilder {
+    // configuration options for SdkConfig
+    private var logLevel: CioLogLevel = .error
+
     // configuration options for MessagingPushConfigOptions
     private let cdpApiKey: String
     private var autoFetchDeviceToken: Bool = true
@@ -47,6 +50,16 @@ public class MessagingPushConfigBuilder {
     ///   - cdpApiKey: Customer.io Data Pipeline API Key required for NotificationServiceExtension only to track metrics
     public init(cdpApiKey: String) {
         self.cdpApiKey = cdpApiKey
+    }
+
+    /// Configures the log level for NotificationServiceExtension, allowing customization of SDK log
+    /// verbosity to help setup and debugging
+    @discardableResult
+    @available(iOS, unavailable)
+    @available(iOSApplicationExtension, introduced: 13.0)
+    public func logLevel(_ logLevel: CioLogLevel) -> MessagingPushConfigBuilder {
+        self.logLevel = logLevel
+        return self
     }
 
     /// Enable automatic fetching of device token by the SDK without the need to write custom code by the customer.
@@ -75,6 +88,7 @@ public class MessagingPushConfigBuilder {
     /// Builds and returns `MessagingPushConfigOptions` instance from the configured properties.
     public func build() -> MessagingPushConfigOptions {
         let configOptions = MessagingPushConfigOptions(
+            logLevel: logLevel,
             cdpApiKey: cdpApiKey,
             autoFetchDeviceToken: autoFetchDeviceToken,
             autoTrackPushEvents: autoTrackPushEvents,

--- a/Sources/MessagingPush/Config/MessagingPushConfigOptions.swift
+++ b/Sources/MessagingPush/Config/MessagingPushConfigOptions.swift
@@ -4,6 +4,7 @@ import CioInternalCommon
 ///
 /// Use `MessagingPushConfigBuilder` for constructing its instances. For detailed usage, see builder class documentation.
 public struct MessagingPushConfigOptions {
+    public let logLevel: CioLogLevel
     public let cdpApiKey: String
     public let autoFetchDeviceToken: Bool
     public let autoTrackPushEvents: Bool

--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -68,7 +68,9 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
     @discardableResult
     public static func initializeForExtension(withConfig config: MessagingPushConfigOptions) -> MessagingPushInstance {
         shared.initializeModuleIfNotAlready {
-            shared.getImplementation(config: config)
+            // Set logLevel of shared logger only when module is initialized from NotificationServiceExtension.
+            DIGraphShared.shared.logger.setLogLevel(config.logLevel)
+            return shared.getImplementation(config: config)
         }
 
         return shared

--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -68,7 +68,7 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
     @discardableResult
     public static func initializeForExtension(withConfig config: MessagingPushConfigOptions) -> MessagingPushInstance {
         shared.initializeModuleIfNotAlready {
-            // Set logLevel of shared logger only when module is initialized from NotificationServiceExtension.
+            // set logLevel of shared logger only when module is initialized from NotificationServiceExtension.
             DIGraphShared.shared.logger.setLogLevel(config.logLevel)
             return shared.getImplementation(config: config)
         }

--- a/Tests/DataPipeline/APITest.swift
+++ b/Tests/DataPipeline/APITest.swift
@@ -81,10 +81,6 @@ class DataPipelineAPITest: UnitTest {
         CustomerIO.shared.deviceAttributes = dictionaryData
         mock.deviceAttributes = dictionaryData
 
-        // extensions
-        CustomerIO.shared.setDebugLogsEnabled()
-        CustomerIO.shared.setDebugLogsEnabled(false)
-
         // plugins
         CustomerIO.shared.apply { (_: Plugin) in }
         CustomerIO.shared.add(plugin: UtilityPluginMock())

--- a/Tests/DataPipeline/Config/SDKConfigBuilderTest.swift
+++ b/Tests/DataPipeline/Config/SDKConfigBuilderTest.swift
@@ -179,6 +179,19 @@ class SDKConfigBuilderTest: UnitTest {
         XCTAssertTrue(configuredPlugin is AutoTrackingScreenViews)
         waitForExpectations()
     }
+
+    func test_debugLogsEnabled_expectLoggerPluginAttached() {
+        let (_, dataPipelineConfig) = SDKConfigBuilder(cdpApiKey: .random)
+            .logLevel(.debug)
+            .build()
+
+        let autoConfiguredPlugins = dataPipelineConfig.autoConfiguredPlugins
+        let configuredPlugin = autoConfiguredPlugins.first
+
+        XCTAssertEqual(autoConfiguredPlugins.count, 1)
+        XCTAssertNotNil(configuredPlugin)
+        XCTAssertTrue(configuredPlugin is ConsoleLogger)
+    }
 }
 
 /// Helper methods to assert custom types.

--- a/Tests/DataPipeline/Core/UnitTest.swift
+++ b/Tests/DataPipeline/Core/UnitTest.swift
@@ -59,7 +59,6 @@ open class UnitTest: SharedTests.UnitTestBase<CustomerIO> {
 
         // setup shared instance with desired implementation for unit tests
         customerIO = CustomerIO.setUpSharedInstanceForUnitTest(implementation: implementation)
-        customerIO.setDebugLogsEnabled(sdkConfig.logLevel == .debug)
 
         // wait for analytics queue to start emitting events
         analytics = implementation.analytics

--- a/Tests/MessagingPush/Config/MessagingPushConfigBuilderTest.swift
+++ b/Tests/MessagingPush/Config/MessagingPushConfigBuilderTest.swift
@@ -79,6 +79,7 @@ class MessagingPushConfigBuilderTest: UnitTest {
 extension MessagingPushConfigBuilderTest {
     // Extension method to conveniently assert default values.
     private func XCTAssertDefaultValues(config: MessagingPushConfigOptions, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(config.logLevel, .error, file: file, line: line)
         XCTAssertTrue(config.autoFetchDeviceToken, file: file, line: line)
         XCTAssertTrue(config.autoTrackPushEvents, file: file, line: line)
         XCTAssertTrue(config.showPushAppInForeground, file: file, line: line)

--- a/Tests/Shared/Core/UnitTestBase.swift
+++ b/Tests/Shared/Core/UnitTestBase.swift
@@ -75,6 +75,8 @@ open class UnitTestBase<Component>: XCTestCase {
 
         // setup and override dependencies before creating SDK instance, as Shared graph may be initialized and used immediately
         setUpDependencies()
+        // set log level after setting up dependencies
+        log.setLogLevel(self.sdkConfig.logLevel)
         // setup SDK instance and set necessary components for testing
         initializeSDKComponents()
 


### PR DESCRIPTION
### Changes

- Fixed singleton logger instance
- Based on changes done in #639, added logger plugin to builder to utilize `autoConfiguredPlugins`
- Removed `setDebugLogsEnabled` extension as I think it was initially added to help `Tracking` module and no longer needed
- Fixed logLevel for NSE
- Updated tests and sample apps