### PR TITLE
chore: improve logs when forwarding push events to 3rd party handlers

### DIFF
--- a/Sources/MessagingPush/PushHandling/PushEventHandlerProxy.swift
+++ b/Sources/MessagingPush/PushHandling/PushEventHandlerProxy.swift
@@ -58,11 +58,11 @@ class PushEventHandlerProxyImpl: PushEventHandlerProxy {
 
                     // Using logs to give feedback to customer if 1 or more delegates do not call the async completion handler.
                     // These logs could help in debuggging to determine what delegate did not call the completion handler.
-                    self.logger.info("Sending push notification, \(pushAction.push.title), event to: \(nameOfDelegateClass)). Customer.io SDK will wait for async completion handler to be called...")
+                    self.logger.info("Sending push notification, \(pushAction.push.title), action event to: \(nameOfDelegateClass)). Customer.io SDK will wait for async completion handler to be called...")
 
                     delegate.onPushAction(pushAction) {
                         Task { @MainActor in // in case the delegate calls the completion handler on a background thread, we need to switch back to the main thread.
-                            self.logger.info("Received async completion handler from \(nameOfDelegateClass).")
+                            self.logger.info("Received async completion handler from \(nameOfDelegateClass) for action push event.")
 
                             if !hasResumed {
                                 hasResumed = true
@@ -109,11 +109,11 @@ class PushEventHandlerProxyImpl: PushEventHandlerProxy {
 
                     // Using logs to give feedback to customer if 1 or more delegates do not call the async completion handler.
                     // These logs could help in debuggging to determine what delegate did not call the completion handler.
-                    self.logger.info("Sending push notification, \(push.title), event to: \(nameOfDelegateClass)). Customer.io SDK will wait for async completion handler to be called...")
+                    self.logger.info("Sending push notification, \(push.title), will display event to: \(nameOfDelegateClass)). Customer.io SDK will wait for async completion handler to be called...")
 
                     delegate.shouldDisplayPushAppInForeground(push, completionHandler: { delegateShouldDisplayPushResult in
                         Task { @MainActor in // in case the delegate calls the completion handler on a background thread, we need to switch back to the main thread.
-                            self.logger.info("Received async completion handler from \(nameOfDelegateClass).")
+                            self.logger.info("Received async completion handler from \(nameOfDelegateClass) for will display event.")
 
                             if !hasResumed {
                                 hasResumed = true

--- a/Sources/MessagingPush/UserNotificationsFramework/Wrappers.swift
+++ b/Sources/MessagingPush/UserNotificationsFramework/Wrappers.swift
@@ -117,8 +117,14 @@ public struct UNNotificationWrapper: PushNotification {
     }
 }
 
-class UNUserNotificationCenterDelegateWrapper: PushEventHandler {
+class UNUserNotificationCenterDelegateWrapper: PushEventHandler, CustomStringConvertible {
     private let delegate: UNUserNotificationCenterDelegate
+
+    var description: String {
+        let nestedDelegateDescription = String(describing: delegate)
+
+        return "Cio.NotificationCenterDelegateWrapper(\(nestedDelegateDescription))"
+    }
 
     var identifier: String {
         String(describing: delegate)
@@ -154,11 +160,5 @@ class UNUserNotificationCenterDelegateWrapper: PushEventHandler {
         if delegateGotCalled == nil { // delegate did not implement this optional method. Call the completionHandler for them.
             completionHandler(false)
         }
-    }
-}
-
-extension UNUserNotificationCenterDelegateWrapper: CustomStringConvertible {
-    var description: String {
-        String(describing: delegate)
     }
 }


### PR DESCRIPTION
Part of: https://linear.app/customerio/issue/MBL-383/[bug]-customer-unable-to-handle-push-notification-event-on-ios-with

(identical to this PR: https://github.com/customerio/customerio-ios/pull/745, but this points to v3 branch)

To help customers faster, our debug logs need an improvement with the push event handling feature. This PR makes the following improvements:

```
// Example log before this PR
Sending push notification, <title of push>, event to: UNUserNotificationCenterDelegateWrapper. Customer.io SDK will wait for async completion handler to be called...
// Example log after this PR
Sending push notification, <title of push>, will display event to: Cio.NotificationCenterDelegateWrapper(<APN_UIKit.AppDelegate: 0x303f88c80>)). Customer.io SDK will wait for async completion handler to be called...
```

These logs are improved in 2 ways:
1. The 3rd party push click handler is described (<APN_UIKit.AppDelegate: 0x303f88c80>) so we know what 3rd party push click handler is called but maybe did not call the completion handler. 
2. We display *what* push event if sent to the 3rd party handler (will display). 