### PR TITLE
fix: do not bundle .md files in cocoapods deployments

### DIFF
--- a/CustomerIOCommon.podspec
+++ b/CustomerIOCommon.podspec
@@ -18,5 +18,7 @@ Pod::Spec.new do |spec|
   # spec.tvos.deployment_target = '13.0'
 
   spec.source_files  = "Sources/Common/**/*"
+  spec.exclude_files = "Sources/**/*{.md}"
+
   spec.module_name = "CioInternalCommon" # the `import X` name when using SDK in Swift files
 end

--- a/CustomerIOMessagingInApp.podspec
+++ b/CustomerIOMessagingInApp.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |spec|
   # spec.tvos.deployment_target = '13.0'
 
   spec.source_files  = "Sources/MessagingInApp/**/*"
+  spec.exclude_files = "Sources/**/*{.md}"
   spec.module_name = "CioMessagingInApp"  # the `import X` name when using SDK in Swift files
   
   spec.dependency "CustomerIOTracking", "= #{spec.version.to_s}"

--- a/CustomerIOMessagingPush.podspec
+++ b/CustomerIOMessagingPush.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |spec|
   # spec.tvos.deployment_target = '13.0'
 
   spec.source_files  = "Sources/MessagingPush/**/*"
+  spec.exclude_files = "Sources/**/*{.md}"
   spec.module_name = "CioMessagingPush"  # the `import X` name when using SDK in Swift files
   
   spec.dependency "CustomerIOTracking", "= #{spec.version.to_s}"

--- a/CustomerIOMessagingPushAPN.podspec
+++ b/CustomerIOMessagingPushAPN.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |spec|
   # spec.tvos.deployment_target = '13.0'
 
   spec.source_files  = "Sources/MessagingPushAPN/**/*"
+  spec.exclude_files = "Sources/**/*{.md}"
   spec.module_name = "CioMessagingPushAPN" # the `import X` name when using SDK in Swift files
   
   spec.dependency "CustomerIOMessagingPush", "= #{spec.version.to_s}"

--- a/CustomerIOMessagingPushFCM.podspec
+++ b/CustomerIOMessagingPushFCM.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |spec|
   # spec.tvos.deployment_target = '13.0'
 
   spec.source_files  = "Sources/MessagingPushFCM/**/*"
+  spec.exclude_files = "Sources/**/*{.md}"
   spec.module_name = "CioMessagingPushFCM" # the `import X` name when using SDK in Swift files 
   
   spec.dependency "CustomerIOMessagingPush", "= #{spec.version.to_s}"  

--- a/CustomerIOTracking.podspec
+++ b/CustomerIOTracking.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |spec|
   # spec.tvos.deployment_target = '13.0'
 
   spec.source_files  = "Sources/Tracking/**/*"
+  spec.exclude_files = "Sources/**/*{.md}"
   spec.module_name = "CioTracking" # the `import X` name when using SDK in Swift files
 
   spec.dependency "CustomerIOCommon", "= #{spec.version.to_s}"


### PR DESCRIPTION
Fixes: https://linear.app/customerio/issue/MBL-180/[bug]-resolve-md-file-causing-compilation-issues-for-ios-customers

Customers experience compilation errors in their iOS/RN/Flutter/Expo apps due to customer's apps trying to parse .md files that are bundled with our SDK in production releases.

In a recent release of our SDK, we wrote a new md file for internal documentation of the code: https://github.com/customerio/customerio-ios/blob/f50e5b81dd9896e1d76d5dd27fe94709f176dbd1/Sources/MessagingPush/UserNotificationsFramework/README.md. This file is being included in the source code that is shipped in production releases of our iOS SDK.

This change filters out .md files in cocoapods deployments.

Notes:
* From reviewing other SDKs who also encountered this error, the SDKs were only modifying cocoapods files and not SPM. All customers reporting this issue are only experiencing the issue with cocoapods. Therefore, I do not see a need to modify SPM files at this time. 

Testing done:
* Run `pod install` before and after this change. Inspect `Pods/CustomerIOMessagingPush/` directory to see if the .md file got removed successfully after this change.

commit-id:fbcc8fed