### PR TITLE
docs: VisionOS sample app minor UI tweak

### DIFF
--- a/Apps/VisionOS/VisionOS/AppDelegate.swift
+++ b/Apps/VisionOS/VisionOS/AppDelegate.swift
@@ -13,8 +13,11 @@ class AppDelegate: NSObject, UIApplicationDelegate {
          You will need cdpApiKey to initialize CustomerIO
          Learn more about it here: https://customer.io/docs/sdk/ios/quick-start-guide/#prerequisites
          */
-
-        let workspaceSettings = AppState.shared.workspaceSettings
+        
+        // Uncomment the following line and set CDP API Key if it is more convenient than setting it in the UI
+        // AppState.shared.workspaceSettings.cdpApiKy = "CDP_API_KEY"
+        
+        var workspaceSettings = AppState.shared.workspaceSettings
         if workspaceSettings.isSet() {
             CustomerIO.initialize(
                 withConfig:

--- a/Apps/VisionOS/VisionOS/MainScreen.swift
+++ b/Apps/VisionOS/VisionOS/MainScreen.swift
@@ -50,7 +50,7 @@ struct MainScreen: View {
                         CustomerIO.shared.identify(traits: profile.traits.toDictionary())
                     }
 
-                    viewModel.successMessage = "Now you can use other features such as event tracking"
+                    viewModel.successMessage = "Any subsequent activities will be attributed to the identified profile"
 
                     // For debug purpose only
                     CustomerIO.shared.flush()


### PR DESCRIPTION
- Updates the success message for the identify call
- Add an inline comment in the AppDelegate for simple instruction to set the CDP API Key in the code instead of the UI