### PR TITLE
fix: tuist users not able to install CIO iOS SDK SPM manifest issue

### DIFF
--- a/CustomerIODataPipelines.podspec
+++ b/CustomerIODataPipelines.podspec
@@ -28,5 +28,5 @@ Pod::Spec.new do |spec|
   spec.dependency "CustomerIOTrackingMigration", "= #{spec.version.to_s}"
 
   # Add Segment SDK as a dependency, as this module is designed to be compatible with it.
-  spec.dependency 'AnalyticsSwiftCIO', '= 1.5.13+cio.1'
+  spec.dependency 'AnalyticsSwiftCIO', '= 1.5.14+cio.1'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,7 @@ let package = Package(
         .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git", "8.7.0"..<"11.0.0"),
 
         // Make sure the version number is same for DataPipelines cocoapods.
-        .package(name: "CioAnalytics", url: "https://github.com/customerio/cdp-analytics-swift.git", .exact("1.5.13+cio.1"))
+        .package(name: "CioAnalytics", url: "https://github.com/customerio/cdp-analytics-swift.git", .exact("1.5.14+cio.1"))
     ],
     targets: [ 
         // Common - Code used by multiple modules in the SDK project.


### PR DESCRIPTION
Resolves: https://github.com/customerio/customerio-ios/issues/790 

# Problem 

iOS developers who want to use tools such as Tuist to generate xcode projects are currently experiencing an error when resolving the CIO iOS SDK via SPM.

See [this PR for the full details of the problem and solution](https://github.com/customerio/cdp-analytics-swift/pull/7). 

# Solution 

In order for customers to be able to install the iOS SDK via tuist, the iOS SDK's SPM manifest file must point to the correct version of `CioAnalytics` that includes the bug fix. 

After this PR gets deployed, customers should be able to install the iOS SDK via tuist on the latest version. 

# Testing 

Installed this git branch in SPM and Cocoapods sample apps. Verified that the correct source code was downloaded and that the apps compile successfully. 

I am also going to run the sample apps quick that are built in this PR to verify that CDP API calls work as expected. 