### PR TITLE
chore: remove unwanted public apis

### DIFF
--- a/Sources/DataPipeline/Config/SDKConfigBuilder.swift
+++ b/Sources/DataPipeline/Config/SDKConfigBuilder.swift
@@ -60,6 +60,7 @@ public class SDKConfigBuilder {
         return self
     }
 
+    #if canImport(UIKit)
     /// Enable this property if you want SDK to automatically track screen views for UIKit based apps.
     /// - Parameters:
     ///   - enabled: `true` to enable auto tracking of screen views, `false` to disable.
@@ -82,6 +83,7 @@ public class SDKConfigBuilder {
         self.filterAutoScreenViewEvents = filterAutoScreenViewEvents
         return self
     }
+    #endif
 
     /// To help you get setup with the SDK or debug SDK, change the log level of logs you wish to
     /// view from the SDK.

--- a/Sources/DataPipeline/CustomerIO+Segment.swift
+++ b/Sources/DataPipeline/CustomerIO+Segment.swift
@@ -20,36 +20,6 @@ public extension CustomerIO {
         DataPipeline.shared.analytics.userId
     }
 
-    /// Returns the current operating mode this instance was given.
-    var operatingMode: OperatingMode {
-        DataPipeline.shared.analytics.operatingMode
-    }
-
-    /// Adjusts the flush interval post configuration.
-    var flushInterval: TimeInterval {
-        DataPipeline.shared.analytics.flushInterval
-    }
-
-    /// Adjusts the flush-at count post configuration.
-    var flushAt: Int {
-        DataPipeline.shared.analytics.flushAt
-    }
-
-    /// Returns a list of currently active flush policies.
-    var flushPolicies: [FlushPolicy] {
-        DataPipeline.shared.analytics.flushPolicies
-    }
-
-    /// Returns the traits that were specified in the last identify call.
-    func traits<T: Codable>() -> T? {
-        DataPipeline.shared.analytics.traits()
-    }
-
-    /// Returns the traits that were specified in the last identify call, as a dictionary.
-    func traits() -> [String: Any]? {
-        DataPipeline.shared.analytics.traits()
-    }
-
     /// Tells this instance of Analytics to flush any queued events up to Segment.com.  This command will also
     /// be sent to each plugin present in the system.  A completion handler can be optionally given and will be
     /// called when flush has completed.
@@ -61,28 +31,6 @@ public extension CustomerIO {
     /// command will also be sent to each plugin present in the system.
     func reset() {
         DataPipeline.shared.analytics.reset()
-    }
-
-    /// Retrieve the version of this library in use.
-    /// - Returns: A string representing the version in "BREAKING.FEATURE.FIX" format.
-    func version() -> String {
-        DataPipeline.shared.analytics.version()
-    }
-}
-
-public extension CustomerIO {
-    /// Manually retrieve the settings that were supplied from Segment.com.
-    /// - Returns: A Settings object containing integration settings, tracking plan, etc.
-    func settings() -> Settings? {
-        DataPipeline.shared.analytics.settings()
-    }
-
-    /// Manually enable a destination plugin.  This is useful when a given DestinationPlugin doesn't have any Segment tie-ins at all.
-    /// This will allow the destination to be processed in the same way within this library.
-    /// - Parameters:
-    ///   - plugin: The destination plugin to enable.
-    func manuallyEnableDestination(plugin: DestinationPlugin) {
-        DataPipeline.shared.analytics.manuallyEnableDestination(plugin: plugin)
     }
 }
 
@@ -114,43 +62,6 @@ public extension CustomerIO {
     /// a background thread if needed.
     func waitUntilStarted() {
         DataPipeline.shared.analytics.waitUntilStarted()
-    }
-}
-
-public extension CustomerIO {
-    /**
-     Call openURL as needed or when instructed to by either UIApplicationDelegate or UISceneDelegate.
-     This is necessary to track URL referrers across events.  This method will also iterate
-     any plugins that are watching for openURL events.
-
-     Example:
-     ```
-     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-         let myStruct = MyStruct(options)
-         analytics?.openURL(url, options: options)
-         return true
-     }
-     ```
-     */
-    func openURL<T: Codable>(_ url: URL, options: T? = nil) {
-        DataPipeline.shared.analytics.openURL(url, options: options)
-    }
-
-    /**
-     Call openURL as needed or when instructed to by either UIApplicationDelegate or UISceneDelegate.
-     This is necessary to track URL referrers across events.  This method will also iterate
-     any plugins that are watching for openURL events.
-
-     Example:
-     ```
-     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-         analytics?.openURL(url, options: options)
-         return true
-     }
-     ```
-     */
-    func openURL(_ url: URL, options: [String: Any] = [:]) {
-        DataPipeline.shared.analytics.openURL(url, options: options)
     }
 }
 

--- a/Tests/DataPipeline/APITest.swift
+++ b/Tests/DataPipeline/APITest.swift
@@ -97,25 +97,13 @@ class DataPipelineAPITest: UnitTest {
         let _: Bool = CustomerIO.shared.enabled
         let _: String = CustomerIO.shared.anonymousId
         let _: String? = CustomerIO.shared.userId
-        let _: OperatingMode = CustomerIO.shared.operatingMode
-        let _: TimeInterval = CustomerIO.shared.flushInterval
-        let _: Int = CustomerIO.shared.flushAt
-        let _: [FlushPolicy] = CustomerIO.shared.flushPolicies
-        let _: CodableExample? = CustomerIO.shared.traits()
-        let _: [String: Any]? = CustomerIO.shared.traits()
         CustomerIO.shared.flush {}
         CustomerIO.shared.reset()
-        let _: String = CustomerIO.shared.version()
-        let _: Settings? = CustomerIO.shared.settings()
-        CustomerIO.shared.manuallyEnableDestination(plugin: DestinationPluginMock())
         let _: Bool = CustomerIO.shared.hasUnsentEvents
         let _: [URL]? = CustomerIO.shared.pendingUploads
         CustomerIO.shared.purgeStorage()
         CustomerIO.shared.purgeStorage(fileURL: exampleURL)
         CustomerIO.shared.waitUntilStarted()
-        CustomerIO.shared.openURL(exampleURL)
-        CustomerIO.shared.openURL(exampleURL, options: codedData)
-        CustomerIO.shared.openURL(exampleURL, options: dictionaryData)
     }
 
     func test_allPublicModuleConfigOptions() throws {


### PR DESCRIPTION
closes: https://linear.app/customerio/issue/MBL-181/remove-config-settings-from-public-api

### Changes

- Removed following public apis as discussed in the ticket
  - `operatingMode`
  - `flushInterval`
  - `flushAt`
  - `flushPolicies`
  - `traits`
  - `version`
  - `settings`
  - `manuallyEnableDestination`
  - `openURL`
- Fixed API tests