### PR TITLE
chore: get WebView for inline message and add to Inline View to display

### DIFF
--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -3,13 +3,14 @@ import Foundation
 import UIKit
 
 protocol GistInstance: AutoMockable {
+    var siteId: String { get }
     func showMessage(_ message: Message, position: MessagePosition) -> Bool
 }
 
 public class Gist: GistInstance, GistDelegate {
     var messageQueueManager: MessageQueueManager = DIGraphShared.shared.messageQueueManager
     var shownModalMessageQueueIds: Set<String> = [] // all modal messages that have been shown in the app already.
-    private var messageManagers: [MessageManager] = []
+    private var messageManagers: [ModalMessageManager] = []
     public var siteId: String = ""
     public var dataCenter: String = ""
 
@@ -29,8 +30,9 @@ public class Gist: GistInstance, GistDelegate {
         Logger.instance.enabled = logging
         messageQueueManager.setup(skipQueueCheck: false)
 
-        // Initialising Gist web with an empty message to fetch fonts and other assets.
-        _ = Gist.shared.getMessageView(Message(messageId: ""))
+        // To finish initializing of Gist, we want to fetch fonts and other assets for HTML in-app messages.
+        // To do that, we try to display a message with an empty message id.
+        _ = InlineMessageManager(siteId: self.siteId, message: Message(messageId: ""))
     }
 
     // MARK: User
@@ -74,11 +76,6 @@ public class Gist: GistInstance, GistDelegate {
 
     public func showMessage(_ message: Message) -> Bool {
         showMessage(message, position: .center)
-    }
-
-    public func getMessageView(_ message: Message) -> GistView {
-        let messageManager = createMessageManager(siteId: siteId, message: message)
-        return messageManager.getMessageView()
     }
 
     public func dismissMessage(instanceId: String? = nil, completionHandler: (() -> Void)? = nil) {
@@ -144,18 +141,18 @@ public class Gist: GistInstance, GistDelegate {
 
     // Message Manager
 
-    private func createMessageManager(siteId: String, message: Message) -> MessageManager {
-        let messageManager = MessageManager(siteId: siteId, message: message)
+    private func createMessageManager(siteId: String, message: Message) -> ModalMessageManager {
+        let messageManager = ModalMessageManager(siteId: siteId, message: message)
         messageManager.delegate = self
         messageManagers.append(messageManager)
         return messageManager
     }
 
-    private func getModalMessageManager() -> MessageManager? {
-        messageManagers.first(where: { !$0.isMessageEmbed })
+    private func getModalMessageManager() -> ModalMessageManager? {
+        messageManagers.first
     }
 
-    func messageManager(instanceId: String) -> MessageManager? {
+    func messageManager(instanceId: String) -> ModalMessageManager? {
         messageManagers.first(where: { $0.currentMessage.instanceId == instanceId })
     }
 

--- a/Sources/MessagingInApp/Gist/Managers/InlineMessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/InlineMessageManager.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+// Callbacks specific to inline message events.
+protocol InlineMessageManagerDelegate: AnyObject {
+    func sizeChanged(width: CGFloat, height: CGFloat)
+}
+
+/**
+ Class that implements the business logic for a inline message being displayed. Handle when action buttons are clicked, render the HTML message, and get callbacks for inline message events.
+
+ Usage:
+ ```
+ let inlineMessageManager = InlineMessageManager(siteId: "", message: message)
+ inlineMessageManager.inlineMessageDelegate = self // Get callbacks for inline message events.
+ inlineMessageManager.inlineMessageView // View that displays the in-app web message
+ ```
+ */
+class InlineMessageManager: MessageManager {
+    var inlineMessageView: GistView? {
+        let view = super.gistView
+        view?.delegate = self
+        return view
+    }
+
+    weak var inlineMessageDelegate: InlineMessageManagerDelegate?
+
+    override func onReplaceMessage(newMessageToShow: Message) {
+        // Not yet implemented. Planned in future update.
+    }
+
+    override func onDoneLoadingMessage(routeLoaded: String, onComplete: @escaping () -> Void) {
+        // The Inline View is responsible for making the in-app message visible in the UI. No logic needed in the manager.
+        onComplete()
+    }
+
+    override func onDeepLinkOpened() {
+        // Do not do anything. Continue showing the in-app message.
+    }
+
+    override func onCloseAction() {
+        // Not yet implemented. Planned in future update.
+    }
+}
+
+extension InlineMessageManager: GistViewDelegate {
+    func sizeChanged(message: Message, width: CGFloat, height: CGFloat) {
+        inlineMessageDelegate?.sizeChanged(width: width, height: height)
+    }
+
+    func action(message: Message, currentRoute: String, action: String, name: String) {
+        // Action button handling is processed by the superclass. Ignore this callback and instead use one of the superclass event callback functions.
+    }
+}

--- a/Sources/MessagingInApp/Gist/Managers/ModalMessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/ModalMessageManager.swift
@@ -1,0 +1,62 @@
+import Foundation
+import UIKit
+
+/**
+ Class that implements the business logic for a modal message being displayed. Handle when action buttons are clicked, render the HTML message, and get callbacks for modal message events.
+ */
+class ModalMessageManager: MessageManager {
+    private var messageLoaded = false
+    private var modalViewManager: ModalViewManager?
+    var messagePosition: MessagePosition = .top
+
+    func showMessage(position: MessagePosition) {
+        messagePosition = position
+    }
+
+    override func onDoneLoadingMessage(routeLoaded: String, onComplete: @escaping () -> Void) {
+        if routeLoaded == currentMessage.messageId, !messageLoaded {
+            messageLoaded = true
+
+            if UIApplication.shared.applicationState == .active {
+                modalViewManager = ModalViewManager(gistView: gistView, position: messagePosition)
+                modalViewManager?.showModalView {
+                    onComplete()
+                }
+            } else {
+                Gist.shared.removeMessageManager(instanceId: currentMessage.instanceId)
+            }
+        }
+    }
+
+    override func onDeepLinkOpened() {
+        dismissMessage()
+    }
+
+    override func onCloseAction() {
+        removePersistentMessage()
+        dismissMessage()
+    }
+
+    func removePersistentMessage() {
+        if currentMessage.gistProperties.persistent == true {
+            Logger.instance.debug(message: "Persistent message dismissed, logging view")
+            Gist.shared.logMessageView(message: currentMessage)
+        }
+    }
+
+    func dismissMessage(completionHandler: (() -> Void)? = nil) {
+        if let modalViewManager = modalViewManager {
+            modalViewManager.dismissModalView { [weak self] in
+                guard let self = self else { return }
+                self.delegate?.messageDismissed(message: self.currentMessage)
+                completionHandler?()
+            }
+        }
+    }
+
+    override func onReplaceMessage(newMessageToShow: Message) {
+        dismissMessage {
+            _ = Gist.shared.showMessage(newMessageToShow)
+        }
+    }
+}

--- a/Sources/MessagingInApp/Gist/Managers/Models/Message.swift
+++ b/Sources/MessagingInApp/Gist/Managers/Models/Message.swift
@@ -25,10 +25,6 @@ public class Message {
 
     var properties = [String: Any]()
 
-    public var isEmbedded: Bool {
-        Gist.shared.messageManager(instanceId: instanceId)?.isMessageEmbed ?? false
-    }
-
     public init(messageId: String) {
         self.queueId = nil
         self.priority = nil

--- a/Sources/MessagingInApp/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingInApp/autogenerated/AutoMockable.generated.swift
@@ -95,7 +95,45 @@ class GistInstanceMock: GistInstance, Mock {
         Mocks.shared.add(mock: self)
     }
 
+    /**
+     When setter of the property called, the value given to setter is set here.
+     When the getter of the property called, the value set here will be returned. Your chance to mock the property.
+     */
+    var underlyingSiteId: String!
+    /// `true` if the getter or setter of property is called at least once.
+    var siteIdCalled: Bool {
+        siteIdGetCalled || siteIdSetCalled
+    }
+
+    /// `true` if the getter called on the property at least once.
+    var siteIdGetCalled: Bool {
+        siteIdGetCallsCount > 0
+    }
+
+    var siteIdGetCallsCount = 0
+    /// `true` if the setter called on the property at least once.
+    var siteIdSetCalled: Bool {
+        siteIdSetCallsCount > 0
+    }
+
+    var siteIdSetCallsCount = 0
+    /// The mocked property with a getter and setter.
+    var siteId: String {
+        get {
+            mockCalled = true
+            siteIdGetCallsCount += 1
+            return underlyingSiteId
+        }
+        set(value) {
+            mockCalled = true
+            siteIdSetCallsCount += 1
+            underlyingSiteId = value
+        }
+    }
+
     public func resetMock() {
+        siteIdGetCallsCount = 0
+        siteIdSetCallsCount = 0
         showMessageCallsCount = 0
         showMessageReceivedArguments = nil
         showMessageReceivedInvocations = []
@@ -500,10 +538,8 @@ class MessageQueueManagerMock: MessageQueueManager, Mock {
         intervalGetCallsCount = 0
         intervalSetCallsCount = 0
         setupCallsCount = 0
-
-        mockCalled = false // do last as resetting properties above can make this true
-        setupSkipQueueCheckReceivedArguments = nil
-        setupSkipQueueCheckReceivedInvocations = []
+        setupReceivedArguments = nil
+        setupReceivedInvocations = []
 
         mockCalled = false // do last as resetting properties above can make this true
         fetchUserMessagesFromLocalStoreCallsCount = 0
@@ -533,36 +569,22 @@ class MessageQueueManagerMock: MessageQueueManager, Mock {
         setupCallsCount > 0
     }
 
-    /**
-     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
-     */
-    var setupClosure: (() -> Void)?
-
-    /// Mocked function for `setup()`. Your opportunity to return a mocked value and check result of mock in test code.
-    func setup() {
-        mockCalled = true
-        setupCallsCount += 1
-        setupClosure?()
-    }
-
-    // MARK: - setup
-
     /// The arguments from the *last* time the function was called.
-    @Atomic private(set) var setupSkipQueueCheckReceivedArguments: Bool?
+    @Atomic private(set) var setupReceivedArguments: Bool?
     /// Arguments from *all* of the times that the function was called.
-    @Atomic private(set) var setupSkipQueueCheckReceivedInvocations: [Bool] = []
+    @Atomic private(set) var setupReceivedInvocations: [Bool] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    var setupSkipQueueCheckClosure: ((Bool) -> Void)?
+    var setupClosure: ((Bool) -> Void)?
 
     /// Mocked function for `setup(skipQueueCheck: Bool)`. Your opportunity to return a mocked value and check result of mock in test code.
     func setup(skipQueueCheck: Bool) {
         mockCalled = true
         setupCallsCount += 1
-        setupSkipQueueCheckReceivedArguments = skipQueueCheck
-        setupSkipQueueCheckReceivedInvocations.append(skipQueueCheck)
-        setupSkipQueueCheckClosure?(skipQueueCheck)
+        setupReceivedArguments = skipQueueCheck
+        setupReceivedInvocations.append(skipQueueCheck)
+        setupClosure?(skipQueueCheck)
     }
 
     // MARK: - fetchUserMessagesFromLocalStore

--- a/Tests/MessagingInApp/Views/InAppMessageViewTest.swift
+++ b/Tests/MessagingInApp/Views/InAppMessageViewTest.swift
@@ -43,4 +43,37 @@ class InAppMessageViewTest: UnitTest {
         let actualElementId = queueMock.getInlineMessagesReceivedArguments
         XCTAssertEqual(actualElementId, givenElementId)
     }
+
+    // MARK: Display in-app message
+
+    func test_displayInAppMessage_givenNoMessageAvailable_expectDoNotDisplayAMessage() {
+        queueMock.getInlineMessagesReturnValue = []
+
+        let inlineView = InAppMessageView(elementId: .random)
+
+        XCTAssertNil(getInAppMessageWebView(fromInlineView: inlineView))
+    }
+
+    func test_displayInAppMessage_givenMessageAvailable_expectDisplayMessage() {
+        let givenInlineMessage = Message.randomInline
+        queueMock.getInlineMessagesReturnValue = [givenInlineMessage]
+
+        let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+
+        XCTAssertNotNil(getInAppMessageWebView(fromInlineView: inlineView))
+    }
+}
+
+extension InAppMessageViewTest {
+    func getInAppMessageWebView(fromInlineView view: InAppMessageView) -> GistView? {
+        let gistViews: [GistView] = view.subviews.map { $0 as? GistView }.mapNonNil()
+
+        if gistViews.isEmpty {
+            return nil
+        }
+
+        XCTAssertEqual(gistViews.count, 1)
+
+        return gistViews.first
+    }
 }


### PR DESCRIPTION
Part of: https://linear.app/customerio/issue/MBL-310/create-a-uikit-uiview-that-displays-an-inline-in-app-message-sent-from

Create a WebView to display inline in-app message and display in the Inline UIView. To do this, we can re-use a lot of the same logic that Modal messages use to create WebViews and display them.

Testing:
There are some automated tests added in this commit.

Reviewer notes:
This commit will not show an in-app message if you were to add it to a sample app. Autolayout constraints need to be added to have Views resize and that will come in a future commit.

---

**Stack**:
- #720
- #718
- #717 ⬅
- #716


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*