### PR TITLE
chore: do not dismiss modal when page route changed and regex pattern matches

### DIFF
--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -63,7 +63,7 @@ public class Gist: GistDelegate {
         if let messageManager = getModalMessageManager() {
             let modalMessageLoadingOrDisplayed = messageManager.currentMessage
 
-            if modalMessageLoadingOrDisplayed.doesHavePageRule() {
+            if modalMessageLoadingOrDisplayed.doesHavePageRule(), !modalMessageLoadingOrDisplayed.doesPageRuleMatch(route: currentRoute) {
                 // the page rule has changed and the currently loading/visible modal has page rules set, it should no longer be shown.
                 Logger.instance.debug(message: "Cancelled showing message with id: \(modalMessageLoadingOrDisplayed.messageId)")
 

--- a/Sources/MessagingInApp/Gist/Managers/MessageQueueManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/MessageQueueManager.swift
@@ -122,17 +122,10 @@ class MessageQueueManager {
 
         let position = message.gistProperties.position
 
-        if let routeRule = message.gistProperties.routeRule {
-            let cleanRouteRule = routeRule.replacingOccurrences(of: "\\", with: "/")
-            if let regex = try? NSRegularExpression(pattern: cleanRouteRule) {
-                let range = NSRange(location: 0, length: Gist.shared.getCurrentRoute().utf16.count)
-                if regex.firstMatch(in: Gist.shared.getCurrentRoute(), options: [], range: range) == nil {
-                    Logger.instance.debug(message: "Current route is \(Gist.shared.getCurrentRoute()), needed \(cleanRouteRule)")
-                    return // exit early to not show the message since page rule doesnt match
-                }
-            } else {
-                Logger.instance.info(message: "Problem processing route rule message regex: \(cleanRouteRule)")
-                return // exit early to not show the message since we cannot parse the page rule for message.
+        if message.doesHavePageRule(), let cleanPageRule = message.cleanPageRule {
+            if !message.doesPageRuleMatch(route: Gist.shared.getCurrentRoute()) {
+                Logger.instance.debug(message: "Current route is \(Gist.shared.getCurrentRoute()), needed \(cleanPageRule)")
+                return // exit early to not show the message since page rule doesnt match
             }
         }
 

--- a/Sources/MessagingInApp/Gist/Managers/Models/Message.swift
+++ b/Sources/MessagingInApp/Gist/Managers/Models/Message.swift
@@ -97,4 +97,39 @@ extension Message {
     func doesHavePageRule() -> Bool {
         gistProperties.routeRule != nil
     }
+
+    var cleanPageRule: String? {
+        guard let routeRule = gistProperties.routeRule else {
+            return nil
+        }
+        return routeRule.replacingOccurrences(of: "\\", with: "/")
+    }
+
+    /*
+     The HTTP response to get messages formats the page rules as regex.
+
+     You can expect to see the following options.
+     1. In Fly, if you use "Contains", the page rule will be formatted as ^(.*home.*)$ where "home" is what is entered in as the page rule. No matter if wildcards are used before or after "home" in Fly, the pattern will always be formatted as ^(.*N.*)$
+     2. In Fly, if you use "Equals", the page rule will be formatted as ^(home)$ where "home" is what is entered in as the page rule. If wildcards are entered, they will be included in the pattern. Example: "home*" will be formatted as ^(home.*)$
+
+     You can also use "OR" in Fly.
+     Example OR: `^(home)|(settings)$`, if "home" and "settings" are entered in as the page rule using equals.
+     */
+    func doesPageRuleMatch(route: String) -> Bool {
+        guard let cleanRouteRule = cleanPageRule else {
+            return false
+        }
+
+        if let regex = try? NSRegularExpression(pattern: cleanRouteRule) {
+            let range = NSRange(location: 0, length: route.utf16.count)
+            if regex.firstMatch(in: route, options: [], range: range) == nil {
+                return false // exit early to not show the message since page rule doesnt match
+            }
+        } else {
+            Logger.instance.info(message: "Problem processing route rule message regex: \(cleanRouteRule)")
+            return false // exit early to not show the message since we cannot parse the page rule for message.
+        }
+
+        return true
+    }
 }

--- a/Tests/MessagingInApp/Extensions/GistExtensions.swift
+++ b/Tests/MessagingInApp/Extensions/GistExtensions.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 extension Message {
-    convenience init(messageId: String, campaignId: String, pageRule: String? = nil, queueId: String? = .random) {
+    convenience init(messageId: String = .random, campaignId: String = .random, pageRule: String? = nil, queueId: String? = .random) {
         var gistProperties = [
             "gist": [
                 "campaignId": campaignId

--- a/Tests/MessagingInApp/Gist/Managers/Models/MessageTest.swift
+++ b/Tests/MessagingInApp/Gist/Managers/Models/MessageTest.swift
@@ -2,6 +2,8 @@
 import XCTest
 
 class MessageTest: XCTestCase {
+    // MARK: - doesHavePageRule
+
     func test_doesHavePageRule_givenNoRouteRule_expectFalse() {
         let message = Message(messageId: "testMessageId")
         let result = message.doesHavePageRule()
@@ -17,6 +19,47 @@ class MessageTest: XCTestCase {
     func test_doesHavePageRule_givenEmptyProperties_expectFalse() {
         let message = Message(messageId: "testMessageId", properties: [:])
         let result = message.doesHavePageRule()
+        XCTAssertFalse(result)
+    }
+
+    // MARK: - doesPageRuleMatch
+
+    func test_doesPageRuleMatch_givenNoRouteRule_expectFalse() {
+        let message = Message(pageRule: nil)
+        let result = message.doesPageRuleMatch(route: "home")
+        XCTAssertFalse(result)
+    }
+
+    func test_doesPageRuleMatch_givenContainsRegexPattern_expectMatchRoutesThatContain() {
+        let message = Message(pageRule: "^(.*home.*)$")
+        XCTAssertTrue(message.doesPageRuleMatch(route: "home"))
+        XCTAssertTrue(message.doesPageRuleMatch(route: "foohomebar"))
+        XCTAssertTrue(message.doesPageRuleMatch(route: "homebar"))
+        XCTAssertTrue(message.doesPageRuleMatch(route: "foohome"))
+        XCTAssertFalse(message.doesPageRuleMatch(route: "hom"))
+    }
+
+    func test_doesPageRuleMatch_givenEqualsRegexPattern_expectMatchRoutesThatEqual() {
+        let message = Message(pageRule: "^(home)$")
+        XCTAssertTrue(message.doesPageRuleMatch(route: "home"))
+        XCTAssertFalse(message.doesPageRuleMatch(route: "foohomebar"))
+        XCTAssertFalse(message.doesPageRuleMatch(route: "homebar"))
+        XCTAssertFalse(message.doesPageRuleMatch(route: "foohome"))
+        XCTAssertFalse(message.doesPageRuleMatch(route: "hom"))
+    }
+
+    func test_doesPageRuleMatch_givenWildcardRouteRule_expectAlwaysTrue() {
+        let message = Message(pageRule: "^(.*)$")
+        XCTAssertTrue(message.doesPageRuleMatch(route: "home"))
+        XCTAssertTrue(message.doesPageRuleMatch(route: "foohomebar"))
+        XCTAssertTrue(message.doesPageRuleMatch(route: "homebar"))
+        XCTAssertTrue(message.doesPageRuleMatch(route: "foohome"))
+        XCTAssertTrue(message.doesPageRuleMatch(route: "hom"))
+    }
+
+    func test_doesPageRuleMatch_givenInvalidRegex_expectFalse() {
+        let message = Message(pageRule: "[")
+        let result = message.doesPageRuleMatch(route: "home")
         XCTAssertFalse(result)
     }
 }

--- a/Tests/MessagingInApp/MessagingInAppIntegrationTests.swift
+++ b/Tests/MessagingInApp/MessagingInAppIntegrationTests.swift
@@ -32,7 +32,7 @@ class MessagingInAppIntegrationTest: IntegrationTest {
         navigateToScreen(screenName: "Home")
 
         let givenMessages = [
-            Message(messageId: "welcome-banner", campaignId: .random, pageRule: "Home")
+            Message(messageId: "welcome-banner", campaignId: .random, pageRule: "^(Home)$")
         ]
 
         onDoneFetching(messages: givenMessages)
@@ -51,7 +51,7 @@ class MessagingInAppIntegrationTest: IntegrationTest {
         navigateToScreen(screenName: "Home")
 
         let givenMessages = [
-            Message(messageId: "welcome-banner", campaignId: .random, pageRule: "Home")
+            Message(messageId: "welcome-banner", campaignId: .random, pageRule: "^(Home)$")
         ]
         onDoneFetching(messages: givenMessages)
         XCTAssertTrue(isCurrentlyLoadingMessage)
@@ -66,7 +66,7 @@ class MessagingInAppIntegrationTest: IntegrationTest {
         navigateToScreen(screenName: "Home")
 
         let givenMessages = [
-            Message(messageId: "welcome-banner", campaignId: .random)
+            Message(pageRule: nil)
         ]
         onDoneFetching(messages: givenMessages)
         XCTAssertTrue(isCurrentlyLoadingMessage)
@@ -76,7 +76,7 @@ class MessagingInAppIntegrationTest: IntegrationTest {
 
         doneLoadingMessage(givenMessages[0])
 
-        XCTAssertNotNil(currentlyShownModalMessage)
+        XCTAssertEqual(currentlyShownModalMessage?.queueId, givenMessages[0].queueId)
         XCTAssertFalse(didCallGlobalEventListener)
     }
 
@@ -84,7 +84,7 @@ class MessagingInAppIntegrationTest: IntegrationTest {
         navigateToScreen(screenName: "Home")
 
         let givenMessages = [
-            Message(messageId: "welcome-banner", campaignId: .random, pageRule: "Home")
+            Message(messageId: "welcome-banner", campaignId: .random, pageRule: "^(Home)$")
         ]
         onDoneFetching(messages: givenMessages)
         XCTAssertTrue(isCurrentlyLoadingMessage)
@@ -105,7 +105,7 @@ class MessagingInAppIntegrationTest: IntegrationTest {
         navigateToScreen(screenName: "Home")
 
         let givenMessages = [
-            Message(messageId: "welcome-banner", campaignId: .random, pageRule: "Home")
+            Message(messageId: "welcome-banner", campaignId: .random, pageRule: "^(Home)$")
         ]
         onDoneFetching(messages: givenMessages)
 
@@ -117,6 +117,29 @@ class MessagingInAppIntegrationTest: IntegrationTest {
 
         XCTAssertNotNil(currentlyShownModalMessage)
         XCTAssertFalse(didCallGlobalEventListener)
+    }
+
+    // page routes can contain regex which could make the message match the next screen navigated to.
+    func test_givenChangedRouteButMessageStillMatchesNewRoute_expectDoNotDismissModal() {
+        navigateToScreen(screenName: "Home")
+
+        let givenMessages = [
+            Message(messageId: "welcome-banner", campaignId: .random, pageRule: "^(.*Home.*)$")
+        ]
+        onDoneFetching(messages: givenMessages)
+
+        doneLoadingMessage(givenMessages[0])
+
+        XCTAssertNotNil(currentlyShownModalMessage)
+
+        let messageShownBeforeNavigate = currentlyShownModalMessage
+
+        navigateToScreen(screenName: "HomeSettings")
+
+        XCTAssertNotNil(currentlyShownModalMessage)
+
+        // because the message is identical, it was not canceled when the page route changed.
+        XCTAssertEqual(messageShownBeforeNavigate?.instanceId, currentlyShownModalMessage?.instanceId)
     }
 }
 


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #739

## Full chain of PRs as of 2024-06-14

* PR #740: `levi/compare-regex-page-rules` ➔ `levi/instantly-dismiss-modals`
* PR #739: `levi/instantly-dismiss-modals` ➔ `levi/ignore-cio-autoscreenviews`
* PR #732: `levi/ignore-cio-autoscreenviews` ➔ `levi/inapp-strict-pagerules`
* PR #731: `levi/inapp-strict-pagerules` ➔ `main`

<!-- end git-machete generated -->

Part of: https://linear.app/customerio/issue/MBL-355/ios-fix-in-app-message-displayed-on-wrong-page

Because page rules can contain regex, you could change screens in the app and the currently shown message can still match that screen. Do not cancel if the message matches the new route.

Testing
* Added automated tests.