### PR TITLE
chore: Overriding device.type for VisionOS

### DIFF
--- a/Sources/DataPipeline/Plugins/Context.swift
+++ b/Sources/DataPipeline/Plugins/Context.swift
@@ -34,6 +34,13 @@ class Context: Plugin {
                 workingEvent.context = try JSON(context)
             }
 
+            // Our push logic is currently hardcoded against ios
+            // this is the current mitigation to ensure push notification
+            // works for visionos till the backend handles "visionos"
+            if context[keyPath: "device.type"] as? String == "visionos" {
+                context[keyPath: "device.type"] = "ios"
+            }
+
             // set the user agent
             context["userAgent"] = userAgentUtil.getUserAgentHeaderValue()
 


### PR DESCRIPTION
The push notification logic won't work if the device.type isn't ios. This PR is a mitigation for now to enable push notifications on VisionOS till we have a better handling on the backend