### PR TITLE
ci: sdk binary size main build cache hit

### DIFF
--- a/.github/actions/generate-sdk-size-report/action.yml
+++ b/.github/actions/generate-sdk-size-report/action.yml
@@ -50,6 +50,7 @@ runs:
     uses: ./.github/actions/main-sample-app-build 
     with:
       set-latest-main-build: ${{ steps.build-sample-app.outputs.app-xcarchive-name }}
+      GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64: ${{ inputs.GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64 }}
 
   - name: Make the SDK size report
     uses: mathiasvr/command-output@v2.0.0
@@ -78,6 +79,8 @@ runs:
     if: ${{ github.event_name == 'pull_request' }}
     id: download-latest-main-build
     uses: ./.github/actions/main-sample-app-build
+    with:
+      GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64: ${{ inputs.GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64 }}
 
   - name: Generate SDK binary diff report between main branch and current branch 
     if: ${{ steps.download-latest-main-build.outputs.apn-app-xcarchive-path != '' }}

--- a/.github/actions/main-sample-app-build/action.yml
+++ b/.github/actions/main-sample-app-build/action.yml
@@ -83,21 +83,24 @@ runs:
 
     # It's easiest if the latest main build always has the same name that easily identifies it. 
     # Therefore, we take the input build and copy it to have the name that we expect to upload.
-    # If cache is found, we copy the cache build to expected name.
-    # If cache is not found, we need to copy the fallback build to expected name.
     - name: If saving a new build, create copy that we will save. 
       if: ${{ inputs.set-latest-main-build != '' }}
       working-directory: ${{ env.APN_SAMPLE_APP_BUILD_PATH }}
       shell: bash
       run: |
-        if [[ "${{ inputs.set-latest-main-build }}" != "" ]]; then
-          cp -r ${{ inputs.set-latest-main-build }} ${{ env.BUILD_FILE_NAME }}
-        elif [[ "${{ env.BUILD_CACHE_HIT }}" == "false" ]]; then
-          cp -r ${{ steps.fallback-build-main.outputs.app-xcarchive-name }} ${{ env.BUILD_FILE_NAME }}
-        fi
+        cp -r ${{ inputs.set-latest-main-build }} ${{ env.BUILD_FILE_NAME }}
+
+    # If the cache was not found, we need to copy the fallback build to the expected name.
+    # This is similar to the previous step, but we are doing it for the case where cache was not found.
+    - name: If cache was not found, copy fallback build to expected name
+      if: ${{ env.BUILD_CACHE_HIT == 'false' }}
+      working-directory: ${{ env.APN_SAMPLE_APP_BUILD_PATH }}
+      shell: bash
+      run: |
+        cp -r ${{ steps.fallback-build-main.outputs.app-xcarchive-name }} ${{ env.BUILD_FILE_NAME }}
 
     - name: Save latest main sample app build
-      if: inputs.set-latest-main-build != '' || env.BUILD_CACHE_HIT == 'false'
+      if: ${{ inputs.set-latest-main-build != '' || env.BUILD_CACHE_HIT == 'false' }}
       uses: actions/cache/save@v4
       with:
         # the key must be unique. caches are immutable so the key must always be unique. 

--- a/.github/actions/main-sample-app-build/action.yml
+++ b/.github/actions/main-sample-app-build/action.yml
@@ -50,7 +50,6 @@ runs:
     
     # If the cache is found, we set the cache-hit status to true.
     # This is useful for future steps to know if the cache was found or not.
-    # Also, if the cache is found, we do not need to save the build.
     - name: Set cache-hit and should-save-build values
       shell: bash
       run: |
@@ -59,7 +58,7 @@ runs:
         echo "Cache Hit Value: $build_cache_hit"
 
     # If the cache is not found, we need to build the sample app for main branch.
-    # So, we checkout the main branch and build the sample app.
+    # So we checkout the main branch and build the sample app.
     - name: Checkout main branch
       if: ${{ env.BUILD_CACHE_HIT == 'false' }}
       uses: actions/checkout@v4
@@ -92,7 +91,7 @@ runs:
         cp -r ${{ inputs.set-latest-main-build }} ${{ env.BUILD_FILE_NAME }}
 
     # If the cache was not found, we need to copy the fallback build to the expected name.
-    # This is similar to the previous step, but we are doing it for the case where the cache was not found.
+    # This is similar to the previous step, but we are doing it for the case where cache was not found.
     - name: If cache was not found, copy fallback build to expected name
       if: ${{ env.BUILD_CACHE_HIT == 'false' }}
       working-directory: ${{ env.APN_SAMPLE_APP_BUILD_PATH }}

--- a/.github/actions/main-sample-app-build/action.yml
+++ b/.github/actions/main-sample-app-build/action.yml
@@ -8,6 +8,10 @@ inputs:
     type: string
     required: false 
     default: ''
+  GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64:
+    description: 'Maps to the secret, GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64. Used for code signing. See the Fastlane config files to learn more.'
+    type: string
+    required: true
 
 outputs:
   apn-app-xcarchive-path:
@@ -29,6 +33,7 @@ runs:
         echo "CACHE_KEY_BASE=APN-UIKit-build-main-" >> $GITHUB_ENV
 
     - name: Download latest main sample app build to compare against 
+      id: restore-build
       if: ${{ inputs.set-latest-main-build == '' }}
       uses: actions/cache/restore@v4
       with:
@@ -43,6 +48,40 @@ runs:
         restore-keys: |
           ${{ env.CACHE_KEY_BASE }}
     
