### PR TITLE
chore: add animations and activity indicator while rendering next message

### DIFF
--- a/Sources/MessagingInApp/Views/InAppMessageView.swift
+++ b/Sources/MessagingInApp/Views/InAppMessageView.swift
@@ -158,7 +158,7 @@ public class InAppMessageView: UIView {
                 activityIndicator.heightAnchor.constraint(equalTo: heightAnchor)
             ])
 
-            animateCrossFade(fromView: currentlyDisplayedInAppWebView, toView: activityIndicator) {
+            animateFadeInOutInlineView(fromView: currentlyDisplayedInAppWebView, toView: activityIndicator) {
                 // After animation is over, cleanup resources and begin rendering of the next message.
                 self.stopShowingMessageAndCleanup()
                 self.beginShowing(message: message)
@@ -233,7 +233,7 @@ public class InAppMessageView: UIView {
     }
 
     // Takes in 2 Views. In 1 single animation, fades in 1 View while fading out the other.
-    private func animateCrossFade(fromView: UIView, toView: UIView, onComplete: (() -> Void)?) {
+    private func animateFadeInOutInlineView(fromView: UIView, toView: UIView, onComplete: (() -> Void)?) {
         runningCrossFadeAnimation?.stopAnimation(true) // cancel previous fade animation if there is one to assert this one will be called.
 
         // Set an initial state for `toView` to begin the animation. Make sure the View is not hidden and is fully opaque.
@@ -270,7 +270,7 @@ extension InAppMessageView: InlineMessageManagerDelegate {
             self.animateHeight(to: height)
 
             if let messageRenderingLoadingView = self.messageRenderingLoadingView {
-                animateCrossFade(fromView: messageRenderingLoadingView, toView: inAppMessageView) {
+                animateFadeInOutInlineView(fromView: messageRenderingLoadingView, toView: inAppMessageView) {
                     messageRenderingLoadingView.removeFromSuperview()
                 }
             }

--- a/Sources/MessagingInApp/Views/InAppMessageView.swift
+++ b/Sources/MessagingInApp/Views/InAppMessageView.swift
@@ -46,6 +46,15 @@ public class InAppMessageView: UIView {
     var previouslyShownMessages: [Message] = []
 
     var runningHeightChangeAnimation: UIViewPropertyAnimator?
+    var runningCrossFadeAnimation: UIViewPropertyAnimator?
+
+    var messageRenderingLoadingView: UIView? {
+        subviews.first { $0 is UIActivityIndicatorView }
+    }
+
+    var inAppMessageView: UIView? {
+        subviews.first { $0 == inlineMessageManager?.inlineMessageView }
+    }
 
     var inlineMessageManager: InlineMessageManager?
 
@@ -116,13 +125,44 @@ public class InAppMessageView: UIView {
             return // already showing this message, exit early.
         }
 
-        stopShowingMessageAndCleanup()
+        // If a different message is currently being shown, we want to replace the currently shown message with new message.
+        if let currentlyDisplayedInAppWebView = inlineMessageManager?.inlineMessageView, messageRenderingLoadingView == nil {
+            // To provide the user with feedback indicating a new message is being rendered, show an activity indicator while the new message is loading.
+            let activityIndicator = UIActivityIndicatorView(style: .large)
+            activityIndicator.startAnimating()
+            activityIndicator.isHidden = true // start hidden so when we add the subview, it does not cause a flicker in the UI. Wait to show it when the animation begins.
 
+            addSubview(activityIndicator)
+            assert(messageRenderingLoadingView != nil, "Expect activity indicator to be added as a subview")
+
+            // Set autolayout constraints to position the activity indicator.
+            activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                activityIndicator.centerXAnchor.constraint(equalTo: centerXAnchor),
+                activityIndicator.centerYAnchor.constraint(equalTo: centerYAnchor),
+                activityIndicator.widthAnchor.constraint(equalTo: widthAnchor),
+                activityIndicator.heightAnchor.constraint(equalTo: heightAnchor)
+            ])
+
+            animateCrossFade(fromView: currentlyDisplayedInAppWebView, toView: activityIndicator) {
+                // After animation is over, cleanup resources and begin rendering of the next message.
+                self.stopShowingMessageAndCleanup()
+                self.beginShowing(message: message)
+            }
+        } else {
+            beginShowing(message: message)
+        }
+    }
+
+    // Call when you want to begin the process of showing a new message.
+    private func beginShowing(message: Message) {
         // Create a new manager for this new message to display and then display the manager's WebView.
         let newInlineMessageManager = InlineMessageManager(siteId: gist.siteId, message: message)
         newInlineMessageManager.inlineMessageDelegate = self
 
         let inlineView = newInlineMessageManager.inlineMessageView
+        inlineView.isHidden = true // start hidden while the message renders. When complete, it will show the View.
+
         addSubview(inlineView)
 
         // Setup the WebView to be the same size as this View. When this View changes size, the WebView will change, too.
@@ -177,6 +217,28 @@ public class InAppMessageView: UIView {
 
         runningHeightChangeAnimation?.startAnimation()
     }
+
+    // Takes in 2 Views. In 1 single animation, fades in 1 View while fading out the other.
+    private func animateCrossFade(fromView: UIView, toView: UIView, onComplete: (() -> Void)?) {
+        runningCrossFadeAnimation?.stopAnimation(true) // cancel previous fade animation if there is one to assert this one will be called.
+
+        // Set an initial state for `toView` to begin the animation. Make sure the View is not hidden and is fully opaque.
+        toView.isHidden = false
+        toView.alpha = 0
+
+        // These are the final values that we are looking for after the animation.
+        runningCrossFadeAnimation = UIViewPropertyAnimator(duration: 0.1, curve: .linear, animations: {
+            fromView.alpha = 0
+            toView.alpha = 1
+        })
+
+        runningCrossFadeAnimation?.addCompletion { _ in
+            fromView.isHidden = true
+            onComplete?()
+        }
+
+        runningCrossFadeAnimation?.startAnimation()
+    }
 }
 
 extension InAppMessageView: InlineMessageManagerDelegate {
@@ -185,7 +247,19 @@ extension InAppMessageView: InlineMessageManagerDelegate {
         Task { @MainActor in // only update UI on main thread. This delegate function may not get called from UI thread.
             // We keep the width the same to what the customer set it as.
             // Update the height to match the aspect ratio of the web content.
+
+            guard let inAppMessageView = self.inAppMessageView else {
+                return
+            }
+
+            inAppMessageView.isHidden = false
             self.animateHeight(to: height)
+
+            if let messageRenderingLoadingView = self.messageRenderingLoadingView {
+                animateCrossFade(fromView: messageRenderingLoadingView, toView: inAppMessageView) {
+                    messageRenderingLoadingView.removeFromSuperview()
+                }
+            }
         }
     }
 


### PR DESCRIPTION
https://linear.app/customerio/issue/MBL-313/after-close-action-pressed-replace-in-app-message-with-next-in-queue

### Problem: 
As a marketer, I want to display another in-app message inline when close button pressed so I can rotate between multiple in-app messages.

When you click close button and a new inline message needs to be displayed, it could take a couple seconds for renderer response. The transition between messages should be seamless and not disrupt the user experience.

### Solution: 
When the close button is pressed...
1. Fade out the currently shown in-app message while also fading in an iOS [Activity Indicator](https://developer.apple.com/design/human-interface-guidelines/progress-indicators). The height of the View remains the same as what the old in-app message's height was. 
2. Show the activity indicator while the next message is rendering. 
3. After rendering is done, fade out the activity indicator, fade in the next in-app message, and animate the height to match the new in-app message. 

Here is a demo of what this looks like in the UIKit sample app: 


https://github.com/customerio/customerio-ios/assets/2041082/7483321a-51a9-4520-bab4-f9c1564a347c



### Testing:
* Automated test suite should pass and not need any modifications since this is only adding animations between state changes. 
* Testing for this PR is entirely in sample app QA testing. [Test case added to Qase](https://app.qase.io/project/SM?previewMode=side&suite=112&case=1187).