### PR TITLE
fix: auto register device token feature forwards token to 3rd party SDKs

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
@@ -70,6 +70,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 .autoFetchDeviceToken(true)
                 .build()
         )
+
+        // When `autoFetchDeviceToken` false, we need to call this manually. so we add it here.
+        UIApplication.shared.registerForRemoteNotifications()
     }
 
     // Handle Universal Link deep link from the Customer.io SDK. This function will get called if a push notification
@@ -83,6 +86,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         return deepLinkHandler.handleUniversalLinkDeepLink(universalLinkUrl)
+    }
+
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        // When you uninstall and reinstall the app (to clear device token persisted to the device data), run sample app with `autoFetchDeviceToken` false. You should see this function get called. Then, run app with `autoFetchDeviceToken` true and you should see this function *not* get called.
+
+        // We need this function to always get called. That's what needs fixed.
+
+        print("APN device token got")
     }
 
     // MARK: UISceneSession Lifecycle

--- a/Sources/MessagingPush/AppDelegateSwizzler.swift
+++ b/Sources/MessagingPush/AppDelegateSwizzler.swift
@@ -5,53 +5,68 @@ public protocol AppDelegateSwizzlerDelegate: AnyObject {
     func didReceiveAPNSToken(_ deviceToken: Data)
 }
 
+// Type alias for the original method's implementation
 public typealias RegisterForNotificationsClosureType = @convention(c) (AnyObject, Selector, UIApplication, Data) -> Void
 
 @available(iOSApplicationExtension, unavailable)
 public class AppDelegateSwizzler {
     private static let shared = AppDelegateSwizzler()
     private weak var delegate: AppDelegateSwizzlerDelegate?
+
+    // Stores the original implementation of the method that our SDK replaces with swizzling.
+    // By storing the original implementation, we can call it from our swizzled method.
+    // This allows us to add our custom logic to the method without losing the original functionality.
     private static var registerForNotificationsOriginalImp: RegisterForNotificationsClosureType?
 
-    public class func startSwizzlingIfPossible(_ delegate: AppDelegateSwizzlerDelegate) {
+    // Method to start swizzling and set the delegate
+    public class func startSwizzling(_ delegate: AppDelegateSwizzlerDelegate) {
         shared.delegate = delegate
     }
 
+    // Setup the swizzling code, just once, by putting in constructor.
     private init() {
         guard
             let originalClass = object_getClass(UIApplication.shared.delegate),
             let swizzledClass = object_getClass(self)
         else { return }
 
+        // Selectors for the original and swizzled methods
         let originalSelector = #selector(UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:))
         let swizzledSelector = #selector(swizzled_application(_:didRegisterForRemoteNotificationsWithDeviceToken:))
 
+        // Perform the swizzling
         swizzle(originalClass, swizzledClass, originalSelector, swizzledSelector)
     }
 
+    // Method to perform the swizzling
     private func swizzle(_ originalClass: AnyClass, _ swizzledClass: AnyClass, _ originalSelector: Selector, _ swizzledSelector: Selector) {
         guard let swizzledMethod = class_getInstanceMethod(swizzledClass, swizzledSelector) else {
             return
         }
 
+        // Check if the original method exists
         if let originalMethod = class_getInstanceMethod(originalClass, originalSelector) {
-            print("we did the swizzle. \(String(describing: originalClass)) \(String(describing: originalSelector)) \(String(describing: swizzledClass)) \(String(describing: swizzledSelector))")
-
+            // Get the implementation of the original method
             let imp = method_getImplementation(originalMethod)
+            // Store the original implementation in the static variable
+            // Due to the nature of how `IMP` works and the need to cast it to a specific function pointer type, `unsafeBitCast` is necessary to cast the `IMP` to the correct function pointer type because Swift does not support direct casting between arbitrary pointer types and function types.
+            // This ensures that the cast is performed correctly and safely within the constraints of Swift's type system.
             AppDelegateSwizzler.registerForNotificationsOriginalImp = unsafeBitCast(imp, to: RegisterForNotificationsClosureType.self)
 
-            // exchange implementation
+            // Exchange the implementations of the original and swizzled methods
             method_exchangeImplementations(originalMethod, swizzledMethod)
         } else {
-            // add implementation
+            // Add the swizzled method if the original method does not exist
             class_addMethod(originalClass, originalSelector, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod))
         }
     }
 
+    // Swizzled method implementation. This function gets called instead of the original method in the app.
     @objc private func swizzled_application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        // call parent method
-        AppDelegateSwizzler.registerForNotificationsOriginalImp?(UIApplication.shared.delegate!, #selector(UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)), application, deviceToken)
-
+        // Perform the custom logic in our SDK when a APN device token is registered to the app!
         Self.shared.delegate?.didReceiveAPNSToken(deviceToken)
+
+        // Call the original method using the stored implementation. This ensures the original functionality of the customer's app is not lost.
+        AppDelegateSwizzler.registerForNotificationsOriginalImp?(UIApplication.shared.delegate!, #selector(UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)), application, deviceToken)
     }
 }

--- a/Sources/MessagingPush/AppDelegateSwizzler.swift
+++ b/Sources/MessagingPush/AppDelegateSwizzler.swift
@@ -1,0 +1,57 @@
+import Foundation
+import UIKit
+
+public protocol AppDelegateSwizzlerDelegate: AnyObject {
+    func didReceiveAPNSToken(_ deviceToken: Data)
+}
+
+public typealias RegisterForNotificationsClosureType = @convention(c) (AnyObject, Selector, UIApplication, Data) -> Void
+
+@available(iOSApplicationExtension, unavailable)
+public class AppDelegateSwizzler {
+    private static let shared = AppDelegateSwizzler()
+    private weak var delegate: AppDelegateSwizzlerDelegate?
+    private static var registerForNotificationsOriginalImp: RegisterForNotificationsClosureType?
+
+    public class func startSwizzlingIfPossible(_ delegate: AppDelegateSwizzlerDelegate) {
+        shared.delegate = delegate
+    }
+
+    private init() {
+        guard
+            let originalClass = object_getClass(UIApplication.shared.delegate),
+            let swizzledClass = object_getClass(self)
+        else { return }
+
+        let originalSelector = #selector(UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:))
+        let swizzledSelector = #selector(swizzled_application(_:didRegisterForRemoteNotificationsWithDeviceToken:))
+
+        swizzle(originalClass, swizzledClass, originalSelector, swizzledSelector)
+    }
+
+    private func swizzle(_ originalClass: AnyClass, _ swizzledClass: AnyClass, _ originalSelector: Selector, _ swizzledSelector: Selector) {
+        guard let swizzledMethod = class_getInstanceMethod(swizzledClass, swizzledSelector) else {
+            return
+        }
+
+        if let originalMethod = class_getInstanceMethod(originalClass, originalSelector) {
+            print("we did the swizzle. \(String(describing: originalClass)) \(String(describing: originalSelector)) \(String(describing: swizzledClass)) \(String(describing: swizzledSelector))")
+
+            let imp = method_getImplementation(originalMethod)
+            AppDelegateSwizzler.registerForNotificationsOriginalImp = unsafeBitCast(imp, to: RegisterForNotificationsClosureType.self)
+
+            // exchange implementation
+            method_exchangeImplementations(originalMethod, swizzledMethod)
+        } else {
+            // add implementation
+            class_addMethod(originalClass, originalSelector, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod))
+        }
+    }
+
+    @objc private func swizzled_application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        // call parent method
+        AppDelegateSwizzler.registerForNotificationsOriginalImp?(UIApplication.shared.delegate!, #selector(UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)), application, deviceToken)
+
+        Self.shared.delegate?.didReceiveAPNSToken(deviceToken)
+    }
+}

