### PR TITLE
docs: [vision-on-sample-app][8/n] Identify view

### DIFF
--- a/Apps/VisionOS/VisionOS.xcodeproj/project.pbxproj
+++ b/Apps/VisionOS/VisionOS.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		60C32BFB2BABAFBE006F5DC3 /* MainLayoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6023AD3B2B913954001540EF /* MainLayoutView.swift */; };
 		60C32BFD2BABAFFB006F5DC3 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 60C32BFC2BABAFFB006F5DC3 /* MarkdownUI */; };
 		60C32BFF2BABB02E006F5DC3 /* Splash in Frameworks */ = {isa = PBXBuildFile; productRef = 60C32BFE2BABB02E006F5DC3 /* Splash */; };
+		60DE3F7B2BAD38C600C6816C /* IdentifyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DE3F7A2BAD38C600C6816C /* IdentifyView.swift */; };
+		60DE3F7D2BAD392000C6816C /* CodeSnippetHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DE3F7C2BAD392000C6816C /* CodeSnippetHelper.swift */; };
 		60E792522BACDE72003736F4 /* SDKInitializationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E792512BACDE72003736F4 /* SDKInitializationView.swift */; };
 		60F967352B9125D000A4E95E /* VisionOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967342B9125D000A4E95E /* VisionOSApp.swift */; };
 		60F967372B9125D000A4E95E /* MainScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967362B9125D000A4E95E /* MainScreen.swift */; };
