### PR TITLE
fix: crash when switching screens frequently

### DIFF
--- a/Sources/MessagingInApp/State/InAppMessageMiddleware.swift
+++ b/Sources/MessagingInApp/State/InAppMessageMiddleware.swift
@@ -7,7 +7,7 @@ import Foundation
 private func middleware(
     completion: @escaping MiddlewareCompletion
 ) -> InAppMessageMiddleware {
-    { _,
+    { dispatch,
         // swiftlint:disable:next closure_parameter_position
         getState in {
             // swiftlint:disable:next closure_parameter_position
@@ -15,12 +15,6 @@ private func middleware(
                 // swiftlint:disable:next closure_parameter_position
                 action in
                 let getStateOrDefault = { getState() ?? InAppMessageState() }
-                // Use dispatch from InAppMessageManager so that next action is queued in correct order and dispatched
-                // only after the current action is processed
-                // Ideally, we should have dispatch as a parameter with completion, but we'll keep it simple for now
-                let dispatch: DispatchFunction = { action in
-                    DIGraphShared.shared.inAppMessageManager.dispatch(action: action)
-                }
                 completion(dispatch, getStateOrDefault, next, action)
             }
         }


### PR DESCRIPTION
closes: https://linear.app/customerio/issue/MBL-573/in-app-message-delivery-issue

changes:
- When utilizing `dispatcher` from `Digraph` we are accessing it very frequently when the screen changes very frequently, so instead of fetching/creating an instance every time, let's utilize the the instance provided by middleware.  