### PR TITLE
chore: firebase version update

### DIFF
--- a/CustomerIOMessagingPushFCM.podspec
+++ b/CustomerIOMessagingPushFCM.podspec
@@ -30,5 +30,5 @@ Pod::Spec.new do |spec|
   # Add FCM SDK as a dependency, as our SDK is designed to be compatible with it. 
   # No version is specified which means that by default, the latest version is installed for customers. 
   # Customers can override this by adding the pod to their Podfile themselves to specify a version they want to use. 
-  spec.dependency "FirebaseMessaging", ">= 8.7.0", "< 11"
+  spec.dependency "FirebaseMessaging", ">= 8.7.0", "< 12"
 end

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,8 @@ let package = Package(
         // https://web.archive.org/web/20220525200227/https://www.timc.dev/posts/understanding-swift-packages/
         //
         // Update to exact version until wrapper SDKs become part of testing pipeline.
-        .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git", "8.7.0"..<"11.0.0"),
+        .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git", "8.7.0"..<"12.0.0"),
+        
 
         // Make sure the version number is same for DataPipelines cocoapods.
         .package(name: "CioAnalytics", url: "https://github.com/customerio/cdp-analytics-swift.git", .exact("1.5.14+cio.1"))


### PR DESCRIPTION
Linear ticket: https://linear.app/customerio/issue/MBL-472/firebase-1100-support

### Problem
Customers are currently facing issues when upgrading to Firebase's latest version, 11.2. They want to use the latest version of the dependency, but our package restricts usage to versions up to 11.0, preventing them from installing higher versions.

### Solution
Update the version range and test if the app successfully upgrades to the latest Firebase version while using our SDK.

### Changes
Updated the range to >8.7.0 <12.0.0 and tested on UIKit and CocoaPod sample apps. There are no major breaking changes as per the [official Firebase document](https://firebase.google.com/support/release-notes/ios#11.0.0) that affects our SDK.

------
Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [x] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After code reviews are approved and you determine this PR is ready to merge, select *Squash and Merge* button on this screen, leave the title and description to the default values, then merge the PR.
