### PR TITLE
ci: print the binary size of the SDK

### DIFF
--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -123,6 +123,32 @@ jobs:
       env: 
         GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64: ${{ secrets.GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64 }}
         FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64: ${{ secrets.FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64 }}
+
+    - name: Setup to determine binary size of SDK
+      working-directory: Apps/${{ matrix.sample-app }}/build/    
+      run: |
+        brew install bloaty
+        mv *.xcarchive App.xcarchive # rename the file to a static value. Bloaty requires a hard-coded path to files to work. 
+
+    - name: Print the binary size of our SDK in an app, minus dependencies      
+      # We only need to run bloaty on 1 app.
+      if: ${{ matrix.sample-app == 'APN-UIKit' }}
+      working-directory: Apps/${{ matrix.sample-app }}/build/
+      run: |
+        bloaty --source-filter ".*(customerio-ios\/Sources).*" \
+          -d compileunits --debug-file=App.xcarchive/dSYMs/APN\ UIKit.app.dSYM/Contents/Resources/DWARF/APN\ UIKit \
+          App.xcarchive/Products/Applications/APN\ UIKit.app/APN\ UIKit \
+          -n 0
+    
+    - name: Print the binary size of our SDK in an app, including dependencies
+      # We only need to run bloaty on 1 app.
+      if: ${{ matrix.sample-app == 'APN-UIKit' }}
+      working-directory: Apps/${{ matrix.sample-app }}/build/
+      run: |
+        bloaty --source-filter ".*(customerio-ios\/Sources)|(SourcePackages\/checkouts).*" \
+          -d compileunits --debug-file=App.xcarchive/dSYMs/APN\ UIKit.app.dSYM/Contents/Resources/DWARF/APN\ UIKit \
+          App.xcarchive/Products/Applications/APN\ UIKit.app/APN\ UIKit \
+          -n 0
     
     - name: Update sample builds PR comment with build information 
       if: ${{ github.event_name == 'pull_request' }}

--- a/Apps/.gitignore
+++ b/Apps/.gitignore
@@ -6,3 +6,4 @@ Pods/
 **/fastlane/report.xml
 **/fastlane/README.md
 BuildEnvironment.swift
+build/

--- a/Apps/fastlane/Fastfile
+++ b/Apps/fastlane/Fastfile
@@ -64,10 +64,13 @@ platform :ios do
     # prevents builds from being flaky. As app sizese get bigger, it takes fastlane longer to initialize the build process. Increase this value to compensate for that. 
     ENV["FASTLANE_XCODEBUILD_SETTINGS_RETRIES"] = "10" 
 
+    # Make sure that builds generated include dSYM files. This is needed for CI to parse the builds for tracking SDK size and debugging errors during testing. 
+    # In XCode, set the build setting to "DWARF with dSYM File": https://stackoverflow.com/a/31511058 
     build_ios_app(
       export_method: "ad-hoc",
       configuration: "Release",
-      xcodebuild_formatter: "xcbeautify"
+      xcodebuild_formatter: "xcbeautify",
+      build_path: "build" # Save derived data to Apps/X/build folder. CI will parse this folder later for tracking SDK size. 
     )
 
     # function 'setup_google_bucket_access' is a re-usable function inside of apple-code-signing Fastfile that we imported. 


### PR DESCRIPTION
Part of: https://linear.app/customerio/issue/MBL-155/track-the-binary-size-of-our-ios-sdk-upon-every-release

Modify the CI to print the binary size of the SDK files in a compiled sample app.

To view the SDK size report, you must view the CI logs. This was a decision the team made as the initial scope of the feature.

commit-id:7c521be9