@@ -39,6 +41,8 @@
 		6023AD4B2B9153EB001540EF /* LineView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineView.swift; sourceTree = "<group>"; };
 		606F2C202B9B79F3004E7318 /* PropertiesInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertiesInputView.swift; sourceTree = "<group>"; };
 		60C32BEB2BABAD4D006F5DC3 /* ViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
+		60DE3F7A2BAD38C600C6816C /* IdentifyView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentifyView.swift; sourceTree = "<group>"; };
+		60DE3F7C2BAD392000C6816C /* CodeSnippetHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodeSnippetHelper.swift; sourceTree = "<group>"; };
 		60E792512BACDE72003736F4 /* SDKInitializationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SDKInitializationView.swift; sourceTree = "<group>"; };
 		60F9672D2B9125D000A4E95E /* VisionOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VisionOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		60F967342B9125D000A4E95E /* VisionOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisionOSApp.swift; sourceTree = "<group>"; };
@@ -84,6 +88,7 @@
 		60E792502BACDE36003736F4 /* APIViews */ = {
 			isa = PBXGroup;
 			children = (
+				60DE3F7A2BAD38C600C6816C /* IdentifyView.swift */,
 				60E792512BACDE72003736F4 /* SDKInitializationView.swift */,
 			);
 			path = APIViews;
@@ -152,6 +157,7 @@
 		60F967562B912C1000A4E95E /* ViewUtils */ = {
 			isa = PBXGroup;
 			children = (
+				60DE3F7C2BAD392000C6816C /* CodeSnippetHelper.swift */,
 				60F967572B912C1000A4E95E /* SyntaxHighlighting */,
 				60F9675A2B912C1000A4E95E /* MarkdownTheme.swift */,
 			);
@@ -251,10 +257,12 @@
 				60C32BF62BABAFBE006F5DC3 /* LineView.swift in Sources */,
 				60C32BF72BABAFBE006F5DC3 /* FloatingTitleTextField.swift in Sources */,
 				60C32BF82BABAFBE006F5DC3 /* ToastView.swift in Sources */,
+				60DE3F7B2BAD38C600C6816C /* IdentifyView.swift in Sources */,
 				60C32BF92BABAFBE006F5DC3 /* Logo.swift in Sources */,
 				60C32BFA2BABAFBE006F5DC3 /* PropertiesInputView.swift in Sources */,
 				60C32BFB2BABAFBE006F5DC3 /* MainLayoutView.swift in Sources */,
 				60F967542B91288400A4E95E /* Payloads.swift in Sources */,
+				60DE3F7D2BAD392000C6816C /* CodeSnippetHelper.swift in Sources */,
 				60F967372B9125D000A4E95E /* MainScreen.swift in Sources */,
 				60F9675B2B912C1000A4E95E /* TextOutputFormat.swift in Sources */,
 				60F9675D2B912C1000A4E95E /* MarkdownTheme.swift in Sources */,

--- a/Apps/VisionOS/VisionOS/APIViews/IdentifyView.swift
+++ b/Apps/VisionOS/VisionOS/APIViews/IdentifyView.swift
@@ -1,0 +1,95 @@
+import MarkdownUI
+import Splash
+import SwiftUI
+
+private func identifyCodeSnippet(_ profile: Profile) -> String {
+    let propertiesStr = propertiesToTutorialString(
+        profile.traits,
+        linePrefix: "\t\t"
+    )
+
+    if !profile.userId.isEmpty, !profile.traits.isEmpty {
+        return
+            """
+            CustomerIO.shared.identify(
+                userId: "\(profile.userId)",
+                traits: \(propertiesStr)
+            )
+            """
+    } else if !profile.userId.isEmpty {
+        return
+            """
+            CustomerIO.shared.identify(
+                userId: "\(profile.userId)"
+            )
+            """
+    } else if !profile.traits.isEmpty {
+        return
+            """
+            CustomerIO.shared.identify(",
+                traits: \(propertiesStr)
+            )
+            """
+    }
+    return "// enter user id or add a trait"
+}
+
+struct IdentifyView: View {
+    @ObservedObject var state = AppState.shared
+    @State private var profile = AppState.shared.profile
+    @EnvironmentObject private var viewModel: ViewModel
+
+    let onSuccess: (Profile) -> Void
+
+    var body: some View {
+        ScrollView(.vertical) {
+            VStack(alignment: .leading) {
+                Markdown {
+                    """
+                    Before you can track events, set devices attributes or update user trains, you must identify the user first.
+                    To identify a user, you must set a userId or traits or both.
+                    [Learn more](https://customer.io/docs/journeys/identifying-people/#identifiers).
+
+                    ```swift
+                    \(identifyCodeSnippet(profile))
+                    ```
+
+                    """
+                }
+
+                HStack(alignment: .bottom) {
+                    FloatingTitleTextField(title: "User ID", text: $profile.userId)
+                    Button("Generate UUID") {
+                        profile.userId = UUID().uuidString
+                    }
+                }
+
+                PropertiesInputView(
+                    properties: $profile.traits,
+                    addPropertiesLabel: "Traits can be any codable value. In this example we are using key->value pairs."
+                )
+
+                Divider()
+                HStack {
+                    Button("Identify") {
+                        profile.loggedIn = true
+                        if profile.userId.isEmpty, profile.traits.isEmpty {
+                            viewModel.errorMessage = "You must set an id or at least one trait"
+                            return
+                        }
+                        state.profile = profile
+                        onSuccess(state.profile)
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    AppState.shared.profile = Profile.empty()
+    return MainLayoutView(selectedExample: .constant(.identify)) {
+        IdentifyView { _ in
+        }
+    }
+}

--- a/Apps/VisionOS/VisionOS/MainScreen.swift
+++ b/Apps/VisionOS/VisionOS/MainScreen.swift
@@ -27,7 +27,16 @@ struct MainScreen: View {
                             .build())
                 }
             case .identify:
-                Text("Identify")
+                IdentifyView { profile in
+                    if !profile.userId.isEmpty, !profile.traits.isEmpty {
+                        CustomerIO.shared.identify(userId: profile.userId, traits: profile.traits)
+                    }
+                    if !profile.userId.isEmpty {
+                        CustomerIO.shared.identify(userId: profile.userId)
+                    } else {
+                        CustomerIO.shared.identify(traits: profile.traits)
+                    }
+                }
             case .track:
                 Text("Track")
             case .profileAttributes:

--- a/Apps/VisionOS/VisionOS/ViewUtils/CodeSnippetHelper.swift
+++ b/Apps/VisionOS/VisionOS/ViewUtils/CodeSnippetHelper.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+extension String {
+    func escapeQuotes() -> String {
+        replacingOccurrences(of: "\"", with: "\"\"")
+    }
+}
+
+func propertiesToTutorialString(
+    _ properties: [Property],
+    linePrefix: String = ""
+) -> String {
+    let senatizedProperties = properties.filter { p in
+        !p.name.isEmpty && !p.value.isEmpty
+    }.map { p in
+        Property(
+            name: p.name
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .escapeQuotes(),
+            value: p.value
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .escapeQuotes()
+        )
+    }
+    if senatizedProperties.isEmpty {
+        return ""
+    }
+
+    var res = "["
+    var sep = ""
+    senatizedProperties.forEach { p in
+        res += """
+        \(sep)"\(p.name)": "\(p.value)"
+        """
+        sep = ", "
+    }
+    res += "]"
+    return res
+}


### PR DESCRIPTION
This is a PR in a series of PRs to build sample app that runs Identify and Track in VisionPro
The app is built to be an interactive walk through guidance for developers who are integrating Customer.io Swift SDK in their VisioPro apps.
For more context:

- See the project [one pager](https://www.notion.so/custio/Spacial-Identify-and-Tracking-6587d848bbde494095c0585237326ed3?pvs=4)
- See [Linear Issue](https://linear.app/customerio/issue/MBL-115/sample-app-for-visionpro)

This PR introduces a the "Identify" example screen. It demonstrates the requirements of the API, allows the user to enter profile attributes to be send alongside the identify call.

