### PR TITLE
test: refactor tests to use 1 enginewebproviderstub

### DIFF
--- a/Tests/MessagingInApp/EngineWeb/EngineWebProviderStub.swift
+++ b/Tests/MessagingInApp/EngineWeb/EngineWebProviderStub.swift
@@ -3,21 +3,6 @@ import Foundation
 import UIKit
 
 class EngineWebProviderStub: EngineWebProvider {
-    let engineWebMock: EngineWebInstance
-
-    init(engineWebMock: EngineWebInstance) {
-        self.engineWebMock = engineWebMock
-    }
-
-    func getEngineWebInstance(configuration: EngineWebConfiguration) -> EngineWebInstance {
-        engineWebMock
-    }
-}
-
-// In order to test multiple instances of inline Views, you need to create multiple separate EngineWebInstance instances for each View instance.
-// This is a new stub that allows this.
-// A follow-up refactor that makes this stub the default would be a good chance to the test suite.
-class EngineWebProviderStub2: EngineWebProvider {
     func getEngineWebInstance(configuration: EngineWebConfiguration) -> EngineWebInstance {
         let newMock = EngineWebInstanceMock()
 

--- a/Tests/MessagingInApp/Views/InAppMessageViewTest.swift
+++ b/Tests/MessagingInApp/Views/InAppMessageViewTest.swift
@@ -4,17 +4,13 @@ import Foundation
 import SharedTests
 import XCTest
 
-class InAppMessageViewTest: UnitTest {
+class InAppMessageViewTest: IntegrationTest {
     private let queueMock = MessageQueueManagerMock()
-    private var engineProvider: EngineWebProviderStub2!
 
     override func setUp() {
         super.setUp()
 
-        engineProvider = EngineWebProviderStub2()
-
         DIGraphShared.shared.override(value: queueMock, forType: MessageQueueManager.self)
-        DIGraphShared.shared.override(value: engineProvider, forType: EngineWebProvider.self)
     }
 
     // MARK: View constructed
@@ -402,30 +398,6 @@ extension InAppMessageViewTest {
     // Tells you the message the Inline View is either rendering or has already rendered.
     func getInAppMessage(forView view: InAppMessageView) -> Message? {
         getInAppMessageWebView(fromInlineView: view)?.message
-    }
-
-    func onCloseActionButtonPressed(onInlineView inlineView: InAppMessageView) async {
-        // Triggering the close button from the web engine simulates the user tapping the close button on the in-app WebView.
-        // This behaves more like an integration test because we are also able to test the message manager, too.
-        getWebEngineForInlineView(inlineView)?.delegate?.tap(name: "", action: GistMessageActions.close.rawValue, system: false)
-
-        // When onCloseAction() is called on the inline View, it adds a task to the main thread queue. Our test wants to wait until this task is done running.
-        await waitForMainThreadToFinishPendingTasks()
-    }
-
-    // Call when the in-app webview rendering process has finished.
-    func onDoneRenderingInAppMessage(_ message: Message, insideOfInlineView inlineView: InAppMessageView, heightOfRenderedMessage: CGFloat = 100, widthOfRenderedMessage: CGFloat = 100) async {
-        // The engine is like a HTTP layer in that it calls the Gist web server to get back rendered in-app messages.
-        // To mock the web server call with a successful response back, call these delegate functions:
-        getWebEngineForInlineView(inlineView)?.delegate?.routeLoaded(route: message.templateId)
-        getWebEngineForInlineView(inlineView)?.delegate?.sizeChanged(width: widthOfRenderedMessage, height: heightOfRenderedMessage)
-
-        // When sizeChanged() is called on the inline View, it adds a task to the main thread queue. Our test wants to wait until this task is done running.
-        await waitForMainThreadToFinishPendingTasks()
-    }
-
-    func getWebEngineForInlineView(_ view: InAppMessageView) -> EngineWebInstance? {
-        view.inlineMessageManager?.engine
     }
 
     func getInAppMessageWebView(fromInlineView view: InAppMessageView) -> GistView? {


### PR DESCRIPTION
Follow-up to resolve [this PR suggestion](https://github.com/customerio/customerio-ios/pull/756/files#r1661294641). 

The `EngineWebProviderStub` allows us to mock events that happen to in-app message WebViews in our tests. The previous stub only allowed us to call mocks on 1 instance of a inline View object. The new stub allows us to call mocks on 2+ separate instances. 

This PR is a refactor to the test suite that uses the new `EngineWebProviderStub` instance. This PR should not modify any logic or test functions. It should be purely a refactor. 