### PR TITLE
chore: revert push module config to use static

### DIFF
--- a/Sources/MessagingPush/Config/MessagingPushConfigOptions.swift
+++ b/Sources/MessagingPush/Config/MessagingPushConfigOptions.swift
@@ -16,6 +16,6 @@ public struct MessagingPushConfigOptions {
 // in constructor.
 extension DIGraphShared {
     var messagingPushConfigOptions: MessagingPushConfigOptions {
-        MessagingPush.shared.moduleConfig
+        MessagingPush.moduleConfig
     }
 }

--- a/Sources/MessagingPush/MessagingPushInstance.swift
+++ b/Sources/MessagingPush/MessagingPushInstance.swift
@@ -10,7 +10,6 @@ import UserNotifications
 // 1. Cannot be used in an App Extension so therefore, we cannot guarantee that the function
 //    exists in the SDK code at compile time.
 public protocol MessagingPushInstance: AutoMockable {
-    var moduleConfig: MessagingPushConfigOptions { get }
     func registerDeviceToken(_ deviceToken: String)
     func deleteDeviceToken()
     func trackMetric(

--- a/Sources/MessagingPush/RichPush/RichPushHttpClient.swift
+++ b/Sources/MessagingPush/RichPush/RichPushHttpClient.swift
@@ -126,7 +126,7 @@ public class RichPushHttpClient: HttpClient {
 
         self.publicSession = Self.getBasicSession()
         self.cioApiSession = Self.getCIOApiSession(
-            key: MessagingPush.shared.moduleConfig.cdpApiKey,
+            key: MessagingPush.moduleConfig.cdpApiKey,
             userAgentHeaderValue: deviceInfo.getUserAgentHeaderValue()
         )
     }

--- a/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
@@ -190,45 +190,7 @@ public class MessagingPushInstanceMock: MessagingPushInstance, Mock {
         Mocks.shared.add(mock: self)
     }
 
-    /**
-     When setter of the property called, the value given to setter is set here.
-     When the getter of the property called, the value set here will be returned. Your chance to mock the property.
-     */
-    public var underlyingModuleConfig: MessagingPushConfigOptions!
-    /// `true` if the getter or setter of property is called at least once.
-    public var moduleConfigCalled: Bool {
-        moduleConfigGetCalled || moduleConfigSetCalled
-    }
-
-    /// `true` if the getter called on the property at least once.
-    public var moduleConfigGetCalled: Bool {
-        moduleConfigGetCallsCount > 0
-    }
-
-    public var moduleConfigGetCallsCount = 0
-    /// `true` if the setter called on the property at least once.
-    public var moduleConfigSetCalled: Bool {
-        moduleConfigSetCallsCount > 0
-    }
-
-    public var moduleConfigSetCallsCount = 0
-    /// The mocked property with a getter and setter.
-    public var moduleConfig: MessagingPushConfigOptions {
-        get {
-            mockCalled = true
-            moduleConfigGetCallsCount += 1
-            return underlyingModuleConfig
-        }
-        set(value) {
-            mockCalled = true
-            moduleConfigSetCallsCount += 1
-            underlyingModuleConfig = value
-        }
-    }
-
     public func resetMock() {
-        moduleConfigGetCallsCount = 0
-        moduleConfigSetCallsCount = 0
         registerDeviceTokenCallsCount = 0
         registerDeviceTokenReceivedArguments = nil
         registerDeviceTokenReceivedInvocations = []

--- a/Sources/MessagingPushAPN/MessagingPushAPN.swift
+++ b/Sources/MessagingPushAPN/MessagingPushAPN.swift
@@ -87,7 +87,7 @@ public class MessagingPushAPN: MessagingPushAPNInstance {
         // initialize parent module to initialize features shared by APN and FCM modules
         let implementation = MessagingPush.initialize(withConfig: config)
 
-        let pushConfigOptions = implementation.moduleConfig
+        let pushConfigOptions = MessagingPush.moduleConfig
         if pushConfigOptions.autoFetchDeviceToken {
             shared.setupAutoFetchDeviceToken()
         }

--- a/Sources/MessagingPushFCM/MessagingPushFCM.swift
+++ b/Sources/MessagingPushFCM/MessagingPushFCM.swift
@@ -91,7 +91,7 @@ public class MessagingPushFCM: MessagingPushFCMInstance {
         // initialize parent module to initialize features shared by APN and FCM modules
         let implementation = MessagingPush.initialize(withConfig: config)
 
-        let pushConfigOptions = implementation.moduleConfig
+        let pushConfigOptions = MessagingPush.moduleConfig
         if pushConfigOptions.autoFetchDeviceToken {
             shared.setupAutoFetchDeviceToken()
         }

--- a/Tests/MessagingPushAPN/APITest.swift
+++ b/Tests/MessagingPushAPN/APITest.swift
@@ -36,7 +36,7 @@ class MessagingPushAPNAPITest: UnitTest {
 
         // `moduleConfig` is not really meant to be accessed by customers, so it is okay to not have it in the mock.
         // However, it is public so we should make sure it does not change.
-        _ = MessagingPush.shared.moduleConfig
+        _ = MessagingPush.moduleConfig
 
         MessagingPush.shared.registerDeviceToken(apnDeviceToken: Data())
         mock.registerDeviceToken(apnDeviceToken: Data())

--- a/Tests/MessagingPushFCM/APITest.swift
+++ b/Tests/MessagingPushFCM/APITest.swift
@@ -36,7 +36,7 @@ class MessagingPushFCMAPITest: UnitTest {
 
         // `moduleConfig` is not really meant to be accessed by customers, so it is okay to not have it in the mock.
         // However, it is public so we should make sure it does not change.
-        _ = MessagingPush.shared.moduleConfig
+        _ = MessagingPush.moduleConfig
 
         MessagingPush.shared.registerDeviceToken(fcmToken: "")
         mock.registerDeviceToken(fcmToken: "")


### PR DESCRIPTION
### Background

The PR fixes an issue where `RichPushHttpClient` was trying to access push module config before it was set as it is initialized with `MessagingPushImplementation` due to changes made in #560 

### Changes

- Reverted push module to be static because it matches with `DataPipeline` module implementation
- Event though we could update `RichPushHttpClient` to use config from implementation, but this appears to be error-prone and has a chance of breaking things in future. So we have reverted back to use static module config directly.