### PR TITLE
feat: fetch in-app messages on new profile identification

### DIFF
--- a/Sources/MessagingInApp/Gist/EngineWeb/EngineWeb.swift
+++ b/Sources/MessagingInApp/Gist/EngineWeb/EngineWeb.swift
@@ -75,6 +75,7 @@ public class EngineWeb: NSObject {
     }
 
     public func cleanEngineWeb() {
+        Logger.instance.debug(message: "Cleaning EngineWeb")
         webView.removeFromSuperview()
         webView.configuration.userContentController.removeAllUserScripts()
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "gist")

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -23,6 +23,9 @@ public class Gist: GistDelegate {
         self.dataCenter = dataCenter
         Logger.instance.enabled = logging
         messageQueueManager.setup()
+
+        // Initialising Gist web with an empty message to fetch fonts and other assets.
+        _ = Gist.shared.getMessageView(Message(messageId: ""))
     }
 
     // MARK: User

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -23,15 +23,13 @@ public class Gist: GistDelegate {
         self.dataCenter = dataCenter
         Logger.instance.enabled = logging
         messageQueueManager.setup()
-
-        // Initialising Gist web with an empty message to fetch fonts and other assets.
-        _ = Gist.shared.getMessageView(Message(messageId: ""))
     }
 
     // MARK: User
 
     public func setUserToken(_ userToken: String) {
         UserManager().setUserToken(userToken: userToken)
+        messageQueueManager.fetchUserMessagesFromRemoteQueue()
     }
 
     public func clearUserToken() {

--- a/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
@@ -50,6 +50,8 @@ class MessageManager: EngineWebDelegate {
     }
 
     private func loadModalMessage() {
+        Logger.instance.debug(message: "Loading modal message with id: \(currentMessage.messageId), messageLoaded: \(messageLoaded)")
+
         if messageLoaded {
             modalViewManager = ModalViewManager(gistView: gistView, position: messagePosition)
             modalViewManager?.showModalView { [weak self] in
@@ -61,6 +63,8 @@ class MessageManager: EngineWebDelegate {
     }
 
     func dismissMessage(completionHandler: (() -> Void)? = nil) {
+        Logger.instance.debug(message: "Dismissing message with id: \(currentMessage.messageId)")
+
         if let modalViewManager = modalViewManager {
             modalViewManager.dismissModalView { [weak self] in
                 guard let self = self else { return }
@@ -71,6 +75,8 @@ class MessageManager: EngineWebDelegate {
     }
 
     func removePersistentMessage() {
+        Logger.instance.debug(message: "Removing persistent message with id: \(currentMessage.messageId)")
+
         if currentMessage.gistProperties.persistent == true {
             Logger.instance.debug(message: "Persistent message dismissed, logging view")
             Gist.shared.logMessageView(message: currentMessage)

--- a/Sources/MessagingInApp/Gist/Managers/ModalViewManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/ModalViewManager.swift
@@ -19,6 +19,7 @@ class ModalViewManager {
     }
 
     func showModalView(completionHandler: @escaping () -> Void) {
+        Logger.instance.debug(message: "Showing modal view")
         viewController.view.isHidden = true
         window = getUIWindow()
         window.rootViewController = viewController
@@ -43,6 +44,7 @@ class ModalViewManager {
             UIView.animate(withDuration: 0.1, delay: 0, options: [.curveEaseIn], animations: {
                 self.viewController.view.backgroundColor = UIColor.black.withAlphaComponent(0.2)
             }, completion: nil)
+            Logger.instance.debug(message: "Modal view shown")
             completionHandler()
         })
 
@@ -50,6 +52,7 @@ class ModalViewManager {
     }
 
     func dismissModalView(completionHandler: @escaping () -> Void) {
+        Logger.instance.debug(message: "Dismissing modal view")
         var finalPosition: CGFloat = 0
         switch position {
         case .top:
@@ -69,6 +72,7 @@ class ModalViewManager {
                 self.window?.isHidden = false
                 self.viewController.removeFromParent()
                 self.window = nil
+                Logger.instance.debug(message: "Modal view dismissed")
                 completionHandler()
             })
         })

--- a/Sources/MessagingInApp/Gist/Managers/UserManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/UserManager.swift
@@ -9,10 +9,12 @@ class UserManager {
     }
 
     func setUserToken(userToken: String) {
+        Logger.instance.info(message: "User token set: \(userToken)")
         defaults.set(userToken, forKey: userTokenKey)
     }
 
     func clearUserToken() {
+        Logger.instance.info(message: "User token cleared")
         defaults.removeObject(forKey: userTokenKey)
     }
 }

--- a/Sources/MessagingInApp/MessagingInAppImplementation.swift
+++ b/Sources/MessagingInApp/MessagingInAppImplementation.swift
@@ -28,6 +28,7 @@ class MessagingInAppImplementation: MessagingInAppInstance {
     }
 
     func initialize() {
+        logger.debug("initializing in-app messaging with region: \(region)")
         inAppProvider.initialize(siteId: siteId, region: region, delegate: self, enableLogging: logLevel == .debug)
 
         // if identifier is already present, set the userToken again so in case if the customer was already identified and


### PR DESCRIPTION
part of [MBL-483](https://linear.app/customerio/issue/MBL-483/add-logs-that-would-help-troubleshoot-pocket-prep-issue)

### Changes

- Fetch in-app messages from remote whenever a profile is identified to speed up first message display and adjust the polling interval as received
- Improved logging

### Resources

- [Slack discussion about removing in-app message preloading](https://customerio.slack.com/archives/C036FTE6UJ0/p1721046751535539)