### PR TITLE
chore: in-app messaging config from dictionary

### DIFF
--- a/Sources/Common/autogenerated/AutoMockable.generated.swift
+++ b/Sources/Common/autogenerated/AutoMockable.generated.swift
@@ -1832,6 +1832,11 @@ public class LoggerMock: Logger, Mock {
     public func resetMock() {
         logLevelGetCallsCount = 0
         logLevelSetCallsCount = 0
+        setLogDispatcherCallsCount = 0
+        setLogDispatcherReceivedArguments = nil
+        setLogDispatcherReceivedInvocations = []
+
+        mockCalled = false // do last as resetting properties above can make this true
         setLogLevelCallsCount = 0
         setLogLevelReceivedArguments = nil
         setLogLevelReceivedInvocations = []
@@ -1852,6 +1857,33 @@ public class LoggerMock: Logger, Mock {
         errorReceivedInvocations = []
 
         mockCalled = false // do last as resetting properties above can make this true
+    }
+
+    // MARK: - setLogDispatcher
+
+    /// Number of times the function was called.
+    @Atomic public private(set) var setLogDispatcherCallsCount = 0
+    /// `true` if the function was ever called.
+    public var setLogDispatcherCalled: Bool {
+        setLogDispatcherCallsCount > 0
+    }
+
+    /// The arguments from the *last* time the function was called.
+    @Atomic public private(set) var setLogDispatcherReceivedArguments: ((CioLogLevel, String) -> Void)??
+    /// Arguments from *all* of the times that the function was called.
+    @Atomic public private(set) var setLogDispatcherReceivedInvocations: [((CioLogLevel, String) -> Void)?] = []
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     */
+    public var setLogDispatcherClosure: ((((CioLogLevel, String) -> Void)?) -> Void)?
+
+    /// Mocked function for `setLogDispatcher(_ dispatcher: ((CioLogLevel, String) -> Void)?)`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func setLogDispatcher(_ dispatcher: ((CioLogLevel, String) -> Void)?) {
+        mockCalled = true
+        setLogDispatcherCallsCount += 1
+        setLogDispatcherReceivedArguments = dispatcher
+        setLogDispatcherReceivedInvocations.append(dispatcher)
+        setLogDispatcherClosure?(dispatcher)
     }
 
     // MARK: - setLogLevel

--- a/Sources/MessagingInApp/Config/MessagingInAppConfigBuilder.swift
+++ b/Sources/MessagingInApp/Config/MessagingInAppConfigBuilder.swift
@@ -39,26 +39,51 @@ public class MessagingInAppConfigBuilder {
 
 /// Defines errors that can occur during the `MessagingInAppConfigBuilder` building process.
 public enum MessagingInAppConfigBuilderError: Error {
+    case malformedConfig
     case missingSiteId
-    case missingRegion
+    case invalidRegionType
 }
 
 public extension MessagingInAppConfigBuilder {
     /// Constants used to map each of the options in MessagingInAppConfigOptions.
-    enum Keys: String {
+    private enum Keys: String {
         case siteId
         case region
     }
 
     /// Constructs `MessagingInAppConfigOptions` by parsing and applying configurations from provided dictionary.
+    /// The method is used to create `MessagingInAppConfigOptions` from wrapper SDK configurations.
     @available(iOSApplicationExtension, unavailable)
-    static func build(from dictionary: [String: Any]) throws -> MessagingInAppConfigOptions {
-        guard let siteId = dictionary[Keys.siteId.rawValue] as? String else {
+    static func build(from sdkConfig: [String: Any?], withConfig inAppConfigKey: String = "inApp") throws -> MessagingInAppConfigOptions? {
+        // If the inApp config is not present, then we assume the user does not want to use in-app messaging feature.
+        guard let inAppConfig = sdkConfig[inAppConfigKey] else {
+            return nil
+        }
+        // If the inApp config is present but it is not a dictionary, then we throw an error to indicate that the config is invalid.
+        guard let config = inAppConfig as? [String: Any] else {
+            throw MessagingInAppConfigBuilderError.malformedConfig
+        }
+
+        guard let siteId = config[Keys.siteId.rawValue] as? String else {
             throw MessagingInAppConfigBuilderError.missingSiteId
         }
-        guard let region = (dictionary[Keys.region.rawValue] as? String).map(Region.getRegion) else {
-            throw MessagingInAppConfigBuilderError.missingRegion
+
+        // By default, region is provided only in top-level configuration in wrapper SDKs.
+        // This prevents users from having to specify region more than once in the configuration.
+        // Therefore, we retrieve the region from top-level configuration here.
+        // If the region is not present, the default region is used.
+        let regionStr: String
+        if let regionRawValue = sdkConfig[Keys.region.rawValue] {
+            // This check ensures region is always provided as a string, and throwing an error can help
+            // identify potential bugs when passing configuration values from wrappers.
+            guard let rawValueAsString = regionRawValue as? String else {
+                throw MessagingInAppConfigBuilderError.invalidRegionType
+            }
+            regionStr = rawValueAsString
+        } else {
+            regionStr = ""
         }
+        let region = Region.getRegion(from: regionStr)
 
         return MessagingInAppConfigBuilder(siteId: siteId, region: region).build()
     }

--- a/Sources/MessagingInApp/Config/MessagingInAppConfigBuilder.swift
+++ b/Sources/MessagingInApp/Config/MessagingInAppConfigBuilder.swift
@@ -54,9 +54,9 @@ public extension MessagingInAppConfigBuilder {
     /// Constructs `MessagingInAppConfigOptions` by parsing and applying configurations from provided dictionary.
     /// The method is used to create `MessagingInAppConfigOptions` from wrapper SDK configurations.
     @available(iOSApplicationExtension, unavailable)
-    static func build(from sdkConfig: [String: Any?], withConfig inAppConfigKey: String = "inApp") throws -> MessagingInAppConfigOptions? {
+    static func build(from sdkConfig: [String: Any?]) throws -> MessagingInAppConfigOptions? {
         // If the inApp config is not present, then we assume the user does not want to use in-app messaging feature.
-        guard let inAppConfig = sdkConfig[inAppConfigKey] else {
+        guard let inAppConfig = sdkConfig["inApp"] else {
             return nil
         }
         // If the inApp config is present but it is not a dictionary, then we throw an error to indicate that the config is invalid.

--- a/Tests/Common/Type/RegionTest.swift
+++ b/Tests/Common/Type/RegionTest.swift
@@ -16,6 +16,18 @@ class RegionTest: UnitTest {
         XCTAssertEqual(given, expected)
     }
 
+    func test_from_givenIncorrectString_expectDefaultRegion() {
+        let given = Region.getRegion(from: "OK")
+        let expected = Region.US
+        XCTAssertEqual(given, expected)
+    }
+
+    func test_from_givenEmptyString_expectDefaultRegion() {
+        let given = Region.getRegion(from: "")
+        let expected = Region.US
+        XCTAssertEqual(given, expected)
+    }
+
     func test_from_expectConvertToAndFromRegion() {
         let expected = Region.US
         let actual = Region.getRegion(from: Region.US.rawValue)

--- a/Tests/MessagingInApp/Config/MessagingInAppConfigBuilderTest.swift
+++ b/Tests/MessagingInApp/Config/MessagingInAppConfigBuilderTest.swift
@@ -14,13 +14,15 @@ class MessagingInAppConfigBuilderTest: UnitTest {
         XCTAssertEqual(config.region, givenRegion)
     }
 
-    func test_initializeFromDictionaryWithCustomValues_expectCustomValues() {
+    func test_initializeFromDictionaryWithCustomValues_expectCorrectValues() {
         let givenSiteId = String.random
         let givenRegion = "EU"
 
         let givenDict: [String: Any] = [
-            "siteId": givenSiteId,
-            "region": givenRegion
+            "region": givenRegion,
+            "inApp": [
+                "siteId": givenSiteId
+            ]
         ]
 
         let config = try? MessagingInAppConfigBuilder.build(from: givenDict)
@@ -30,28 +32,65 @@ class MessagingInAppConfigBuilderTest: UnitTest {
         XCTAssertEqual(config?.region.rawValue, givenRegion)
     }
 
+    func test_initializeFromDictionaryWithCustomKey_expectCorrectValues() {
+        let givenSiteId = String.random
+        let givenRegion = "US"
+
+        let givenDict: [String: Any] = [
+            "region": givenRegion,
+            "in-app": [
+                "siteId": givenSiteId
+            ]
+        ]
+
+        let config = try? MessagingInAppConfigBuilder.build(from: givenDict, withConfig: "in-app")
+
+        XCTAssertNotNil(config)
+        XCTAssertEqual(config?.siteId, givenSiteId)
+        XCTAssertEqual(config?.region.rawValue, givenRegion)
+    }
+
     func test_initializeFromEmptyDictionary_expectThrowError() {
-        let givenDict: [String: Any] = [:]
+        let givenDict: [String: Any] = [
+            "inApp": [:]
+        ]
 
         XCTAssertThrowsError(try MessagingInAppConfigBuilder.build(from: givenDict)) { error in
             XCTAssertEqual(error as? MessagingInAppConfigBuilderError, MessagingInAppConfigBuilderError.missingSiteId)
         }
     }
 
-    func test_initializeFromDictionaryWithOnlySiteId_expectThrowError() {
+    func test_initializeFromMalformedDictionary_expectThrowError() {
         let givenDict: [String: Any] = [
-            "siteId": String.random
+            "inApp": String.random
         ]
 
         XCTAssertThrowsError(try MessagingInAppConfigBuilder.build(from: givenDict)) { error in
-            XCTAssertEqual(error as? MessagingInAppConfigBuilderError, MessagingInAppConfigBuilderError.missingRegion)
+            XCTAssertEqual(error as? MessagingInAppConfigBuilderError, MessagingInAppConfigBuilderError.malformedConfig)
         }
+    }
+
+    func test_initializeFromDictionaryWithOnlySiteId_expectConfigWithDefaultRegion() {
+        let givenSiteId = String.random
+        let givenDict: [String: Any] = [
+            "inApp": [
+                "siteId": givenSiteId
+            ]
+        ]
+
+        let config = try? MessagingInAppConfigBuilder.build(from: givenDict)
+
+        XCTAssertNotNil(config)
+        XCTAssertEqual(config?.siteId, givenSiteId)
+        XCTAssertEqual(config?.region, .US)
     }
 
     func test_initializeFromDictionaryWithIncorrectSiteIdType_expectThrowError() {
         let givenDict: [String: Any] = [
-            "siteId": 100,
-            "region": "US"
+            "region": "US",
+            "inApp": [
+                "siteId": 100
+            ]
         ]
 
         XCTAssertThrowsError(try MessagingInAppConfigBuilder.build(from: givenDict)) { error in
@@ -61,7 +100,10 @@ class MessagingInAppConfigBuilderTest: UnitTest {
 
     func test_initializeFromDictionaryWithOnlyRegion_expectThrowError() {
         let givenDict: [String: Any] = [
-            "region": String.random
+            "region": String.random,
+            "inApp": [
+                "apiKey": String.random
+            ]
         ]
 
         XCTAssertThrowsError(try MessagingInAppConfigBuilder.build(from: givenDict)) { error in
@@ -72,20 +114,24 @@ class MessagingInAppConfigBuilderTest: UnitTest {
     func test_initializeFromDictionaryWithIncorrectRegionType_expectThrowError() {
         let givenSiteId = String.random
         let givenDict: [String: Any] = [
-            "siteId": givenSiteId,
-            "region": Region.US
+            "region": Region.US,
+            "inApp": [
+                "siteId": givenSiteId
+            ]
         ]
 
         XCTAssertThrowsError(try MessagingInAppConfigBuilder.build(from: givenDict)) { error in
-            XCTAssertEqual(error as? MessagingInAppConfigBuilderError, MessagingInAppConfigBuilderError.missingRegion)
+            XCTAssertEqual(error as? MessagingInAppConfigBuilderError, MessagingInAppConfigBuilderError.invalidRegionType)
         }
     }
 
     func test_initializeFromDictionaryWithIncorrectRegionValue_expectDefaultValues() {
         let givenSiteId = String.random
         let givenDict: [String: Any] = [
-            "siteId": givenSiteId,
-            "region": "OK"
+            "region": "OK",
+            "inApp": [
+                "siteId": givenSiteId
+            ]
         ]
 
         let config = try? MessagingInAppConfigBuilder.build(from: givenDict)

--- a/Tests/MessagingInApp/Config/MessagingInAppConfigBuilderTest.swift
+++ b/Tests/MessagingInApp/Config/MessagingInAppConfigBuilderTest.swift
@@ -32,24 +32,6 @@ class MessagingInAppConfigBuilderTest: UnitTest {
         XCTAssertEqual(config?.region.rawValue, givenRegion)
     }
 
-    func test_initializeFromDictionaryWithCustomKey_expectCorrectValues() {
-        let givenSiteId = String.random
-        let givenRegion = "US"
-
-        let givenDict: [String: Any] = [
-            "region": givenRegion,
-            "in-app": [
-                "siteId": givenSiteId
-            ]
-        ]
-
-        let config = try? MessagingInAppConfigBuilder.build(from: givenDict, withConfig: "in-app")
-
-        XCTAssertNotNil(config)
-        XCTAssertEqual(config?.siteId, givenSiteId)
-        XCTAssertEqual(config?.region.rawValue, givenRegion)
-    }
-
     func test_initializeFromEmptyDictionary_expectThrowError() {
         let givenDict: [String: Any] = [
             "inApp": [:]


### PR DESCRIPTION
part of: [MBL-538](https://linear.app/customerio/issue/MBL-538/add-feature-for-inapp-messages-in-ios-rn), [MBL-546](https://linear.app/customerio/issue/MBL-546/inapp-event-listeners-ios-and-android-rn)

### Changes

- Updated `Logger` class to allow setting log dispatcher for intercepting logs, ensuring only one logger instance and matching Android behavior
- Updated `MessagingInAppConfigBuilder` to meet React Native package expectations and provide clearer error explanations
- Updated tests for `Region` and `MessagingInAppConfigBuilder` to validate changes