### PR TITLE
chore: Use actual os name for the user agent

### DIFF
--- a/Sources/Common/Service/UserAgentUtil.swift
+++ b/Sources/Common/Service/UserAgentUtil.swift
@@ -23,7 +23,7 @@ public class UserAgentUtilImpl: UserAgentUtil {
      * `Customer.io iOS Client/1.0.0-alpha.16`
      */
     public func getUserAgentHeaderValue() -> String {
-        var userAgent = "Customer.io iOS Client/\(deviceInfo.sdkVersion)"
+        var userAgent = "Customer.io \(deviceInfo.osName ?? "iOS" ) Client/\(deviceInfo.sdkVersion)"
 
         if let deviceModel = deviceInfo.deviceModel,
            let deviceOsVersion = deviceInfo.osVersion,

--- a/Sources/Common/Service/UserAgentUtil.swift
+++ b/Sources/Common/Service/UserAgentUtil.swift
@@ -23,7 +23,7 @@ public class UserAgentUtilImpl: UserAgentUtil {
      * `Customer.io iOS Client/1.0.0-alpha.16`
      */
     public func getUserAgentHeaderValue() -> String {
-        var userAgent = "Customer.io \(deviceInfo.osName ?? "iOS" ) Client/\(deviceInfo.sdkVersion)"
+        var userAgent = "Customer.io \(deviceInfo.osName ?? "iOS") Client/\(deviceInfo.sdkVersion)"
 
         if let deviceModel = deviceInfo.deviceModel,
            let deviceOsVersion = deviceInfo.osVersion,

--- a/Tests/Common/Service/UserAgentUtilTest.swift
+++ b/Tests/Common/Service/UserAgentUtilTest.swift
@@ -39,4 +39,19 @@ class UserAgentUtilTest: UnitTest {
 
         XCTAssertEqual(expected, actual)
     }
+
+    func test_getUserAgent_givenDeviceInfoAvailable_expectLongVisonOsUserAgent() {
+        let expected = "Customer.io visionOS Client/3.0.1 (Apple Vision Pro; visionOS 1.1) io.customer.visionos-sample-app.VisionOS/1.0"
+        deviceInfoMock.underlyingSdkVersion = "3.0.1"
+        deviceInfoMock.underlyingDeviceModel = "Apple Vision Pro"
+        deviceInfoMock.underlyingOsVersion = "1.1"
+        deviceInfoMock.underlyingOsName = "visionOS"
+        deviceInfoMock.underlyingCustomerAppName = "VisionOS"
+        deviceInfoMock.underlyingCustomerBundleId = "io.customer.visionos-sample-app.VisionOS"
+        deviceInfoMock.underlyingCustomerAppVersion = "1.0"
+
+        let actual = userAgentUtil.getUserAgentHeaderValue()
+
+        XCTAssertEqual(expected, actual)
+    }
 }


### PR DESCRIPTION
The user agent is currently hard-coded to use iOS as the os name. I changed it to pick the value from the `deviceInfo` object and default to `iOS`