### PR TITLE
test: fix flaky tests that run code on another thread

### DIFF
--- a/Tests/Common/Module/ModuleTopLevelObjectTest.swift
+++ b/Tests/Common/Module/ModuleTopLevelObjectTest.swift
@@ -37,7 +37,7 @@ class ModuleTopLevelObjectTest: UnitTest {
                 expectAllThreadsToComplete.fulfill()
             }
 
-            waitForExpectations(1) // test may take up to 1 second to finish because it is running so many times. CI server is a less powerful machine and this test is flaky when we set wait() for < 1 second.
+            waitForExpectations()
 
             // Even though we call initialize twice, the initialize count should only be 1.
             XCTAssertEqual(ModuleTopLevelObjectStub.shared.initializeCount, 1)

--- a/Tests/MessagingPush/PushHandling/PushEventHandlerProxyTest.swift
+++ b/Tests/MessagingPush/PushHandling/PushEventHandlerProxyTest.swift
@@ -28,7 +28,7 @@ class PushEventHandlerProxyTest: UnitTest {
             delegate1.onPushActionClosure = { _, completion in
                 expectDelegatesReceiveEvent.fulfill()
 
-                self.runOnMain {
+                self.runOnBackground {
                     completion()
                 }
             }
@@ -69,7 +69,7 @@ class PushEventHandlerProxyTest: UnitTest {
             delegate1.shouldDisplayPushAppInForegroundClosure = { _, completion in
                 expectDelegatesReceiveEvent.fulfill()
 
-                self.runOnMain {
+                self.runOnBackground {
                     completion(false)
                 }
             }

--- a/Tests/Shared/Core/UnitTestBase.swift
+++ b/Tests/Shared/Core/UnitTestBase.swift
@@ -165,13 +165,7 @@ open class UnitTestBase<Component>: XCTestCase {
     }
 
     public func runOnBackground(_ block: @escaping () -> Void) {
-        CioThreadUtil().runBackground {
-            block()
-        }
-    }
-
-    public func runOnMain(_ block: @escaping () -> Void) {
-        CioThreadUtil().runMain {
+        Task {
             block()
         }
     }


### PR DESCRIPTION
Part of: https://linear.app/customerio/issue/MBL-164/cdp-branch-flaky-tests-on-ci

There is a set of flaky tests that all have 1 thing in common: They are the only tests that call the functions `runOnBackground` or `runOnMain`. 

From my own personal experience and research online, tests that use GCD can have unexpected/flaky results, especially on simulators. Recent versions of Xcode or Swift may also have changed the behavior to become flaky. 

This commit changes to using swift concurrency instead of GCD to run test functions on background threads. We hope that all of these tests pass on the CI with no more flaky results. 

commit-id:cc25358b