### PR TITLE
fix: getting messages by elementId has a consistent Array order

### DIFF
--- a/Sources/MessagingInApp/Gist/Managers/Models/Message.swift
+++ b/Sources/MessagingInApp/Gist/Managers/Models/Message.swift
@@ -162,18 +162,23 @@ extension Array where Element == Message {
     func sortByMessagePriority() -> [Message] {
         sorted {
             switch ($0.priority, $1.priority) {
+            // Both messages have a priority, so we compare them.
             case (let priority0?, let priority1?):
-                // Both messages have a priority, so we compare them.
-
                 // if the messages do not have the same priority, sort by the priority.
                 if priority0 != priority1 {
                     return priority0 < priority1
                 }
 
-                // If messages have same priority, sort by something else to assert that the function return value is always the same no matter if the order of the input array is different.
+                // If messages have same priority, sort by something else to assert that the function return value has a consistent output order.
 
-                // Because the priorities are the same, it doesn't matter what message is next. Use a unique value to perform the comparison.
-                return $0.instanceId < $1.instanceId
+                // first try the id because it's set by the backend and is unique.
+                if let id0 = $0.id, let id1 = $1.id {
+                    return id0 < id1
+                }
+
+                // If the id values are nil, unfortunately, there is no other property of Messages that are consistent.
+
+                return $0.instanceId < $1.instanceId // fallback to instanceid which is unique, but are generated for each new instance of Message created.
             case (nil, _):
                 // The first message has no priority, it should be considered greater so that it ends up at the end of the sorted array.
                 return false

--- a/Tests/MessagingInApp/Extensions/GistExtensions.swift
+++ b/Tests/MessagingInApp/Extensions/GistExtensions.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 extension Message {
-    convenience init(messageId: String = .random, campaignId: String = .random, pageRule: String? = nil, queueId: String = .random, elementId: String? = nil, priority: Int? = nil) {
+    convenience init(messageId: String = .random, campaignId: String = .random, pageRule: String? = nil, queueId: String? = .random, elementId: String? = nil, priority: Int? = nil) {
         var gistProperties = [
             "campaignId": campaignId
         ]

--- a/Tests/MessagingInApp/Gist/Managers/MessageQueueManagerTest.swift
+++ b/Tests/MessagingInApp/Gist/Managers/MessageQueueManagerTest.swift
@@ -68,16 +68,22 @@ class MessageQueueManagerTest: UnitTest {
     func test_getInlineMessages_givenMessagesWithSamePriority_expectConsistentReturnValue() {
         let givenElementId = String.random
 
-        // Create multiple messages with the same priority.
-        let givenMessage1 = Message(elementId: givenElementId, priority: 1)
-        let givenMessage2 = Message(elementId: givenElementId, priority: 1)
-        let givenMessage3 = Message(elementId: givenElementId, priority: 1)
+        // Create multiple messages with the same priority. This means we need to use a different Message property to sort the Messages.
+        let givenMessage1 = Message(queueId: .random, elementId: givenElementId, priority: 1)
+        let givenMessage2 = Message(queueId: .random, elementId: givenElementId, priority: 1)
+        let givenMessage3 = Message(queueId: .random, elementId: givenElementId, priority: 1)
+
+        // Because queueId is optional, add some messages with a nil queueid to test the sorted order is still consistent.
+        let givenMessage4 = Message(queueId: nil, elementId: givenElementId, priority: 1)
+        let givenMessage5 = Message(queueId: nil, elementId: givenElementId, priority: 1)
 
         // Get the output 1 time to get a sample to compare against.
         manager.localMessageStore = [
             "1": givenMessage1,
             "2": givenMessage2,
-            "3": givenMessage3
+            "3": givenMessage3,
+            "4": givenMessage4,
+            "5": givenMessage5
         ]
         let expectedOrder = manager.getInlineMessages(forElementId: givenElementId)
 
@@ -93,6 +99,40 @@ class MessageQueueManagerTest: UnitTest {
 
             // We expect that the output order is always the same
             XCTAssertEqual(expectedOrder, manager.getInlineMessages(forElementId: givenElementId))
+        }
+    }
+
+    // we expect the messages returned are in the same order before and after a fetch is performed.
+    func test_getInlineMessages_expectConsistentReturnValueAfterFetch() {
+        let givenElementId = String.random
+
+        // Create multiple messages with the same priority. This means we need to use a different Message property to sort the Messages.
+        let givenMessageBeforeFetch1 = Message(queueId: .random, elementId: givenElementId, priority: 1)
+        let givenMessageBeforeFetch2 = Message(queueId: .random, elementId: givenElementId, priority: 1)
+        let givenMessageBeforeFetch3 = Message(queueId: .random, elementId: givenElementId, priority: 1)
+
+        // Get the output 1 time to get a sample to compare against.
+        manager.localMessageStore = [
+            "1": givenMessageBeforeFetch1,
+            "2": givenMessageBeforeFetch2,
+            "3": givenMessageBeforeFetch3
+        ]
+        let actualOrderBeforeFetch = manager.getInlineMessages(forElementId: givenElementId)
+
+        // Create new Message instances and assert that the output is always the same.
+        for _ in 0 ..< 100 {
+            let givenMessageAfterFetch1 = Message(queueId: givenMessageBeforeFetch1.id, elementId: givenElementId, priority: givenMessageBeforeFetch1.priority)
+            let givenMessageAfterFetch2 = Message(queueId: givenMessageBeforeFetch2.id, elementId: givenElementId, priority: givenMessageBeforeFetch2.priority)
+            let givenMessageAfterFetch3 = Message(queueId: givenMessageBeforeFetch3.id, elementId: givenElementId, priority: givenMessageBeforeFetch3.priority)
+
+            manager.localMessageStore = [
+                "1": givenMessageAfterFetch1,
+                "2": givenMessageAfterFetch2,
+                "3": givenMessageAfterFetch3
+            ]
+
+            // We expect that the output order is always the same
+            XCTAssertEqual(actualOrderBeforeFetch, manager.getInlineMessages(forElementId: givenElementId))
         }
     }
 


### PR DESCRIPTION
[linear.app/customerio/issue/MBL-313/after-close-action-pressed-replace-in-app-message-with-next-in-queue](https://linear.app/customerio/issue/MBL-313/after-close-action-pressed-replace-in-app-message-with-next-in-queue)

I was encountering a bug during sample app testing that resulted in the inline View randomly changing what message it was showing.

Reproduce steps:
* Send 2+ messages with same element id and priority to device
* Open app and wait until 1 inline View is in foreground and View is showing a message.
* Wait 10-60 seconds. You should notice that the inline View will randomly change to displaying the other message that you sent to the device, without you touching the screen.

Testing
* All logic tested from the added automated tests.
