### PR TITLE
chore: improve reliability dismissing modal messages on page rule change

### DIFF
--- a/Sources/Common/Type/DoNotTrackAutomaticScreenViewEvent.swift
+++ b/Sources/Common/Type/DoNotTrackAutomaticScreenViewEvent.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+/// Inherit in a UIViewController subclass to avoid having an automatic screenview event tracked for it.
+/// Currently only being used internally. `public` only because multiple SDK modules use it.
+public protocol DoNotTrackScreenViewEvent {}

--- a/Sources/DataPipeline/Plugins/AutoTrackingScreenViews.swift
+++ b/Sources/DataPipeline/Plugins/AutoTrackingScreenViews.swift
@@ -83,6 +83,13 @@ extension AutoTrackingScreenViews {
             return
         }
 
+        // View is an internal Cio View, ignore event.
+        // This logic needs to exist outside of the `filterAutoScreenViewEvents` feature because customers can override the event filter.
+        // There are side effects (such as infinite loops) caused when our SDK tracks screenview events for internal classes.
+        if viewController is DoNotTrackScreenViewEvent {
+            return
+        }
+
         // Before we track event, apply a filter to remove events that could be unhelpful.
         let customerOverridenFilter = filterAutoScreenViewEvents
         let defaultSdkFilter: (UIViewController) -> Bool = { viewController in

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -150,17 +150,6 @@ public class Gist: GistDelegate {
         }
         let currentMessage = messageManagerToCancel.currentMessage
 
-        if messageManagerToCancel.isShowingMessage {
-            // The modal is already visible, don't cancel it.
-            // This can prevent an infinite loop scenario:
-            // * page rule changed and that triggers showing a Modal
-            // * Modal message is displayed on screen
-            // * Modal being displayed triggers an auto screenview tracking event. This triggers a SDK page route change
-            // * Request to cancel modal message
-            // * Back to the foreground screen that originally triggered showing a Modal message...repeat...
-            return
-        }
-
         guard currentMessage.gistProperties.routeRule != nil else {
             // The message does not have page rules setup so do not cancel showing it. Let it proceed.
             return

--- a/Sources/MessagingInApp/Gist/Views/GistModalViewController.swift
+++ b/Sources/MessagingInApp/Gist/Views/GistModalViewController.swift
@@ -1,7 +1,11 @@
+import CioInternalCommon
 import Foundation
 import UIKit
 
-class GistModalViewController: UIViewController, GistViewDelegate {
+/*
+ Important that automatic screenview events are not tracked when Modal is showing on screen. Automatic screenview events sets the page rule route in the in-app SDK. When the page rule route changes, our SDK performs logic such as dismissing in-app messages.
+ */
+class GistModalViewController: UIViewController, GistViewDelegate, DoNotTrackScreenViewEvent {
     var currentHeight: CGFloat = 0.0
     weak var gistView: GistView!
     var position: MessagePosition!

--- a/Tests/DataPipeline/DataPipelineImplementation+ScreenViewsTest.swift
+++ b/Tests/DataPipeline/DataPipelineImplementation+ScreenViewsTest.swift
@@ -107,6 +107,14 @@ class DataPipelineScreenViewsTest: IntegrationTest {
         assertEventTracked(numberOfEventsAdded: 1)
     }
 
+    func test_performScreenTracking_givenScreenInheritsDoNotTrackScreenViewEvent_expectNoTracking() {
+        class DoNotTrackScreen: UIViewController, DoNotTrackScreenViewEvent {}
+
+        autoTrackingScreenViews.performScreenTracking(onViewController: DoNotTrackScreen())
+
+        assertNoEventTracked()
+    }
+
     // MARK: getNameForAutomaticScreenViewTracking
 
     func test_getNameForAutomaticScreenViewTracking_givenViewWithNoTitle_expectNil() {


### PR DESCRIPTION
Part of: https://linear.app/customerio/issue/MBL-355/ios-fix-in-app-message-displayed-on-wrong-page

There is a scenario where a modal message can be displayed on the wrong screen due to a timing issue. Although the time window where this could happen is small, it was encountered during QA testing.

Test case to reproduce:
* In-app message with page rule "Dashboard" sent to device. User on "Dashboard" screen. In-app message begins to render.
* Similar to what is explained [here](https://customerio.slack.com/archives/C06H7MMLH6C/p1716391939537599), if the user of the app clicks a button to begin navigating to another screen in the app and the modal message finishes rendering during the screen transition animation, the modal will be displayed and will remain displayed after the animation is complete and the next screen is shown.

Solution:
Dismiss the modal when the screen transition animation ends and a new page rule is triggered. Ensure that when a Modal message is shown, it does not trigger an automatic screenview event. This allows the SDK to recognize user navigation to a new screen accurately.

Testing:
* Automated tests added to verify auto screenview tracking.
* QA test verified that when a Gist Modal message shown, an automatic screenview event not tracked.

<!-- start git-machete generated -->

# Based on PR #731

## Full chain of PRs as of 2024-06-14

* PR #732: `levi/ignore-cio-autoscreenviews` ➔ `levi/inapp-strict-pagerules`
* PR #731: `levi/inapp-strict-pagerules` ➔ `main`

<!-- end git-machete generated -->