### PR TITLE
fix: install 3.0 with Swift Package Manager from Xcode

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,7 @@ let package = Package(
         .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git", "8.7.0"..<"11.0.0"),
 
         // The version is a git commit hash. Make sure the commit is the same as what the DataPipelines CocoaPods is using.
-        .package(name: "Segment", url: "https://github.com/customerio/cdp-analytics-swift.git", .revision("b2f8f5b68dd0d8796b4bacdec39aacb5b6387a41"))
+        .package(name: "Segment", url: "https://github.com/customerio/cdp-analytics-swift.git", .exact("1.5.5-cio.1"))
     ],
     targets: [ 
         // Common - Code used by multiple modules in the SDK project.


### PR DESCRIPTION
Resolve error, "Failed to resolve dependencies Dependencies could not be resolved because root depends on 'customerio-ios' 3.0.0..<4.0.0. 'customerio-ios' >= 3.0.0 cannot be used because no versions of 'customerio-ios' match the requirement and package is required using a stable-version but depends on an unstable-version package"
