### PR TITLE
ci: fix main branch sample app caching

### DIFF
--- a/.github/actions/generate-sdk-size-report/action.yml
+++ b/.github/actions/generate-sdk-size-report/action.yml
@@ -49,7 +49,7 @@ runs:
     if: github.ref == 'refs/heads/main'   
     uses: ./.github/actions/main-sample-app-build 
     with:
-      apn-app-xcarchive-name: ${{ steps.build-sample-app.outputs.app-xcarchive-name }}
+      set-latest-main-build: ${{ steps.build-sample-app.outputs.app-xcarchive-name }}
 
   - name: Make the SDK size report
     uses: mathiasvr/command-output@v2.0.0


### PR DESCRIPTION
I noticed in a recent PR I opened that the CI was not able to download the latest main branch sample app cached build. After scrolling through the long logs, I noticed an action was not called with the correct inputs. Unfortunately, it seems like if an action receives incorrect inputs, it does not throw errors as I expected but it instead continues running.