### PR TITLE
ci: call-out SDK diff report 32 byte difference

### DIFF
--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -199,5 +199,7 @@ jobs:
           ``` 
           ${{ steps.generate-sdk-size-report.outputs.sdk-size-diff-report }}
           ```
+
+          > Note: The SDK diff report above may indicate that the SDK binary size will increase or decrease even if no source code was changed in the PR. See ticket MBL-249 that is tracking this known behavior.  
           
           </details>


### PR DESCRIPTION
Part of: https://linear.app/customerio/issue/MBL-155/track-the-binary-size-of-our-ios-sdk-upon-every-release

I noticed that some people on the team have opened PRs in the past couple of days and became confused by the diff report generated in their PR. Adding this comment to the diff reports calling out this inaccuracy and link to the ticket where we are trying this inaccuracy to avoid team confusion when they view a diff report.

---

**Stack**:
- #709
- #701 ⬅
- #700
- #699


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*