### PR TITLE
Update FirebaseMessaging Dependency in v2 Branch for Compatibility with New Firebase Versions

### DIFF
--- a/CustomerIOMessagingPushFCM.podspec
+++ b/CustomerIOMessagingPushFCM.podspec
@@ -30,5 +30,5 @@ Pod::Spec.new do |spec|
   # Add FCM SDK as a dependency, as our SDK is designed to be compatible with it. 
   # No version is specified which means that by default, the latest version is installed for customers. 
   # Customers can override this by adding the pod to their Podfile themselves to specify a version they want to use. 
-  spec.dependency "FirebaseMessaging", ">= 8.7.0", "< 11"
+  spec.dependency "FirebaseMessaging", ">= 8.7.0", "< 12"
 end

--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let package = Package(
         // https://web.archive.org/web/20220525200227/https://www.timc.dev/posts/understanding-swift-packages/
         //
         // Update to exact version until wrapper SDKs become part of testing pipeline.
-        .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git", "8.7.0"..<"11.0.0")
+        .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git", "8.7.0"..<"12.0.0"),
     ],
     targets: [ 
         // Common - Code used by multiple modules in the SDK project.


### PR DESCRIPTION

### **Description:**

This pull request updates the `FirebaseMessaging` dependency in the **v2 branch** of the **Customer.io iOS SDK** to ensure compatibility with Firebase versions up to but not including **12.0.0**. 

### **Reason for the Update:**
- The **Customer.io Flutter plugin** currently depends on the **v2 iOS SDK** and has not yet been updated to support the **v3 iOS SDK**.
- To avoid waiting for the Flutter plugin to be updated, we need to ensure that the v2 iOS SDK remains compatible with the latest Firebase versions, those latest Firebase versions include fixes for building with **Xcode 16**.

### **Impact:**
- This update ensures that projects using the **Customer.io Flutter plugin** (and thus the v2 iOS SDK) can build successfully with the latest versions of Firebase and thus with Xcode 16.
- The update preserves compatibility with existing functionality in the v2.x SDK, while allowing newer Firebase versions to be used.

Updated the range to >8.7.0 <12.0.0 and tested on UIKit and CocoaPod sample apps. There are no major breaking changes as per the [official Firebase document](https://firebase.google.com/support/release-notes/ios#11.0.0) that affects this SDK.

Closes #823

--------

* [ ]  [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request.
* [ ]  Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1).
* [ ]  Wait until the pull request has been reviewed _and approved_ by a teammate
* [ ]  After code reviews are approved and you determine this PR is ready to merge, select _Squash and Merge_ button on this screen, leave the title and description to the default values, then merge the PR.