### PR TITLE
feat: persistent and non-persistent inline in-app messages

### DIFF
--- a/Sources/Common/Util/JsonAdapter.swift
+++ b/Sources/Common/Util/JsonAdapter.swift
@@ -59,17 +59,42 @@ public class JsonAdapter {
         self.log = log
     }
 
-    public func fromDictionary<T: Decodable>(_ dictionary: [AnyHashable: Any]) -> T? {
-        do {
-            let jsonData = try JSONSerialization.data(withJSONObject: dictionary)
+    // MARK: Dictionary to JSON
 
-            return fromJson(jsonData)
-        } catch {
-            log.error("\(error.localizedDescription), dictionary: \(dictionary)")
+    public func fromDictionary<T: Decodable>(_ dictionary: [AnyHashable: Any]) -> T? {
+        commonDecodeDictionary(dictionary)
+    }
+
+    public func fromDictionary<T: Decodable>(_ dictionary: [[AnyHashable: Any]]) -> T? {
+        commonDecodeDictionary(dictionary)
+    }
+
+    public func fromDictionary(_ dictionary: [AnyHashable: Any]) -> Data? {
+        commonDecodeDictionaryToData(dictionary)
+    }
+
+    public func fromDictionary(_ dictionary: [[AnyHashable: Any]]) -> Data? {
+        commonDecodeDictionaryToData(dictionary)
+    }
+
+    private func commonDecodeDictionary<T: Decodable>(_ dictionary: Any) -> T? {
+        guard let data = commonDecodeDictionaryToData(dictionary) else {
+            return nil
         }
 
+        return fromJson(data)
+    }
+
+    private func commonDecodeDictionaryToData(_ dictionary: Any) -> Data? {
+        do {
+            return try JSONSerialization.data(withJSONObject: dictionary)
+        } catch {
+            log.error("\(error.localizedDescription), object: \(dictionary)")
+        }
         return nil
     }
+
+    // MARK: JSON to Dictionary
 
     public func toDictionary<T: Encodable>(_ obj: T) -> [AnyHashable: Any]? {
         guard let data = toJson(obj) else {

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -8,7 +8,7 @@ protocol GistInstance: AutoMockable {
 }
 
 public class Gist: GistInstance, GistDelegate {
-    var shownModalMessageQueueIds: Set<String> = [] // all modal messages that have been shown in the app already.
+    var shownMessageQueueIds: Set<String> = [] // all messages that have been shown in the app already.
     var messageQueueManager: MessageQueueManager {
         DIGraphShared.shared.messageQueueManager
     }
@@ -135,16 +135,9 @@ public class Gist: GistInstance, GistDelegate {
     }
 
     func logMessageView(message: Message) {
-        // This function body reports metrics and makes sure that messages are not shown 2+ times.
-        // For inline messages, we have not yet implemented either of these features.
-        // Therefore, if the message is not a modal, exit early.
-        guard message.isModalMessage else {
-            return
-        }
-
         messageQueueManager.removeMessageFromLocalStore(message: message)
         if let id = message.id {
-            shownModalMessageQueueIds.insert(id)
+            shownMessageQueueIds.insert(id)
         }
         let userToken = UserManager().getUserToken()
         LogManager(siteId: siteId, dataCenter: dataCenter)

--- a/Sources/MessagingInApp/Gist/Managers/InlineMessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/InlineMessageManager.swift
@@ -48,6 +48,8 @@ class InlineMessageManager: MessageManager {
     }
 
     override func onCloseAction() {
+        super.onCloseAction()
+
         inlineMessageDelegate?.onCloseAction()
     }
 

--- a/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
@@ -68,7 +68,10 @@ class MessageManager {
 
     // Called when close action button pressed.
     func onCloseAction() {
-        // Expect subclass implements this.
+        // Common logic for all types of messages when a close button is pressed.
+        removePersistentMessage()
+
+        // subclass can override method and call super method.
     }
 
     // Called when a deep link action button was clicked in a message and the SDK opened the deep link.
@@ -84,6 +87,13 @@ class MessageManager {
     // Called when an action button is clicked and the action is to show a different in-app message.
     func onReplaceMessage(newMessageToShow: Message) {
         // subclass should implement
+    }
+
+    func removePersistentMessage() {
+        if currentMessage.gistProperties.persistent == true {
+            Logger.instance.debug(message: "Persistent message dismissed, logging view")
+            Gist.shared.logMessageView(message: currentMessage)
+        }
     }
 }
 

--- a/Sources/MessagingInApp/Gist/Managers/ModalMessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/ModalMessageManager.swift
@@ -51,15 +51,9 @@ class ModalMessageManager: MessageManager {
     }
 
     override func onCloseAction() {
-        removePersistentMessage()
-        dismissMessage()
-    }
+        super.onCloseAction()
 
-    func removePersistentMessage() {
-        if currentMessage.gistProperties.persistent == true {
-            Logger.instance.debug(message: "Persistent message dismissed, logging view")
-            Gist.shared.logMessageView(message: currentMessage)
-        }
+        dismissMessage()
     }
 
     func dismissMessage(completionHandler: (() -> Void)? = nil) {

--- a/Sources/MessagingInApp/Views/InAppMessageView.swift
+++ b/Sources/MessagingInApp/Views/InAppMessageView.swift
@@ -183,6 +183,9 @@ public class InAppMessageView: UIView {
         // Create a new manager for this new message to display and then display the manager's WebView.
         let newInlineMessageManager = InlineMessageManager(siteId: gist.siteId, message: message)
         newInlineMessageManager.inlineMessageDelegate = self
+
+        // Gist class is what Modal messages use as the modal message manager delegate.
+        // So we can re-use modal message logic, set the Gist class for inline managers, too.
         newInlineMessageManager.delegate = Gist.shared
 
         let inlineView = newInlineMessageManager.inlineMessageView

--- a/Sources/MessagingInApp/Views/InAppMessageView.swift
+++ b/Sources/MessagingInApp/Views/InAppMessageView.swift
@@ -183,6 +183,7 @@ public class InAppMessageView: UIView {
         // Create a new manager for this new message to display and then display the manager's WebView.
         let newInlineMessageManager = InlineMessageManager(siteId: gist.siteId, message: message)
         newInlineMessageManager.inlineMessageDelegate = self
+        newInlineMessageManager.delegate = Gist.shared
 
         let inlineView = newInlineMessageManager.inlineMessageView
         inlineView.isHidden = true // start hidden while the message renders. When complete, it will show the View.

--- a/Tests/MessagingInApp/Core/IntegrationTest.swift
+++ b/Tests/MessagingInApp/Core/IntegrationTest.swift
@@ -38,12 +38,100 @@ open class IntegrationTest: UnitTest {
             completionHandler(.success((body, response)))
         }
     }
+
+    // Given a list of messages, this function sets up a HTTP response for the fetch user queue request.
+    func setupMockFetchResponse(messagesFetched messages: [Message]) {
+        if messages.isEmpty {
+            setupHttpResponse(code: 200, body: "[]".data)
+            return
+        }
+
+        // Construct a JSON string that will become the HTTP response body.
+        // The format of the JSON is the same as what /api/v1/users endpoint returns from Gist backend.
+        //
+        // We are opting to construct JSON strings manually with a dictionary because the data types used for parsing HTTP response bodies, `UserQueueResponse`, is not easily able to inherit the `Codable` protocol because of `[String: Any]`.
+        //
+
+        /* Example JSON string to modal the dictionary off of:
+         [
+           {
+             "queueId": "e972deff-caa5-4b4c-be22-824fe323781d",
+             "messageId": "levi-load-page-button",
+             "priority": 5,
+             "properties": {
+               "gist": {
+                 "position": "center",
+                 "campaignId": "delivery-id-here",
+                 "elementId": "inline-element-id-here",
+                 "routeRuleAndroid": "^DO_NOT_DISPLAY_IN_APP$",
+                 "routeRuleApple": "^(.*Dashboard.*)$",
+                 "routeRuleWeb": "^DO_NOT_DISPLAY_IN_APP$"
+               },
+               "name": "okFNkDksSc@customer.io"
+             }
+           }
+         ]
+         */
+
+        var jsonResponseArray: [[String: Any]] = []
+
+        for message in messages {
+            var gistProperties: [String: Any] = ["elementId": message.elementId!]
+
+            if let campaignIdValue = message.gistProperties.campaignId {
+                gistProperties["campaignId"] = campaignIdValue
+            }
+            if let persistentValue = message.gistProperties.persistent {
+                gistProperties["persistent"] = persistentValue
+            }
+
+            let messageDict: [String: Any] = [
+                "queueId": message.id!,
+                "messageId": message.templateId,
+                "priority": message.priority ?? 0,
+                "properties": [
+                    "gist": gistProperties
+                ]
+            ]
+
+            jsonResponseArray.append(messageDict)
+        }
+
+        let jsonData = jsonAdapter.fromDictionary(jsonResponseArray)!
+
+        setupHttpResponse(code: 200, body: jsonData)
+    }
 }
 
 // MARK: utility functions for inline views
 
 @MainActor
 extension IntegrationTest {
+    // When testing inline Views, simulate a fetch of messages from Gist backend.
+    // Given list of messages to return from fetch request, the function will return after the inline View has been notified about this fetch and has processed it.
+    func simulateSdkFetchedMessages(_ messages: [Message], verifyInlineViewNotifiedOfFetch inlineView: InAppMessageView?) async {
+        let expectRefreshViewToBeCalled = expectation(description: "refreshViewToBeCalled")
+        expectRefreshViewToBeCalled.assertForOverFulfill = false
+
+        if let inlineView = inlineView {
+            inlineView.refreshViewListener = {
+                expectRefreshViewToBeCalled.fulfill()
+            }
+        } else {
+            expectRefreshViewToBeCalled.fulfill()
+        }
+
+        setupMockFetchResponse(messagesFetched: messages)
+
+        // Now that the mock is setup, tell the SDK to perform the fetch HTTP request
+        // swiftlint:disable:next force_cast
+        (diGraphShared.messageQueueManager as! MessageQueueManagerImpl).fetchUserMessages()
+
+        await fulfillment(of: [expectRefreshViewToBeCalled], timeout: 0.5)
+
+        inlineView?.refreshViewListener = nil
+    }
+
     func onCloseActionButtonPressed(onInlineView inlineView: InAppMessageView) async {
         // Triggering the close button from the web engine simulates the user tapping the close button on the in-app WebView.
         // This behaves more like an integration test because we are also able to test the message manager, too.
@@ -83,6 +171,21 @@ extension IntegrationTest {
 
 @MainActor
 extension IntegrationTest {
+    func onCustomActionButtonPressed(onInlineView inlineView: InAppMessageView) async {
+        // Triggering the custom action button on inline message from the web engine
+        // mocks the user tap on custom action button
+        getWebEngineForInlineView(inlineView)?.delegate?.tap(name: "", action: "Test", system: false)
+
+        // when a button is pressed, an eventbus event is posted for metrics tracking. Return function after the tracked event is posted.
+        await waitForEventBusEventsToPost()
+    }
+
+    func onDeepLinkActionButtonPressed(onInlineView inlineView: InAppMessageView, deeplink: String) {
+        // Triggering the custom action button on inline message from the web engine
+        // mocks the user tap on custom action button
+        getWebEngineForInlineView(inlineView)?.delegate?.tap(name: "", action: deeplink, system: true)
+    }
+
     func onCloseActionButtonPressedOnModal() async {
         // Triggering the close button from the web engine simulates the user tapping the close button on the in-app WebView.
         // This behaves more like an integration test because we are also able to test the message manager, too.

--- a/Tests/MessagingInApp/Extensions/GistExtensions.swift
+++ b/Tests/MessagingInApp/Extensions/GistExtensions.swift
@@ -2,10 +2,11 @@
 import Foundation
 
 extension Message {
-    convenience init(messageId: String = .random, campaignId: String = .random, pageRule: String? = nil, queueId: String = .random, elementId: String? = nil, priority: Int? = nil) {
+    convenience init(messageId: String = .random, campaignId: String = .random, pageRule: String? = nil, queueId: String = .random, elementId: String? = nil, priority: Int? = nil, persistent: Bool = false) {
         var gistProperties = [
-            "campaignId": campaignId
-        ]
+            "campaignId": campaignId,
+            "persistent": persistent
+        ] as [String: Any]
 
         if let elementId = elementId {
             gistProperties["elementId"] = elementId

--- a/Tests/MessagingInApp/MessagingInAppImplementationTest.swift
+++ b/Tests/MessagingInApp/MessagingInAppImplementationTest.swift
@@ -250,37 +250,6 @@ class MessagingInAppImplementationTest: IntegrationTest {
         XCTAssertEqual(eventBusHandlerMock.postEventCallsCount, 0)
     }
 
-    func test_inAppTracking_givenCustomAction_expectBQTrackInAppClicked() async {
-        // override event bus handler to mock it so we can capture events
-        diGraphShared.override(value: eventBusHandlerMock, forType: EventBusHandler.self)
-
-        await waitForExpectations(initializeModule())
-
-        let givenGistMessage = Message.random
-        let expectedInAppMessage = InAppMessage(gistMessage: givenGistMessage)
-        let givenCurrentRoute = String.random
-        let givenAction = String.random
-        let givenName = String.random
-        let givenMetaData = ["actionName": givenName, "actionValue": givenAction]
-
-        messagingInApp.action(
-            message: givenGistMessage,
-            currentRoute: givenCurrentRoute,
-            action: givenAction,
-            name: givenName
-        )
-
-        XCTAssertEqual(eventBusHandlerMock.postEventCallsCount, 1)
-        guard let postEventArgument = eventBusHandlerMock.postEventArguments as? TrackInAppMetricEvent else {
-            XCTFail("captured arguments must not be nil")
-            return
-        }
-
-        XCTAssertEqual(postEventArgument.deliveryID, expectedInAppMessage.deliveryId)
-        XCTAssertEqual(postEventArgument.event, InAppMetric.clicked.rawValue)
-        XCTAssertEqual(postEventArgument.params, givenMetaData)
-    }
-
     func test_dismissMessage_givenNoInAppMessage_expectNoError() async {
         await waitForExpectations(initializeModule())
 

--- a/Tests/MessagingInApp/Views/InAppMessageViewTest.swift
+++ b/Tests/MessagingInApp/Views/InAppMessageViewTest.swift
@@ -5,7 +5,6 @@ import SharedTests
 import XCTest
 
 class InAppMessageViewTest: IntegrationTest {
-    private let queueMock = MessageQueueManagerMock()
     private let engineWebMock = EngineWebInstanceMock()
     private let inlineMessageDelegateMock = InAppMessageViewActionDelegateMock()
     private let eventListenerMock = InAppEventListenerMock()
@@ -23,7 +22,9 @@ class InAppMessageViewTest: IntegrationTest {
 
         super.setUp()
 
-        DIGraphShared.shared.override(value: queueMock, forType: MessageQueueManager.self)
+        // Set a random user token so that the SDK can perform fetches for user messages.
+        UserManager().setUserToken(userToken: .random)
+
         DIGraphShared.shared.override(value: deeplinkUtilMock, forType: DeepLinkUtil.self)
 
         messagingInAppImplementation.setEventListener(eventListenerMock)
@@ -33,6 +34,8 @@ class InAppMessageViewTest: IntegrationTest {
 
     @MainActor
     func test_whenViewConstructedUsingStoryboards_expectCheckForMessagesToDisplay() {
+        let queueMock = setupQueueMock()
+
         let view = InAppMessageView(coder: EmptyNSCoder())!
 
         // We do not check messages until elementId is set.
@@ -51,6 +54,7 @@ class InAppMessageViewTest: IntegrationTest {
 
     @MainActor
     func test_whenViewConstructedUsingStoryboards_expectStartDismissedAfterConstructed() {
+        let queueMock = setupQueueMock()
         queueMock.getInlineMessagesReturnValue = []
 
         let view = InAppMessageView(coder: EmptyNSCoder())!
@@ -64,6 +68,7 @@ class InAppMessageViewTest: IntegrationTest {
 
     @MainActor
     func test_whenViewConstructedViaCode_expectCheckForMessagesToDisplay() {
+        let queueMock = setupQueueMock()
         let givenElementId = String.random
         queueMock.getInlineMessagesReturnValue = []
 
@@ -77,6 +82,7 @@ class InAppMessageViewTest: IntegrationTest {
 
     @MainActor
     func test_whenViewConstructedViaCode_expectStartDismissedAfterConstructed() {
+        let queueMock = setupQueueMock()
         queueMock.getInlineMessagesReturnValue = []
 
         let view = InAppMessageView(elementId: .random)
@@ -88,7 +94,7 @@ class InAppMessageViewTest: IntegrationTest {
 
     @MainActor
     func test_displayInAppMessage_givenNoMessageAvailable_expectDoNotDisplayAMessage() async {
-        queueMock.getInlineMessagesReturnValue = []
+        await simulateSdkFetchedMessages([], verifyInlineViewNotifiedOfFetch: nil)
 
         let inlineView = InAppMessageView(elementId: .random)
 
@@ -99,7 +105,7 @@ class InAppMessageViewTest: IntegrationTest {
     @MainActor
     func test_displayInAppMessage_givenMessageAvailable_expectDisplayMessage() async {
         let givenInlineMessage = Message.randomInline
-        queueMock.getInlineMessagesReturnValue = [givenInlineMessage]
+        await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
         let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
         await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: inlineView)
@@ -113,7 +119,8 @@ class InAppMessageViewTest: IntegrationTest {
     func test_displayInAppMessage_givenMultipleMessagesInQueue_expectDisplayFirstMessage() async {
         let givenElementId = String.random
         let givenInlineMessages = [Message(elementId: givenElementId), Message(elementId: givenElementId)]
-        queueMock.getInlineMessagesReturnValue = givenInlineMessages
+
+        await simulateSdkFetchedMessages(givenInlineMessages, verifyInlineViewNotifiedOfFetch: nil)
 
         let inlineView = InAppMessageView(elementId: givenElementId)
 
@@ -131,16 +138,17 @@ class InAppMessageViewTest: IntegrationTest {
 
     @MainActor
     func test_givenFirstFetchDoesNotContainAnyMessage_givenInAppMessageFetchedAfterViewConstructed_expectShowInAppMessageFetched() async {
+        let givenElementId = String.random
         // start with no messages available.
-        queueMock.getInlineMessagesReturnValue = []
+        await simulateSdkFetchedMessages([], verifyInlineViewNotifiedOfFetch: nil)
 
-        let view = InAppMessageView(elementId: .random)
+        let view = InAppMessageView(elementId: givenElementId)
         XCTAssertFalse(isInlineViewVisible(view))
         XCTAssertNil(getInAppMessage(forView: view)) // expect no message rendering.
 
         // Modify queue to return a message after the UI has been constructed and not showing a WebView.
-        let givenInlineMessage = Message.randomInline
-        await simulateSdkFetchedMessages([givenInlineMessage])
+        let givenInlineMessage = Message(elementId: givenElementId)
+        await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: view)
         XCTAssertEqual(getInAppMessage(forView: view), givenInlineMessage) // expect to begin rendering message
 
         await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: view)
@@ -152,6 +160,8 @@ class InAppMessageViewTest: IntegrationTest {
     // Test that the eventbus listening does not impact memory management of the View instance.
     @MainActor
     func test_deinit_givenObservingEventBusEvent_expectNoMemoryLeaks() {
+        let queueMock = setupQueueMock()
+
         // Before we try to deinit the View, make sure the eventbus observer has executed at least once.
         // This is important if the observer holds a strong reference to something preventing the View deinit.
         let expectToCheckIfInAppMessagesAvailableToDisplay = expectation(description: "expect to check for in-app messages")
@@ -176,13 +186,13 @@ class InAppMessageViewTest: IntegrationTest {
     @MainActor
     func test_givenAlreadyShowingMessage_whenSameMessageFetched_expectDoNotReloadTheMessageAgain() async {
         let givenInlineMessage = Message.randomInline
-        queueMock.getInlineMessagesReturnValue = [givenInlineMessage]
+        await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
         let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
 
         let webViewBeforeFetch = inlineView.inAppMessageView
 
-        await simulateSdkFetchedMessages([givenInlineMessage])
+        await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: inlineView)
 
         let webViewAfterFetch = inlineView.inAppMessageView
 
@@ -193,7 +203,7 @@ class InAppMessageViewTest: IntegrationTest {
     @MainActor
     func test_givenAlreadyShowingInAppMessage_whenNewMessageFetched_expectDoNotReplaceContents() async {
         let givenOldInlineMessage = Message.randomInline
-        queueMock.getInlineMessagesReturnValue = [givenOldInlineMessage]
+        await simulateSdkFetchedMessages([givenOldInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
         let inlineView = InAppMessageView(elementId: givenOldInlineMessage.elementId!)
         let webViewBeforeFetch = inlineView.inAppMessageView
@@ -201,7 +211,7 @@ class InAppMessageViewTest: IntegrationTest {
         // Make sure message is a new message, but has same elementId.
         let givenNewInlineMessage = Message(queueId: .random, elementId: givenOldInlineMessage.elementId)
 
-        await simulateSdkFetchedMessages([givenNewInlineMessage])
+        await simulateSdkFetchedMessages([givenNewInlineMessage], verifyInlineViewNotifiedOfFetch: inlineView)
 
         let webViewAfterFetch = inlineView.inAppMessageView
 
@@ -215,7 +225,7 @@ class InAppMessageViewTest: IntegrationTest {
     @MainActor
     func test_expiration_givenDisplayedMessageExpires_expectContinueShowingMessageUntilClose() async {
         let givenInlineMessage = Message.randomInline
-        queueMock.getInlineMessagesReturnValue = [givenInlineMessage]
+        await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
         let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
 
@@ -225,7 +235,7 @@ class InAppMessageViewTest: IntegrationTest {
         XCTAssertEqual(getInAppMessage(forView: inlineView), givenInlineMessage)
 
         // Simulate message expiration.
-        await simulateSdkFetchedMessages([])
+        await simulateSdkFetchedMessages([], verifyInlineViewNotifiedOfFetch: inlineView)
 
         // Expect still showing the same message as before the fetch call.
         XCTAssertTrue(isInlineViewVisible(inlineView))
@@ -241,7 +251,7 @@ class InAppMessageViewTest: IntegrationTest {
     func test_expiration_givenExpiredMessageNotYetDisplayed_expectDoNotDisplayMessage() async {
         let givenMessageDisplayed = Message(elementId: .random)
         let givenMessageThatExpires = Message(elementId: .random)
-        queueMock.getInlineMessagesReturnValue = [givenMessageDisplayed, givenMessageThatExpires]
+        await simulateSdkFetchedMessages([givenMessageDisplayed, givenMessageThatExpires], verifyInlineViewNotifiedOfFetch: nil)
 
         let inlineView = InAppMessageView(elementId: givenMessageDisplayed.elementId!)
 
@@ -251,7 +261,7 @@ class InAppMessageViewTest: IntegrationTest {
         XCTAssertEqual(getInAppMessage(forView: inlineView), givenMessageDisplayed)
 
         // Simulate message expiration.
-        await simulateSdkFetchedMessages([givenMessageDisplayed])
+        await simulateSdkFetchedMessages([givenMessageDisplayed], verifyInlineViewNotifiedOfFetch: inlineView)
 
         // Expect still showing the same message as before the fetch call.
         XCTAssertEqual(getInAppMessage(forView: inlineView), givenMessageDisplayed)
@@ -268,7 +278,7 @@ class InAppMessageViewTest: IntegrationTest {
     @MainActor
     func test_onCloseAction_givenCloseActionClickedOnInAppMessage_expectDismissInlineView() async {
         let givenInlineMessage = Message.randomInline
-        queueMock.getInlineMessagesReturnValue = [givenInlineMessage]
+        await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
         let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
         await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: inlineView)
@@ -284,7 +294,7 @@ class InAppMessageViewTest: IntegrationTest {
     func test_onCloseAction_givenMultipleMessagesInQueue_expectDisplayNextMessageInQueueAfterClose() async {
         let givenElementId = String.random
         let givenMessages = [Message(elementId: givenElementId), Message(elementId: givenElementId)]
-        queueMock.getInlineMessagesReturnValue = givenMessages
+        await simulateSdkFetchedMessages(givenMessages, verifyInlineViewNotifiedOfFetch: nil)
 
         let view = InAppMessageView(elementId: givenElementId)
 
@@ -306,7 +316,7 @@ class InAppMessageViewTest: IntegrationTest {
     func test_onCloseAction_givenMultipleMessagesInQueue_expectShowLoadingViewWhileRenderingNextMessage() async {
         let givenElementId = String.random
         let givenMessages = [Message(elementId: givenElementId), Message(elementId: givenElementId)]
-        queueMock.getInlineMessagesReturnValue = givenMessages
+        await simulateSdkFetchedMessages(givenMessages, verifyInlineViewNotifiedOfFetch: nil)
 
         let view = InAppMessageView(elementId: givenElementId)
 
@@ -335,9 +345,10 @@ class InAppMessageViewTest: IntegrationTest {
 
     @MainActor
     func test_onCloseAction_givenMessageClosed_givenNewMessageFetched_expectDisplayNewMessage() async {
-        let givenMessageThatGetsClosed = Message.randomInline
-        let givenNewMessageFetched = Message.randomInline
-        queueMock.getInlineMessagesReturnValue = [givenMessageThatGetsClosed]
+        let givenElementId = String.random
+        let givenMessageThatGetsClosed = Message(elementId: givenElementId)
+        let givenNewMessageFetched = Message(elementId: givenElementId)
+        await simulateSdkFetchedMessages([givenMessageThatGetsClosed], verifyInlineViewNotifiedOfFetch: nil)
 
         let inlineView = InAppMessageView(elementId: givenMessageThatGetsClosed.elementId!)
         await onDoneRenderingInAppMessage(givenMessageThatGetsClosed, insideOfInlineView: inlineView)
@@ -346,7 +357,7 @@ class InAppMessageViewTest: IntegrationTest {
         XCTAssertFalse(isInlineViewVisible(inlineView))
         XCTAssertNil(getInAppMessage(forView: inlineView))
 
-        await simulateSdkFetchedMessages([givenNewMessageFetched]) // simulate new message fetched
+        await simulateSdkFetchedMessages([givenNewMessageFetched], verifyInlineViewNotifiedOfFetch: inlineView) // simulate new message fetched
         XCTAssertEqual(getInAppMessage(forView: inlineView), givenNewMessageFetched) // expect to begin rendering new message
         await onDoneRenderingInAppMessage(givenNewMessageFetched, insideOfInlineView: inlineView)
         XCTAssertTrue(isInlineViewVisible(inlineView)) // expect show next message once it's done rendering
@@ -356,7 +367,7 @@ class InAppMessageViewTest: IntegrationTest {
     func test_onCloseAction_givenMultipleViewInstances_givenCloseMessageOnOneView_expectOtherViewStillShowingOriginalMessage() async {
         let givenElementId = String.random
         let givenMessages = [Message(elementId: givenElementId)]
-        queueMock.getInlineMessagesReturnValue = givenMessages
+        await simulateSdkFetchedMessages(givenMessages, verifyInlineViewNotifiedOfFetch: nil)
 
         let inlineView1 = InAppMessageView(elementId: givenElementId)
         let inlineView2 = InAppMessageView(elementId: givenElementId)
@@ -379,7 +390,7 @@ class InAppMessageViewTest: IntegrationTest {
     // This test function hightlights a behavior that could happen, but we don't expect it to according to our documentation of the inline View.
     @MainActor
     func test_heightAndWidth_givenUserSetsHeightConstraint_expectSdkAddsASeparateConstraint() async {
-        queueMock.getInlineMessagesReturnValue = []
+        await simulateSdkFetchedMessages([], verifyInlineViewNotifiedOfFetch: nil)
 
         let givenHeightUserSetsOnView: CGFloat = 100
         let givenWidthUserSetsOnView: CGFloat = 100
@@ -390,7 +401,7 @@ class InAppMessageViewTest: IntegrationTest {
         NSLayoutConstraint.activate([view.heightAnchor.constraint(equalToConstant: givenHeightUserSetsOnView)])
         NSLayoutConstraint.activate([view.widthAnchor.constraint(equalToConstant: givenWidthUserSetsOnView)])
 
-        await simulateSdkFetchedMessages([])
+        await simulateSdkFetchedMessages([], verifyInlineViewNotifiedOfFetch: view)
 
         // Expects that the View has 2 height constraints: Sdk added and customer added.
         XCTAssertEqual(view.heightConstraints.map(\.constant), [0, 100])
@@ -399,16 +410,18 @@ class InAppMessageViewTest: IntegrationTest {
 
     @MainActor
     func test_heightAndWidth_givenViewDisplaysMessage_expectSdkModifiesTheHeightToSizeOfMessage() async {
-        queueMock.getInlineMessagesReturnValue = [] // start with no messages available
+        let givenElementId = String.random
+
+        await simulateSdkFetchedMessages([], verifyInlineViewNotifiedOfFetch: nil) // start with no messages available
 
         let givenWidthUserSetsOnView: CGFloat = 100
 
-        let view = InAppMessageView(elementId: .random)
+        let view = InAppMessageView(elementId: givenElementId)
         NSLayoutConstraint.activate([view.widthAnchor.constraint(equalToConstant: givenWidthUserSetsOnView)])
 
         // The SDK fetches a message and renders it. We expect the View displays this message.
-        let givenInlineMessage = Message.randomInline
-        await simulateSdkFetchedMessages([givenInlineMessage])
+        let givenInlineMessage = Message(elementId: givenElementId)
+        await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: view)
         // The width of the rendered message is expected to equal what the customer sets the View for. We do not modify the View's width.
         // Notice the height of the rendered Message is different from what the customer set the View.
         await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: view, heightOfRenderedMessage: 300, widthOfRenderedMessage: givenWidthUserSetsOnView)
@@ -421,7 +434,7 @@ class InAppMessageViewTest: IntegrationTest {
 
     @MainActor
     func test_heightAndWidth_givenNoMessageToDisplay_expectSdkModifiesTheHeightToNotShowView() async {
-        queueMock.getInlineMessagesReturnValue = []
+        await simulateSdkFetchedMessages([], verifyInlineViewNotifiedOfFetch: nil)
 
         let givenWidthUserSetsOnView: CGFloat = 100
 
@@ -440,7 +453,7 @@ class InAppMessageViewTest: IntegrationTest {
     func test_onInlineButtonAction_givenDelegateSet_expectCustomCallback() async {
         let givenInlineMessage = Message.randomInline
         let gistInAppInlineMessage = InAppMessage(gistMessage: givenInlineMessage)
-        queueMock.getInlineMessagesReturnValue = [givenInlineMessage]
+        await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
         let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
         inlineView.onActionDelegate = inlineMessageDelegateMock
@@ -462,7 +475,7 @@ class InAppMessageViewTest: IntegrationTest {
     func test_onInlineButtonAction_givenDelegateNotSet_expectGlobalCallback() async {
         let givenInlineMessage = Message.randomInline
         let gistInAppInlineMessage = InAppMessage(gistMessage: givenInlineMessage)
-        queueMock.getInlineMessagesReturnValue = [givenInlineMessage]
+        await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
         let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
         await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: inlineView)
@@ -483,7 +496,7 @@ class InAppMessageViewTest: IntegrationTest {
         let gistInAppInlineMessage1 = InAppMessage(gistMessage: givenInlineMessage1)
 
         let givenInlineMessage2 = Message.randomInline
-        queueMock.getInlineMessagesReturnValue = [givenInlineMessage1, givenInlineMessage2]
+        await simulateSdkFetchedMessages([givenInlineMessage1, givenInlineMessage2], verifyInlineViewNotifiedOfFetch: nil)
 
         let inlineActionDelegate1 = InAppMessageViewActionDelegateMock()
         let inlineActionDelegate2 = InAppMessageViewActionDelegateMock()
@@ -512,7 +525,9 @@ class InAppMessageViewTest: IntegrationTest {
         // match the view that triggered the button tap
         XCTAssertTrue(inlineActionDelegate1.onActionClickCalled)
         XCTAssertEqual(inlineActionDelegate1.onActionClickCallsCount, 1)
+
         XCTAssertFalse(eventListenerMock.messageActionTakenCalled)
+
         XCTAssertEqual(inlineActionDelegate1.onActionClickReceivedArguments?.message, gistInAppInlineMessage1)
         XCTAssertEqual(inlineActionDelegate1.onActionClickReceivedArguments?.actionValue, "Test")
         XCTAssertEqual(inlineActionDelegate1.onActionClickReceivedArguments?.actionName, "")
@@ -523,7 +538,7 @@ class InAppMessageViewTest: IntegrationTest {
     @MainActor
     func test_showAnotherMessageAction_givenClickActionButton_expectShowLoadingViewAfterClickButton() async {
         let givenMessage = Message.randomInline
-        queueMock.getInlineMessagesReturnValue = [givenMessage]
+        await simulateSdkFetchedMessages([givenMessage], verifyInlineViewNotifiedOfFetch: nil)
 
         let view = InAppMessageView(elementId: givenMessage.elementId!)
 
@@ -539,7 +554,7 @@ class InAppMessageViewTest: IntegrationTest {
     @MainActor
     func test_showAnotherMessageAction_givenNewMessageFinishesRendering_expectToDisplayMessage() async {
         let givenMessage = Message.randomInline
-        queueMock.getInlineMessagesReturnValue = [givenMessage]
+        await simulateSdkFetchedMessages([givenMessage], verifyInlineViewNotifiedOfFetch: nil)
 
         let view = InAppMessageView(elementId: givenMessage.elementId!)
 
@@ -559,11 +574,12 @@ class InAppMessageViewTest: IntegrationTest {
 
     @MainActor
     func test_showAnotherMessageAction_givenCloseNewMessage_expectShowNextMessageInQueue() async {
-        let givenMessage = Message.randomInline
-        let givenNextMessageInQueue = Message.randomInline
-        queueMock.getInlineMessagesReturnValue = [givenMessage, givenNextMessageInQueue]
+        let givenElementId = String.random
+        let givenMessage = Message(elementId: givenElementId)
+        let givenNextMessageInQueue = Message(elementId: givenElementId)
+        await simulateSdkFetchedMessages([givenMessage, givenNextMessageInQueue], verifyInlineViewNotifiedOfFetch: nil)
 
-        let view = InAppMessageView(elementId: givenMessage.elementId!)
+        let view = InAppMessageView(elementId: givenElementId)
 
         await onDoneRenderingInAppMessage(givenMessage, insideOfInlineView: view)
 
@@ -580,7 +596,7 @@ class InAppMessageViewTest: IntegrationTest {
     @MainActor
     func test_showAnotherMessageAction_givenShowingNewMessage_givenNewMessagesFetched_expectContinueShowingMessage() async {
         let givenMessage = Message.randomInline
-        queueMock.getInlineMessagesReturnValue = [givenMessage]
+        await simulateSdkFetchedMessages([givenMessage], verifyInlineViewNotifiedOfFetch: nil)
 
         let view = InAppMessageView(elementId: givenMessage.elementId!)
 
@@ -593,14 +609,14 @@ class InAppMessageViewTest: IntegrationTest {
 
         // Expect that after a fetch, we do not change what message is being displayed.
         XCTAssertEqual(getInAppMessage(forView: view)?.templateId, givenNewMessageToShow.templateId)
-        await simulateSdkFetchedMessages([Message.randomInline])
+        await simulateSdkFetchedMessages([Message.randomInline], verifyInlineViewNotifiedOfFetch: view)
         XCTAssertEqual(getInAppMessage(forView: view)?.templateId, givenNewMessageToShow.templateId)
     }
 
     @MainActor
     func test_showAnotherMessageAction_givenMultipleShowAnotherMessageActions_expectShowNextMessages() async {
         let givenMessage = Message.randomInline
-        queueMock.getInlineMessagesReturnValue = [givenMessage]
+        await simulateSdkFetchedMessages([givenMessage], verifyInlineViewNotifiedOfFetch: nil)
 
         let view = InAppMessageView(elementId: givenMessage.elementId!)
 
@@ -624,7 +640,7 @@ class InAppMessageViewTest: IntegrationTest {
     @MainActor
     func test_deeplinks_givenButtonTappedWithValidDeeplink_expectOpenDeeplink() async {
         let givenInlineMessage = Message.randomInline
-        queueMock.getInlineMessagesReturnValue = [givenInlineMessage]
+        await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
         let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
         await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: inlineView)
@@ -646,7 +662,7 @@ class InAppMessageViewTest: IntegrationTest {
     @MainActor
     func test_deeplinks_givenButtonTappedWithInValidDeeplink_expectOpenDeeplink() async {
         let givenInlineMessage = Message.randomInline
-        queueMock.getInlineMessagesReturnValue = [givenInlineMessage]
+        await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
         let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
         await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: inlineView)
@@ -664,12 +680,92 @@ class InAppMessageViewTest: IntegrationTest {
         XCTAssertFalse(deeplinkUtilMock.handleDeepLinkCalled)
     }
 
+    // MARK: persistent and non-persistent
+
+    @MainActor
+    func test_persistentAndNonPersistent_givenNonPersistentMessage_givenMessageShown_expectMessageNotShownAgain() async {
+        let givenInlineMessage = Message(elementId: .random, persistent: false)
+        await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
+
+        let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        XCTAssertEqual(getInAppMessage(forView: inlineView), givenInlineMessage)
+        await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: inlineView)
+
+        // Expect that when a new inline View is being constructed, it does not show the non-persistent message that has already been shown.
+        let differentView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        XCTAssertNil(getInAppMessage(forView: differentView))
+    }
+
+    @MainActor
+    func test_persistentAndNonPersistent_givenNonPersistentMessage_givenMessageNotYetShown_expectCanDisplayMessageMultipleTimes() async {
+        let givenInlineMessage = Message(elementId: .random, persistent: false)
+        await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
+
+        let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        XCTAssertEqual(getInAppMessage(forView: inlineView), givenInlineMessage)
+
+        // Expect that when a new inline View is being constructed, it shows the same non-persistent message that has not been shown yet.
+        let differentView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        XCTAssertEqual(getInAppMessage(forView: differentView), givenInlineMessage)
+    }
+
+    @MainActor
+    func test_persistentAndNonPersistent_givenPersistentMessage_givenMessageShown_expectMessageShownAgain() async {
+        let givenInlineMessage = Message(elementId: .random, persistent: true)
+        await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
+
+        let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        XCTAssertEqual(getInAppMessage(forView: inlineView), givenInlineMessage)
+        await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: inlineView)
+
+        // Expect that when a new inline View is being constructed, it shows the persistent message that has already been shown.
+        let differentView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        XCTAssertEqual(getInAppMessage(forView: differentView), givenInlineMessage)
+    }
+
+    @MainActor
+    func test_persistentAndNonPersistent_givenPersistentMessage_givenCloseMessage_expectDoNotShowMessageAgain() async {
+        let givenInlineMessage = Message(elementId: .random, persistent: true)
+        await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
+
+        let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        XCTAssertEqual(getInAppMessage(forView: inlineView), givenInlineMessage)
+        await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: inlineView)
+
+        // Expect that when the close button is tapped, the message is no longer shown
+        await onCloseActionButtonPressed(onInlineView: inlineView)
+
+        // Expect that when a new inline View is being constructed, it does not show the persistent message that has already been shown.
+        let differentView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        XCTAssertNil(getInAppMessage(forView: differentView))
+    }
+
+    @MainActor
+    func test_persistentAndNonPersistent_givenPersistentMessage_givenMessageExpires_expectContinueShowingIfAlreadyDisplayed_expectDoNotShowAgainInFuture() async {
+        let givenInlineMessage = Message(elementId: .random, persistent: true)
+        await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
+
+        let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        XCTAssertEqual(getInAppMessage(forView: inlineView), givenInlineMessage)
+        await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: inlineView)
+
+        // Expire the message
+        await simulateSdkFetchedMessages([], verifyInlineViewNotifiedOfFetch: inlineView)
+
+        // We expect to continue displaying the expired message on inline View that already displayed it
+        XCTAssertEqual(getInAppMessage(forView: inlineView), givenInlineMessage)
+
+        // Expect we will not show the message again in the future
+        let differentView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        XCTAssertNil(getInAppMessage(forView: differentView))
+    }
+
     // MARK: - Track open
 
     @MainActor
     func test_onInlineMessageRenderingNotShown_expectShouldNotTrackOpenedMetric() async {
         let givenInlineMessage = Message.randomInline
-        queueMock.getInlineMessagesReturnValue = [givenInlineMessage]
+        await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
         _ = InAppMessageView(elementId: givenInlineMessage.elementId!)
 
@@ -679,7 +775,7 @@ class InAppMessageViewTest: IntegrationTest {
     @MainActor
     func test_onInlineMessageShown_expectTrackOpenedMetric() async {
         let givenInlineMessage = Message.randomInline
-        queueMock.getInlineMessagesReturnValue = [givenInlineMessage]
+        await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
         let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
         await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: inlineView)
@@ -692,7 +788,7 @@ class InAppMessageViewTest: IntegrationTest {
     @MainActor
     func test_onInlineMessageShown_onButtonTap_expectTrackClickedMetric() async {
         let givenInlineMessage = Message.randomInline
-        queueMock.getInlineMessagesReturnValue = [givenInlineMessage]
+        await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
         let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
         await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: inlineView)
@@ -705,7 +801,7 @@ class InAppMessageViewTest: IntegrationTest {
     @MainActor
     func test_onInlineMessageShown_onMultipleButtonTap_expectMultipleTrackClickedMetric() async {
         let givenInlineMessage = Message.randomInline
-        queueMock.getInlineMessagesReturnValue = [givenInlineMessage]
+        await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
         let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
         await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: inlineView)
@@ -724,7 +820,7 @@ class InAppMessageViewTest: IntegrationTest {
     @MainActor
     func test_onInlineMessageShown_expectGlobalMessageShownListener() async {
         let givenInlineMessage = Message.randomInline
-        queueMock.getInlineMessagesReturnValue = [givenInlineMessage]
+        await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
         let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
         await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: inlineView)
@@ -734,48 +830,35 @@ class InAppMessageViewTest: IntegrationTest {
 
     // Tests a scenario where multiple inline messages are displayed to the user,
     // then expect multiple MessageShown global event listeners to be called for each message shown.
-    /* @MainActor
-     func test_givenMultipleInlineMessageRendered_expectTrackMultipleMessageShownListenerCalls() async {
-         // FIXME: This test is failing because the queueMock is being mocked and is not a real instance.
-         // the queue's real instance is able to return a message by elemenetid. when you mock the queue, it will
-         // ignore the elementid and always return the same message.
-         // So, this test wants each inline View to have a separate message but instead each view will get the same message.
-         // PR that would fix this test: https://github.com/customerio/customerio-ios/pull/776
+    @MainActor
+    func test_givenMultipleInlineMessageRendered_expectTrackMultipleMessageShownListenerCalls() async {
+        let givenInlineMessage1 = Message.randomInline
+        let givenInlineMessage2 = Message.randomInline
+        await simulateSdkFetchedMessages([givenInlineMessage1, givenInlineMessage2], verifyInlineViewNotifiedOfFetch: nil)
 
-         let givenInlineMessage1 = Message.randomInline
-         let givenInlineMessage2 = Message.randomInline
-         queueMock.getInlineMessagesReturnValue = [givenInlineMessage1, givenInlineMessage2]
+        let inlineView1 = InAppMessageView(elementId: givenInlineMessage1.elementId!)
+        let inlineView2 = InAppMessageView(elementId: givenInlineMessage2.elementId!)
 
-         let inlineView1 = InAppMessageView(elementId: givenInlineMessage1.elementId!)
-         let inlineView2 = InAppMessageView(elementId: givenInlineMessage2.elementId!)
+        await onDoneRenderingInAppMessage(givenInlineMessage1, insideOfInlineView: inlineView1)
 
-         await onDoneRenderingInAppMessage(givenInlineMessage1, insideOfInlineView: inlineView1)
+        assert(message: givenInlineMessage1, didCallMessageShownEventListener: true)
+        assert(message: givenInlineMessage2, didCallMessageShownEventListener: false)
 
-         assert(message: givenInlineMessage1, didCallMessageShownEventListener: true)
-         assert(message: givenInlineMessage2, didCallMessageShownEventListener: false)
+        await onDoneRenderingInAppMessage(givenInlineMessage2, insideOfInlineView: inlineView2)
 
-         await onDoneRenderingInAppMessage(givenInlineMessage2, insideOfInlineView: inlineView2)
-
-         assert(message: givenInlineMessage1, didCallMessageShownEventListener: true)
-         assert(message: givenInlineMessage2, didCallMessageShownEventListener: true)
-     }*/
+        assert(message: givenInlineMessage1, didCallMessageShownEventListener: true)
+        assert(message: givenInlineMessage2, didCallMessageShownEventListener: true)
+    }
 }
 
 @MainActor
 extension InAppMessageViewTest {
-    func onCustomActionButtonPressed(onInlineView inlineView: InAppMessageView) async {
-        // Triggering the custom action button on inline message from the web engine
-        // mocks the user tap on custom action button
-        getWebEngineForInlineView(inlineView)?.delegate?.tap(name: "", action: "Test", system: false)
+    func setupQueueMock() -> MessageQueueManagerMock {
+        let mock = MessageQueueManagerMock()
 
-        // when a button is pressed, an eventbus event is posted for metrics tracking. Return function after the tracked event is posted.
-        await waitForEventBusEventsToPost()
-    }
+        diGraphShared.override(value: mock, forType: MessageQueueManager.self)
 
-    func onDeepLinkActionButtonPressed(onInlineView inlineView: InAppMessageView, deeplink: String) {
-        // Triggering the custom action button on inline message from the web engine
-        // mocks the user tap on custom action button
-        getWebEngineForInlineView(inlineView)?.delegate?.tap(name: "", action: deeplink, system: true)
+        return mock
     }
 
     // Only tells you if the View is visible in the UI to the user. Does not tell you if the View is in the process of rendering a message.
@@ -843,19 +926,5 @@ extension InAppMessageViewTest {
         } else {
             XCTAssertTrue(foundEvents.isEmpty, "Expected not to find messageShown listener called, but it was.", file: file, line: line)
         }
-    }
-
-    func simulateSdkFetchedMessages(_ messages: [Message]) async {
-        // Because eventbus operations are async, use an expectation that waits until eventbus event is posted and observer is called.
-        let expectToCheckIfInAppMessagesAvailableToDisplay = expectation(description: "expect to check for in-app messages")
-
-        queueMock.getInlineMessagesClosure = { [weak expectToCheckIfInAppMessagesAvailableToDisplay] _ in
-            expectToCheckIfInAppMessagesAvailableToDisplay?.fulfill()
-
-            return messages
-        }
-        // Imagine the in-app SDK has fetched new messages. It sends an event to the eventbus.
-        DIGraphShared.shared.eventBusHandler.postEvent(InAppMessagesFetchedEvent())
-        await waitForExpectations([expectToCheckIfInAppMessagesAvailableToDisplay])
     }
 }

--- a/Tests/Shared/Core/UnitTestBase.swift
+++ b/Tests/Shared/Core/UnitTestBase.swift
@@ -224,6 +224,7 @@ open class UnitTestBase<Component>: XCTestCase {
 
         // Loop through all pending tasks in the EventBus and wait for them to complete.
         for task in realInstanceEventBus.taskBag {
+            // swiftlint:disable:next force_try
             try! await task.value
         }
     }


### PR DESCRIPTION
https://linear.app/customerio/issue/MBL-329/after-inline-view-shown-determine-if-it-should-show-again-or-not

# Problem 

As a marketer, I want to customize an inline in-app message to be shown only once or shown multiple times. 

According [to the in-app docs](https://customer.io/docs/journeys/send-in-app-message/#persist-message), persistent messages are defined as: 

> By default, in-app messages only show once—the message disappears after the customer clicks, taps, or refreshes the page. You can check the Persist Message option to show your message across multiple sessions and page views. Persisted messages continue being displayed until the expiration date or until the customer clicks Close or the icon. Make sure your messages include a Close button or an icon so that customers can permanently dismiss your message.

# Solution 

Re-use the existing logic that Modal messages use for persistent and non-persistent messaging. 

# Testing 

* Automated tests will be added in a follow-up PR as there are required changes to the test suite to write these tests. 
* In UIKit sample app, I tested these QA use cases:

1. Given non-persistent message, given message shown, kill-app and re-open it. Expect that we do not show the message again. 
2. Given persistent message, given message shown, kill-app and re-open it. Expect that we do show the message again. Click the close button and kill app, re-open app, expect to not see the message again. 