### PR TITLE
fix: remove gist pre-loading

### DIFF
--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -23,9 +23,6 @@ public class Gist: GistDelegate {
         self.dataCenter = dataCenter
         Logger.instance.enabled = logging
         messageQueueManager.setup()
-
-        // Initialising Gist web with an empty message to fetch fonts and other assets.
-        _ = Gist.shared.getMessageView(Message(messageId: ""))
     }
 
     // For testing to reset the singleton state


### PR DESCRIPTION
With our in-app rendering move from flutter to html, we don't need to pre-load flutter engine to download assets.

more context here: https://customerio.slack.com/archives/C036FTE6UJ0/p1721046751535539