### PR TITLE
ci: fix CI generating SDK size reports during deployments

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -28,15 +28,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download the latest main sample app build to generate SDK size diff report       
-        id: main-sample-app-build
-        uses: ./.github/actions/main-sample-app-build
-
-      - uses: ./.github/actions/generate-sdk-size-report      
+      - uses: ./.github/actions/generate-sdk-size-report
         id: generate-sdk-size-report
         with:
-          apn-app-xcarchive-name: ${{ steps.main-sample-app-build.outputs.apn-app-xcarchive-name }}
-          generate-main-diff-report: false
+          GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64: ${{ secrets.GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64 }} 
 
   deploy-git-tag:
     name: Deploy git tag


### PR DESCRIPTION
The CI is currently failing to generate SDK size reports during releases of the SDK. This is caused due to a recent configuration change in the GitHub Action that generates these reports. The configuration was not updated in all workflows that use this action.

This commit provides the latest configuration of the Action to get the CI generating SDK size reports again during releases.