### PR TITLE
chore: clear in-app message cache on sdk logout

### DIFF
--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -44,6 +44,7 @@ public class Gist: GistDelegate {
 
     public func clearUserToken() {
         cancelModalMessage(ifDoesNotMatchRoute: "") // provide a new route to trigger a modal cancel.
+        messageQueueManager.clearLocalStore()
         UserManager().clearUserToken()
         messageQueueManager.clearUserMessagesFromLocalStore()
     }

--- a/Sources/MessagingInApp/Gist/Managers/MessageQueueManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/MessageQueueManager.swift
@@ -28,6 +28,11 @@ class MessageQueueManager {
         }
     }
 
+    func clearLocalStore() {
+        localMessageStore = [:]
+        QueueManager(siteId: Gist.shared.siteId, dataCenter: Gist.shared.dataCenter).clearCachedUserQueue()
+    }
+
     deinit {
         queueTimer?.invalidate()
     }

--- a/Sources/MessagingInApp/Gist/Managers/QueueManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/QueueManager.swift
@@ -22,6 +22,10 @@ class QueueManager {
         self.dataCenter = dataCenter
     }
 
+    func clearCachedUserQueue() {
+        cachedFetchUserQueueResponse = nil
+    }
+
     func fetchUserQueue(userToken: String, completionHandler: @escaping (Result<[UserQueueResponse]?, Error>) -> Void) {
         do {
             try gistQueueNetwork.request(siteId: siteId, dataCenter: dataCenter, userToken: userToken, request: QueueEndpoint.getUserQueue, completionHandler: { response in


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #748

## Full chain of PRs as of 2024-06-21

* PR #749: `levi/cache-inapp-response-clear-on-logout` ➔ `levi/cache-inapp-responses-integration-tests`
* PR #748: `levi/cache-inapp-responses-integration-tests` ➔ `levi/cache-inapp-response-test-setup`
* PR #747: `levi/cache-inapp-response-test-setup` ➔ `levi/cache-inapp-responses-at-network-level`
* PR #746: `levi/cache-inapp-responses-at-network-level` ➔ `main`

<!-- end git-machete generated -->

Part of: https://linear.app/customerio/issue/MBL-373/[bug]-in-app-messages-do-not-show-on-ios-if-page-rules-are-enabled-and

When SDK is logged out, clear the in-app network cache to prevent displaying messages to the wrong Journeys profile.

Testing:
* Automated tests added.
* QA test case in the linear ticket passed in sample apps.

Reviewer notes:
* This implementation was chosen to match the behavior of Android 3.11.0