--- a/Sources/MessagingPushAPN/MessagingPushAPN+PushConfigs.swift
+++ b/Sources/MessagingPushAPN/MessagingPushAPN+PushConfigs.swift
@@ -10,7 +10,7 @@ extension MessagingPushAPN: AppDelegateSwizzlerDelegate {
     @available(iOSApplicationExtension, unavailable)
     func setupAutoFetchDeviceToken() {
         // Swizzle method `didRegisterForRemoteNotificationsWithDeviceToken`
-        AppDelegateSwizzler.startSwizzlingIfPossible(self)
+        AppDelegateSwizzler.startSwizzling(self)
         // Register for push notifications to invoke`didRegisterForRemoteNotificationsWithDeviceToken` method
         UIApplication.shared.registerForRemoteNotifications()
     }

--- a/Sources/MessagingPushAPN/MessagingPushAPN+PushConfigs.swift
+++ b/Sources/MessagingPushAPN/MessagingPushAPN+PushConfigs.swift
@@ -1,50 +1,17 @@
+import CioMessagingPush
 import Foundation
 import UIKit
 
-extension MessagingPushAPN {
+extension MessagingPushAPN: AppDelegateSwizzlerDelegate {
+    public func didReceiveAPNSToken(_ deviceToken: Data) {
+        MessagingPush.shared.registerDeviceToken(apnDeviceToken: deviceToken)
+    }
+
     @available(iOSApplicationExtension, unavailable)
     func setupAutoFetchDeviceToken() {
         // Swizzle method `didRegisterForRemoteNotificationsWithDeviceToken`
-        swizzleDidRegisterForRemoteNotifications()
+        AppDelegateSwizzler.startSwizzlingIfPossible(self)
         // Register for push notifications to invoke`didRegisterForRemoteNotificationsWithDeviceToken` method
         UIApplication.shared.registerForRemoteNotifications()
-    }
-
-    @available(iOSApplicationExtension, unavailable)
-    private func swizzleDidRegisterForRemoteNotifications() {
-        let appDelegate = UIApplication.shared.delegate
-        let appDelegateClass: AnyClass? = object_getClass(appDelegate)
-
-        // Swizzle `didRegisterForRemoteNotificationsWithDeviceToken`
-        let originalSelector = #selector(UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:))
-        let swizzledSelector = #selector(application(_:didRegisterForRemoteNotificationsWithDeviceToken:))
-        swizzle(forOriginalClass: appDelegateClass, forSwizzledClass: MessagingPushAPN.self, original: originalSelector, new: swizzledSelector)
-
-        // Swizzle `didFailToRegisterForRemoteNotificationsWithError`
-        let originalSelectorForDidFail = #selector(UIApplicationDelegate.application(_:didFailToRegisterForRemoteNotificationsWithError:))
-        let swizzledSelectorForDidFail = #selector(application(_:didFailToRegisterForRemoteNotificationsWithError:))
-        swizzle(forOriginalClass: appDelegateClass, forSwizzledClass: MessagingPushAPN.self, original: originalSelectorForDidFail, new: swizzledSelectorForDidFail)
-    }
-
-    private func swizzle(forOriginalClass: AnyClass?, forSwizzledClass: AnyClass?, original: Selector, new: Selector) {
-        guard let swizzledMethod = class_getInstanceMethod(forSwizzledClass, new) else { return }
-        guard let originalMethod = class_getInstanceMethod(forOriginalClass, original) else {
-            // Add method if it doesn't exist
-            class_addMethod(forOriginalClass, new, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod))
-            return
-        }
-        method_exchangeImplementations(originalMethod, swizzledMethod)
-    }
-
-    // Swizzled method for APN device token.
-    @objc
-    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        Self.shared.registerDeviceToken(apnDeviceToken: deviceToken)
-    }
-
-    // Swizzled method for `didFailToRegisterForRemoteNotificationsWithError'
-    @objc
-    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
-        MessagingPushAPN.shared.deleteDeviceToken()
     }
 }

