### PR TITLE
fix: track bq migration for identify profile events with no attributes

### DIFF
--- a/Sources/Migration/DataPipelineMigrationAssistant.swift
+++ b/Sources/Migration/DataPipelineMigrationAssistant.swift
@@ -108,15 +108,15 @@ public class DataPipelineMigrationAssistant {
         guard let trackTaskData: IdentifyProfileQueueTaskData = jsonAdapter.fromJson(taskData) else {
             return false
         }
-        if let attributedString = trackTaskData.attributesJsonString, attributedString.contains("null") {
+
+        // If there are no profile attributes or profile attributes not in a valid format, JSON adapter will return nil and we will perform a migration without the profile attributes.
+        guard let profileAttributesString: String = trackTaskData.attributesJsonString, let profileAttributes: [String: Any] = jsonAdapter.fromJsonString(profileAttributesString) else {
             migrationHandler.processIdentifyFromBGQ(identifier: trackTaskData.identifier, timestamp: timestamp, body: nil)
             return true
         }
-        guard let profileAttributes: [String: Any] = jsonAdapter.fromJsonString(trackTaskData.attributesJsonString!) else {
-            migrationHandler.processIdentifyFromBGQ(identifier: trackTaskData.identifier, timestamp: timestamp, body: nil)
-            return true
-        }
+
         migrationHandler.processIdentifyFromBGQ(identifier: trackTaskData.identifier, timestamp: timestamp, body: profileAttributes)
+
         return true
     }
 

--- a/Tests/Migration/DataPipelineMigrationAssistantTests.swift
+++ b/Tests/Migration/DataPipelineMigrationAssistantTests.swift
@@ -139,12 +139,30 @@ class DataPipelineMigrationAssistantTests: UnitTest {
 
     // MARK: getAndProcessTask
 
-    func test_givenIdentifyProfileWithoutBody_expectTaskRunAndProcessedDeleted() {
+    func test_givenIdentifyProfileWithEmptyBody_expectTaskRunAndProcessedDeleted() {
         let givenType = QueueTaskType.identifyProfile
 
         let givenCreatedTask = QueueTaskMetadata.random
 
         let trackDeliveryMetricData = IdentifyProfileQueueTaskData(identifier: String.random, attributesJsonString: "")
+
+        guard let jsonData = try? JSONEncoder().encode(trackDeliveryMetricData) else {
+            XCTFail("Failed to create task data")
+            return
+        }
+
+        backgroundQueueMock.getTaskDetailReturnValue = TaskDetail(data: jsonData, taskType: givenType, timestamp: dateUtilStub.now)
+
+        XCTAssertNotNil(migrationAssistant.getAndProcessTask(for: givenCreatedTask, siteId: testSiteId))
+        XCTAssertEqual(backgroundQueueMock.deleteProcessedTaskCallsCount, 1)
+    }
+
+    func test_givenIdentifyProfileWithoutBody_expectTaskRunAndProcessedDeleted() {
+        let givenType = QueueTaskType.identifyProfile
+
+        let givenCreatedTask = QueueTaskMetadata.random
+
+        let trackDeliveryMetricData = IdentifyProfileQueueTaskData(identifier: String.random, attributesJsonString: nil)
 
         guard let jsonData = try? JSONEncoder().encode(trackDeliveryMetricData) else {
             XCTFail("Failed to create task data")


### PR DESCRIPTION
Part of: https://linear.app/customerio/issue/MBL-251/track-bq-cdp-migration-causes-crash-in-ios-301-for-identifying-a

If there is an event in the Track BQ for identifying a profile with no profile attributes, the CDP migration could cause a crash. This commit fixes this crash by performing a safe optional unwrap.

Testing consideration:
* Added new unit test reproducing the issue.

---

**Stack**:
- #704
- #702 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*