### PR TITLE
feat: privacy manifest files

### DIFF
--- a/CustomerIOMessagingInApp.podspec
+++ b/CustomerIOMessagingInApp.podspec
@@ -17,8 +17,12 @@ Pod::Spec.new do |spec|
   # spec.osx.deployment_target = "10.15"
   # spec.tvos.deployment_target = '13.0'
 
-  spec.source_files  = "Sources/MessagingInApp/**/*"
-  spec.exclude_files = "Sources/**/*{.md}"
+  path_to_source_for_module = "Sources/MessagingInApp"
+  spec.source_files = "#{path_to_source_for_module}/**/*{.swift}"
+  spec.resource_bundle = {
+    "#{spec.module_name}_Privacy" => "#{path_to_source_for_module}/Resources/PrivacyInfo.xcprivacy"
+  }
+
   spec.module_name = "CioMessagingInApp"  # the `import X` name when using SDK in Swift files
   
   spec.dependency "CustomerIOTracking", "= #{spec.version.to_s}"

--- a/CustomerIOMessagingPushAPN.podspec
+++ b/CustomerIOMessagingPushAPN.podspec
@@ -17,8 +17,12 @@ Pod::Spec.new do |spec|
   # spec.osx.deployment_target = "10.15"
   # spec.tvos.deployment_target = '13.0'
 
-  spec.source_files  = "Sources/MessagingPushAPN/**/*"
-  spec.exclude_files = "Sources/**/*{.md}"
+  path_to_source_for_module = "Sources/MessagingPushAPN"
+  spec.source_files = "#{path_to_source_for_module}/**/*{.swift}"
+  spec.resource_bundle = {
+    "#{spec.module_name}_Privacy" => "#{path_to_source_for_module}/Resources/PrivacyInfo.xcprivacy"
+  }
+
   spec.module_name = "CioMessagingPushAPN" # the `import X` name when using SDK in Swift files
   
   spec.dependency "CustomerIOMessagingPush", "= #{spec.version.to_s}"

--- a/CustomerIOMessagingPushFCM.podspec
+++ b/CustomerIOMessagingPushFCM.podspec
@@ -17,8 +17,12 @@ Pod::Spec.new do |spec|
   # spec.osx.deployment_target = "10.15"
   # spec.tvos.deployment_target = '13.0'
 
-  spec.source_files  = "Sources/MessagingPushFCM/**/*"
-  spec.exclude_files = "Sources/**/*{.md}"
+  path_to_source_for_module = "Sources/MessagingPushFCM"
+  spec.source_files = "#{path_to_source_for_module}/**/*{.swift}"
+  spec.resource_bundle = {
+    "#{spec.module_name}_Privacy" => "#{path_to_source_for_module}/Resources/PrivacyInfo.xcprivacy"
+  }
+  
   spec.module_name = "CioMessagingPushFCM" # the `import X` name when using SDK in Swift files 
   
   spec.dependency "CustomerIOMessagingPush", "= #{spec.version.to_s}"  

--- a/CustomerIOTracking.podspec
+++ b/CustomerIOTracking.podspec
@@ -17,8 +17,11 @@ Pod::Spec.new do |spec|
   # spec.osx.deployment_target = "10.15"
   # spec.tvos.deployment_target = '13.0'
 
-  spec.source_files  = "Sources/Tracking/**/*"
-  spec.exclude_files = "Sources/**/*{.md}"
+  path_to_source_for_module = "Sources/Tracking"
+  spec.source_files = "#{path_to_source_for_module}/**/*{.swift}"
+  spec.resource_bundle = {
+    "#{spec.module_name}_Privacy" => "#{path_to_source_for_module}/Resources/PrivacyInfo.xcprivacy"
+  }
   spec.module_name = "CioTracking" # the `import X` name when using SDK in Swift files
 
   spec.dependency "CustomerIOCommon", "= #{spec.version.to_s}"

--- a/Package.swift
+++ b/Package.swift
@@ -54,7 +54,10 @@ let package = Package(
         // Tracking
         .target(name: "CioTracking",
                 dependencies: ["CioInternalCommon"],
-                path: "Sources/Tracking"),
+                path: "Sources/Tracking",
+                resources: [
+                    .process("Resources/PrivacyInfo.xcprivacy"),
+                ]),
         .testTarget(name: "TrackingTests",
                     dependencies: ["CioTracking", "SharedTests"],
                     path: "Tests/Tracking"),
@@ -78,14 +81,20 @@ let package = Package(
         // APN
         .target(name: "CioMessagingPushAPN",
                 dependencies: ["CioMessagingPush"],
-                path: "Sources/MessagingPushAPN"),
+                path: "Sources/MessagingPushAPN",
+                resources: [
+                    .process("Resources/PrivacyInfo.xcprivacy"),
+                ]),
         .testTarget(name: "MessagingPushAPNTests",
                     dependencies: ["CioMessagingPushAPN", "SharedTests"],
                     path: "Tests/MessagingPushAPN"),
         // FCM 
         .target(name: "CioMessagingPushFCM",
                 dependencies: ["CioMessagingPush", .product(name: "FirebaseMessaging", package: "Firebase")],
-                path: "Sources/MessagingPushFCM"),
+                path: "Sources/MessagingPushFCM",
+                resources: [
+                    .process("Resources/PrivacyInfo.xcprivacy"),
+                ]),
         .testTarget(name: "MessagingPushFCMTests",
                     dependencies: ["CioMessagingPushFCM", "SharedTests"],
                     path: "Tests/MessagingPushFCM"),
