### PR TITLE
fix: differentiate every push event handler installed in app

### DIFF
--- a/Sources/MessagingPush/PushHandling/PushEventHandler.swift
+++ b/Sources/MessagingPush/PushHandling/PushEventHandler.swift
@@ -4,6 +4,10 @@ import Foundation
 // A protocol that can handle push notification events. Such as when a push is received on the device or when a push is clicked on.
 // Note: This is meant to be an abstraction of the iOS `UNUserNotificationCenterDelegate` protocol.
 protocol PushEventHandler: AutoMockable {
+    // The SDK manages multiple push event handlers. We need a way to differentiate them between one another.
+    // The return value should uniquely identify the handler from other handlers installed in the app.
+    var identifier: String { get }
+
     // Called when a push notification was acted upon. Either clicked or swiped away.
     //
     // Replacement of: `userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void)`

--- a/Sources/MessagingPush/PushHandling/PushEventHandlerProxy.swift
+++ b/Sources/MessagingPush/PushHandling/PushEventHandlerProxy.swift
@@ -21,7 +21,7 @@ protocol PushEventHandlerProxy: AutoMockable {
 // sourcery: InjectSingleton
 class PushEventHandlerProxyImpl: PushEventHandlerProxy {
     // Use a map so that we only save 1 instance of a given handler.
-    @Atomic private var nestedDelegates: [String: PushEventHandler] = [:]
+    @Atomic var nestedDelegates: [String: PushEventHandler] = [:]
 
     private let logger: Logger
 
@@ -30,7 +30,7 @@ class PushEventHandlerProxyImpl: PushEventHandlerProxy {
     }
 
     func addPushEventHandler(_ newHandler: PushEventHandler) {
-        nestedDelegates[String(describing: newHandler)] = newHandler
+        nestedDelegates[newHandler.identifier] = newHandler
     }
 
     func onPushAction(_ pushAction: PushNotificationAction, completionHandler: @escaping () -> Void) {

--- a/Sources/MessagingPush/PushHandling/PushEventHandlerProxy.swift
+++ b/Sources/MessagingPush/PushHandling/PushEventHandlerProxy.swift
@@ -58,11 +58,11 @@ class PushEventHandlerProxyImpl: PushEventHandlerProxy {
 
                     // Using logs to give feedback to customer if 1 or more delegates do not call the async completion handler.
                     // These logs could help in debuggging to determine what delegate did not call the completion handler.
-                    self.logger.info("Sending push notification, \(pushAction.push.title), event to: \(nameOfDelegateClass)). Customer.io SDK will wait for async completion handler to be called...")
+                    self.logger.info("Sending push notification, \(pushAction.push.title), action event to: \(nameOfDelegateClass)). Customer.io SDK will wait for async completion handler to be called...")
 
                     delegate.onPushAction(pushAction) {
                         Task { @MainActor in // in case the delegate calls the completion handler on a background thread, we need to switch back to the main thread.
-                            self.logger.info("Received async completion handler from \(nameOfDelegateClass).")
+                            self.logger.info("Received async completion handler from \(nameOfDelegateClass) for action push event.")
 
                             if !hasResumed {
                                 hasResumed = true
@@ -109,11 +109,11 @@ class PushEventHandlerProxyImpl: PushEventHandlerProxy {
 
                     // Using logs to give feedback to customer if 1 or more delegates do not call the async completion handler.
                     // These logs could help in debuggging to determine what delegate did not call the completion handler.
-                    self.logger.info("Sending push notification, \(push.title), event to: \(nameOfDelegateClass)). Customer.io SDK will wait for async completion handler to be called...")
+                    self.logger.info("Sending push notification, \(push.title), will display event to: \(nameOfDelegateClass)). Customer.io SDK will wait for async completion handler to be called...")
 
                     delegate.shouldDisplayPushAppInForeground(push, completionHandler: { delegateShouldDisplayPushResult in
                         Task { @MainActor in // in case the delegate calls the completion handler on a background thread, we need to switch back to the main thread.
-                            self.logger.info("Received async completion handler from \(nameOfDelegateClass).")
+                            self.logger.info("Received async completion handler from \(nameOfDelegateClass) for will display event.")
 
                             if !hasResumed {
                                 hasResumed = true

--- a/Sources/MessagingPush/PushHandling/iOSPushEventListener.swift
+++ b/Sources/MessagingPush/PushHandling/iOSPushEventListener.swift
@@ -20,6 +20,10 @@ class IOSPushEventListener: PushEventHandler {
         self.logger = logger
     }
 
+    var identifier: String {
+        "Cio.iOSPushEventListener"
+    }
+
     func onPushAction(_ pushAction: PushNotificationAction, completionHandler: @escaping () -> Void) {
         guard let dateWhenPushDelivered = pushAction.push.deliveryDate else {
             logger.debug("[onPushAction] early exist due to missing deliveryDate for action: \(pushAction)")

--- a/Sources/MessagingPush/UserNotificationsFramework/Wrappers.swift
+++ b/Sources/MessagingPush/UserNotificationsFramework/Wrappers.swift
@@ -120,6 +120,10 @@ public struct UNNotificationWrapper: PushNotification {
 class UNUserNotificationCenterDelegateWrapper: PushEventHandler {
     private let delegate: UNUserNotificationCenterDelegate
 
+    var identifier: String {
+        String(describing: delegate)
+    }
+
     init(delegate: UNUserNotificationCenterDelegate) {
         self.delegate = delegate
     }

--- a/Sources/MessagingPush/UserNotificationsFramework/Wrappers.swift
+++ b/Sources/MessagingPush/UserNotificationsFramework/Wrappers.swift
@@ -117,8 +117,14 @@ public struct UNNotificationWrapper: PushNotification {
     }
 }
 
-class UNUserNotificationCenterDelegateWrapper: PushEventHandler {
+class UNUserNotificationCenterDelegateWrapper: PushEventHandler, CustomStringConvertible {
     private let delegate: UNUserNotificationCenterDelegate
+
+    var description: String {
+        let nestedDelegateDescription = String(describing: delegate)
+
+        return "Cio.NotificationCenterDelegateWrapper(\(nestedDelegateDescription))"
+    }
 
     var identifier: String {
         String(describing: delegate)
@@ -154,11 +160,5 @@ class UNUserNotificationCenterDelegateWrapper: PushEventHandler {
         if delegateGotCalled == nil { // delegate did not implement this optional method. Call the completionHandler for them.
             completionHandler(false)
         }
-    }
-}
-
-extension UNUserNotificationCenterDelegateWrapper: CustomStringConvertible {
-    var description: String {
-        String(describing: delegate)
     }
 }

--- a/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
@@ -562,7 +562,45 @@ class PushEventHandlerMock: PushEventHandler, Mock {
         Mocks.shared.add(mock: self)
     }
 
+    /**
+     When setter of the property called, the value given to setter is set here.
+     When the getter of the property called, the value set here will be returned. Your chance to mock the property.
+     */
+    var underlyingIdentifier: String!
+    /// `true` if the getter or setter of property is called at least once.
+    var identifierCalled: Bool {
+        identifierGetCalled || identifierSetCalled
+    }
+
+    /// `true` if the getter called on the property at least once.
+    var identifierGetCalled: Bool {
+        identifierGetCallsCount > 0
+    }
+
+    var identifierGetCallsCount = 0
+    /// `true` if the setter called on the property at least once.
+    var identifierSetCalled: Bool {
+        identifierSetCallsCount > 0
+    }
+
+    var identifierSetCallsCount = 0
+    /// The mocked property with a getter and setter.
+    var identifier: String {
+        get {
+            mockCalled = true
+            identifierGetCallsCount += 1
+            return underlyingIdentifier
+        }
+        set(value) {
+            mockCalled = true
+            identifierSetCallsCount += 1
+            underlyingIdentifier = value
+        }
+    }
+
     public func resetMock() {
+        identifierGetCallsCount = 0
+        identifierSetCallsCount = 0
         onPushActionCallsCount = 0
         onPushActionReceivedArguments = nil
         onPushActionReceivedInvocations = []

--- a/Tests/MessagingPush/Core/IntegrationTest.swift
+++ b/Tests/MessagingPush/Core/IntegrationTest.swift
@@ -26,4 +26,12 @@ open class IntegrationTest: UnitTest {
 
         return MessagingPush.shared
     }
+
+    // Create new mock instance and setup with set of defaults.
+    func getNewPushEventHandler() -> PushEventHandlerMock {
+        let newInstance = PushEventHandlerMock()
+        // We expect that each instance has it's own unique identifier.
+        newInstance.underlyingIdentifier = .random
+        return newInstance
+    }
 }

--- a/Tests/MessagingPush/PushHandling/AutomaticPushClickedIntegrationTest.swift
+++ b/Tests/MessagingPush/PushHandling/AutomaticPushClickedIntegrationTest.swift
@@ -73,7 +73,7 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
     func test_givenOtherPushHandlers_givenClickedOnCioPush_expectPushClickHandledByCioSdk() {
         let expectOtherClickHandlerToGetCallback = expectation(description: "Receive a callback")
 
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
         givenOtherPushHandler.onPushActionClosure = { _, onComplete in
             expectOtherClickHandlerToGetCallback.fulfill()
             onComplete()
@@ -90,7 +90,7 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
 
     func test_givenOtherPushHandlers_givenClickedOnPushNotSentFromCio_expectPushClickHandledByOtherHandler() {
         let givenPush = PushNotificationStub.getPushNotSentFromCIO()
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
 
         let expectOtherClickHandlerHandlesPush = expectation(description: "Other push handler should handle push.")
         givenOtherPushHandler.onPushActionClosure = { _, onComplete in
@@ -108,21 +108,17 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
 
     // Important to test that 2+ 3rd party push handlers for some use cases.
     func test_givenMultiplePushHandlers_givenClickedOnCioPush_expectPushClickHandledByCioSdk() {
-        let expectOtherPushHandlersCalled = expectation(description: "Receive a callback")
-        expectOtherPushHandlersCalled.expectedFulfillmentCount = 2
+        let expectHandler1Called = expectation(description: "Receive a callback")
+        let expectHandler2Called = expectation(description: "Receive a callback")
 
-        // In order to add 2+ push handlers to SDK, each class needs to have a unique name.
-        // The SDK only accepts unique push event handlers. Creating this class makes each push handler unique.
-        class PushEventHandlerMock2: PushEventHandlerMock {}
-
-        let givenOtherPushHandler1 = PushEventHandlerMock()
-        let givenOtherPushHandler2 = PushEventHandlerMock2()
+        let givenOtherPushHandler1 = getNewPushEventHandler()
+        let givenOtherPushHandler2 = getNewPushEventHandler()
         givenOtherPushHandler1.onPushActionClosure = { _, onComplete in
-            expectOtherPushHandlersCalled.fulfill()
+            expectHandler1Called.fulfill()
             onComplete()
         }
         givenOtherPushHandler2.onPushActionClosure = { _, onComplete in
-            expectOtherPushHandlersCalled.fulfill()
+            expectHandler2Called.fulfill()
             onComplete()
         }
         addOtherPushEventHandler(givenOtherPushHandler1)
@@ -144,7 +140,7 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
     func test_givenMultiplePushHandlers_givenClickedOnCioPush_givenOtherPushHandlerDoesNotCallCompletionHandler_expectCompletionHandlerDoesNotGetCalled() {
         let expectOtherClickHandlerToGetCallback = expectation(description: "Receive a callback")
         let givenPush = PushNotificationStub.getPushSentFromCIO()
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
 
         givenOtherPushHandler.onPushActionClosure = { _, _ in
             // Do not call completion handler.
@@ -163,7 +159,7 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
 
     func test_givenMultiplePushHandlers_givenClickedOnCioPush_givenOtherPushHandlerCallsCompletionHandler_expectCioSdkHandlesPush() {
         let givenPush = PushNotificationStub.getPushSentFromCIO()
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
         givenOtherPushHandler.onPushActionClosure = { _, onComplete in
             onComplete()
         }
@@ -189,7 +185,7 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
 
     func test_onPushAction_givenMultiplePushClickHandlers_simulateFcmSdkSwizzlingBehavior_expectNoInfiniteLoop() {
         let givenPush = PushNotificationStub.getPushNotSentFromCIO()
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
         let givenPushClickAction = PushNotificationActionStub(push: givenPush, didClickOnPush: true)
 
         let expectOtherClickHandlerHandlesPush = expectation(description: "Other push handler should handle push.")
@@ -211,7 +207,7 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
 
     func test_shouldDisplayPushAppInForeground_givenMultiplePushClickHandlers_simulateFcmSdkSwizzlingBehavior_expectNoInfiniteLoop() {
         let givenPush = PushNotificationStub.getPushNotSentFromCIO()
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
 
         let expectOtherClickHandlerHandlesPush = expectation(description: "Other push handler should handle push.")
         expectOtherClickHandlerHandlesPush.expectedFulfillmentCount = 1 // the other push click handler should only be called once, indicating an infinite loop is not created.
@@ -242,7 +238,7 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
 
     func test_onPushAction_givenMultiplePushClickHandlers_thirdPartySdkCallsCompletionHandlerTwice_expectSdkDoesNotCrash() {
         let givenPush = PushNotificationStub.getPushNotSentFromCIO()
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
         let givenPushClickAction = PushNotificationActionStub(push: givenPush, didClickOnPush: true)
 
         let expectOtherClickHandlerHandlesPush = expectation(description: "Other push handler should handle push.")
@@ -264,7 +260,7 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
 
     func test_shouldDisplayPushAppInForeground_givenMultiplePushClickHandlers_thirdPartySdkCallsCompletionHandlerTwice_expectSdkDoesNotCrash() {
         let givenPush = PushNotificationStub.getPushNotSentFromCIO()
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
 
         let expectOtherClickHandlerHandlesPush = expectation(description: "Other push handler should handle push.")
         expectOtherClickHandlerHandlesPush.expectedFulfillmentCount = 1 // the other push click handler should only be called once, indicating an infinite loop is not created.
@@ -296,7 +292,7 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
     func test_givenClickOnLocalPush_expectOtherClickHandlerHandlesClickEvent() {
         let givenLocalPush = PushNotificationStub.getLocalPush(pushId: .random)
 
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
         let expectOtherClickHandlerHandlesPush = expectation(description: "Other push handler should handle push.")
         expectOtherClickHandlerHandlesPush.expectedFulfillmentCount = 1
         givenOtherPushHandler.onPushActionClosure = { _, onComplete in
@@ -316,7 +312,7 @@ class AutomaticPushClickedIntegrationTest: IntegrationTest {
         let givenLocalPush = PushNotificationStub.getLocalPush(pushId: givenHardCodedPushId)
         let givenSecondLocalPush = PushNotificationStub.getLocalPush(pushId: givenHardCodedPushId)
 
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
         let expectOtherClickHandlerHandlesPush = expectation(description: "Other push handler should handle push.")
         expectOtherClickHandlerHandlesPush.expectedFulfillmentCount = 2 // Expect click handler to be able to handle both pushes, because each push is unique.
         givenOtherPushHandler.onPushActionClosure = { _, onComplete in

--- a/Tests/MessagingPush/PushHandling/AutomaticPushDeliveredAppInForegroundTest.swift
+++ b/Tests/MessagingPush/PushHandling/AutomaticPushDeliveredAppInForegroundTest.swift
@@ -54,7 +54,7 @@ class AutomaticPushDeliveredAppInForegrondTest: IntegrationTest {
         let givenPush = PushNotificationStub.getPushNotSentFromCIO()
         var otherPushHandlerCalled = false
 
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
         givenOtherPushHandler.shouldDisplayPushAppInForegroundClosure = { _, onComplete in
             otherPushHandlerCalled = true
 
@@ -72,7 +72,7 @@ class AutomaticPushDeliveredAppInForegrondTest: IntegrationTest {
         let givenPush = PushNotificationStub.getPushSentFromCIO()
         let expectOtherPushHandlerCallbackCalled = expectation(description: "Expect other push handler callback called")
 
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
         givenOtherPushHandler.shouldDisplayPushAppInForegroundClosure = { _, onComplete in
             // We expect that other push handler gets callback of push event from CIO push
             expectOtherPushHandlerCallbackCalled.fulfill()
@@ -97,12 +97,8 @@ class AutomaticPushDeliveredAppInForegrondTest: IntegrationTest {
         let expectOtherPushHandlerCallbackCalled = expectation(description: "Expect other push handler callback called")
         expectOtherPushHandlerCallbackCalled.expectedFulfillmentCount = 2
 
-        // In order to add 2+ push handlers to SDK, each class needs to have a unique name.
-        // The SDK only accepts unique push event handlers. Creating this class makes each push handler unique.
-        class PushEventHandlerMock2: PushEventHandlerMock {}
-
-        let givenOtherPushHandler1 = PushEventHandlerMock()
-        let givenOtherPushHandler2 = PushEventHandlerMock2()
+        let givenOtherPushHandler1 = getNewPushEventHandler()
+        let givenOtherPushHandler2 = getNewPushEventHandler()
         givenOtherPushHandler1.shouldDisplayPushAppInForegroundClosure = { _, onComplete in
             expectOtherPushHandlerCallbackCalled.fulfill()
 
@@ -128,7 +124,7 @@ class AutomaticPushDeliveredAppInForegrondTest: IntegrationTest {
 
         let expectOtherClickHandlerToGetCallback = expectation(description: "Receive a callback")
         let givenPush = PushNotificationStub.getPushSentFromCIO()
-        let givenOtherPushHandler = PushEventHandlerMock()
+        let givenOtherPushHandler = getNewPushEventHandler()
 
         givenOtherPushHandler.shouldDisplayPushAppInForegroundClosure = { _, _ in
             // Do not call completion handler.

--- a/Tests/MessagingPush/PushHandling/PushEventHandlerProxyTest.swift
+++ b/Tests/MessagingPush/PushHandling/PushEventHandlerProxyTest.swift
@@ -3,7 +3,7 @@ import Foundation
 import SharedTests
 import XCTest
 
-class PushEventHandlerProxyTest: UnitTest {
+class PushEventHandlerProxyTest: IntegrationTest {
     private var proxy: PushEventHandlerProxyImpl!
 
     override func setUp() {
@@ -12,13 +12,47 @@ class PushEventHandlerProxyTest: UnitTest {
         proxy = PushEventHandlerProxyImpl(logger: log)
     }
 
+    // MARK: addPushEventHandler
+
+    func test_addPushEventHandler_givenMultipleNotificationCenterDelegateWrapperClasses_expectSaveBothDelegates() {
+        class Delegate1: NSObject, UNUserNotificationCenterDelegate {}
+        class Delegate2: NSObject, UNUserNotificationCenterDelegate {}
+
+        XCTAssertEqual(proxy.nestedDelegates.count, 0)
+        proxy.addPushEventHandler(UNUserNotificationCenterDelegateWrapper(delegate: Delegate1()))
+        XCTAssertEqual(proxy.nestedDelegates.count, 1)
+        proxy.addPushEventHandler(UNUserNotificationCenterDelegateWrapper(delegate: Delegate2()))
+        XCTAssertEqual(proxy.nestedDelegates.count, 2)
+    }
+
+    func test_addPushEventHandler_givenIdenticalNotificationCenterDelegates_expectSaveOnly1Delegate() {
+        class Delegate: NSObject, UNUserNotificationCenterDelegate {}
+
+        let instance = Delegate()
+
+        XCTAssertEqual(proxy.nestedDelegates.count, 0)
+        proxy.addPushEventHandler(UNUserNotificationCenterDelegateWrapper(delegate: instance))
+        XCTAssertEqual(proxy.nestedDelegates.count, 1)
+        proxy.addPushEventHandler(UNUserNotificationCenterDelegateWrapper(delegate: instance))
+        XCTAssertEqual(proxy.nestedDelegates.count, 1)
+    }
+
+    func test_addPushEventHandler_givenNewInstancesSameObjectNotificationCenterDelegateWrappers_expectSaveBothDelegate() {
+        class Delegate: NSObject, UNUserNotificationCenterDelegate {}
+
+        XCTAssertEqual(proxy.nestedDelegates.count, 0)
+        proxy.addPushEventHandler(UNUserNotificationCenterDelegateWrapper(delegate: Delegate()))
+        XCTAssertEqual(proxy.nestedDelegates.count, 1)
+        proxy.addPushEventHandler(UNUserNotificationCenterDelegateWrapper(delegate: Delegate()))
+        XCTAssertEqual(proxy.nestedDelegates.count, 2)
+    }
+
     // MARK: thread safety
 
     func test_onPushAction_ensureThreadSafetyCallingDelegates() {
         runTest(numberOfTimes: 100) { // Ensure no race conditions by running test many times.
-            let delegate1 = PushEventHandlerMock()
-            class PushEventHandlerMock2: PushEventHandlerMock {}
-            let delegate2 = PushEventHandlerMock2()
+            let delegate1 = getNewPushEventHandler()
+            let delegate2 = getNewPushEventHandler()
 
             let expectDelegatesReceiveEvent = expectation(description: "delegate1 received event")
             expectDelegatesReceiveEvent.expectedFulfillmentCount = 2 // 1 for each delegate. We do not care what order the delegates get called as long as all get called.
@@ -57,9 +91,8 @@ class PushEventHandlerProxyTest: UnitTest {
         runTest(numberOfTimes: 100) { // Ensure no race conditions by running test many times.
             let givenPush = PushNotificationStub.getPushSentFromCIO()
 
-            let delegate1 = PushEventHandlerMock()
-            class PushEventHandlerMock2: PushEventHandlerMock {}
-            let delegate2 = PushEventHandlerMock2()
+            let delegate1 = getNewPushEventHandler()
+            let delegate2 = getNewPushEventHandler()
 
             let expectDelegatesReceiveEvent = expectation(description: "delegate1 received event")
             expectDelegatesReceiveEvent.expectedFulfillmentCount = 2 // 1 for each delegate. We do not care what order the delegates get called as long as all get called.
@@ -114,7 +147,7 @@ class PushEventHandlerProxyTest: UnitTest {
         let push = PushNotificationStub.getPushSentFromCIO()
         var actual: Bool!
 
-        let handler = PushEventHandlerMock()
+        let handler = getNewPushEventHandler()
         handler.shouldDisplayPushAppInForegroundClosure = { _, onComplete in
             onComplete(true)
         }
@@ -138,7 +171,7 @@ class PushEventHandlerProxyTest: UnitTest {
 
         // First, test that `false` is the default return result.
 
-        let handler1 = PushEventHandlerMock()
+        let handler1 = getNewPushEventHandler()
         handler1.shouldDisplayPushAppInForegroundClosure = { _, onComplete in
             onComplete(false)
         }
@@ -155,8 +188,7 @@ class PushEventHandlerProxyTest: UnitTest {
 
         // Next, add another push handler that's return result is `true`.
         // We expect return result to now be `true`, since 1 handler returned `true`.
-        class PushEventHandlerMock2: PushEventHandlerMock {}
-        let handler2 = PushEventHandlerMock2()
+        let handler2 = getNewPushEventHandler()
         handler2.shouldDisplayPushAppInForegroundClosure = { _, onComplete in
             onComplete(true)
         }
@@ -171,8 +203,7 @@ class PushEventHandlerProxyTest: UnitTest {
         XCTAssertTrue(actual)
 
         // Finally, check that once 1 handler returns `true`, the return result is always `true`.
-        class PushEventHandlerMock3: PushEventHandlerMock {}
-        let handler3 = PushEventHandlerMock3()
+        let handler3 = getNewPushEventHandler()
         handler3.shouldDisplayPushAppInForegroundClosure = { _, onComplete in
             onComplete(false)
         }


### PR DESCRIPTION
https://linear.app/customerio/issue/MBL-383/[bug]-customer-unable-to-handle-push-notification-event-on-ios-with

(This PR is identical to the one merged into v2: https://github.com/customerio/customerio-ios/pull/743)

Summary of bug: The iOS SDK had a bug where it was only able to store 1 3rd party push click handing SDK and ignore others that were installed. After this fix, all 3rd party SDKs installed in the app are called for push events in the app.

Testing: 
* Automated tests in this PR reproduce the bug and confirm the bug has been fixed. 
* I tested this in FCM sample app. See [this follow-up PR](https://github.com/customerio/customerio-ios/pull/752) to learn how I tested this. 