+    # If the cache is found, we set the cache-hit status to true.
+    # This is useful for future steps to know if the cache was found or not.
+    # Also, if the cache is found, we do not need to save the build.
+    - name: Set cache-hit and should-save-build values
+      shell: bash
+      run: |
+        build_cache_hit="${{ steps.restore-build.outputs.cache-hit || 'false' }}"
+        echo "BUILD_CACHE_HIT=$build_cache_hit" >> $GITHUB_ENV
+        echo "Cache Hit Value: $build_cache_hit"
+
+    # If the cache is not found, we need to build the sample app for main branch.
+    # So, we checkout the main branch and build the sample app.
+    - name: Checkout main branch
+      if: ${{ env.BUILD_CACHE_HIT == 'false' }}
+      uses: actions/checkout@v4
+      with:
+        ref: main
+
+    # Build the sample app for main branch if the cache is not found.
+    - name: Make a build of the sample app to generate report for 
+      if: ${{ env.BUILD_CACHE_HIT == 'false' }}
+      uses: ./.github/actions/build-sample-app
+      id: fallback-build-main
+      with:
+        apn-or-fcm: 'APN'
+        sample-app: 'APN-UIKit'
+        # Pass in a hard-coded version and build number to ensure that all sample app builds that are compiled for SDK size reports are consistent.
+        # When we compare size reports between different builds, we want to ensure that the only difference is the SDK code that was modified in a PR. 
+        fastlane-build-args: '{"app_version": "1.0.0", "build_number": "1"}'
+        # workspace credentials do not matter since we are not using this app build. 
+        customerio-workspace-siteid: "12345"
+        customerio-workspace-cdp-api-key: "12345"      
+        GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64: ${{ inputs.GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64 }}
+
     # It's easiest if the latest main build always has the same name that easily identifies it. 
     # Therefore, we take the input build and copy it to have the name that we expect to upload.
     - name: If saving a new build, create copy that we will save. 
@@ -52,8 +91,17 @@ runs:
       run: |
         cp -r ${{ inputs.set-latest-main-build }} ${{ env.BUILD_FILE_NAME }}
 
+    # If the cache was not found, we need to copy the fallback build to the expected name.
+    # This is similar to the previous step, but we are doing it for the case where the cache was not found.
+    - name: If cache was not found, copy fallback build to expected name
+      if: ${{ env.BUILD_CACHE_HIT == 'false' }}
+      working-directory: ${{ env.APN_SAMPLE_APP_BUILD_PATH }}
+      shell: bash
+      run: |
+        cp -r ${{ steps.fallback-build-main.outputs.app-xcarchive-name }} ${{ env.BUILD_FILE_NAME }}
+
     - name: Save latest main sample app build
-      if: ${{ inputs.set-latest-main-build != '' }}
+      if: ${{ inputs.set-latest-main-build != '' || env.BUILD_CACHE_HIT == 'false' }}
       uses: actions/cache/save@v4
       with:
         # the key must be unique. caches are immutable so the key must always be unique. 

--- a/.github/actions/main-sample-app-build/action.yml
+++ b/.github/actions/main-sample-app-build/action.yml
@@ -83,24 +83,21 @@ runs:
 
     # It's easiest if the latest main build always has the same name that easily identifies it. 
     # Therefore, we take the input build and copy it to have the name that we expect to upload.
+    # If cache is found, we copy the cache build to expected name.
+    # If cache is not found, we need to copy the fallback build to expected name.
     - name: If saving a new build, create copy that we will save. 
       if: ${{ inputs.set-latest-main-build != '' }}
       working-directory: ${{ env.APN_SAMPLE_APP_BUILD_PATH }}
       shell: bash
       run: |
-        cp -r ${{ inputs.set-latest-main-build }} ${{ env.BUILD_FILE_NAME }}
-
-    # If the cache was not found, we need to copy the fallback build to the expected name.
-    # This is similar to the previous step, but we are doing it for the case where cache was not found.
-    - name: If cache was not found, copy fallback build to expected name
-      if: ${{ env.BUILD_CACHE_HIT == 'false' }}
-      working-directory: ${{ env.APN_SAMPLE_APP_BUILD_PATH }}
-      shell: bash
-      run: |
-        cp -r ${{ steps.fallback-build-main.outputs.app-xcarchive-name }} ${{ env.BUILD_FILE_NAME }}
+        if [[ "${{ inputs.set-latest-main-build }}" != "" ]]; then
+          cp -r ${{ inputs.set-latest-main-build }} ${{ env.BUILD_FILE_NAME }}
+        elif [[ "${{ env.BUILD_CACHE_HIT }}" == "false" ]]; then
+          cp -r ${{ steps.fallback-build-main.outputs.app-xcarchive-name }} ${{ env.BUILD_FILE_NAME }}
+        fi
 
     - name: Save latest main sample app build
-      if: ${{ inputs.set-latest-main-build != '' || env.BUILD_CACHE_HIT == 'false' }}
+      if: inputs.set-latest-main-build != '' || env.BUILD_CACHE_HIT == 'false'
       uses: actions/cache/save@v4
       with:
         # the key must be unique. caches are immutable so the key must always be unique. 


### PR DESCRIPTION
closes: [MBL-510](https://linear.app/customerio/issue/MBL-510/[ios]-fix-sdk-binary-size-on-ci)

### Background

SDK binary size task started failing because sample app build from `main` branch could not be restored from the cache. This PR refactors cache handling logic for `main` build in SDK size action and introduces more streamlined approach to check for cache hits and handle fallback builds when the cache is unavailable.

### Changes

- Introduced `cache_hit` variable to store cache-hit status and use it throughout the workflow
- Simplified conditionals that depend on the cache-hit status, reducing redundant checks
- Ensured `main` build is cached correctly, whether from a restored cache or a newly triggered fallback build
