### PR TITLE
fix: apple privacy mission permission for extension

### DIFF
--- a/Sources/MessagingPushAPN/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/MessagingPushAPN/Resources/PrivacyInfo.xcprivacy
@@ -33,6 +33,7 @@
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
 				<string>CA92.1</string>
+                <string>1C8F.1</string>
 			</array>
 		</dict>
 	</array>

--- a/Sources/MessagingPushFCM/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/MessagingPushFCM/Resources/PrivacyInfo.xcprivacy
@@ -33,6 +33,7 @@
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
 				<string>CA92.1</string>
+                <string>1C8F.1</string>
 			</array>
 		</dict>
 	</array>

--- a/Sources/Tracking/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/Tracking/Resources/PrivacyInfo.xcprivacy
@@ -61,6 +61,7 @@
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
 				<string>CA92.1</string>
+                <string>1C8F.1</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
closes: https://linear.app/customerio/issue/MBL-263/missing-privacy-manifest-for-notificationservice-extension

adds `1C8F.1`

> Declare this reason to access user defaults to read and write information that is only accessible to the apps, app extensions, and App Clips that are members of the same App Group as the app itself.