### PR TITLE
fix: journey id in migration payload

### DIFF
--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -319,9 +319,8 @@ extension DataPipelineImplementation {
         var trackDeleteEvent = TrackEvent(event: "Device Deleted", properties: nil)
         trackDeleteEvent.userId = identifier
         trackDeleteEvent.timestamp = timestamp
-        let journeyDict: [String: Any] = ["journeys": ["identifiers": ["id": identifier]]]
         let deviceDict: [String: Any] = ["device": ["token": token, "type": "ios"]]
-        if let context = try? JSON(deviceDict.mergeWith(journeyDict)) {
+        if let context = try? JSON(deviceDict) {
             trackDeleteEvent.context = context
         }
         analytics.process(event: trackDeleteEvent)
@@ -331,11 +330,10 @@ extension DataPipelineImplementation {
         var trackRegisterTokenEvent = TrackEvent(event: "Device Created or Updated", properties: nil)
         trackRegisterTokenEvent.userId = identifier
         trackRegisterTokenEvent.timestamp = timestamp
-        let journeyDict: [String: Any] = ["journeys": ["identifiers": ["id": identifier]]]
-        var tokenDict: [String: Any] = ["token": token, "type": "ios"]
+        let tokenDict: [String: Any] = ["token": token, "type": "ios"]
 
         let deviceDict: [String: Any] = ["device": tokenDict]
-        if let context = try? JSON(deviceDict.mergeWith(journeyDict)) {
+        if let context = try? JSON(deviceDict) {
             trackRegisterTokenEvent.context = context
         }
         if let attributes = attributes, let attributes = try? JSON(attributes) {

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -288,11 +288,6 @@ extension DataPipelineImplementation {
     func processIdentifyFromBGQ(identifier: String, timestamp: String, body: [String: Any]?) {
         var identifyEvent = IdentifyEvent(userId: identifier, traits: nil)
         identifyEvent.timestamp = timestamp
-
-        let contextDict = ["journeys": ["identifiers": ["id": identifier]]]
-        if let context = try? JSON(contextDict) {
-            identifyEvent.context = context
-        }
         if let traits = body {
             let jsonTraits = try? JSON(traits)
             identifyEvent.traits = jsonTraits


### PR DESCRIPTION
Since we don't have much context on whether the users will be relying on `id` or `email` while migrating their events from tracking to CDP, we need to remove it and rely on the `userId` attribute being added. 

I have verified these manually and test cases are going to follow later and will be handled by Amans PR.