--- a/Sources/MessagingPushFCM/MessagingPushFCM+PushConfigs.swift
+++ b/Sources/MessagingPushFCM/MessagingPushFCM+PushConfigs.swift
@@ -1,3 +1,4 @@
+import CioMessagingPush
 import FirebaseCore
 import FirebaseMessaging
 import Foundation
@@ -5,36 +6,8 @@ import Foundation
 import UIKit
 #endif
 
-extension MessagingPushFCM {
-    @available(iOSApplicationExtension, unavailable)
-    func setupAutoFetchDeviceToken() {
-        swizzleDidRegisterForRemoteNotifications()
-        UIApplication.shared.registerForRemoteNotifications()
-    }
-
-    @available(iOSApplicationExtension, unavailable)
-    private func swizzleDidRegisterForRemoteNotifications() {
-        let appDelegate = UIApplication.shared.delegate
-        let appDelegateClass: AnyClass? = object_getClass(appDelegate)
-        let originalSelector = #selector(UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:))
-        let swizzledSelector = #selector(application(_:didRegisterForRemoteNotificationsWithDeviceToken:))
-        swizzle(forOriginalClass: appDelegateClass, forSwizzledClass: MessagingPushFCM.self, original: originalSelector, new: swizzledSelector)
-    }
-
-    private func swizzle(forOriginalClass: AnyClass?, forSwizzledClass: AnyClass?, original: Selector, new: Selector) {
-        guard let swizzledMethod = class_getInstanceMethod(forSwizzledClass, new) else { return }
-        guard let originalMethod = class_getInstanceMethod(forOriginalClass, original) else {
-            // Add method if it doesn't exist
-            class_addMethod(forOriginalClass, new, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod))
-            return
-        }
-        method_exchangeImplementations(originalMethod, swizzledMethod)
-    }
-
-    // Swizzled method for APN device token.
-    // Fetch the FCM token using the Firebase delegate method when the APN token is set.
-    @objc
-    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+extension MessagingPushFCM: AppDelegateSwizzlerDelegate {
+    public func didReceiveAPNSToken(_ deviceToken: Data) {
         Messaging.messaging().apnsToken = deviceToken
         // Registers listener with FCM SDK to always have the latest FCM token.
         // Used to automatically register it with the SDK.
@@ -44,5 +17,11 @@ extension MessagingPushFCM {
             }
             Self.shared.registerDeviceToken(fcmToken: token)
         })
