### PR TITLE
ci: fix flaky test suite runs on CI

### DIFF
--- a/.github/actions/setup-ios/action.yml
+++ b/.github/actions/setup-ios/action.yml
@@ -7,4 +7,4 @@ runs:
   - name: Install XCode 
     uses: maxim-lobanov/setup-xcode@v1
     with:
-      xcode-version: "15"
+      xcode-version: "15.3"


### PR DESCRIPTION
I've noticed that our test suite has become flaky and now takes an hour to run instead of the usual 5 minutes. This started with the release of Xcode 15.4. Our CI is set to use the latest major version, so it switched to 15.4 automatically. Other developers online have reported similar issues with 15.4. Reverting to Xcode 15.3, which was stable for us, seems like a good workaround to stabilize our CI.