### PR TITLE
chore: firebase version upgrade for v2

### DIFF
--- a/CustomerIOMessagingPushFCM.podspec
+++ b/CustomerIOMessagingPushFCM.podspec
@@ -30,5 +30,5 @@ Pod::Spec.new do |spec|
   # Add FCM SDK as a dependency, as our SDK is designed to be compatible with it. 
   # No version is specified which means that by default, the latest version is installed for customers. 
   # Customers can override this by adding the pod to their Podfile themselves to specify a version they want to use. 
-  spec.dependency "FirebaseMessaging", ">= 8.7.0", "< 11"
+  spec.dependency "FirebaseMessaging", ">= 8.7.0", "< 12"
 end

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let package = Package(
         // https://web.archive.org/web/20220525200227/https://www.timc.dev/posts/understanding-swift-packages/
         //
         // Update to exact version until wrapper SDKs become part of testing pipeline.
-        .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git", "8.7.0"..<"11.0.0")
+        .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git",  "8.7.0"..<"12.0.0")
     ],
     targets: [ 
         // Common - Code used by multiple modules in the SDK project.


### PR DESCRIPTION
Linear ticket: 

### Problem
Customers are currently facing issues when upgrading to Firebase's latest version, 11.2. They want to use the latest version of the dependency, but our package restricts usage to versions up to 11.0, preventing them from installing higher versions.

### Solution
Update the version range and test if the app successfully upgrades to the latest Firebase version while using our SDK.
