### PR TITLE
test: persistent and non-persistent messages

### DIFF
--- a/Tests/MessagingInApp/Core/IntegrationTest.swift
+++ b/Tests/MessagingInApp/Core/IntegrationTest.swift
@@ -81,6 +81,9 @@ open class IntegrationTest: UnitTest {
             if let campaignIdValue = message.gistProperties.campaignId {
                 gistProperties["campaignId"] = campaignIdValue
             }
+            if let persistentValue = message.gistProperties.persistent {
+                gistProperties["persistent"] = persistentValue
+            }
 
             let messageDict: [String: Any] = [
                 "queueId": message.id!,

--- a/Tests/MessagingInApp/Extensions/GistExtensions.swift
+++ b/Tests/MessagingInApp/Extensions/GistExtensions.swift
@@ -2,10 +2,11 @@
 import Foundation
 
 extension Message {
-    convenience init(messageId: String = .random, campaignId: String = .random, pageRule: String? = nil, queueId: String = .random, elementId: String? = nil, priority: Int? = nil) {
+    convenience init(messageId: String = .random, campaignId: String = .random, pageRule: String? = nil, queueId: String = .random, elementId: String? = nil, priority: Int? = nil, persistent: Bool = false) {
         var gistProperties = [
-            "campaignId": campaignId
-        ]
+            "campaignId": campaignId,
+            "persistent": persistent
+        ] as [String: Any]
 
         if let elementId = elementId {
             gistProperties["elementId"] = elementId

--- a/Tests/MessagingInApp/Views/InAppMessageViewTest.swift
+++ b/Tests/MessagingInApp/Views/InAppMessageViewTest.swift
@@ -740,6 +740,26 @@ class InAppMessageViewTest: IntegrationTest {
         XCTAssertNil(getInAppMessage(forView: differentView))
     }
 
+    @MainActor
+    func test_persistentAndNonPersistent_givenPersistentMessage_givenMessageExpires_expectContinueShowingIfAlreadyDisplayed_expectDoNotShowAgainInFuture() async {
+        let givenInlineMessage = Message(elementId: .random, persistent: true)
+        await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
+
+        let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        XCTAssertEqual(getInAppMessage(forView: inlineView), givenInlineMessage)
+        await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: inlineView)
+
+        // Expire the message
+        await simulateSdkFetchedMessages([], verifyInlineViewNotifiedOfFetch: inlineView)
+
+        // We expect to continue displaying the expired message on inline View that already displayed it
+        XCTAssertEqual(getInAppMessage(forView: inlineView), givenInlineMessage)
+
+        // Expect we will not show the message again in the future
+        let differentView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        XCTAssertNil(getInAppMessage(forView: differentView))
+    }
+
     // MARK: - Track open
 
     @MainActor


### PR DESCRIPTION
Automated tests for: https://linear.app/customerio/issue/MBL-329/after-inline-view-shown-determine-if-it-should-show-again-or-not

Given the acceptance criteria in the ticket and the description of persistent and non-persistent messages, I wrote automated test functions for the feature. 

I tried to write automated tests for all test cases that we would use to manually QA test this feature. If you believe a test case is missing, please call it out. 