### PR TITLE
fix: action tracking for in-app

### DIFF
--- a/Sources/MessagingInApp/MessagingInAppImplementation.swift
+++ b/Sources/MessagingInApp/MessagingInAppImplementation.swift
@@ -94,7 +94,7 @@ extension MessagingInAppImplementation: GistDelegate {
         // a close action does not count as a clicked action.
         if action != "gist://close" {
             if let deliveryId = getDeliveryId(from: message) {
-                eventBusHandler.postEvent(TrackInAppMetricEvent(deliveryID: deliveryId, event: InAppMetric.clicked.rawValue, params: ["action_name": name, "action_value": action]))
+                eventBusHandler.postEvent(TrackInAppMetricEvent(deliveryID: deliveryId, event: InAppMetric.clicked.rawValue, params: ["actionName": name, "actionValue": action]))
             }
         }
 

--- a/Tests/DataPipeline/DataPipelineCompatibilityTests.swift
+++ b/Tests/DataPipeline/DataPipelineCompatibilityTests.swift
@@ -416,8 +416,8 @@ class DataPipelineCompatibilityTests: IntegrationTest {
         let givenDeliveryID = String.random
         let givenMetric = Metric.delivered.rawValue
         let givenMetaData: [String: String] = [
-            "action_name": "TestClick",
-            "action_value": "Test"
+            "actionName": "TestClick",
+            "actionValue": "Test"
         ]
 
         let expectedData: [String: Any] = [

--- a/Tests/MessagingInApp/MessagingInAppImplementationTest.swift
+++ b/Tests/MessagingInApp/MessagingInAppImplementationTest.swift
@@ -261,7 +261,7 @@ class MessagingInAppImplementationTest: IntegrationTest {
         let givenCurrentRoute = String.random
         let givenAction = String.random
         let givenName = String.random
-        let givenMetaData = ["action_name": givenName, "action_value": givenAction]
+        let givenMetaData = ["actionName": givenName, "actionValue": givenAction]
 
         messagingInApp.action(
             message: givenGistMessage,


### PR DESCRIPTION
closes: https://linear.app/customerio/issue/INAPP-12554/in-app-tracked-responses-does-not-match-clicked-metrics-in-env-154794

updates keys of `actionValue` and `actionName` in properties, for `Report Delivery Event` event. 