### PR TITLE
test: replace async events in synchronous functions to reduce test flake

### DIFF
--- a/Sources/Common/Communication/EventBus.swift
+++ b/Sources/Common/Communication/EventBus.swift
@@ -26,7 +26,7 @@ public protocol EventBus: AutoMockable {
     /// Removes all observers from the EventBus.
     ///
     /// The function can be used for cleaning up or resetting the event handling system.
-    func removeAllObservers() async
+    func removeAllObservers()
 }
 
 /// EventBusObserversHolder is a private helper class used within SharedEventBus.
@@ -42,7 +42,7 @@ class EventBusObserversHolder {
 
     /// Dictionary holding arrays of observer tokens for each event type.
     /// The keys are event types (as String), and the values are arrays of NotificationCenter tokens.
-    var observers: [String: [NSObjectProtocol]] = [:]
+    @Atomic var observers: [String: [NSObjectProtocol]] = [:]
 
     /// Removes all observers from the EventBus.
     ///
@@ -69,8 +69,8 @@ class EventBusObserversHolder {
 // sourcery: InjectRegisterShared = "EventBus"
 // sourcery: InjectSingleton
 // swiftlint:enable orphaned_doc_comment
-actor SharedEventBus: EventBus {
-    private let holder = EventBusObserversHolder()
+class SharedEventBus: EventBus {
+    @Atomic private var holder = EventBusObserversHolder()
 
     init() {
         DIGraphShared.shared.logger.debug("SharedEventBus initialized")
@@ -121,7 +121,7 @@ actor SharedEventBus: EventBus {
         }
     }
 
-    func removeAllObservers() async {
+    func removeAllObservers() {
         holder.removeAllObservers()
     }
 }

--- a/Sources/Common/Communication/EventBusHandler.swift
+++ b/Sources/Common/Communication/EventBusHandler.swift
@@ -8,7 +8,7 @@ public protocol EventBusHandler {
     func postEvent<E: EventRepresentable>(_ event: E)
     func postEventAndWait<E: EventRepresentable>(_ event: E) async
     func removeFromStorage<E: EventRepresentable>(_ event: E) async
-    func removeAllObservers() async
+    func removeAllObservers()
 }
 
 // swiftlint:disable orphaned_doc_comment
@@ -46,6 +46,7 @@ public class CioEventBusHandler: EventBusHandler {
 
     deinit {
         taskBag.cancelAll()
+        eventBus.removeAllObservers()
     }
 
     /// Loads events from persistent storage into in-memory storage for quick access and event replay.
@@ -143,7 +144,7 @@ public class CioEventBusHandler: EventBusHandler {
     }
 
     /// Resets the EventBus to initial state by removing all observers and stored events.
-    public func removeAllObservers() async {
-        await eventBus.removeAllObservers()
+    public func removeAllObservers() {
+        eventBus.removeAllObservers()
     }
 }

--- a/Tests/Shared/Core/UnitTestBase.swift
+++ b/Tests/Shared/Core/UnitTestBase.swift
@@ -101,6 +101,11 @@ open class UnitTestBase<Component>: XCTestCase {
 
     // Clean up the test environment by releasing resources, clearing mocks, and resetting states during teardown.
     open func cleanupTestEnvironment() {
+        // need to remove the observers for integration tests that utilizes actual NotificationCenter
+        // otherwise, results are flaky
+//     https://linear.app/customerio/issue/MBL-208/possible-memory-leak-in-datapipelinesimplementation
+        diGraphShared.eventBusHandler.removeAllObservers()
+
         // Delete all persistent data to ensure a clean state for each test when called during teardown.
         deleteAllPersistentData()
         // Reset mocks at the very end to prevent `EXC_BAD_ACCESS` errors by avoiding access to deallocated objects.
@@ -112,9 +117,6 @@ open class UnitTestBase<Component>: XCTestCase {
 
     // All data that the SDK writes, delete it here so each test function has a clean environment to run and does not depend on the result of the previous test.
     open func deleteAllPersistentData() {
-        // need to remove the observers for integration tests that utilizes actual NotificationCenter
-        // otherwise, results are flaky
-        Task { await diGraphShared.eventBusHandler.removeAllObservers() }
         deleteAllFiles()
         deleteKeyValueStoredData()
     }


### PR DESCRIPTION
Closes: https://linear.app/customerio/issue/MBL-198/fix-flaky-tests-on-main

The test suite at the moment is trying to perform an async operation inside of a synchronous tearDown() function. I believe that this is the reason that some tests have been flaky on the CI lately. There is no guarantee the async operation will be completed by the time tearDown() is done executing. This may cause tearDown() to not properly reset the test suite state, but also may cause crashes when running tests if the async operation tries to access memory that no longer exists.

The goal of this change was to get tests passing again. I modified the async tearDown() operation to be a sync operation. To do that, I had to change the EventBus from an actor to a class. The EventBus remains to be thread safe after this change.

I went with this solution because it is small in scope and I am not yet sure that the EventBus should be an actor. With the little support our SDK has for swift concurrency, I think using an actor is causing more harm then good. As our codebase evolves to include more swift concurrency functionality, an actor may make sense again.