### PR TITLE
docs: [vision-os-sample-app][11/n] Device Attributes

### DIFF
--- a/Apps/VisionOS/VisionOS.xcodeproj/project.pbxproj
+++ b/Apps/VisionOS/VisionOS.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		6023AD372B9137F0001540EF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6023AD362B9137F0001540EF /* AppDelegate.swift */; };
 		6066B2632BAFC86F005A4135 /* TrackEventsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6066B2622BAFC86F005A4135 /* TrackEventsView.swift */; };
 		6066B2652BAFCBEB005A4135 /* ProfileAttributesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6066B2642BAFCBEB005A4135 /* ProfileAttributesView.swift */; };
+		6081D4F82BB0E70900E0F897 /* DeviceAttributeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6081D4F72BB0E70900E0F897 /* DeviceAttributeView.swift */; };
 		60B151FB2BAB4AA9003C4726 /* DataPipelines in Frameworks */ = {isa = PBXBuildFile; productRef = 60B151FA2BAB4AA9003C4726 /* DataPipelines */; };
 		60C32BEC2BABAD4D006F5DC3 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C32BEB2BABAD4D006F5DC3 /* ViewModel.swift */; };
 		60C32BF62BABAFBE006F5DC3 /* LineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6023AD4B2B9153EB001540EF /* LineView.swift */; };
@@ -44,6 +45,8 @@
 		6066B2622BAFC86F005A4135 /* TrackEventsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackEventsView.swift; sourceTree = "<group>"; };
 		6066B2642BAFCBEB005A4135 /* ProfileAttributesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileAttributesView.swift; sourceTree = "<group>"; };
 		606F2C202B9B79F3004E7318 /* PropertiesInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertiesInputView.swift; sourceTree = "<group>"; };
+		60ADD6BF2BB69BE2004F8C1F /* VisionOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = VisionOS.entitlements; sourceTree = "<group>"; };
+		6081D4F72BB0E70900E0F897 /* DeviceAttributeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceAttributeView.swift; sourceTree = "<group>"; };
 		60B792DB2BAFC0F700E8F886 /* TrackEventsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackEventsView.swift; sourceTree = "<group>"; };
 		60C32BEB2BABAD4D006F5DC3 /* ViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		60DE3F7A2BAD38C600C6816C /* IdentifyView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentifyView.swift; sourceTree = "<group>"; };
@@ -105,6 +108,7 @@
 				60DE3F7A2BAD38C600C6816C /* IdentifyView.swift */,
 				6066B2622BAFC86F005A4135 /* TrackEventsView.swift */,
 				6066B2642BAFCBEB005A4135 /* ProfileAttributesView.swift */,
+				6081D4F72BB0E70900E0F897 /* DeviceAttributeView.swift */,
 			);
 			path = APIViews;
 			sourceTree = "<group>";
@@ -276,6 +280,7 @@
 				60C32BF82BABAFBE006F5DC3 /* ToastView.swift in Sources */,
 				60DE3F7B2BAD38C600C6816C /* IdentifyView.swift in Sources */,
 				60C32BF92BABAFBE006F5DC3 /* Logo.swift in Sources */,
+				6081D4F82BB0E70900E0F897 /* DeviceAttributeView.swift in Sources */,
 				60C32BFA2BABAFBE006F5DC3 /* PropertiesInputView.swift in Sources */,
 				60C32BFB2BABAFBE006F5DC3 /* MainLayoutView.swift in Sources */,
 				60F967542B91288400A4E95E /* Payloads.swift in Sources */,

--- a/Apps/VisionOS/VisionOS/APIViews/DeviceAttributeView.swift
+++ b/Apps/VisionOS/VisionOS/APIViews/DeviceAttributeView.swift
@@ -1,0 +1,54 @@
+import MarkdownUI
+import SwiftUI
+
+func deviceAttributesCodeSnippet(_ attributes: [Attribute]) -> String {
+    
+    if attributes.isEmpty {
+        return "// enter device attributes"
+    } else {
+        let attributesStr = propertiesToTutorialString(attributes)
+        return
+            """
+            CustomerIO.shared.deviceAttributes = \(attributesStr)
+            """
+    }
+}
+
+struct DeviceAttributesView: View {
+    @ObservedObject var state = AppState.shared
+
+    @State private var attributes: [Attribute] = []
+
+    let onSuccess: (_ deviceAttributes: [Attribute]) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Markdown {
+                """
+                You can set/update device attributes at any point in your app by setting values in the
+                `CustomerIO.shared.deviceAttributes` dictionary.
+                If you are interested to learn about how device attributes is being used,
+                [click here](https://customer.io/docs/journeys/attributes/#attribute-segment).
+
+                ```swift
+                \(deviceAttributesCodeSnippet(attributes))
+                ```
+
+                """
+            }
+
+            PropertiesInputView(terminology: .attributes, properties: $attributes)
+
+            Button("Set/Update device attribute") {
+                onSuccess(attributes)
+            }
+        }
+    }
+}
+
+#Preview {
+    MainLayoutView(selectedExample: .constant(.deviceAttributes)) {
+        DeviceAttributesView { _ in
+        }
+    }
+}

