### PR TITLE
fix: crash on emulator while development

### DIFF
--- a/CustomerIODataPipelines.podspec
+++ b/CustomerIODataPipelines.podspec
@@ -28,5 +28,5 @@ Pod::Spec.new do |spec|
   spec.dependency "CustomerIOTrackingMigration", "= #{spec.version.to_s}"
 
   # Add Segment SDK as a dependency, as this module is designed to be compatible with it.
-  spec.dependency 'AnalyticsSwiftCIO', '= 1.5.12+cio.1'
+  spec.dependency 'AnalyticsSwiftCIO', '= 1.5.13+cio.1'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,7 @@ let package = Package(
         .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git", "8.7.0"..<"11.0.0"),
 
         // Make sure the version number is same for DataPipelines cocoapods.
-        .package(name: "CioAnalytics", url: "https://github.com/customerio/cdp-analytics-swift.git", .exact("1.5.12+cio.1"))
+        .package(name: "CioAnalytics", url: "https://github.com/customerio/cdp-analytics-swift.git", .exact("1.5.13+cio.1"))
     ],
     targets: [ 
         // Common - Code used by multiple modules in the SDK project.


### PR DESCRIPTION
closes: https://github.com/customerio/customerio-ios/issues/721

Remove reliance on `WWebview`, which can cause crash at times during development.