### PR TITLE
chore: ignore inline in-app messages

### DIFF
--- a/Sources/MessagingInApp/Extensions/GistExtensions.swift
+++ b/Sources/MessagingInApp/Extensions/GistExtensions.swift
@@ -1,10 +1,22 @@
 import Foundation
 
-extension Message {
+extension Message: CustomStringConvertible {
     // Used for getting details about the Message object for sending to logs.
     //
     // We are logging the Gist campaign id as delivery id because we call it delivery id on our system.
     var describeForLogs: String {
         "id: \(messageId), queueId: \(queueId ?? "none"), deliveryId: \(gistProperties.campaignId ?? "none")"
+    }
+
+    // Provides string representation of Message object with all its properties for debugging purposes.
+    public var description: String {
+        "Message(messageId=\(messageId), instanceId=\(instanceId), priority=\(String(describing: priority)), queueId=\(String(describing: queueId)), properties=\(gistProperties))"
+    }
+}
+
+extension GistProperties: CustomStringConvertible {
+    // Provides string representation of GistProperties object with all its properties for debugging purposes.
+    public var description: String {
+        "GistProperties(routeRule=\(String(describing: routeRule)), elementId=\(String(describing: elementId)), campaignId=\(String(describing: campaignId)), position=\(position), persistent=\(String(describing: persistent)))"
     }
 }

--- a/Sources/MessagingInApp/Extensions/GistExtensions.swift
+++ b/Sources/MessagingInApp/Extensions/GistExtensions.swift
@@ -17,6 +17,6 @@ extension Message: CustomStringConvertible {
 extension GistProperties: CustomStringConvertible {
     // Provides string representation of GistProperties object with all its properties for debugging purposes.
     public var description: String {
-        "GistProperties(routeRule=\(String(describing: routeRule)), elementId=\(String(describing: elementId)), campaignId=\(String(describing: campaignId)), position=\(position), persistent=\(String(describing: persistent)))"
+        "GistProperties(routeRule=\(String(describing: routeRule)), elementId=\(String(describing: elementId)), deliveryId=\(String(describing: campaignId)), position=\(position), persistent=\(String(describing: persistent)))"
     }
 }

--- a/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
@@ -145,6 +145,7 @@ class MessageManager: EngineWebDelegate {
             }
         } else {
             if system {
+                inAppMessageManager.dispatch(action: .dismissMessage(message: currentMessage, shouldLog: false))
                 if let url = URL(string: action), UIApplication.shared.canOpenURL(url) {
                     /*
                      There are 2 types of deep links:
@@ -169,14 +170,12 @@ class MessageManager: EngineWebDelegate {
                         UIApplication.shared.open(url) { handled in
                             if handled {
                                 self.logger.logWithModuleTag("Dismissing from system action: \(action)", level: .info)
-                                self.inAppMessageManager.dispatch(action: .dismissMessage(message: self.currentMessage, shouldLog: false))
                             } else {
                                 self.logger.logWithModuleTag("System action not handled", level: .info)
                             }
                         }
                     } else {
                         logger.logWithModuleTag("Handled by NSUserActivity", level: .info)
-                        inAppMessageManager.dispatch(action: .dismissMessage(message: currentMessage))
                     }
                 }
             }

--- a/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
@@ -14,7 +14,6 @@ class MessageManager: EngineWebDelegate {
     private let currentMessage: Message
     private var currentRoute: String
     private let isMessageEmbed: Bool
-    private var messagePosition: MessagePosition = .center
 
     @Atomic private var isMessageLoaded: Bool = false
     private var inAppMessageStoreSubscriber: InAppMessageStoreSubscriber?
@@ -79,9 +78,8 @@ class MessageManager: EngineWebDelegate {
         }()
     }
 
-    func showMessage(position: MessagePosition) {
+    func showMessage() {
         elapsedTimer.start(title: "Displaying modal for message: \(currentMessage.messageId)")
-        messagePosition = position
     }
 
     private func loadModalMessage() {
@@ -91,7 +89,7 @@ class MessageManager: EngineWebDelegate {
         }
 
         logger.logWithModuleTag("Loading modal message: \(currentMessage.describeForLogs)", level: .debug)
-        modalViewManager = ModalViewManager(gistView: gistView, position: messagePosition)
+        modalViewManager = ModalViewManager(gistView: gistView, position: currentMessage.gistProperties.position)
         modalViewManager?.showModalView { [weak self] in
             guard let self = self else { return }
 

--- a/Sources/MessagingInApp/State/InAppMessageAction.swift
+++ b/Sources/MessagingInApp/State/InAppMessageAction.swift
@@ -10,7 +10,7 @@ enum InAppMessageAction: Equatable, Action {
     case setPageRoute(route: String)
     case processMessageQueue(messages: [Message])
     case clearMessageQueue
-    case loadMessage(message: Message, position: MessagePosition? = nil)
+    case loadMessage(message: Message)
     case embedMessage(message: Message, elementId: String)
     case displayMessage(message: Message)
     case dismissMessage(message: Message, shouldLog: Bool = true, viaCloseAction: Bool = true)
@@ -46,8 +46,8 @@ enum InAppMessageAction: Equatable, Action {
         case (.clearMessageQueue, .clearMessageQueue):
             return true
 
-        case (.loadMessage(let lhsMessage, let lhsPosition), .loadMessage(let rhsMessage, let rhsPosition)):
-            return lhsMessage == rhsMessage && lhsPosition == rhsPosition
+        case (.loadMessage(let lhsMessage), .loadMessage(let rhsMessage)):
+            return lhsMessage == rhsMessage
 
         case (.embedMessage(let lhsMessage, let lhsElementId), .embedMessage(let rhsMessage, let rhsElementId)):
             return lhsMessage == rhsMessage && lhsElementId == rhsElementId

--- a/Sources/MessagingInApp/State/InAppMessageMiddleware.swift
+++ b/Sources/MessagingInApp/State/InAppMessageMiddleware.swift
@@ -54,7 +54,7 @@ func routeMatchingMiddleware(logger: Logger) -> InAppMessageMiddleware {
 func modalMessageDisplayStateMiddleware(logger: Logger, threadUtil: ThreadUtil) -> InAppMessageMiddleware {
     middleware { _, getState, next, action in
         // Continue to next middleware if action is not loadMessage
-        guard case .loadMessage(let message, let position) = action else {
+        guard case .loadMessage(let message) = action else {
             return next(action)
         }
 
@@ -65,11 +65,11 @@ func modalMessageDisplayStateMiddleware(logger: Logger, threadUtil: ThreadUtil) 
             return next(.reportError(message: "Blocked loading message: \(message.describeForLogs) because another message is currently displayed or cancelled: \(currentMessage)"))
         }
 
-        logger.logWithModuleTag("Showing message: \(message) with position: \(String(describing: position))", level: .debug)
+        logger.logWithModuleTag("Showing message: \(message)", level: .debug)
         // Show message on main thread to avoid unexpected crashes
         threadUtil.runMain {
             let messageManager = MessageManager(state: state, message: message)
-            messageManager.showMessage(position: position ?? .center)
+            messageManager.showMessage(position: message.gistProperties.position)
         }
 
         return next(action)

--- a/Sources/MessagingInApp/State/InAppMessageMiddleware.swift
+++ b/Sources/MessagingInApp/State/InAppMessageMiddleware.swift
@@ -69,7 +69,7 @@ func modalMessageDisplayStateMiddleware(logger: Logger, threadUtil: ThreadUtil) 
         // Show message on main thread to avoid unexpected crashes
         threadUtil.runMain {
             let messageManager = MessageManager(state: state, message: message)
-            messageManager.showMessage(position: message.gistProperties.position)
+            messageManager.showMessage()
         }
 
         return next(action)

--- a/Sources/MessagingInApp/State/InAppMessageMiddleware.swift
+++ b/Sources/MessagingInApp/State/InAppMessageMiddleware.swift
@@ -96,9 +96,12 @@ func messageMetricsMiddleware(logger: Logger, logManager: LogManager) -> InAppMe
             } else {
                 logger.logWithModuleTag("Persistent message shown, not logging view for message: \(message.describeForLogs)", level: .debug)
             }
+            return next(action)
 
         case .dismissMessage(let message, let shouldLog, let viaCloseAction):
-            guard shouldLog else { return }
+            guard shouldLog else {
+                return next(action)
+            }
 
             // Log message close only if message was dismissed via close action
             if viaCloseAction {
@@ -113,9 +116,8 @@ func messageMetricsMiddleware(logger: Logger, logManager: LogManager) -> InAppMe
             }
 
         default:
-            break
+            return next(action)
         }
-        return next(action)
     }
 }
 
@@ -169,7 +171,7 @@ func messageQueueProcessorMiddleware(logger: Logger) -> InAppMessageMiddleware {
             // This can happen if there is a message currently displayed or loading
             // or if there are no messages in the queue that match the current route
             logger.logWithModuleTag("No message matched the criteria to be shown", level: .debug)
-            return
+            return next(action)
         }
 
         // Dispatch action to show the message

--- a/Sources/MessagingInApp/State/InAppMessageMiddleware.swift
+++ b/Sources/MessagingInApp/State/InAppMessageMiddleware.swift
@@ -171,7 +171,8 @@ func messageQueueProcessorMiddleware(logger: Logger) -> InAppMessageMiddleware {
             // This can happen if there is a message currently displayed or loading
             // or if there are no messages in the queue that match the current route
             logger.logWithModuleTag("No message matched the criteria to be shown", level: .debug)
-            return next(action)
+            // We don't need to dispatch next action to process remaining messages since processMessageQueue was already dispatched above
+            return
         }
 
         // Dispatch action to show the message

--- a/Sources/MessagingInApp/State/InAppMessageReducer.swift
+++ b/Sources/MessagingInApp/State/InAppMessageReducer.swift
@@ -53,7 +53,7 @@ private func reducer(action: InAppMessageAction, state: InAppMessageState) -> In
     case .clearMessageQueue:
         return state.copy(messagesInQueue: [])
 
-    case .loadMessage(let message, _):
+    case .loadMessage(let message):
         return state.copy(currentMessageState: .loading(message: message))
 
     case .displayMessage(let message):


### PR DESCRIPTION
part of [MBL-480](https://linear.app/customerio/issue/MBL-480/update-in-app-messaging-module-using-state-management-in-ios)

### Changes

- Ignored embedded (inline) in-app messages when filtering messages to be displayed, as inline support is not available in this branch
- Updated `Message` and `GistProperties` classes for improved logging and debugging