### PR TITLE
fix: fetch remote messages on main queue

### DIFF
--- a/Sources/MessagingInApp/Gist/Managers/MessageQueueManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/MessageQueueManager.swift
@@ -70,8 +70,10 @@ class MessageQueueManager {
     }
 
     func fetchUserMessagesFromRemoteQueue() {
-        Logger.instance.debug(message: "Fetching user messages from remote queue")
-        fetchUserMessages()
+        DispatchQueue.main.async {
+            Logger.instance.debug(message: "Fetching user messages from remote queue")
+            self.fetchUserMessages()
+        }
     }
 
     @objc

--- a/Sources/MessagingInApp/Gist/Managers/MessageQueueManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/MessageQueueManager.swift
@@ -70,6 +70,8 @@ class MessageQueueManager {
     }
 
     func fetchUserMessagesFromRemoteQueue() {
+        // Fetching user messages from remote queue should be done on main thread as it directly interacts with WebViews.
+        // Not doing so can cause crashes on wrapper frameworks like React Native.
         DispatchQueue.main.async {
             Logger.instance.debug(message: "Fetching user messages from remote queue")
             self.fetchUserMessages()


### PR DESCRIPTION
part of [MBL-483](https://linear.app/customerio/issue/MBL-483/add-logs-that-would-help-troubleshoot-pocket-prep-issue)

### Changes

- Fetch in-app messages from remote on `DispatchQueue.main` explicitly