### PR TITLE
fix: 3rd party SDK compatibility when SDK forwards push events back to us

### DIFF
--- a/Sources/MessagingPush/PushHandling/PushEventHandlerProxy.swift
+++ b/Sources/MessagingPush/PushHandling/PushEventHandlerProxy.swift
@@ -62,7 +62,7 @@ class PushEventHandlerProxyImpl: PushEventHandlerProxy {
 
                     delegate.onPushAction(pushAction) {
                         Task { @MainActor in // in case the delegate calls the completion handler on a background thread, we need to switch back to the main thread.
-                            self.logger?.info("Received async completion handler from \(nameOfDelegateClass).")
+                            self.logger.info("Received async completion handler from \(nameOfDelegateClass).")
 
                             if !hasResumed {
                                 hasResumed = true
@@ -113,7 +113,7 @@ class PushEventHandlerProxyImpl: PushEventHandlerProxy {
 
                     delegate.shouldDisplayPushAppInForeground(push, completionHandler: { delegateShouldDisplayPushResult in
                         Task { @MainActor in // in case the delegate calls the completion handler on a background thread, we need to switch back to the main thread.
-                            self.logger?.info("Received async completion handler from \(nameOfDelegateClass).")
+                            self.logger.info("Received async completion handler from \(nameOfDelegateClass).")
 
                             if !hasResumed {
                                 hasResumed = true

--- a/Sources/MessagingPush/PushHandling/iOSPushEventListener.swift
+++ b/Sources/MessagingPush/PushHandling/iOSPushEventListener.swift
@@ -31,6 +31,9 @@ class IOSPushEventListener: PushEventHandler {
         guard !pushHistory.hasHandledPush(pushEvent: .didReceive, pushId: push.pushId, pushDeliveryDate: dateWhenPushDelivered) else {
             // push has already been handled. exit early
             logger.debug("[onPushAction] early exist as the push was already handled: \(pushAction)")
+
+            // We expect this function to only be called by a 3rd party SDK that forwarded the push event to our SDK.
+            // Call the completionHandler so the 3rd party SDK knows we are done processing it.
             completionHandler()
             return
         }
@@ -79,6 +82,10 @@ class IOSPushEventListener: PushEventHandler {
 
             // See notes in didReceive function to learn more about this logic of exiting early when we already have handled a push.
             logger.debug("[shouldDisplayPushAppInForeground] early exit as the push was previously handled: \(push)")
+            // We expect this function to only be called by a 3rd party SDK that forwarded the push event to our SDK.
+            // Call the completionHandler so the 3rd party SDK knows we are done processing it.
+            //
+            // For push notifications sent from CIO, the completionHandler return value is irrelevant. For those sent by third-party SDKs, it's up to that SDK to use the return value or not.
             completionHandler(false)
             return
         }

--- a/Sources/MessagingPush/PushHandling/iOSPushEventListener.swift
+++ b/Sources/MessagingPush/PushHandling/iOSPushEventListener.swift
@@ -31,6 +31,7 @@ class IOSPushEventListener: PushEventHandler {
         guard !pushHistory.hasHandledPush(pushEvent: .didReceive, pushId: push.pushId, pushDeliveryDate: dateWhenPushDelivered) else {
             // push has already been handled. exit early
             logger.debug("[onPushAction] early exist as the push was already handled: \(pushAction)")
+            completionHandler()
             return
         }
 
@@ -78,6 +79,7 @@ class IOSPushEventListener: PushEventHandler {
 
             // See notes in didReceive function to learn more about this logic of exiting early when we already have handled a push.
             logger.debug("[shouldDisplayPushAppInForeground] early exit as the push was previously handled: \(push)")
+            completionHandler(false)
             return
         }
 

--- a/Tests/MessagingPush/PushHandling/AutomaticPushClickedIntegrationTest.swift
+++ b/Tests/MessagingPush/PushHandling/AutomaticPushClickedIntegrationTest.swift
@@ -175,19 +175,19 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
         pushClickHandler.assertHandledPushClick(for: givenPush)
     }
 
-    // MARK: prevent infinite loops with notification center proxy
+    // MARK: prevent infinite loops when forwarding push events to other push handlers
 
     /*
-     Some 3rd party SDKs (such as FCM SDK) have an implementation of swizzling that can create an infinite loop with our SDK. .
+     Some 3rd party SDKs (such as FCM SDK) have an implementation of swizzling that can create an infinite loop with our SDK.
 
      Example scenario of infinite loop:
      - iOS delivers a push click event to our SDK via our `UNUserNotificationCenterDelegate` instance.
-     - The push did not come from CIO, so the SDK forwards the event to other `UNUserNotificationCenterDelegate` instances, such as FCM SDK.
+     - Our SDK forwards the push event to other the other `UNUserNotificationCenterDelegate` instances. For example, we forward it to the FCM SDK.
      - The FCM SDK's swizzling implementation involves making a call back to the host app's current UserNotificationCenter.delegate (which is our SDK). See code: https://github.com/firebase/firebase-ios-sdk/blob/5890db966963fd76cfd020d68c0067a7741bef06/FirebaseMessaging/Sources/FIRMessagingRemoteNotificationsProxy.m#L498-L504
-     - This call means that our SDK's `UNUserNotificationCenterDelegate` instance is called *again* to handle this push event. Starting this series of steps over again, creating an infinite loop.
+     - When the FCM SDK does this, it means our SDK's `UNUserNotificationCenterDelegate` instance is called *again* to handle the same push event we're already handling. If our SDK handles this push event again by forwarding the event to the other `UNUserNotificationCenterDelegate` instances, an infinite loop would occur.
      */
 
-    func test_givenMultiplePushClickHandlers_simulateFcmSdkSwizzlingBehavior_expectNoInfiniteLoop() {
+    func test_onPushAction_givenMultiplePushClickHandlers_simulateFcmSdkSwizzlingBehavior_expectNoInfiniteLoop() {
         let givenPush = PushNotificationStub.getPushNotSentFromCIO()
         let givenOtherPushHandler = PushEventHandlerMock()
         let givenPushClickAction = PushNotificationActionStub(push: givenPush, didClickOnPush: true)
@@ -195,15 +195,35 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
         let expectOtherClickHandlerHandlesPush = expectation(description: "Other push handler should handle push.")
         expectOtherClickHandlerHandlesPush.expectedFulfillmentCount = 1 // the other push click handler should only be called once, indicating an infinite loop is not created.
         givenOtherPushHandler.onPushActionClosure = { _, onComplete in
-            // Like the FCM SDK does, make a call back to the app's current `UNUserNotificationCenterDelegate` instance. We simulate this by performing a push click, again.
-            self.performPushAction(givenPushClickAction) {}
-
             expectOtherClickHandlerHandlesPush.fulfill()
-            onComplete()
+
+            // Like the FCM SDK does, make a call back to the app's current `UNUserNotificationCenterDelegate` instance. We simulate this by performing a push click, again.
+            self.performPushAction(givenPushClickAction, withCompletionHandler: onComplete)
         }
         addOtherPushEventHandler(givenOtherPushHandler)
 
         performPushAction(givenPushClickAction)
+
+        waitForExpectations()
+
+        pushClickHandler.assertDidNotHandlePushClick() // CIO SDK should not handle push.
+    }
+
+    func test_shouldDisplayPushAppInForeground_givenMultiplePushClickHandlers_simulateFcmSdkSwizzlingBehavior_expectNoInfiniteLoop() {
+        let givenPush = PushNotificationStub.getPushNotSentFromCIO()
+        let givenOtherPushHandler = PushEventHandlerMock()
+
+        let expectOtherClickHandlerHandlesPush = expectation(description: "Other push handler should handle push.")
+        expectOtherClickHandlerHandlesPush.expectedFulfillmentCount = 1 // the other push click handler should only be called once, indicating an infinite loop is not created.
+        givenOtherPushHandler.shouldDisplayPushAppInForegroundClosure = { _, onComplete in
+            expectOtherClickHandlerHandlesPush.fulfill()
+
+            // Like the FCM SDK does, make a call back to the app's current `UNUserNotificationCenterDelegate` instance. We simulate this by sending the push event back to us.
+            self.sendPushEventShouldShowPushAppInForeground(givenPush, withCompletionHandler: onComplete)
+        }
+        addOtherPushEventHandler(givenOtherPushHandler)
+
+        sendPushEventShouldShowPushAppInForeground(givenPush)
 
         waitForExpectations()
 
@@ -279,9 +299,29 @@ extension AutomaticPushClickedIntegrationTest {
     }
 
     func performPushAction(_ pushAction: PushNotificationAction, withCompletionHandler completionHandler: @escaping () -> Void) {
-        pushEventHandler.onPushAction(pushAction, completionHandler: {
-            completionHandler()
-        })
+        pushEventHandler.onPushAction(pushAction, completionHandler: completionHandler)
+    }
+
+    func sendPushEventShouldShowPushAppInForeground(_ push: PushNotification, expectToCallCompletionHandler: Bool = true) {
+        // Note: It's important that we test that the `withContentHandler` callback function gets called either by our SDK (when we handle it), or the 3rd party handler.
+        //       We add an expectation to verify that 1 push click handler calls it.
+        let expectCompletionHandlerCalled = expectation(description: "Expect completion handler called by a click handler")
+
+        if expectToCallCompletionHandler {
+            expectCompletionHandlerCalled.expectedFulfillmentCount = 1 // Test will fail if called 2+ times which could indicate a bug because only 1 push click handler should be calling it.
+        } else {
+            expectCompletionHandlerCalled.isInverted = true
+        }
+
+        sendPushEventShouldShowPushAppInForeground(push) { _ in
+            expectCompletionHandlerCalled.fulfill()
+        }
+
+        waitForExpectations(for: [expectCompletionHandlerCalled])
+    }
+
+    func sendPushEventShouldShowPushAppInForeground(_ push: PushNotification, withCompletionHandler completionHandler: @escaping (Bool) -> Void) {
+        pushEventHandler.shouldDisplayPushAppInForeground(push, completionHandler: completionHandler)
     }
 
     func addOtherPushEventHandler(_ pushEventHandler: PushEventHandler) {


### PR DESCRIPTION
Part of: https://linear.app/customerio/issue/MBL-364/[bug]-push-notifications-not-showing-while-app-in-foreground-on-ios

When a push event occurs in an iOS app (such as determining if a push should be shown while app in foreground), the CIO SDK forwards that event to all 3rd party SDKs in the app. Some 3rd party SDKs handle these push events by also forwarding those events back to the CIO SDK. This has resulted in push handling in an app to not behave as expected. 

See the ticket and included tests in this PR to learn more about the implementations of these 3rd party SDKs and how we handle them. 

Testing:
* Added automated tests to this PR reproducing each of the problem scenarios I have encountered during QA. 
* QA regression tested push features in iOS, RN, Flutter, and Expo. 

Note to reviewers:
* [This PR is identical to the branch pointing to v2 branch](https://github.com/customerio/customerio-ios/pull/735). 