### PR TITLE
fix: memory access error when constructing StringAnyEncodable instance

### DIFF
--- a/Sources/Common/Util/StringAnyEncodable.swift
+++ b/Sources/Common/Util/StringAnyEncodable.swift
@@ -1,10 +1,9 @@
 import Foundation
 
 public struct StringAnyEncodable: Encodable {
-    private let logger: Logger
     private let data: [String: AnyEncodable]
 
-    public init(logger: Logger, _ data: [String: Any]) {
+    public init(_ data: [String: Any]) {
         // Nested function to convert the ‘Any’ values to ‘AnyEncodable’ recursively
         func encode(value: Any) -> AnyEncodable? {
             switch value {
@@ -12,19 +11,16 @@ public struct StringAnyEncodable: Encodable {
                 return AnyEncodable(enc)
 
             case let dict as [String: Any]:
-                return AnyEncodable(StringAnyEncodable(logger: logger, dict))
+                return AnyEncodable(StringAnyEncodable(dict))
 
             case let list as [Any]:
                 // If the value is an array, recursively encode each element
                 return AnyEncodable(list.compactMap { encode(value: $0) })
 
             default:
-                logger.error("Tried to convert \(data) into [String: AnyEncodable] but the data type is not Encodable.")
                 return nil
             }
         }
-
-        self.logger = logger
         self.data = data.compactMapValues { encode(value: $0) }
     }
 

--- a/Sources/Tracking/CustomerIO.swift
+++ b/Sources/Tracking/CustomerIO.swift
@@ -382,7 +382,7 @@ public class CustomerIO: CustomerIOInstance {
         guard let logger = diGraph?.logger else {
             return
         }
-        automaticScreenView(name: name, data: StringAnyEncodable(logger: logger, data))
+        automaticScreenView(name: name, data: StringAnyEncodable(data))
     }
 
     // Designed to be called from swizzled methods for automatic screen tracking.

--- a/Sources/Tracking/CustomerIOImplementation.swift
+++ b/Sources/Tracking/CustomerIOImplementation.swift
@@ -161,7 +161,7 @@ class CustomerIOImplementation: CustomerIOInstance {
     }
 
     public func identify(identifier: String, body: [String: Any]) {
-        identify(identifier: identifier, body: StringAnyEncodable(logger: logger, body))
+        identify(identifier: identifier, body: StringAnyEncodable(body))
     }
 
     public func clearIdentify() {
@@ -195,11 +195,11 @@ class CustomerIOImplementation: CustomerIOInstance {
     }
 
     public func track(name: String, data: [String: Any]) {
-        track(name: name, data: StringAnyEncodable(logger: logger, data))
+        track(name: name, data: StringAnyEncodable(data))
     }
 
     public func screen(name: String, data: [String: Any]) {
-        screen(name: name, data: StringAnyEncodable(logger: logger, data))
+        screen(name: name, data: StringAnyEncodable(data))
     }
 
     public func screen<RequestBody: Encodable>(
@@ -255,7 +255,7 @@ class CustomerIOImplementation: CustomerIOInstance {
         deviceAttributesProvider.getDefaultDeviceAttributes { defaultDeviceAttributes in
             let deviceAttributes = defaultDeviceAttributes.mergeWith(customAttributes)
 
-            let encodableBody = StringAnyEncodable(logger: self.logger, deviceAttributes) // makes [String: Any] Encodable to use in JSON body.
+            let encodableBody = StringAnyEncodable(deviceAttributes) // makes [String: Any] Encodable to use in JSON body.
             let requestBody = RegisterDeviceRequest(device: Device(
                 token: deviceToken,
                 platform: deviceOsName,

--- a/Tests/Common/Util/StringAnyEncodable.swift
+++ b/Tests/Common/Util/StringAnyEncodable.swift
@@ -31,7 +31,7 @@ class StringAnyEncodableTest: UnitTest {
 
         let data = ["fooBar": Unencodable(data: 12345)] as [String: Any]
 
-        let json = StringAnyEncodable(logger: log, data)
+        let json = StringAnyEncodable(data)
 
         guard let actual = jsonAdapter.toJson(json) else {
             XCTFail("couldn't encode to JSON")
@@ -46,7 +46,7 @@ class StringAnyEncodableTest: UnitTest {
 
         let data = ["fooBar": "bar"] as [String: String]
 
-        let json = StringAnyEncodable(logger: log, data)
+        let json = StringAnyEncodable(data)
 
         guard let actual = jsonAdapter.toJson(json) else {
             XCTFail("couldn't encode to JSON")
@@ -61,7 +61,7 @@ class StringAnyEncodableTest: UnitTest {
 
         let data = ["fooBar": 1.2] as [String: Double]
 
-        let json = StringAnyEncodable(logger: log, data)
+        let json = StringAnyEncodable(data)
 
         guard let actual = jsonAdapter.toJson(json) else {
             XCTFail("couldn't encode to JSON")
@@ -76,7 +76,7 @@ class StringAnyEncodableTest: UnitTest {
 
         let data = ["fooBar": ["bar": 1000] as [String: Int]] as [String: Any]
 
-        let json = StringAnyEncodable(logger: log, data)
+        let json = StringAnyEncodable(data)
 
         guard let actual = jsonAdapter.toJson(json) else {
             XCTFail("couldn't encode to JSON")
@@ -99,7 +99,7 @@ class StringAnyEncodableTest: UnitTest {
             "dictWithArray": ["color": ["Red", "Green", "Blue"]] as [String: [Any]]
         ] as [String: Any]
 
-        let json = StringAnyEncodable(logger: log, data)
+        let json = StringAnyEncodable(data)
 
         guard let actual = jsonAdapter.toJson(json) else {
             XCTFail("couldn't encode to JSON")

--- a/Tests/Tracking/CustomerIOImplementationTest.swift
+++ b/Tests/Tracking/CustomerIOImplementationTest.swift
@@ -334,7 +334,7 @@ class CustomerIOImplementationTest: UnitTest {
                 platform: "iOS",
                 lastUsed: dateUtilStub
                     .givenNow,
-                attributes: StringAnyEncodable(logger: log, givenDefaultAttributes)
+                attributes: StringAnyEncodable(givenDefaultAttributes)
             )
         ))
         XCTAssertEqual(actualQueueTaskData?.attributesJsonString, expectedJsonString)


### PR DESCRIPTION
Ticket: https://linear.app/customerio/issue/MBL-404/[bug]-rn-customer-having-ios-app-crash-randomly-when-setting-profile

The PR is an attempt to fix a bug reported to us. I recommending viewing the ticket for details of the issue, including the stacktrace of the crash. 

Based on the stacktrace provided to us, there is a memory access error when multiple objects are trying to use `logger` instance. Following the stacktrace, I believe that the logger instance is being garbage collected when the `StringAnyInstance` is no longer needed in `CustomerIOImplementation`. By restricting the `logger` instance to only the `CustomerIOImplementation` class, we are removing this scenario from being possible. 


