### PR TITLE
fix: memory access error when constructing StringAnyEncodable instance

### DIFF
--- a/Sources/Common/Util/StringAnyEncodable.swift
+++ b/Sources/Common/Util/StringAnyEncodable.swift
@@ -1,10 +1,9 @@
 import Foundation
 
 public struct StringAnyEncodable: Encodable {
-    private let logger: Logger
     private let data: [String: AnyEncodable]
 
-    public init(logger: Logger, _ data: [String: Any]) {
+    public init(_ data: [String: Any]) {
         // Nested function to convert the ‘Any’ values to ‘AnyEncodable’ recursively
         func encode(value: Any) -> AnyEncodable? {
             switch value {
@@ -12,19 +11,16 @@ public struct StringAnyEncodable: Encodable {
                 return AnyEncodable(enc)
 
             case let dict as [String: Any]:
-                return AnyEncodable(StringAnyEncodable(logger: logger, dict))
+                return AnyEncodable(StringAnyEncodable(dict))
 
             case let list as [Any]:
                 // If the value is an array, recursively encode each element
                 return AnyEncodable(list.compactMap { encode(value: $0) })
 
             default:
-                logger.error("Tried to convert \(data) into [String: AnyEncodable] but the data type is not Encodable.")
                 return nil
             }
         }
-
-        self.logger = logger
         self.data = data.compactMapValues { encode(value: $0) }
     }
 

--- a/Sources/Tracking/CustomerIO.swift
+++ b/Sources/Tracking/CustomerIO.swift
@@ -382,7 +382,7 @@ public class CustomerIO: CustomerIOInstance {
         guard let logger = diGraph?.logger else {
             return
         }
-        automaticScreenView(name: name, data: StringAnyEncodable(logger: logger, data))
+        automaticScreenView(name: name, data: StringAnyEncodable(data))
     }
 
     // Designed to be called from swizzled methods for automatic screen tracking.

--- a/Sources/Tracking/CustomerIOImplementation.swift
+++ b/Sources/Tracking/CustomerIOImplementation.swift
@@ -161,7 +161,7 @@ class CustomerIOImplementation: CustomerIOInstance {
     }
 
     public func identify(identifier: String, body: [String: Any]) {
-        identify(identifier: identifier, body: StringAnyEncodable(logger: logger, body))
+        identify(identifier: identifier, body: StringAnyEncodable(body))
     }
 
     public func clearIdentify() {
@@ -195,11 +195,11 @@ class CustomerIOImplementation: CustomerIOInstance {
     }
 
     public func track(name: String, data: [String: Any]) {
-        track(name: name, data: StringAnyEncodable(logger: logger, data))
+        track(name: name, data: StringAnyEncodable(data))
     }
 
     public func screen(name: String, data: [String: Any]) {
-        screen(name: name, data: StringAnyEncodable(logger: logger, data))
+        screen(name: name, data: StringAnyEncodable(data))
     }
 
     public func screen<RequestBody: Encodable>(
@@ -255,7 +255,7 @@ class CustomerIOImplementation: CustomerIOInstance {
         deviceAttributesProvider.getDefaultDeviceAttributes { defaultDeviceAttributes in
             let deviceAttributes = defaultDeviceAttributes.mergeWith(customAttributes)
 
-            let encodableBody = StringAnyEncodable(logger: self.logger, deviceAttributes) // makes [String: Any] Encodable to use in JSON body.
+            let encodableBody = StringAnyEncodable(deviceAttributes) // makes [String: Any] Encodable to use in JSON body.
             let requestBody = RegisterDeviceRequest(device: Device(
                 token: deviceToken,
                 platform: deviceOsName,


### PR DESCRIPTION
Ticket: https://linear.app/customerio/issue/MBL-404/[bug]-rn-customer-having-ios-app-crash-randomly-when-setting-profile

Based on the stacktrace provided, there is a memory access error when multiple objects are trying to use logger instance. This commit is an attempt at fixing the issue by not passing the logger instance between multiple objects.