### PR TITLE
fix: use git commit instead of git branch for segment dependency

### DIFF
--- a/CustomerIODataPipelines.podspec
+++ b/CustomerIODataPipelines.podspec
@@ -24,5 +24,5 @@ Pod::Spec.new do |spec|
   spec.dependency "CustomerIOTrackingMigration", "= #{spec.version.to_s}"
 
   # Add Segment SDK as a dependency, as this module is designed to be compatible with it.
-  spec.dependency 'AnalyticsSwiftCIO', '~> 1.5.5'
+  spec.dependency 'AnalyticsSwiftCIO', '= 1.5.5-cio.1'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,9 @@ let package = Package(
         //
         // Update to exact version until wrapper SDKs become part of testing pipeline.
         .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git", "8.7.0"..<"11.0.0"),
-        .package(name: "Segment", url: "https://github.com/customerio/cdp-analytics-swift.git", .branch("main"))
+
+        // The version is a git commit hash. Make sure the commit is the same as what the DataPipelines CocoaPods is using.
+        .package(name: "Segment", url: "https://github.com/customerio/cdp-analytics-swift.git", .revision("b2f8f5b68dd0d8796b4bacdec39aacb5b6387a41"))
     ],
     targets: [ 
         // Common - Code used by multiple modules in the SDK project.


### PR DESCRIPTION
Part of: https://linear.app/customerio/issue/MBL-167/segment-dependency-currently-pointing-to-main-branch

In the iOS SDK today, with the Segment CDP SDK, we are currently specifying the version of the segment SDK as "main branch". Using a git branch as the version of a dependency poses risks, potentially leading to difficulties for customers during SDK updates and app compilation, increasing the chance of crashes or compilation issues.

This change uses a hard-coded git commit. The git commit used is the latest commit on the "main" branch.

There are pros and cons to using a git commit as the version, as specified in the ticket description. We can change to a different version such as a git tag in the future.

commit-id:45c2d17e