### PR TITLE
refactor: safely unwrap register device BQ tasks in migration code

### DIFF
--- a/Sources/Migration/DataPipelineMigrationAssistant.swift
+++ b/Sources/Migration/DataPipelineMigrationAssistant.swift
@@ -108,15 +108,15 @@ public class DataPipelineMigrationAssistant {
         guard let trackTaskData: IdentifyProfileQueueTaskData = jsonAdapter.fromJson(taskData) else {
             return false
         }
-        if let attributedString = trackTaskData.attributesJsonString, attributedString.contains("null") {
+
+        // If there are no profile attributes or profile attributes not in a valid format, JSON adapter will return nil and we will perform a migration without the profile attributes.
+        guard let profileAttributesString: String = trackTaskData.attributesJsonString, let profileAttributes: [String: Any] = jsonAdapter.fromJsonString(profileAttributesString) else {
             migrationHandler.processIdentifyFromBGQ(identifier: trackTaskData.identifier, timestamp: timestamp, body: nil)
             return true
         }
-        guard let profileAttributes: [String: Any] = jsonAdapter.fromJsonString(trackTaskData.attributesJsonString!) else {
-            migrationHandler.processIdentifyFromBGQ(identifier: trackTaskData.identifier, timestamp: timestamp, body: nil)
-            return true
-        }
+
         migrationHandler.processIdentifyFromBGQ(identifier: trackTaskData.identifier, timestamp: timestamp, body: profileAttributes)
+
         return true
     }
 

--- a/Sources/Migration/DataPipelineMigrationAssistant.swift
+++ b/Sources/Migration/DataPipelineMigrationAssistant.swift
@@ -147,7 +147,7 @@ public class DataPipelineMigrationAssistant {
         guard let registerPushTaskData: RegisterPushNotificationQueueTaskData = jsonAdapter.fromJson(taskData) else {
             return false
         }
-        guard let allAttributes: [String: Any] = jsonAdapter.fromJsonString(registerPushTaskData.attributesJsonString!) else {
+        guard let attributesJsonString = registerPushTaskData.attributesJsonString, let allAttributes: [String: Any] = jsonAdapter.fromJsonString(attributesJsonString) else {
             return false
         }
         guard let device = allAttributes["device"] as? [String: Any] else {

--- a/Tests/Migration/DataPipelineMigrationAssistantTests.swift
+++ b/Tests/Migration/DataPipelineMigrationAssistantTests.swift
@@ -359,6 +359,18 @@ class DataPipelineMigrationAssistantTests: UnitTest {
         XCTAssertNotNil(migrationAssistant.getAndProcessTask(for: givenCreatedTask, siteId: testSiteId))
         XCTAssertEqual(backgroundQueueMock.deleteProcessedTaskCallsCount, 0)
 
+        // When data is found but attributes are null
+        let pushTokenTaskDataWithNilAttributesString = RegisterPushNotificationQueueTaskData(profileIdentifier: String.random, attributesJsonString: nil)
+
+        guard let jsonData = try? JSONEncoder().encode(pushTokenTaskDataWithNilAttributesString) else {
+            XCTFail("Failed to create task data")
+            return
+        }
+        backgroundQueueMock.getTaskDetailReturnValue = TaskDetail(data: jsonData, taskType: givenType, timestamp: dateUtilStub.now)
+
+        XCTAssertNotNil(migrationAssistant.getAndProcessTask(for: givenCreatedTask, siteId: testSiteId))
+        XCTAssertEqual(backgroundQueueMock.deleteProcessedTaskCallsCount, 0)
+
         // When data is found but attributes are invalid
         let pushTokenTaskDataWithEmptyJsonString = RegisterPushNotificationQueueTaskData(profileIdentifier: String.random, attributesJsonString: "")
 

--- a/Tests/Migration/DataPipelineMigrationAssistantTests.swift
+++ b/Tests/Migration/DataPipelineMigrationAssistantTests.swift
@@ -139,12 +139,30 @@ class DataPipelineMigrationAssistantTests: UnitTest {
 
     // MARK: getAndProcessTask
 
-    func test_givenIdentifyProfileWithoutBody_expectTaskRunAndProcessedDeleted() {
+    func test_givenIdentifyProfileWithEmptyBody_expectTaskRunAndProcessedDeleted() {
         let givenType = QueueTaskType.identifyProfile
 
         let givenCreatedTask = QueueTaskMetadata.random
 
         let trackDeliveryMetricData = IdentifyProfileQueueTaskData(identifier: String.random, attributesJsonString: "")
+
+        guard let jsonData = try? JSONEncoder().encode(trackDeliveryMetricData) else {
+            XCTFail("Failed to create task data")
+            return
+        }
+
+        backgroundQueueMock.getTaskDetailReturnValue = TaskDetail(data: jsonData, taskType: givenType, timestamp: dateUtilStub.now)
+
+        XCTAssertNotNil(migrationAssistant.getAndProcessTask(for: givenCreatedTask, siteId: testSiteId))
+        XCTAssertEqual(backgroundQueueMock.deleteProcessedTaskCallsCount, 1)
+    }
+
+    func test_givenIdentifyProfileWithoutBody_expectTaskRunAndProcessedDeleted() {
+        let givenType = QueueTaskType.identifyProfile
+
+        let givenCreatedTask = QueueTaskMetadata.random
+
+        let trackDeliveryMetricData = IdentifyProfileQueueTaskData(identifier: String.random, attributesJsonString: nil)
 
         guard let jsonData = try? JSONEncoder().encode(trackDeliveryMetricData) else {
             XCTFail("Failed to create task data")


### PR DESCRIPTION
As a continuation of the PR, https://github.com/customerio/customerio-ios/pull/702, this commit safely unwraps all of the optional values in the Track BQ to CDP migration code.

I do not expect that register device attributes string to be null because the attributes string will contain at least the device token. In PR discussion (https://github.com/customerio/customerio-ios/pull/702#discussion_r1567022655), we were not sure a bug could happen from this code but we still wanted to safety unwrap the optional to avoid any possible crashes.

commit-id:24cb8fd5

---

**Stack**:
- #704 ⬅
- #702


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*