### PR TITLE
test: fix inline View tests 

### DIFF
--- a/Tests/MessagingInApp/Core/IntegrationTest.swift
+++ b/Tests/MessagingInApp/Core/IntegrationTest.swift
@@ -153,6 +153,11 @@ extension IntegrationTest {
         await waitForMainThreadToFinishPendingTasks()
     }
 
+    func onDoneRenderingInAppMessageWithError(_ message: Message, insideOfInlineView inlineView: InlineMessageUIView) async {
+        // To mock the web server call with a failed response back, call routeError delegate function:
+        getWebEngineForInlineView(inlineView)?.delegate?.routeError(route: message.templateId)
+    }
+
     func onShowAnotherMessageActionButtonPressed(onInlineView inlineView: InlineMessageUIView, newMessageTemplateId: String = .random) async {
         // Triggering the button from the web engine simulates the user tapping the button on the in-app WebView.
         // This behaves more like an integration test because we are also able to test the message manager, too.

--- a/Tests/MessagingInApp/Views/InAppMessageViewTest.swift
+++ b/Tests/MessagingInApp/Views/InAppMessageViewTest.swift
@@ -136,7 +136,7 @@ class InAppMessageViewTest: IntegrationTest {
         let givenInlineMessage = Message.randomInline
         await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
-        let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        let inlineView = InlineMessageUIView(elementId: givenInlineMessage.elementId!)
         await onDoneRenderingInAppMessageWithError(givenInlineMessage, insideOfInlineView: inlineView)
 
         // Inline message does not display
@@ -779,7 +779,7 @@ class InAppMessageViewTest: IntegrationTest {
         let givenInlineMessage = Message.randomInline
         await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
-        let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        let inlineView = InlineMessageUIView(elementId: givenInlineMessage.elementId!)
         await onDoneRenderingInAppMessageWithError(givenInlineMessage, insideOfInlineView: inlineView)
 
         assert(message: givenInlineMessage, didCallErrorWithMessageEventListener: true)
@@ -793,7 +793,7 @@ class InAppMessageViewTest: IntegrationTest {
         let givenInlineMessage = Message.randomInline
         await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
-        let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        let inlineView = InlineMessageUIView(elementId: givenInlineMessage.elementId!)
 
         // Expect do not call event listener yet
         assert(message: givenInlineMessage, didCallMessageShownEventListener: false)
@@ -813,7 +813,7 @@ class InAppMessageViewTest: IntegrationTest {
         let givenInlineMessage = Message(elementId: .random, persistent: true)
         await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
-        let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        let inlineView = InlineMessageUIView(elementId: givenInlineMessage.elementId!)
         await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: inlineView)
 
         assert(message: givenInlineMessage, didCallMessageShownEventListener: true)
@@ -832,7 +832,7 @@ class InAppMessageViewTest: IntegrationTest {
         let givenInlineMessage = Message.randomInline
         await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
-        let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        let inlineView = InlineMessageUIView(elementId: givenInlineMessage.elementId!)
         await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: inlineView)
 
         assert(message: givenInlineMessage, didCallMessageActionTakenEventListener: false)
@@ -852,7 +852,7 @@ class InAppMessageViewTest: IntegrationTest {
         let givenInlineMessage2 = Message(elementId: givenElementId)
         await simulateSdkFetchedMessages([givenInlineMessage1, givenInlineMessage2], verifyInlineViewNotifiedOfFetch: nil)
 
-        let inlineView = InAppMessageView(elementId: givenElementId)
+        let inlineView = InlineMessageUIView(elementId: givenElementId)
         await onDoneRenderingInAppMessage(givenInlineMessage1, insideOfInlineView: inlineView)
 
         assert(message: givenInlineMessage1, didCallMessageShownEventListener: true)
@@ -870,7 +870,7 @@ class InAppMessageViewTest: IntegrationTest {
         let givenInlineMessage = Message.randomInline
         await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
-        let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        let inlineView = InlineMessageUIView(elementId: givenInlineMessage.elementId!)
         await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: inlineView)
 
         assert(message: givenInlineMessage, didCallMessageActionTakenEventListener: false)
@@ -885,7 +885,7 @@ class InAppMessageViewTest: IntegrationTest {
         let givenInlineMessage = Message.randomInline
         await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
-        let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        let inlineView = InlineMessageUIView(elementId: givenInlineMessage.elementId!)
         await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: inlineView)
 
         assert(message: givenInlineMessage, didCallMessageActionTakenEventListener: false)
@@ -900,7 +900,7 @@ class InAppMessageViewTest: IntegrationTest {
         let givenInlineMessage = Message.randomInline
         await simulateSdkFetchedMessages([givenInlineMessage], verifyInlineViewNotifiedOfFetch: nil)
 
-        let inlineView = InAppMessageView(elementId: givenInlineMessage.elementId!)
+        let inlineView = InlineMessageUIView(elementId: givenInlineMessage.elementId!)
         await onDoneRenderingInAppMessage(givenInlineMessage, insideOfInlineView: inlineView)
 
         assert(message: givenInlineMessage, didCallMessageActionTakenEventListener: false)


### PR DESCRIPTION
Automated tests are not compiling on `feature/inline-inapp` branch after latest set of PRs that I merged. I believe this happened because of a merge conflict I resolved in 1 of the PRs but didn't propagate that merge up the PR stack. 

I fixed those issues and got tests passing again. 