+    }
+
+    @available(iOSApplicationExtension, unavailable)
+    func setupAutoFetchDeviceToken() {
+        AppDelegateSwizzler.startSwizzlingIfPossible(self)
+        UIApplication.shared.registerForRemoteNotifications()
     }
 }

--- a/Sources/MessagingPushFCM/MessagingPushFCM+PushConfigs.swift
+++ b/Sources/MessagingPushFCM/MessagingPushFCM+PushConfigs.swift
@@ -21,7 +21,7 @@ extension MessagingPushFCM: AppDelegateSwizzlerDelegate {
 
     @available(iOSApplicationExtension, unavailable)
     func setupAutoFetchDeviceToken() {
-        AppDelegateSwizzler.startSwizzlingIfPossible(self)
+        AppDelegateSwizzler.startSwizzling(self)
         UIApplication.shared.registerForRemoteNotifications()
     }
 }


### PR DESCRIPTION
Ticket: https://linear.app/customerio/issue/MBL-182/

# Problem 

The CIO SDK has a feature which allows it to automatically receive the APN device token from the running iOS app, without customers needing to provide the token directly to the SDK. We do this via swizzling the `AppDelegate.application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data)` function. 

The current swizzling implementation is missing one important piece - forward the function call back to the original implementation. Meaning, when our SDK swizzles `AppDelegate.application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data)`, the app's original `AppDelegate.application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data)` implementation will not get called unless our SDK forwards the function call to the original implementation. 

# Solution 

A popular way to do swizzling is to use code that looks like recursion. [If you look at the way we currently implement the automatic screen view tracking for UIKit](https://github.com/customerio/customerio-ios/blob/b7d7d4fec2bd4be9f25b3b8937b01c7dc5360e0a/Sources/DataPipeline/Plugins/AutoTrackingScreenViews.swift), there's a great example: 

```swift
    // This function gets called automatically when a UIViewController has it's `viewDidAppear` function called. 
    @objc func cio_swizzled_UIKit_viewDidAppear(_ animated: Bool) {
        performAutomaticScreenTracking() // Here, we track a screenview event. 

		// When you do swizzling, you override the app's original implementation of the function. 
        // This means that `UIViewController.viewDidAppear` will not be called for a customer's app (bad!). 

		// To fix that, you need to forward the function call back to the original 
        // implementation that you replaced. 
        // 
        // This function below looks like recursion, but it's actually how you call 
        // the original implementation! 
        cio_swizzled_UIKit_viewDidAppear(animated)
    }
```

In our [current implementation of automatic device token registration](https://github.com/customerio/customerio-ios/blob/b7d7d4fec2bd4be9f25b3b8937b01c7dc5360e0a/Sources/MessagingPushAPN/MessagingPushAPN%2BPushConfigs.swift#L39-L43), we are missing this code to forward the function back to the original implementation. This has been causing bugs for customers because this means that 3rd party SDKs are never able to receive a device token after the CIO SDK has processed it. 

The problem is, this recursion approach sometimes doesn't work. If the customer's app delegate includes the `didRegisterForRemoteToken` function, swizzling works, but if it's absent, it doesn't. This is the same issue that auto push click handling feature faces. This indicates to me this behavior has to do with swizzling protocol functions that are optional. 

This PR introduces a different solution to forward the function call to the original implementation. I intentionally added comments to the `AppDelegateSwizzler` file to explain the implementation. I suggest reading the comments in that file to learn this alternative method of swizzling. Ask questions in the file if you do not understand something. 

# Testing 

Unfortunately, I have had unreliable results when writing automated tests for swizzling code. Therefore, I relied on sample app testing for all of the code in this PR. I performed the following actions to test: 

1. **Remove any workarounds:** If there is any code in the sample apps that is manually registering a device token with the CIO SDK, remove it. We want to test the swizzling code only. 
1. **Reproduce the bug:** Add `AppDelegate.application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data)` to `AppDelegate`. Because the SDK does not currently call the original implementation, we expect that this function will *not* get called in the sample apps. 
1. **Install new swizzling implementation to see if callbacks work:** Without modifying any other code in the sample apps or SDK, install this PR's code in the sample app. We now expect that the `AppDelegate.didRegisterForRemoteNotificationsWithDeviceToken` function to get executed. 
1. **Test swizzling code still works if we don't implement `AppDelegate` functions:** as mentioned above, I have experienced inconsistent results with some swizzling implementations if the `AppDelegate` does and does not override the `application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data)` function. Run the app with this PR's bug fix with and without this function overriden. We expect that the CIO SDK gets the device token in both scenarios. 