@@ -93,7 +102,10 @@ let package = Package(
         // Messaging in-app
         .target(name: "CioMessagingInApp",
                 dependencies: ["CioTracking"],
-                path: "Sources/MessagingInApp"),
+                path: "Sources/MessagingInApp",
+                resources: [
+                    .process("Resources/PrivacyInfo.xcprivacy"),
+                ]),
         .testTarget(name: "MessagingInAppTests",
                     dependencies: ["CioMessagingInApp", "SharedTests"],
                     path: "Tests/MessagingInApp"),

--- a/Sources/MessagingInApp/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/MessagingInApp/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+	See DataPipelines module for documentation of this file. Including resources for each section to learn more. 	
+   -->   
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeProductInteraction</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>				
+				<string>NSPrivacyCollectedDataTypePurposeProductPersonalization</string>
+			</array>
+		</dict>		
+	</array>
+
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/Sources/MessagingPushAPN/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/MessagingPushAPN/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+	See DataPipelines module for documentation of this file. Including resources for each section to learn more. 	
+
+	**Important** - Keep this file in sync with other push modules in SDK. 
+   -->   
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeProductInteraction</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>				
+				<string>NSPrivacyCollectedDataTypePurposeProductPersonalization</string>
+			</array>
+		</dict>		
+	</array>
+
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/Sources/MessagingPushFCM/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/MessagingPushFCM/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+	See DataPipelines module for documentation of this file. Including resources for each section to learn more. 	
+
+	**Important** - Keep this file in sync with other push modules in SDK. 
+   -->   
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeProductInteraction</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>				
+				<string>NSPrivacyCollectedDataTypePurposeProductPersonalization</string>
+			</array>
+		</dict>		
+	</array>
+
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/Sources/Tracking/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/Tracking/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+	Docs for this section: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests
+	This section is describing what information our SDK collects about the app user. 
+	
+	It's my understanding that this section is for what our SDK requires, not what a customer can do with our SDK. Therefore, if something is optional, use `false`.
+	Customers must create their own privacy file for what their app does and provide that to Apple. That's where customers report what they might be using our SDK for. 
+   -->   
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+	
+	  <!-- 
+	  Section for SDKs that capture "Such as screen name, handle, account ID, assigned user ID, customer number, or other user- or account-level ID that can be used to identify a particular user or account."
+	  -->
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeUserID</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/> <!-- because of anonymous profiles, linking to a person is optional -->
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>				
+				<string>NSPrivacyCollectedDataTypePurposeProductPersonalization</string>
+			</array>
+		</dict>
+		
+		<!--
+		Section for SDKs that capture "Such as app launches, taps, clicks, scrolling information, music listening data, video views, saved place in a game, video, or song, or other information about how the user interacts with the app."
+		-->
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeProductInteraction</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>				
+				<string>NSPrivacyCollectedDataTypePurposeProductPersonalization</string>
+			</array>
+		</dict>		
+	</array>
+
+  <!-- 
+  Document on this section: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api
+  Documents if our SDK uses certain system calls and why. Prevents SDK using fingerprinting.   
+  -->
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	
+	<!-- "third-party SDK uses data for tracking as defined under the App Tracking Transparency framework."
+	See section "Asking permission to track" in this webpage: 
+	https://developer.apple.com/app-store/user-privacy-and-data-use/ 
+	-->
+	<key>NSPrivacyTracking</key>
+	<false/>
+	
+	<!-- Because we use NSPrivacyTracking=false, this section is not required.
+	<key>NSPrivacyTrackingDomains</key> 
+	-->
+</dict>
+</plist>


### PR DESCRIPTION
Closes: https://linear.app/customerio/issue/MBL-187/update-values-based-on-linear-doc
Part of: https://linear.app/customerio/issue/MBL-189/release-ios

Create privacy manifest files for all target modules that customers could decide to install in an app. Update package manager config files to include these new resource files.

Testing criteria CocoaPods:
* `pod update`, opened app in xcode
* Verified that in 'Pods' project settings, there are new targets added for each module (example: `CustomerIODataPipelines-CustomerIODataPipelines_Privacy`). I then verified in each of the `_Privacy targets > Build phases > compile sources` list, the privacy manifest files were listed and they resource to a valid path.
* App compiled without any new warnings.

Testing criteria SPM:
* Opened sample app in xcode.
* Fixed all warnings xcode gave me while resolving the CIO package.
* Compiled app without any new warnings.