### PR TITLE
docs: remove unneeded code in SwiftUI sample app

### DIFF
--- a/Apps/CocoaPods-FCM/src/View/CustomEventView.swift
+++ b/Apps/CocoaPods-FCM/src/View/CustomEventView.swift
@@ -1,4 +1,5 @@
 import CioDataPipelines
+import CioMessagingInApp
 import SwiftUI
 
 struct CustomEventView: View {
@@ -19,6 +20,8 @@ struct CustomEventView: View {
             VStack {
                 Text("Send Custom Event").bold().font(.system(size: 20))
 
+                InlineMessage(elementId: "custom-screen")
+
                 VStack(spacing: 8) {
                     LabeledStringTextField(title: "Event Name", appiumId: "Event Name Input", value: $eventName)
                     LabeledStringTextField(title: "Property Name", appiumId: "Property Name Input", value: $propertyName)
@@ -38,6 +41,9 @@ struct CustomEventView: View {
 
                     nonBlockingMessage = successMessage
                 }.setAppiumId("Send Event Button")
+
+                Text("This screen contains inline in-app Views with elementIds: custom-screen")
+                    .font(.caption)
             }.padding([.horizontal], 20)
         }.overlay(
             ToastView(message: $nonBlockingMessage)

--- a/Apps/CocoaPods-FCM/src/View/DashboardView.swift
+++ b/Apps/CocoaPods-FCM/src/View/DashboardView.swift
@@ -51,7 +51,7 @@ struct DashboardView: View {
                     Group {
                         InlineMessage(elementId: "dashboard-announcement", onActionClick: { _, _, _ in
                             print("Custom callback received")
-                        }).frame(maxWidth: .infinity)
+                        })
                         ColorButton("Send Random Event") {
                             switch Int.random(in: 0 ..< 3) {
                             case 0:

--- a/Apps/CocoaPods-FCM/src/View/DashboardView.swift
+++ b/Apps/CocoaPods-FCM/src/View/DashboardView.swift
@@ -27,30 +27,36 @@ struct DashboardView: View {
 
     @EnvironmentObject var userManager: UserManager
     var body: some View {
-        ZStack {
-            VStack {
-                SettingsButton {
-                    subscreenShown = .settings
+        ScrollView {
+            ZStack {
+                VStack {
+                    SettingsButton {
+                        subscreenShown = .settings
+                    }
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+                    .padding(.trailing, 10)
+                    Spacer()
                 }
-                .frame(maxWidth: .infinity, alignment: .trailing)
-                .padding(.trailing, 10)
-                Spacer()
-            }
-            .sheet(isPresented: .constant(subscreenShown == .settings), onDismiss: { subscreenShown = nil }) {
-                SettingsView {
-                    subscreenShown = nil
+                .sheet(isPresented: .constant(subscreenShown == .settings), onDismiss: { subscreenShown = nil }) {
+                    SettingsView {
+                        subscreenShown = nil
+                    }
                 }
-            }
 
-            ScrollView {
                 VStack(spacing: 15) {
                     if let loggedInUserEmail = userManager.email {
                         Text(loggedInUserEmail)
                     }
                     Text("What would you like to test?")
                     Group {
-                        InlineMessage(elementId: "dashboard-announcement", onActionClick: { _, _, _ in
-                            print("Custom callback received")
+                        InlineMessage(elementId: "dashboard-announcement", onActionClick: { message, actionValue, actionName in
+                            CustomerIO.shared.track(name: "inline custom button action", properties: [
+                                "source": "onActionClick View callback",
+                                "delivery-id": message.deliveryId ?? "(none)",
+                                "message-id": message.messageId,
+                                "action-value": actionValue,
+                                "action-name": actionName
+                            ])
                         })
                         ColorButton("Send Random Event") {
                             switch Int.random(in: 0 ..< 3) {
@@ -127,6 +133,9 @@ struct DashboardView: View {
                                 }
                             }
                         }.setAppiumId("Show Push Prompt Button")
+
+                        InlineMessage(elementId: "dashboard-announcement-code")
+
                         ColorButton("Logout") {
                             CustomerIO.shared.clearIdentify()
 
@@ -135,6 +144,9 @@ struct DashboardView: View {
                     }
 
                     EnvironmentText()
+
+                    Text("This screen contains inline in-app Views with elementIds: dashboard-announcement, dashboard-announcement-code")
+                        .font(.caption)
                 }
                 .padding()
             }

--- a/Sources/MessagingInApp/Views/SwiftUIInline.swift
+++ b/Sources/MessagingInApp/Views/SwiftUIInline.swift
@@ -73,6 +73,10 @@ public struct InlineMessageUIViewRepresentable: UIViewRepresentable {
 
         inlineMessageView.delegate = context.coordinator
 
+        // Set the compression resistance of the content view to low so that the content view can be compressed to fit the available space.
+        // This fixes an issue where you rotate screen from portrait to landscape and back to portrait. Without this change, the view remains in landscape mode.
+        inlineMessageView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
         return inlineMessageView
     }
 

--- a/Tests/MessagingInApp/Core/IntegrationTest.swift
+++ b/Tests/MessagingInApp/Core/IntegrationTest.swift
@@ -153,6 +153,11 @@ extension IntegrationTest {
         await waitForMainThreadToFinishPendingTasks()
     }
 
+    func onDoneRenderingInAppMessageWithError(_ message: Message, insideOfInlineView inlineView: InlineMessageUIView) async {
+        // To mock the web server call with a failed response back, call routeError delegate function:
+        getWebEngineForInlineView(inlineView)?.delegate?.routeError(route: message.templateId)
+    }
+
     func onShowAnotherMessageActionButtonPressed(onInlineView inlineView: InlineMessageUIView, newMessageTemplateId: String = .random) async {
         // Triggering the button from the web engine simulates the user tapping the button on the in-app WebView.
         // This behaves more like an integration test because we are also able to test the message manager, too.

--- a/Tests/MessagingInApp/Views/InAppMessageViewTest.swift
+++ b/Tests/MessagingInApp/Views/InAppMessageViewTest.swift
@@ -136,7 +136,7 @@ class InAppMessageViewTest: IntegrationTest {
         let givenInlineMessage = Message.randomInline
         await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
-        let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        let inlineView = InlineMessageUIView(elementId: givenInlineMessage.elementId!)
         await onDoneRenderingInAppMessageWithError(givenInlineMessage, insideOfInlineView: inlineView)
 
         // Inline message does not display
@@ -779,7 +779,7 @@ class InAppMessageViewTest: IntegrationTest {
         let givenInlineMessage = Message.randomInline
         await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
-        let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        let inlineView = InlineMessageUIView(elementId: givenInlineMessage.elementId!)
         await onDoneRenderingInAppMessageWithError(givenInlineMessage, insideOfInlineView: inlineView)
 
         assert(message: givenInlineMessage, didCallErrorWithMessageEventListener: true)
@@ -793,7 +793,7 @@ class InAppMessageViewTest: IntegrationTest {
         let givenInlineMessage = Message.randomInline
         await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
-        let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        let inlineView = InlineMessageUIView(elementId: givenInlineMessage.elementId!)
 
         // Expect do not call event listener yet
         assert(message: givenInlineMessage, didCallMessageShownEventListener: false)
@@ -813,7 +813,7 @@ class InAppMessageViewTest: IntegrationTest {
         let givenInlineMessage = Message(elementId: .random, persistent: true)
         await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
-        let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        let inlineView = InlineMessageUIView(elementId: givenInlineMessage.elementId!)
         await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: inlineView)
 
         assert(message: givenInlineMessage, didCallMessageShownEventListener: true)
@@ -832,7 +832,7 @@ class InAppMessageViewTest: IntegrationTest {
         let givenInlineMessage = Message.randomInline
         await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
-        let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        let inlineView = InlineMessageUIView(elementId: givenInlineMessage.elementId!)
         await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: inlineView)
 
         assert(message: givenInlineMessage, didCallMessageActionTakenEventListener: false)
@@ -852,7 +852,7 @@ class InAppMessageViewTest: IntegrationTest {
         let givenInlineMessage2 = Message(elementId: givenElementId)
         await simulateSdkFetchedMessages([givenInlineMessage1, givenInlineMessage2], verifyInlineViewNotifiedOfFetch: nil)
 
-        let inlineView = InAppMessageView(elementId: givenElementId)
+        let inlineView = InlineMessageUIView(elementId: givenElementId)
         await onDoneRenderingInAppMessage(givenInlineMessage1, insideOfInlineView: inlineView)
 
         assert(message: givenInlineMessage1, didCallMessageShownEventListener: true)
@@ -870,7 +870,7 @@ class InAppMessageViewTest: IntegrationTest {
         let givenInlineMessage = Message.randomInline
         await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
-        let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        let inlineView = InlineMessageUIView(elementId: givenInlineMessage.elementId!)
         await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: inlineView)
 
         assert(message: givenInlineMessage, didCallMessageActionTakenEventListener: false)
@@ -885,7 +885,7 @@ class InAppMessageViewTest: IntegrationTest {
         let givenInlineMessage = Message.randomInline
         await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
-        let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        let inlineView = InlineMessageUIView(elementId: givenInlineMessage.elementId!)
         await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: inlineView)
 
         assert(message: givenInlineMessage, didCallMessageActionTakenEventListener: false)
@@ -900,7 +900,7 @@ class InAppMessageViewTest: IntegrationTest {
         let givenInlineMessage = Message.randomInline
         await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
-        let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        let inlineView = InlineMessageUIView(elementId: givenInlineMessage.elementId!)
         await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: inlineView)
 
         assert(message: givenInlineMessage, didCallMessageActionTakenEventListener: false)


### PR DESCRIPTION
Now that the SwiftUI implementation for inline in-app is complete, I decided to check and see if setting the `frame()` on the SwiftUI inline View is required or not anymore. Previously, we discussed that it might be needed for customers to add it to their app. 

I removed the `frame()` call from sample app, tested it, and the inline View is behaving as expected where the width of the inline View equals the width of the parent container. Therefore, I do not think that setting the frame is expected anymore. I think this is the ideal scenario - Customers *can* set the frame, but it is not a requirement.

This PR removes the `.frame()` call that has no effect on the sample app. Also, our SwiftUI inline docs do not mention that using `.frame()` is required so this change will make our sample app match the docs. 