### PR TITLE
fix: differentiate every push event handler installed in app

### DIFF
--- a/Sources/MessagingPush/PushHandling/PushEventHandler.swift
+++ b/Sources/MessagingPush/PushHandling/PushEventHandler.swift
@@ -4,6 +4,10 @@ import Foundation
 // A protocol that can handle push notification events. Such as when a push is received on the device or when a push is clicked on.
 // Note: This is meant to be an abstraction of the iOS `UNUserNotificationCenterDelegate` protocol.
 protocol PushEventHandler: AutoMockable {
+    // The SDK manages multiple push event handlers. We need a way to differentiate them between one another.
+    // The return value should uniquely identify the handler from other handlers installed in the app.
+    var identifier: String { get }
+
     // Called when a push notification was acted upon. Either clicked or swiped away.
     //
     // Replacement of: `userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void)`

--- a/Sources/MessagingPush/PushHandling/PushEventHandlerProxy.swift
+++ b/Sources/MessagingPush/PushHandling/PushEventHandlerProxy.swift
@@ -65,11 +65,11 @@ class PushEventHandlerProxyImpl: PushEventHandlerProxy {
 
                     // Using logs to give feedback to customer if 1 or more delegates do not call the async completion handler.
                     // These logs could help in debuggging to determine what delegate did not call the completion handler.
-                    self.logger?.info("Sending push notification, \(pushAction.push.title), event to: \(nameOfDelegateClass)). Customer.io SDK will wait for async completion handler to be called...")
+                    self.logger?.info("Sending push notification, \(pushAction.push.title), action event to: \(nameOfDelegateClass)). Customer.io SDK will wait for async completion handler to be called...")
 
                     delegate.onPushAction(pushAction) {
                         Task { @MainActor in // in case the delegate calls the completion handler on a background thread, we need to switch back to the main thread.
-                            self.logger?.info("Received async completion handler from \(nameOfDelegateClass).")
+                            self.logger?.info("Received async completion handler from \(nameOfDelegateClass) for action push event.")
 
                             if !hasResumed {
                                 hasResumed = true
@@ -116,11 +116,11 @@ class PushEventHandlerProxyImpl: PushEventHandlerProxy {
 
                     // Using logs to give feedback to customer if 1 or more delegates do not call the async completion handler.
                     // These logs could help in debuggging to determine what delegate did not call the completion handler.
-                    self.logger?.info("Sending push notification, \(push.title), event to: \(nameOfDelegateClass)). Customer.io SDK will wait for async completion handler to be called...")
+                    self.logger?.info("Sending push notification, \(push.title), will display event to: \(nameOfDelegateClass)). Customer.io SDK will wait for async completion handler to be called...")
 
                     delegate.shouldDisplayPushAppInForeground(push, completionHandler: { delegateShouldDisplayPushResult in
                         Task { @MainActor in // in case the delegate calls the completion handler on a background thread, we need to switch back to the main thread.
-                            self.logger?.info("Received async completion handler from \(nameOfDelegateClass).")
+                            self.logger?.info("Received async completion handler from \(nameOfDelegateClass) for will display event.")
 
                             if !hasResumed {
                                 hasResumed = true

--- a/Sources/MessagingPush/PushHandling/PushEventHandlerProxy.swift
+++ b/Sources/MessagingPush/PushHandling/PushEventHandlerProxy.swift
@@ -27,7 +27,7 @@ class PushEventHandlerProxyImpl: PushEventHandlerProxy {
     public static let shared = PushEventHandlerProxyImpl()
 
     // Use a map so that we only save 1 instance of a given handler.
-    @Atomic private var nestedDelegates: [String: PushEventHandler] = [:]
+    @Atomic var nestedDelegates: [String: PushEventHandler] = [:]
 
     private let logger: Logger?
 

--- a/Sources/MessagingPush/PushHandling/PushEventHandlerProxy.swift
+++ b/Sources/MessagingPush/PushHandling/PushEventHandlerProxy.swift
@@ -37,7 +37,7 @@ class PushEventHandlerProxyImpl: PushEventHandlerProxy {
     }
 
     func addPushEventHandler(_ newHandler: PushEventHandler) {
-        nestedDelegates[String(describing: newHandler)] = newHandler
+        nestedDelegates[newHandler.identifier] = newHandler
     }
 
     func onPushAction(_ pushAction: PushNotificationAction, completionHandler: @escaping () -> Void) {

--- a/Sources/MessagingPush/PushHandling/iOSPushEventListener.swift
+++ b/Sources/MessagingPush/PushHandling/iOSPushEventListener.swift
@@ -21,6 +21,10 @@ class IOSPushEventListener: PushEventHandler {
         self.logger = logger
     }
 
+    var identifier: String {
+        "Cio.iOSPushEventListener"
+    }
+
     func onPushAction(_ pushAction: PushNotificationAction, completionHandler: @escaping () -> Void) {
         guard let dateWhenPushDelivered = pushAction.push.deliveryDate else {
             return

--- a/Sources/MessagingPush/UserNotificationsFramework/Wrappers.swift
+++ b/Sources/MessagingPush/UserNotificationsFramework/Wrappers.swift
@@ -120,6 +120,10 @@ public struct UNNotificationWrapper: PushNotification {
 class UNUserNotificationCenterDelegateWrapper: PushEventHandler {
     private let delegate: UNUserNotificationCenterDelegate
 
+    var identifier: String {
+        String(describing: delegate)
+    }
+
     init(delegate: UNUserNotificationCenterDelegate) {
         self.delegate = delegate
     }

--- a/Sources/MessagingPush/UserNotificationsFramework/Wrappers.swift
+++ b/Sources/MessagingPush/UserNotificationsFramework/Wrappers.swift
@@ -117,8 +117,14 @@ public struct UNNotificationWrapper: PushNotification {
     }
 }
 
-class UNUserNotificationCenterDelegateWrapper: PushEventHandler {
+class UNUserNotificationCenterDelegateWrapper: PushEventHandler, CustomStringConvertible {
     private let delegate: UNUserNotificationCenterDelegate
+
+    var description: String {
+        let nestedDelegateDescription = String(describing: delegate)
+
+        return "Cio.NotificationCenterDelegateWrapper(\(nestedDelegateDescription))"
+    }
 
     var identifier: String {
         String(describing: delegate)

--- a/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
@@ -563,7 +563,45 @@ class PushEventHandlerMock: PushEventHandler, Mock {
         Mocks.shared.add(mock: self)
     }
 
+    /**
+     When setter of the property called, the value given to setter is set here.
+     When the getter of the property called, the value set here will be returned. Your chance to mock the property.
+     */
+    var underlyingIdentifier: String!
+    /// `true` if the getter or setter of property is called at least once.
+    var identifierCalled: Bool {
+        identifierGetCalled || identifierSetCalled
+    }
+
+    /// `true` if the getter called on the property at least once.
+    var identifierGetCalled: Bool {
+        identifierGetCallsCount > 0
+    }
+
+    var identifierGetCallsCount = 0
+    /// `true` if the setter called on the property at least once.
+    var identifierSetCalled: Bool {
+        identifierSetCallsCount > 0
+    }
+
+    var identifierSetCallsCount = 0
+    /// The mocked property with a getter and setter.
+    var identifier: String {
+        get {
+            mockCalled = true
+            identifierGetCallsCount += 1
+            return underlyingIdentifier
+        }
+        set(value) {
+            mockCalled = true
+            identifierSetCallsCount += 1
+            underlyingIdentifier = value
+        }
+    }
+
     public func resetMock() {
+        identifierGetCallsCount = 0
+        identifierSetCallsCount = 0
         onPushActionCallsCount = 0
         onPushActionReceivedArguments = nil
         onPushActionReceivedInvocations = []

--- a/Tests/MessagingPush/IntegrationTest.swift
+++ b/Tests/MessagingPush/IntegrationTest.swift
@@ -27,4 +27,12 @@ class IntegrationTest: SharedTests.IntegrationTest {
             MessagingPush.initialize()
         }
     }
+
+    // Create new mock instance and setup with set of defaults.
+    func getNewPushEventHandler() -> PushEventHandlerMock {
+        let newInstance = PushEventHandlerMock()
+        // We expect that each instance has it's own unique identifier.
+        newInstance.underlyingIdentifier = .random
+        return newInstance
+    }
 }

--- a/Tests/MessagingPush/PushHandling/AutomaticPushClickedIntegrationTest.swift
+++ b/Tests/MessagingPush/PushHandling/AutomaticPushClickedIntegrationTest.swift
@@ -106,8 +106,8 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
 
     // Important to test that 2+ 3rd party push handlers for some use cases.
     func test_givenMultiplePushHandlers_givenClickedOnCioPush_expectPushClickHandledByCioSdk() {
-        let expectOtherPushHandlersCalled = expectation(description: "Receive a callback")
-        expectOtherPushHandlersCalled.expectedFulfillmentCount = 2
+        let expectHandler1Called = expectation(description: "Receive a callback")
+        let expectHandler2Called = expectation(description: "Receive a callback")
 
         // In order to add 2+ push handlers to SDK, each class needs to have a unique name.
         // The SDK only accepts unique push event handlers. Creating this class makes each push handler unique.
@@ -116,11 +116,11 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
         let givenOtherPushHandler1 = PushEventHandlerMock()
         let givenOtherPushHandler2 = PushEventHandlerMock2()
         givenOtherPushHandler1.onPushActionClosure = { _, onComplete in
-            expectOtherPushHandlersCalled.fulfill()
+            expectHandler1Called.fulfill()
             onComplete()
         }
         givenOtherPushHandler2.onPushActionClosure = { _, onComplete in
-            expectOtherPushHandlersCalled.fulfill()
+            expectHandler2Called.fulfill()
             onComplete()
         }
         addOtherPushEventHandler(givenOtherPushHandler1)

--- a/Tests/MessagingPush/PushHandling/AutomaticPushClickedIntegrationTest.swift
+++ b/Tests/MessagingPush/PushHandling/AutomaticPushClickedIntegrationTest.swift
@@ -71,7 +71,7 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
     func test_givenOtherPushHandlers_givenClickedOnCioPush_expectPushClickHandledByCioSdk() {
         let expectOtherClickHandlerToGetCallback = expectation(description: "Receive a callback")
 
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
         givenOtherPushHandler.onPushActionClosure = { _, onComplete in
             expectOtherClickHandlerToGetCallback.fulfill()
             onComplete()
@@ -88,7 +88,7 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
 
     func test_givenOtherPushHandlers_givenClickedOnPushNotSentFromCio_expectPushClickHandledByOtherHandler() {
         let givenPush = PushNotificationStub.getPushNotSentFromCIO()
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
 
         let expectOtherClickHandlerHandlesPush = expectation(description: "Other push handler should handle push.")
         givenOtherPushHandler.onPushActionClosure = { _, onComplete in
@@ -109,12 +109,8 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
         let expectHandler1Called = expectation(description: "Receive a callback")
         let expectHandler2Called = expectation(description: "Receive a callback")
 
-        // In order to add 2+ push handlers to SDK, each class needs to have a unique name.
-        // The SDK only accepts unique push event handlers. Creating this class makes each push handler unique.
-        class PushEventHandlerMock2: PushEventHandlerMock {}
-
-        let givenOtherPushHandler1 = PushEventHandlerMock()
-        let givenOtherPushHandler2 = PushEventHandlerMock2()
+        let givenOtherPushHandler1 = getNewPushEventHandler()
+        let givenOtherPushHandler2 = getNewPushEventHandler()
         givenOtherPushHandler1.onPushActionClosure = { _, onComplete in
             expectHandler1Called.fulfill()
             onComplete()
@@ -142,7 +138,7 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
     func test_givenMultiplePushHandlers_givenClickedOnCioPush_givenOtherPushHandlerDoesNotCallCompletionHandler_expectCompletionHandlerDoesNotGetCalled() {
         let expectOtherClickHandlerToGetCallback = expectation(description: "Receive a callback")
         let givenPush = PushNotificationStub.getPushSentFromCIO()
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
 
         givenOtherPushHandler.onPushActionClosure = { _, _ in
             // Do not call completion handler.
@@ -161,7 +157,7 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
 
     func test_givenMultiplePushHandlers_givenClickedOnCioPush_givenOtherPushHandlerCallsCompletionHandler_expectCioSdkHandlesPush() {
         let givenPush = PushNotificationStub.getPushSentFromCIO()
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
         givenOtherPushHandler.onPushActionClosure = { _, onComplete in
             onComplete()
         }
@@ -187,7 +183,7 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
 
     func test_onPushAction_givenMultiplePushClickHandlers_simulateFcmSdkSwizzlingBehavior_expectNoInfiniteLoop() {
         let givenPush = PushNotificationStub.getPushNotSentFromCIO()
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
         let givenPushClickAction = PushNotificationActionStub(push: givenPush, didClickOnPush: true)
 
         let expectOtherClickHandlerHandlesPush = expectation(description: "Other push handler should handle push.")
@@ -209,7 +205,7 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
 
     func test_shouldDisplayPushAppInForeground_givenMultiplePushClickHandlers_simulateFcmSdkSwizzlingBehavior_expectNoInfiniteLoop() {
         let givenPush = PushNotificationStub.getPushNotSentFromCIO()
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
 
         let expectOtherClickHandlerHandlesPush = expectation(description: "Other push handler should handle push.")
         expectOtherClickHandlerHandlesPush.expectedFulfillmentCount = 1 // the other push click handler should only be called once, indicating an infinite loop is not created.
@@ -240,7 +236,7 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
 
     func test_onPushAction_givenMultiplePushClickHandlers_thirdPartySdkCallsCompletionHandlerTwice_expectSdkDoesNotCrash() {
         let givenPush = PushNotificationStub.getPushNotSentFromCIO()
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
         let givenPushClickAction = PushNotificationActionStub(push: givenPush, didClickOnPush: true)
 
         let expectOtherClickHandlerHandlesPush = expectation(description: "Other push handler should handle push.")
@@ -262,7 +258,7 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
 
     func test_shouldDisplayPushAppInForeground_givenMultiplePushClickHandlers_thirdPartySdkCallsCompletionHandlerTwice_expectSdkDoesNotCrash() {
         let givenPush = PushNotificationStub.getPushNotSentFromCIO()
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
 
         let expectOtherClickHandlerHandlesPush = expectation(description: "Other push handler should handle push.")
         expectOtherClickHandlerHandlesPush.expectedFulfillmentCount = 1 // the other push click handler should only be called once, indicating an infinite loop is not created.
@@ -294,7 +290,7 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
     func test_givenClickOnLocalPush_expectOtherClickHandlerHandlesClickEvent() {
         let givenLocalPush = PushNotificationStub.getLocalPush(pushId: .random)
 
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
         let expectOtherClickHandlerHandlesPush = expectation(description: "Other push handler should handle push.")
         expectOtherClickHandlerHandlesPush.expectedFulfillmentCount = 1
         givenOtherPushHandler.onPushActionClosure = { _, onComplete in
@@ -314,7 +310,7 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
         let givenLocalPush = PushNotificationStub.getLocalPush(pushId: givenHardCodedPushId)
         let givenSecondLocalPush = PushNotificationStub.getLocalPush(pushId: givenHardCodedPushId)
 
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
         let expectOtherClickHandlerHandlesPush = expectation(description: "Other push handler should handle push.")
         expectOtherClickHandlerHandlesPush.expectedFulfillmentCount = 2 // Expect click handler to be able to handle both pushes, because each push is unique.
         givenOtherPushHandler.onPushActionClosure = { _, onComplete in

--- a/Tests/MessagingPush/PushHandling/AutomaticPushDeliveredAppInForegroundTest.swift
+++ b/Tests/MessagingPush/PushHandling/AutomaticPushDeliveredAppInForegroundTest.swift
@@ -52,7 +52,7 @@ class AutomaticPushDeliveredAppInForegrondTest: IntegrationTest {
         let givenPush = PushNotificationStub.getPushNotSentFromCIO()
         var otherPushHandlerCalled = false
 
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
         givenOtherPushHandler.shouldDisplayPushAppInForegroundClosure = { _, onComplete in
             otherPushHandlerCalled = true
 
@@ -70,7 +70,7 @@ class AutomaticPushDeliveredAppInForegrondTest: IntegrationTest {
         let givenPush = PushNotificationStub.getPushSentFromCIO()
         let expectOtherPushHandlerCallbackCalled = expectation(description: "Expect other push handler callback called")
 
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
         givenOtherPushHandler.shouldDisplayPushAppInForegroundClosure = { _, onComplete in
             // We expect that other push handler gets callback of push event from CIO push
             expectOtherPushHandlerCallbackCalled.fulfill()
@@ -95,12 +95,8 @@ class AutomaticPushDeliveredAppInForegrondTest: IntegrationTest {
         let expectOtherPushHandlerCallbackCalled = expectation(description: "Expect other push handler callback called")
         expectOtherPushHandlerCallbackCalled.expectedFulfillmentCount = 2
 
-        // In order to add 2+ push handlers to SDK, each class needs to have a unique name.
-        // The SDK only accepts unique push event handlers. Creating this class makes each push handler unique.
-        class PushEventHandlerMock2: PushEventHandlerMock {}
-
-        let givenOtherPushHandler1 = PushEventHandlerMock()
-        let givenOtherPushHandler2 = PushEventHandlerMock2()
+        let givenOtherPushHandler1 = getNewPushEventHandler()
+        let givenOtherPushHandler2 = getNewPushEventHandler()
         givenOtherPushHandler1.shouldDisplayPushAppInForegroundClosure = { _, onComplete in
             expectOtherPushHandlerCallbackCalled.fulfill()
 
@@ -126,7 +122,7 @@ class AutomaticPushDeliveredAppInForegrondTest: IntegrationTest {
 
         let expectOtherClickHandlerToGetCallback = expectation(description: "Receive a callback")
         let givenPush = PushNotificationStub.getPushSentFromCIO()
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
 
         givenOtherPushHandler.shouldDisplayPushAppInForegroundClosure = { _, _ in
             // Do not call completion handler.


### PR DESCRIPTION
https://linear.app/customerio/issue/MBL-383/[bug]-customer-unable-to-handle-push-notification-event-on-ios-with

At runtime when `PushEventHandlerProxy.addPushEventHandler` is called, the given push event handler will overrwrite any previously added push event handlers. This results in the SDK only being aware of 1 push event handler even if the iOS app has N number installed.

Testing
* In Flutter sample app, install CIO SDK, FlutterFire, and set `UNNotificationCenterDelegate.current().delegate = self` in `AppDelegate` for the host app to also handle pushes. This reproduces the bug because we now have at least 2 other push click handlers besides the CIO SDK installed. Set a Xcode breakpoint in `PushEventHandlerProxy.addPushEventHandler` and check what dictionary key is generated. 
* I added new automated tests around `PushEventHandlerProxy.addPushEventHandler` function. 