### PR TITLE
ci: fix PR report comment hitting max limit of characters

### DIFF
--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -194,15 +194,6 @@ jobs:
           </details>
 
           <details>
-          <summary>SDK binary size of this PR, including dependencies</summary>
-          
-          ```  
-          ${{ steps.generate-sdk-size-report.outputs.sdk-size-including-dependencies-report }}
-          ```
-
-          </details>
-
-          <details>
           <summary>SDK binary size diff report between this PR and the main branch</summary>
           
           ``` 

--- a/Apps/APN-UIKit/APN UIKit.xcodeproj/project.pbxproj
+++ b/Apps/APN-UIKit/APN UIKit.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		F74F41FA2A168316000D61B9 /* BuildEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = F74F41F82A168316000D61B9 /* BuildEnvironment.swift */; };
 		F7820EAA2A15631000B346A9 /* DIGraphShared.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7820EA92A15631000B346A9 /* DIGraphShared.swift */; };
 		F78934242A168E09005D3DF7 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F78934232A168E08005D3DF7 /* GoogleService-Info.plist */; };
+		F7D35F0A2BC9869900D25BC2 /* MessagingPushFCM in Frameworks */ = {isa = PBXBuildFile; productRef = F7D35F092BC9869900D25BC2 /* MessagingPushFCM */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -159,6 +160,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F7D35F0A2BC9869900D25BC2 /* MessagingPushFCM in Frameworks */,
 				A776886E2B9875D0004F2A49 /* DataPipelines in Frameworks */,
 				46EE275529E9E2960068F9A3 /* MessagingInApp in Frameworks */,
 				46EE275729E9E2960068F9A3 /* MessagingPushAPN in Frameworks */,
@@ -399,6 +401,7 @@
 				46EE275429E9E2960068F9A3 /* MessagingInApp */,
 				46EE275629E9E2960068F9A3 /* MessagingPushAPN */,
 				A776886D2B9875D0004F2A49 /* DataPipelines */,
+				F7D35F092BC9869900D25BC2 /* MessagingPushFCM */,
 			);
 			productName = "APN UIKit";
 			productReference = 46D5D97D29E459D600EAF40B /* APN UIKit.app */;
@@ -1014,6 +1017,10 @@
 		A776886D2B9875D0004F2A49 /* DataPipelines */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = DataPipelines;
+		};
+		F7D35F092BC9869900D25BC2 /* MessagingPushFCM */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = MessagingPushFCM;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
Part of: https://linear.app/customerio/issue/MBL-155/track-the-binary-size-of-our-ios-sdk-upon-every-release

In the previous commit, there was an error when the CI tried to create a PR comment with all of the SDK size reports in it. The error says it's because the PR comment hit a maximum character limit. To fix this, I removed one of the SDK size reports from the PR comment - the SDK size report that includes dependencies. I chose this solution because this SDK size report is the biggest report there is and also because we currently don't have any metrics tracking our SDK size including dependencies.

commit-id:6c6d1d99

---

**Stack**:
- #709
- #700 ⬅
- #699


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*