--- a/Apps/VisionOS/VisionOS/CommonViews/MainLayoutView.swift
+++ b/Apps/VisionOS/VisionOS/CommonViews/MainLayoutView.swift
@@ -2,7 +2,7 @@ import MarkdownUI
 import SwiftUI
 
 enum CIOExample: String, CaseIterable {
-    case initialize, identify, track, profileAttributes
+    case initialize, identify, track, profileAttributes, deviceAttributes
     var title: String {
         switch self {
         case .initialize:
@@ -13,6 +13,8 @@ enum CIOExample: String, CaseIterable {
             "Event Tracking"
         case .profileAttributes:
             "Profile Attributes"
+        case .deviceAttributes:
+            "Device Attributes"
         }
     }
 
@@ -20,7 +22,7 @@ enum CIOExample: String, CaseIterable {
         switch self {
         case .initialize:
             return true
-        case .identify, .track, .profileAttributes:
+        case .identify, .track, .profileAttributes, .deviceAttributes:
             return AppState.shared.workspaceSettings.isSet()
         }
     }

--- a/Apps/VisionOS/VisionOS/MainScreen.swift
+++ b/Apps/VisionOS/VisionOS/MainScreen.swift
@@ -73,6 +73,15 @@ struct MainScreen: View {
                     // For debug purpose only
                     CustomerIO.shared.flush()
                 }
+                
+            case .deviceAttributes:
+                DeviceAttributesView { deviceAttributes in
+                    CustomerIO.shared.deviceAttributes = deviceAttributes.toDictionary()
+                    
+                    viewModel.successMessage = "Device attributes set successfully"
+                    // For debug purpose only
+                    CustomerIO.shared.flush()
+                }
             }
         }
     }

--- a/Sources/MessagingPush/Config/MessagingPushConfigBuilder.swift
+++ b/Sources/MessagingPush/Config/MessagingPushConfigBuilder.swift
@@ -44,7 +44,9 @@ public class MessagingPushConfigBuilder {
     }
 
     @available(iOS, unavailable)
+    @available(visionOS, unavailable)
     @available(iOSApplicationExtension, introduced: 13.0)
+    @available(visionOSApplicationExtension, introduced: 1.0)
     /// Initializes new `MessagingPushConfigBuilder` with required configuration options.
     /// - Parameters:
     ///   - cdpApiKey: Customer.io Data Pipeline API Key required for NotificationServiceExtension only to track metrics
@@ -56,7 +58,9 @@ public class MessagingPushConfigBuilder {
     /// verbosity to help setup and debugging
     @discardableResult
     @available(iOS, unavailable)
+    @available(visionOS, unavailable)
     @available(iOSApplicationExtension, introduced: 13.0)
+    @available(visionOSApplicationExtension, introduced: 1.0)
     public func logLevel(_ logLevel: CioLogLevel) -> MessagingPushConfigBuilder {
         self.logLevel = logLevel
         return self

--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -69,7 +69,9 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
 
     /// MessagingPush initializer for Notification Service Extension
     @available(iOS, unavailable)
+    @available(visionOS, unavailable)
     @available(iOSApplicationExtension, introduced: 13.0)
+    @available(visionOSApplicationExtension, introduced: 1.0)
     @discardableResult
     public static func initializeForExtension(withConfig config: MessagingPushConfigOptions) -> MessagingPushInstance {
         shared.initializeModuleIfNotAlready {

--- a/Sources/MessagingPushAPN/MessagingPushAPN.swift
+++ b/Sources/MessagingPushAPN/MessagingPushAPN.swift
@@ -97,7 +97,9 @@ public class MessagingPushAPN: MessagingPushAPNInstance {
 
     /// MessagingPushAPN initializer for Notification Service Extension
     @available(iOS, unavailable)
+    @available(visionOS, unavailable)
     @available(iOSApplicationExtension, introduced: 13.0)
+    @available(visionOSApplicationExtension, introduced: 1.0)
     @discardableResult
     public static func initializeForExtension(withConfig config: MessagingPushConfigOptions) -> MessagingPushInstance {
         let implementation = MessagingPush.initializeForExtension(withConfig: config)

--- a/Sources/MessagingPushFCM/MessagingPushFCM.swift
+++ b/Sources/MessagingPushFCM/MessagingPushFCM.swift
@@ -101,7 +101,9 @@ public class MessagingPushFCM: MessagingPushFCMInstance {
 
     /// MessagingPushFCM initializer for Notification Service Extension
     @available(iOS, unavailable)
+    @available(visionOS, unavailable)
     @available(iOSApplicationExtension, introduced: 13.0)
+    @available(visionOSApplicationExtension, introduced: 1.0)
     @discardableResult
     public static func initializeForExtension(withConfig config: MessagingPushConfigOptions) -> MessagingPushInstance {
         let implementation = MessagingPush.initializeForExtension(withConfig: config)


### PR DESCRIPTION
This is a PR in a series of PRs to build sample app that runs Identify and Track in VisionPro The app is built to be an interactive walk through guidance for developers who are integrating Customer.io Swift SDK in their VisioPro apps. For more context:

- See the project [one pager](https://www.notion.so/custio/Spacial-Identify-and-Tracking-6587d848bbde494095c0585237326ed3?pvs=4)
- See [Linear Issue](https://linear.app/customerio/issue/MBL-115/sample-app-for-visionpro)

## In this PR
This PR introduces a screen to demonstrate the usage of the `deviceAttributes` dictionary.


## Test Plan
Ensures device attributes works end to end

