### PR TITLE
chore: Support visionOS 1.0

### DIFF
--- a/Sources/MessagingPush/Config/MessagingPushConfigBuilder.swift
+++ b/Sources/MessagingPush/Config/MessagingPushConfigBuilder.swift
@@ -44,7 +44,9 @@ public class MessagingPushConfigBuilder {
     }
 
     @available(iOS, unavailable)
+    @available(visionOS, unavailable)
     @available(iOSApplicationExtension, introduced: 13.0)
+    @available(visionOSApplicationExtension, introduced: 1.0)
     /// Initializes new `MessagingPushConfigBuilder` with required configuration options.
     /// - Parameters:
     ///   - cdpApiKey: Customer.io Data Pipeline API Key required for NotificationServiceExtension only to track metrics
@@ -56,7 +58,9 @@ public class MessagingPushConfigBuilder {
     /// verbosity to help setup and debugging
     @discardableResult
     @available(iOS, unavailable)
+    @available(visionOS, unavailable)
     @available(iOSApplicationExtension, introduced: 13.0)
+    @available(visionOSApplicationExtension, introduced: 1.0)
     public func logLevel(_ logLevel: CioLogLevel) -> MessagingPushConfigBuilder {
         self.logLevel = logLevel
         return self

--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -69,7 +69,9 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
 
     /// MessagingPush initializer for Notification Service Extension
     @available(iOS, unavailable)
+    @available(visionOS, unavailable)
     @available(iOSApplicationExtension, introduced: 13.0)
+    @available(visionOSApplicationExtension, introduced: 1.0)
     @discardableResult
     public static func initializeForExtension(withConfig config: MessagingPushConfigOptions) -> MessagingPushInstance {
         shared.initializeModuleIfNotAlready {

--- a/Sources/MessagingPushAPN/MessagingPushAPN.swift
+++ b/Sources/MessagingPushAPN/MessagingPushAPN.swift
@@ -97,7 +97,9 @@ public class MessagingPushAPN: MessagingPushAPNInstance {
 
     /// MessagingPushAPN initializer for Notification Service Extension
     @available(iOS, unavailable)
+    @available(visionOS, unavailable)
     @available(iOSApplicationExtension, introduced: 13.0)
+    @available(visionOSApplicationExtension, introduced: 1.0)
     @discardableResult
     public static func initializeForExtension(withConfig config: MessagingPushConfigOptions) -> MessagingPushInstance {
         let implementation = MessagingPush.initializeForExtension(withConfig: config)

--- a/Sources/MessagingPushFCM/MessagingPushFCM.swift
+++ b/Sources/MessagingPushFCM/MessagingPushFCM.swift
@@ -101,7 +101,9 @@ public class MessagingPushFCM: MessagingPushFCMInstance {
 
     /// MessagingPushFCM initializer for Notification Service Extension
     @available(iOS, unavailable)
+    @available(visionOS, unavailable)
     @available(iOSApplicationExtension, introduced: 13.0)
+    @available(visionOSApplicationExtension, introduced: 1.0)
     @discardableResult
     public static func initializeForExtension(withConfig config: MessagingPushConfigOptions) -> MessagingPushInstance {
         let implementation = MessagingPush.initializeForExtension(withConfig: config)


### PR DESCRIPTION
We have APIs, mainly for push, that's restricted to iOS 13.0 and above. They can safely be enabled for VisionOS 1.0 as well.

## Test Plan
Add NSE to a VisionOS app and make sure it builds and works as expected when using rich push