### PR TITLE
test: migration test cases covering all task types

### DIFF
--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -337,7 +337,7 @@ extension DataPipelineImplementation {
         trackRegisterTokenEvent.userId = identifier
         trackRegisterTokenEvent.timestamp = timestamp
         let journeyDict: [String: Any] = ["journeys": ["identifiers": ["id": identifier]]]
-        var tokenDict: [String: Any] = ["token": token, "type": "ios"]
+        let tokenDict: [String: Any] = ["token": token, "type": "ios"]
 
         let deviceDict: [String: Any] = ["device": tokenDict]
         if let context = try? JSON(deviceDict.mergeWith(journeyDict)) {

--- a/Sources/Migration/DataPipelineMigrationAssistant.swift
+++ b/Sources/Migration/DataPipelineMigrationAssistant.swift
@@ -66,7 +66,7 @@ public class DataPipelineMigrationAssistant {
      Retrieves a task from the queue based on its metadata.
      Fetches `type` of the task and processes accordingly
      */
-    private func getAndProcessTask(for task: QueueTaskMetadata, siteId: String) {
+    func getAndProcessTask(for task: QueueTaskMetadata, siteId: String) {
         guard let taskDetail = backgroundQueue.getTaskDetail(task, siteId: siteId) else { return }
         let taskData = taskDetail.data
         let timestamp = taskDetail.timestamp.string(format: .iso8601WithMilliseconds)
@@ -93,7 +93,7 @@ public class DataPipelineMigrationAssistant {
         }
     }
 
-    // Processes in-app metric trackin
+    // Processes in-app metric tracking
     private func processTrackDeliveryMetric(taskData: Data, timestamp: String) -> Bool {
         guard let trackInappTaskData: TrackDeliveryEventRequestBody = jsonAdapter.fromJson(taskData) else {
             return false

--- a/Tests/DataPipeline/DataPipelineImplementation+MigrationTests.swift
+++ b/Tests/DataPipeline/DataPipelineImplementation+MigrationTests.swift
@@ -1,0 +1,80 @@
+@testable import CioDataPipelines
+@testable import CioInternalCommon
+import Foundation
+@testable import SharedTests
+import XCTest
+
+class DataPipelineMigrationTests: IntegrationTest {
+    private var dataPipelineImplementation: DataPipelineImplementation!
+
+    override func setUpDependencies() {
+        super.setUpDependencies()
+    }
+
+    override func setUp() {
+        super.setUp(modifySdkConfig: { _ in
+        })
+
+        // get DataPipelineImplementation instance so we can call its methods directly
+        dataPipelineImplementation = (customerIO.implementation as! DataPipelineImplementation) // swiftlint:disable:this force_cast
+    }
+
+    func test_givenUserAlreadyIdentified_expectIdentifyUser() {
+        let givenIdentifer = String.random
+        XCTAssertNotNil(dataPipelineImplementation.processAlreadyIdentifiedUser(identifier: givenIdentifer))
+        XCTAssertEqual(analytics.userId, givenIdentifer)
+    }
+
+    func test_givenProfileIdentifiedFromBGQ_expectProcessEvent() {
+        let givenIdentifer = String.random
+        let timestamp = dateUtilStub.now.toString()
+        let body = ["foo": "bar"]
+        XCTAssertNotNil(dataPipelineImplementation.processIdentifyFromBGQ(identifier: givenIdentifer, timestamp: timestamp, body: body))
+    }
+
+    func test_givenScreenEventFromBGQ_expectProcessEvent() {
+        let givenIdentifer = String.random
+        let screenName = String.random
+        let timestamp = dateUtilStub.now.toString()
+        let body = ["foo": "bar"]
+        XCTAssertNotNil(dataPipelineImplementation.processScreenEventFromBGQ(identifier: givenIdentifer, name: screenName, timestamp: timestamp, properties: body))
+    }
+
+    func test_givenEventFromBGQ_expectProcessEvent() {
+        let givenIdentifer = String.random
+        let eventName = String.random
+        let timestamp = dateUtilStub.now.toString()
+        let body = ["foo": "bar"]
+        XCTAssertNotNil(dataPipelineImplementation.processEventFromBGQ(identifier: givenIdentifer, name: eventName, timestamp: timestamp, properties: body))
+    }
+
+    func test_givenDeleteTokenFromBGQ_expectProcessEvent() {
+        let givenIdentifer = String.random
+        let token = String.random
+        let timestamp = dateUtilStub.now.toString()
+        XCTAssertNotNil(dataPipelineImplementation.processDeleteTokenFromBGQ(identifier: givenIdentifer, token: token, timestamp: timestamp))
+    }
+
+    func test_givenRegisterDeviceTokenFromBGQ_expectProcessEvent() {
+        let givenIdentifer = String.random
+        let token = String.random
+        let timestamp = dateUtilStub.now.toString()
+        let body = ["foo": "bar"]
+        XCTAssertNotNil(dataPipelineImplementation.processRegisterDeviceFromBGQ(identifier: givenIdentifer, token: token, timestamp: timestamp, attributes: body))
+    }
+
+    func test_givenInAppMetricsFromBGQ_expectProcessEvent() {
+        let deliveryId = String.random
+        let timestamp = dateUtilStub.now.toString()
+        let metaData = ["foo": "bar"]
+        XCTAssertNotNil(dataPipelineImplementation.processMetricsFromBGQ(token: nil, event: "opened", deliveryId: deliveryId, timestamp: timestamp, metaData: metaData))
+    }
+
+    func test_givenPushMetricsFromBGQ_expectProcessEvent() {
+        let token = String.random
+        let deliveryId = String.random
+        let timestamp = dateUtilStub.now.toString()
+        let metaData = ["foo": "bar"]
+        XCTAssertNotNil(dataPipelineImplementation.processMetricsFromBGQ(token: token, event: "opened", deliveryId: deliveryId, timestamp: timestamp, metaData: metaData))
+    }
+}

--- a/Tests/Migration/DataPipelineMigrationAssistantTests.swift
+++ b/Tests/Migration/DataPipelineMigrationAssistantTests.swift
@@ -71,7 +71,10 @@ class DataPipelineMigrationAssistantTests: UnitTest {
 
     func test_givenBacklog_expectTaskRunButNotProcessedDeleted() {
         let givenType = QueueTaskType.identifyProfile
-
+        guard let _ = createTaskAndStoreInInventory(forType: givenType) else {
+            XCTFail("Failed to create task")
+            return
+        }
         backgroundQueueMock.getTaskDetailReturnValue = TaskDetail(data: Data(), taskType: givenType, timestamp: dateUtilStub.now)
 
         XCTAssertNotNil(migrationAssistant.handleQueueBacklog(siteId: testSiteId))

--- a/Tests/Migration/DataPipelineMigrationAssistantTests.swift
+++ b/Tests/Migration/DataPipelineMigrationAssistantTests.swift
@@ -71,11 +71,8 @@ class DataPipelineMigrationAssistantTests: UnitTest {
 
     func test_givenBacklog_expectTaskRunButNotProcessedDeleted() {
         let givenType = QueueTaskType.identifyProfile
-        guard let _ = createTaskAndStoreInInventory(forType: givenType) else {
-            XCTFail("Failed to create task")
-            return
-        }
         backgroundQueueMock.getTaskDetailReturnValue = TaskDetail(data: Data(), taskType: givenType, timestamp: dateUtilStub.now)
+        backgroundQueueMock.getAllStoredTasksReturnValue = []
 
         XCTAssertNotNil(migrationAssistant.handleQueueBacklog(siteId: testSiteId))
         XCTAssertEqual(backgroundQueueMock.deleteProcessedTaskCallsCount, 0)
@@ -145,10 +142,7 @@ class DataPipelineMigrationAssistantTests: UnitTest {
     func test_givenIdentifyProfileWithoutBody_expectTaskRunAndProcessedDeleted() {
         let givenType = QueueTaskType.identifyProfile
 
-        guard let givenCreatedTask = createTaskAndStoreInInventory(forType: givenType) else {
-            XCTFail("Failed to create task")
-            return
-        }
+        let givenCreatedTask = QueueTaskMetadata.random
 
         let trackDeliveryMetricData = IdentifyProfileQueueTaskData(identifier: String.random, attributesJsonString: "")
 
@@ -165,12 +159,6 @@ class DataPipelineMigrationAssistantTests: UnitTest {
 
     func test_givenIdentifyProfileWithBody_expectTaskRunAndProcessedDeleted() {
         let givenType = QueueTaskType.identifyProfile
-
-        guard let givenCreatedTask = createTaskAndStoreInInventory(forType: givenType) else {
-            XCTFail("Failed to create task")
-            return
-        }
-
         let identifyProfileData = IdentifyProfileQueueTaskData(identifier: String.random, attributesJsonString: "{\"foo\": \"bar\"}")
 
         guard let jsonData = try? JSONEncoder().encode(identifyProfileData) else {
@@ -180,6 +168,8 @@ class DataPipelineMigrationAssistantTests: UnitTest {
 
         backgroundQueueMock.getTaskDetailReturnValue = TaskDetail(data: jsonData, taskType: givenType, timestamp: dateUtilStub.now)
 
+        let givenCreatedTask = QueueTaskMetadata.random
+
         XCTAssertNotNil(migrationAssistant.getAndProcessTask(for: givenCreatedTask, siteId: testSiteId))
         XCTAssertEqual(backgroundQueueMock.deleteProcessedTaskCallsCount, 1)
     }
@@ -187,10 +177,7 @@ class DataPipelineMigrationAssistantTests: UnitTest {
     func test_givenTrackDeliveryMetric_expectTaskRunAndProcessedDeleted() {
         let givenType = QueueTaskType.trackDeliveryMetric
 
-        guard let givenCreatedTask = createTaskAndStoreInInventory(forType: givenType) else {
-            XCTFail("Failed to create task")
-            return
-        }
+        let givenCreatedTask = QueueTaskMetadata.random
 
         let trackDeliveryMetricData = TrackDeliveryEventRequestBody(type: .inApp, payload: DeliveryPayload(deliveryId: String.random, event: .clicked, timestamp: dateUtilStub.now, metaData: ["foo": "bar"]))
 
@@ -208,10 +195,7 @@ class DataPipelineMigrationAssistantTests: UnitTest {
     func test_givenTrackDeliveryMetric_expectTaskFailToProcess() {
         let givenType = QueueTaskType.trackDeliveryMetric
 
-        guard let givenCreatedTask = createTaskAndStoreInInventory(forType: givenType) else {
-            XCTFail("Failed to create task")
-            return
-        }
+        let givenCreatedTask = QueueTaskMetadata.random
 
         backgroundQueueMock.getTaskDetailReturnValue = TaskDetail(data: Data(), taskType: givenType, timestamp: dateUtilStub.now)
 
@@ -222,10 +206,7 @@ class DataPipelineMigrationAssistantTests: UnitTest {
     func test_givenTrackEvent_expectTaskRunAndProcessedDeleted() {
         let givenType = QueueTaskType.trackEvent
 
-        guard let givenCreatedTask = createTaskAndStoreInInventory(forType: givenType) else {
-            XCTFail("Failed to create task")
-            return
-        }
+        let givenCreatedTask = QueueTaskMetadata.random
 
         let trackEventAttributedJSON = TrackEventTypeForAnalytics(type: .event, name: String.random, timestamp: dateUtilStub.now)
         let trackEventData = TrackEventQueueTaskData(identifier: String.random, attributesJsonString: jsonAdapter.toJsonString(trackEventAttributedJSON)!)
@@ -244,10 +225,7 @@ class DataPipelineMigrationAssistantTests: UnitTest {
     func test_givenScreenTrackEvent_expectTaskRunAndProcessedDeleted() {
         let givenType = QueueTaskType.trackEvent
 
-        guard let givenCreatedTask = createTaskAndStoreInInventory(forType: givenType) else {
-            XCTFail("Failed to create task")
-            return
-        }
+        let givenCreatedTask = QueueTaskMetadata.random
 
         let trackEventAttributedJSON = TrackEventTypeForAnalytics(type: .screen, name: String.random, timestamp: dateUtilStub.now)
         let trackEventData = TrackEventQueueTaskData(identifier: String.random, attributesJsonString: jsonAdapter.toJsonString(trackEventAttributedJSON)!)
@@ -266,10 +244,7 @@ class DataPipelineMigrationAssistantTests: UnitTest {
     func test_givenRegisterPushToken_expectTaskRunAndProcessedDeleted() {
         let givenType = QueueTaskType.registerPushToken
 
-        guard let givenCreatedTask = createTaskAndStoreInInventory(forType: givenType) else {
-            XCTFail("Failed to create task")
-            return
-        }
+        let givenCreatedTask = QueueTaskMetadata.random
 
         let pushTokenTaskData = RegisterPushNotificationQueueTaskData(profileIdentifier: String.random, attributesJsonString: "{\"device\": {\"id\" : \"\(String.random)\", \"attributes\": {\"foo\":\"bar\"}}}")
 
@@ -287,10 +262,7 @@ class DataPipelineMigrationAssistantTests: UnitTest {
     func test_givenDeletePushToken_expectTaskRunAndProcessedDeleted() {
         let givenType = QueueTaskType.deletePushToken
 
-        guard let givenCreatedTask = createTaskAndStoreInInventory(forType: givenType) else {
-            XCTFail("Failed to create task")
-            return
-        }
+        let givenCreatedTask = QueueTaskMetadata.random
 
         let pushTokenTaskData = DeletePushNotificationQueueTaskData(profileIdentifier: String.random, deviceToken: String.random)
 
@@ -308,10 +280,7 @@ class DataPipelineMigrationAssistantTests: UnitTest {
     func test_givenTrackPushMetric_expectTaskRunAndProcessedDeleted() {
         let givenType = QueueTaskType.trackPushMetric
 
-        guard let givenCreatedTask = createTaskAndStoreInInventory(forType: givenType) else {
-            XCTFail("Failed to create task")
-            return
-        }
+        let givenCreatedTask = QueueTaskMetadata.random
 
         let trackPushMetricData = MetricRequest(deliveryId: String.random, event: .opened, deviceToken: String.random, timestamp: dateUtilStub.now)
 
@@ -330,10 +299,7 @@ class DataPipelineMigrationAssistantTests: UnitTest {
 
     func test_givenInvalidTrackDeliveryMetric_expectTaskNotProcessed() {
         let givenType = QueueTaskType.trackDeliveryMetric
-        guard let givenCreatedTask = createTaskAndStoreInInventory(forType: givenType) else {
-            XCTFail("Failed to create task")
-            return
-        }
+        let givenCreatedTask = QueueTaskMetadata.random
         backgroundQueueMock.getTaskDetailReturnValue = TaskDetail(data: Data(), taskType: givenType, timestamp: dateUtilStub.now)
 
         XCTAssertNotNil(migrationAssistant.getAndProcessTask(for: givenCreatedTask, siteId: testSiteId))
@@ -342,10 +308,7 @@ class DataPipelineMigrationAssistantTests: UnitTest {
 
     func test_givenInvalidTrackEvent_expectTaskNotProcessed() {
         let givenType = QueueTaskType.trackEvent
-        guard let givenCreatedTask = createTaskAndStoreInInventory(forType: givenType) else {
-            XCTFail("Failed to create task")
-            return
-        }
+        let givenCreatedTask = QueueTaskMetadata.random
         backgroundQueueMock.getTaskDetailReturnValue = TaskDetail(data: Data(), taskType: givenType, timestamp: dateUtilStub.now)
 
         XCTAssertNotNil(migrationAssistant.getAndProcessTask(for: givenCreatedTask, siteId: testSiteId))
@@ -355,10 +318,7 @@ class DataPipelineMigrationAssistantTests: UnitTest {
     func test_givenInvalidTrackTypeEvent_expectTaskNotProcessed() {
         let givenType = QueueTaskType.trackEvent
 
-        guard let givenCreatedTask = createTaskAndStoreInInventory(forType: givenType) else {
-            XCTFail("Failed to create task")
-            return
-        }
+        let givenCreatedTask = QueueTaskMetadata.random
 
         let trackEventData = TrackEventQueueTaskData(identifier: String.random, attributesJsonString: "")
 
@@ -374,10 +334,7 @@ class DataPipelineMigrationAssistantTests: UnitTest {
     func test_givenInvalidRegisterPushToken_expectTaskNotProcessed() {
         let givenType = QueueTaskType.registerPushToken
 
-        guard let givenCreatedTask = createTaskAndStoreInInventory(forType: givenType) else {
-            XCTFail("Failed to create task")
-            return
-        }
+        let givenCreatedTask = QueueTaskMetadata.random
 
         // When data is not found in the task
         backgroundQueueMock.getTaskDetailReturnValue = TaskDetail(data: Data(), taskType: givenType, timestamp: dateUtilStub.now)
@@ -412,10 +369,7 @@ class DataPipelineMigrationAssistantTests: UnitTest {
     func test_givenInvalidDeletePushToken_expectTaskNotProcessed() {
         let givenType = QueueTaskType.deletePushToken
 
-        guard let givenCreatedTask = createTaskAndStoreInInventory(forType: givenType) else {
-            XCTFail("Failed to create task")
-            return
-        }
+        let givenCreatedTask = QueueTaskMetadata.random
 
         backgroundQueueMock.getTaskDetailReturnValue = TaskDetail(data: Data(), taskType: givenType, timestamp: dateUtilStub.now)
 
@@ -426,32 +380,10 @@ class DataPipelineMigrationAssistantTests: UnitTest {
     func test_InvalidTrackPushMetric_expectTaskNotProcessed() {
         let givenType = QueueTaskType.trackPushMetric
 
-        guard let givenCreatedTask = createTaskAndStoreInInventory(forType: givenType) else {
-            XCTFail("Failed to create task")
-            return
-        }
+        let givenCreatedTask = QueueTaskMetadata.random
         backgroundQueueMock.getTaskDetailReturnValue = TaskDetail(data: Data(), taskType: givenType, timestamp: dateUtilStub.now)
 
         XCTAssertNotNil(migrationAssistant.getAndProcessTask(for: givenCreatedTask, siteId: testSiteId))
         XCTAssertEqual(backgroundQueueMock.deleteProcessedTaskCallsCount, 0)
-    }
-}
-
-extension DataPipelineMigrationAssistantTests {
-    private func createTaskAndStoreInInventory(forType type: QueueTaskType) -> QueueTaskMetadata? {
-        guard let fileManagerQueueStorage = queueStorage as? FileManagerQueueStorage else {
-            XCTFail("queueStorage could not be cast to FileManagerQueueStorage")
-            return nil
-        }
-
-        guard let givenCreatedTask = fileManagerQueueStorage.create(siteId: testSiteId, type: type.rawValue, data: Data(), groupStart: nil, blockingGroups: nil).createdTask else {
-            XCTFail("Failed to create task")
-            return nil
-        }
-        var inventory: [QueueTaskMetadata] = []
-        inventory.append(givenCreatedTask)
-        backgroundQueueMock.getAllStoredTasksReturnValue = inventory
-
-        return givenCreatedTask
     }
 }

--- a/Tests/Migration/DataPipelineMigrationAssistantTests.swift
+++ b/Tests/Migration/DataPipelineMigrationAssistantTests.swift
@@ -238,6 +238,28 @@ class DataPipelineMigrationAssistantTests: UnitTest {
         XCTAssertEqual(backgroundQueueMock.deleteProcessedTaskCallsCount, 1)
     }
 
+    func test_givenScreenTrackEvent_expectTaskRunAndProcessedDeleted() {
+        let givenType = QueueTaskType.trackEvent
+
+        guard let givenCreatedTask = createTaskAndStoreInInventory(forType: givenType) else {
+            XCTFail("Failed to create task")
+            return
+        }
+
+        let trackEventAttributedJSON = TrackEventTypeForAnalytics(type: .screen, name: String.random, timestamp: dateUtilStub.now)
+        let trackEventData = TrackEventQueueTaskData(identifier: String.random, attributesJsonString: jsonAdapter.toJsonString(trackEventAttributedJSON)!)
+
+        guard let jsonData = try? JSONEncoder().encode(trackEventData) else {
+            XCTFail("Failed to create task data")
+            return
+        }
+
+        backgroundQueueMock.getTaskDetailReturnValue = TaskDetail(data: jsonData, taskType: givenType, timestamp: dateUtilStub.now)
+
+        XCTAssertNotNil(migrationAssistant.getAndProcessTask(for: givenCreatedTask, siteId: testSiteId))
+        XCTAssertEqual(backgroundQueueMock.deleteProcessedTaskCallsCount, 1)
+    }
+
     func test_givenRegisterPushToken_expectTaskRunAndProcessedDeleted() {
         let givenType = QueueTaskType.registerPushToken
 


### PR DESCRIPTION
close: https://linear.app/customerio/issue/MBL-178/increase-test-coverage-of-track-bq-migration

Two of migration files were missing/had insufficient test coverage. The ask of the ticket above was to increase the test coverage to increase confidence in the migration module. Hence, this PR caters the following:

- write test cases of the uncovered methods in MigrationAssistant
- write test cases of the uncovered methods in DataPipelineImplementation

MigrationAssistant's updated coverage - 100% (previously 50%)
DataPipelineImplementation's updated coverage - 90.64% (previously 61.54%)
