### PR TITLE
ci: sdk size reporting missing FCM SDK

### DIFF
--- a/Apps/APN-UIKit/APN UIKit.xcodeproj/project.pbxproj
+++ b/Apps/APN-UIKit/APN UIKit.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		F74F41FA2A168316000D61B9 /* BuildEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = F74F41F82A168316000D61B9 /* BuildEnvironment.swift */; };
 		F7820EAA2A15631000B346A9 /* DIGraphShared.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7820EA92A15631000B346A9 /* DIGraphShared.swift */; };
 		F78934242A168E09005D3DF7 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F78934232A168E08005D3DF7 /* GoogleService-Info.plist */; };
+		F7D35F0A2BC9869900D25BC2 /* MessagingPushFCM in Frameworks */ = {isa = PBXBuildFile; productRef = F7D35F092BC9869900D25BC2 /* MessagingPushFCM */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -159,6 +160,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F7D35F0A2BC9869900D25BC2 /* MessagingPushFCM in Frameworks */,
 				A776886E2B9875D0004F2A49 /* DataPipelines in Frameworks */,
 				46EE275529E9E2960068F9A3 /* MessagingInApp in Frameworks */,
 				46EE275729E9E2960068F9A3 /* MessagingPushAPN in Frameworks */,
@@ -399,6 +401,7 @@
 				46EE275429E9E2960068F9A3 /* MessagingInApp */,
 				46EE275629E9E2960068F9A3 /* MessagingPushAPN */,
 				A776886D2B9875D0004F2A49 /* DataPipelines */,
+				F7D35F092BC9869900D25BC2 /* MessagingPushFCM */,
 			);
 			productName = "APN UIKit";
 			productReference = 46D5D97D29E459D600EAF40B /* APN UIKit.app */;
@@ -1014,6 +1017,10 @@
 		A776886D2B9875D0004F2A49 /* DataPipelines */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = DataPipelines;
+		};
+		F7D35F092BC9869900D25BC2 /* MessagingPushFCM */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = MessagingPushFCM;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
Part of: https://linear.app/customerio/issue/MBL-155/track-the-binary-size-of-our-ios-sdk-upon-every-release

The FCM SDK is currently not being calculated in the SDK size reports, only the APN SDK. After this commit, the SDK size reports generated will include the SDKs: CDP, InApp, FCM, and APN.

Testing consideration:
* Generate a binary report before and after this commit. One report doesn't include FCM SDK source code and the other does.

Notes for reviewer:
* To get the FCM binary size, I added the FCM SDK into the APN app via SPM. The APN sample app is not using FCM for any of the features at runtime. It's only compiling the FCM SDK into the compiled app. This aligns with what we do in the FCM app where we compile the APN SDK in the app but don't use it at runtime.

---

**Stack**:
- #709
- #700
- #699 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*