### PR TITLE
docs: [vision-os-sample-app][7/n] SDK Initialization view

### DIFF
--- a/Apps/VisionOS/VisionOS.xcodeproj/project.pbxproj
+++ b/Apps/VisionOS/VisionOS.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		60C32BFB2BABAFBE006F5DC3 /* MainLayoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6023AD3B2B913954001540EF /* MainLayoutView.swift */; };
 		60C32BFD2BABAFFB006F5DC3 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 60C32BFC2BABAFFB006F5DC3 /* MarkdownUI */; };
 		60C32BFF2BABB02E006F5DC3 /* Splash in Frameworks */ = {isa = PBXBuildFile; productRef = 60C32BFE2BABB02E006F5DC3 /* Splash */; };
+		60E792522BACDE72003736F4 /* SDKInitializationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E792512BACDE72003736F4 /* SDKInitializationView.swift */; };
 		60F967352B9125D000A4E95E /* VisionOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967342B9125D000A4E95E /* VisionOSApp.swift */; };
 		60F967372B9125D000A4E95E /* MainScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F967362B9125D000A4E95E /* MainScreen.swift */; };
 		60F967392B9125D100A4E95E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 60F967382B9125D100A4E95E /* Assets.xcassets */; };
@@ -38,6 +39,7 @@
 		6023AD4B2B9153EB001540EF /* LineView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LineView.swift; sourceTree = "<group>"; };
 		606F2C202B9B79F3004E7318 /* PropertiesInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertiesInputView.swift; sourceTree = "<group>"; };
 		60C32BEB2BABAD4D006F5DC3 /* ViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
+		60E792512BACDE72003736F4 /* SDKInitializationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SDKInitializationView.swift; sourceTree = "<group>"; };
 		60F9672D2B9125D000A4E95E /* VisionOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VisionOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		60F967342B9125D000A4E95E /* VisionOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisionOSApp.swift; sourceTree = "<group>"; };
 		60F967362B9125D000A4E95E /* MainScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainScreen.swift; sourceTree = "<group>"; };
@@ -79,6 +81,14 @@
 			path = CommonViews;
 			sourceTree = "<group>";
 		};
+		60E792502BACDE36003736F4 /* APIViews */ = {
+			isa = PBXGroup;
+			children = (
+				60E792512BACDE72003736F4 /* SDKInitializationView.swift */,
+			);
+			path = APIViews;
+			sourceTree = "<group>";
+		};
 		60F967242B9125D000A4E95E = {
 			isa = PBXGroup;
 			children = (
@@ -103,6 +113,7 @@
 				60F9674F2B91288400A4E95E /* Storage */,
 				60F967562B912C1000A4E95E /* ViewUtils */,
 				6023AD382B913954001540EF /* CommonViews */,
+				60E792502BACDE36003736F4 /* APIViews */,
 				60F967342B9125D000A4E95E /* VisionOSApp.swift */,
 				6023AD362B9137F0001540EF /* AppDelegate.swift */,
 				60F967362B9125D000A4E95E /* MainScreen.swift */,
@@ -249,6 +260,7 @@
 				60F9675D2B912C1000A4E95E /* MarkdownTheme.swift in Sources */,
 				60F967352B9125D000A4E95E /* VisionOSApp.swift in Sources */,
 				60F967532B91288400A4E95E /* AppState.swift in Sources */,
+				60E792522BACDE72003736F4 /* SDKInitializationView.swift in Sources */,
 				60F967552B91288400A4E95E /* UserDefaultsCodable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Apps/VisionOS/VisionOS/APIViews/SDKInitializationView.swift
+++ b/Apps/VisionOS/VisionOS/APIViews/SDKInitializationView.swift
@@ -1,0 +1,49 @@
+import MarkdownUI
+import SwiftUI
+
+struct SDKInitializationView: View {
+    @EnvironmentObject var viewModel: ViewModel
+    @State var workspaceSettings = AppState.shared.workspaceSettings
+
+    let onSuccess: (_ workspaceSettings: WorkspaceSettings) -> Void
+
+    var body: some View {
+        ScrollView(.vertical) {
+            VStack(alignment: .leading) {
+                Markdown {
+                    """
+                    You must have a cdp api key in order to initialize and use the SDK.
+                    Click [here](https://customer.io/docs/sdk/ios/quick-start-guide/#prerequisites) to learn more
+                    about the prerequisites.
+
+                    ```swift
+                    CustomerIO.initialize(withConfig:
+                        SDKConfigBuilder(cdpApiKey: "\(workspaceSettings.cdpApiKy)")
+                        .build())
+                    ```
+                    """
+                }
+                FloatingTitleTextField(title: "CDP API KEY", text: $workspaceSettings.cdpApiKy)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+
+                Button("Initialize") {
+                    if !workspaceSettings.isSet() {
+                        viewModel.errorMessage = "Please make sure to enter the CDP API Key"
+                        return
+                    }
+                    AppState.shared.workspaceSettings = workspaceSettings
+                    onSuccess(AppState.shared.workspaceSettings)
+                }
+
+                Spacer()
+            }
+        }
+    }
+}
+
+#Preview {
+    MainLayoutView(selectedExample: .constant(.initialize)) {
+        SDKInitializationView { _ in }
+    }
+}

--- a/Apps/VisionOS/VisionOS/MainScreen.swift
+++ b/Apps/VisionOS/VisionOS/MainScreen.swift
@@ -1,3 +1,5 @@
+import CioDataPipelines
+import MarkdownUI
 import SwiftUI
 
 /**
@@ -21,12 +23,23 @@ private func getFirstScreen() -> CIOExample {
 
 struct MainScreen: View {
     @ObservedObject var state: AppState = .shared
+    @EnvironmentObject private var viewModel: ViewModel
+
     @State var selectedExample = getFirstScreen()
     var body: some View {
         MainLayoutView(selectedExample: $selectedExample) {
             switch selectedExample {
             case .initialize:
-                Text("SDK Initialization")
+                SDKInitializationView { workspaceSettings in
+                    CustomerIO.initialize(
+                        withConfig:
+                        SDKConfigBuilder(cdpApiKey: workspaceSettings.cdpApiKy)
+                            .logLevel(.debug)
+                            .build())
+
+                    viewModel.successMessage = "SDK Initialized. You can now identify the user"
+                    selectedExample = .identify
+                }
             case .identify:
                 Text("Identify")
             case .track:


### PR DESCRIPTION
## Context
This is a PR in a series of PRs to build sample app that runs Identify and Track in VisionPro

For more context:

- See the project [one pager](https://www.notion.so/custio/Spacial-Identify-and-Tracking-6587d848bbde494095c0585237326ed3?pvs=4)
- See [Linear Issue](https://linear.app/customerio/issue/MBL-115/sample-app-for-visionpro)

## In this PR
This PR introduces the SDK Initialization view where that demonstrates the usage of the `initialize` API

## Test Plan
- `CustomerIO.initialize` is called with the correct value when hitting "Initialize" button
- App state updates to reflect the SDK has been initialized

https://github.com/customerio/customerio-ios/assets/142905621/0e9550fa-2d54-450c-a92d-5a6b92e4684a


--

## PR Stack

- #668 
- #667 
- #666 
- #665 👈
- #664   
- #663 


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"ahmed/visionos/common-views","parentHead":"10edfdd0775b61604c3c0f7e0607f192c409c3be","parentPull":664,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"ahmed/visionos/common-views","parentHead":"10edfdd0775b61604c3c0f7e0607f192c409c3be","parentPull":664,"trunk":"main"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
