### PR TITLE
chore: add nse user agent support

### DIFF
--- a/Sources/Common/Service/UserAgentUtil.swift
+++ b/Sources/Common/Service/UserAgentUtil.swift
@@ -2,16 +2,19 @@ import Foundation
 
 public protocol UserAgentUtil: AutoMockable {
     func getUserAgentHeaderValue() -> String
+    func getNSEUserAgentHeaderValue() -> String
 }
 
 // sourcery: InjectRegisterShared = "UserAgentUtil"
 public class UserAgentUtilImpl: UserAgentUtil {
     private let deviceInfo: DeviceInfo
-    private let sdkClient: SdkClient
+    private let mainTargetSdkClient: SdkClient
+    private let nseSdkClient: SdkClient
 
     init(deviceInfo: DeviceInfo, sdkClient: SdkClient) {
         self.deviceInfo = deviceInfo
-        self.sdkClient = sdkClient
+        self.mainTargetSdkClient = sdkClient
+        self.nseSdkClient = DIGraphShared.shared.nseSdkClient
     }
 
     /**
@@ -25,6 +28,18 @@ public class UserAgentUtilImpl: UserAgentUtil {
      * `Customer.io iOS Client/1.0.0-alpha.16`
      */
     public func getUserAgentHeaderValue() -> String {
+        createUserAgentHeader(sdkClient: mainTargetSdkClient)
+    }
+
+    /**
+     * Same as `getUserAgentHeaderValue` but this function returns value for NSE client
+     */
+    public func getNSEUserAgentHeaderValue() -> String {
+        createUserAgentHeader(sdkClient: nseSdkClient)
+    }
+
+    /// Creates User-Agent header value based on given `SdkClient`
+    private func createUserAgentHeader(sdkClient: SdkClient) -> String {
         var userAgent = "Customer.io \(sdkClient)"
 
         if let deviceModel = deviceInfo.deviceModel,

--- a/Sources/Common/Util/SdkClient.swift
+++ b/Sources/Common/Util/SdkClient.swift
@@ -46,4 +46,10 @@ extension DIGraphShared {
     var customSdkClient: SdkClient {
         CustomerIOSdkClient(deviceInfo: deviceInfo)
     }
+
+    /// SDK client for NSE. It is not injected as dependency, but can be accessed
+    /// using `DIGraphShared.shared.nseSdkClient`.
+    var nseSdkClient: SdkClient {
+        CustomerIOSdkClient(source: "NSE", sdkVersion: SdkVersion.version)
+    }
 }

--- a/Sources/Common/autogenerated/AutoMockable.generated.swift
+++ b/Sources/Common/autogenerated/AutoMockable.generated.swift
@@ -2724,6 +2724,9 @@ public class UserAgentUtilMock: UserAgentUtil, Mock {
         getUserAgentHeaderValueCallsCount = 0
 
         mockCalled = false // do last as resetting properties above can make this true
+        getNSEUserAgentHeaderValueCallsCount = 0
+
+        mockCalled = false // do last as resetting properties above can make this true
     }
 
     // MARK: - getUserAgentHeaderValue
@@ -2749,6 +2752,31 @@ public class UserAgentUtilMock: UserAgentUtil, Mock {
         mockCalled = true
         getUserAgentHeaderValueCallsCount += 1
         return getUserAgentHeaderValueClosure.map { $0() } ?? getUserAgentHeaderValueReturnValue
+    }
+
+    // MARK: - getNSEUserAgentHeaderValue
+
+    /// Number of times the function was called.
+    @Atomic public private(set) var getNSEUserAgentHeaderValueCallsCount = 0
+    /// `true` if the function was ever called.
+    public var getNSEUserAgentHeaderValueCalled: Bool {
+        getNSEUserAgentHeaderValueCallsCount > 0
+    }
+
+    /// Value to return from the mocked function.
+    public var getNSEUserAgentHeaderValueReturnValue: String!
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     The closure has first priority to return a value for the mocked function. If the closure returns `nil`,
+     then the mock will attempt to return the value for `getNSEUserAgentHeaderValueReturnValue`
+     */
+    public var getNSEUserAgentHeaderValueClosure: (() -> String)?
+
+    /// Mocked function for `getNSEUserAgentHeaderValue()`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func getNSEUserAgentHeaderValue() -> String {
+        mockCalled = true
+        getNSEUserAgentHeaderValueCallsCount += 1
+        return getNSEUserAgentHeaderValueClosure.map { $0() } ?? getNSEUserAgentHeaderValueReturnValue
     }
 }
 

--- a/Sources/MessagingPush/MessagingPushImplementation.swift
+++ b/Sources/MessagingPush/MessagingPushImplementation.swift
@@ -6,29 +6,12 @@ class MessagingPushImplementation: MessagingPushInstance {
     let logger: Logger
     let jsonAdapter: JsonAdapter
     let eventBusHandler: EventBusHandler
-    let richPushDeliveryTracker: RichPushDeliveryTracker
-
-    /// testing init
-    init(
-        moduleConfig: MessagingPushConfigOptions,
-        logger: Logger,
-        jsonAdapter: JsonAdapter,
-        eventBusHandler: EventBusHandler,
-        richPushDeliveryTracker: RichPushDeliveryTracker
-    ) {
-        self.moduleConfig = moduleConfig
-        self.logger = logger
-        self.jsonAdapter = jsonAdapter
-        self.eventBusHandler = eventBusHandler
-        self.richPushDeliveryTracker = richPushDeliveryTracker
-    }
 
     init(diGraph: DIGraphShared, moduleConfig: MessagingPushConfigOptions) {
         self.moduleConfig = moduleConfig
         self.logger = diGraph.logger
         self.jsonAdapter = diGraph.jsonAdapter
         self.eventBusHandler = diGraph.eventBusHandler
-        self.richPushDeliveryTracker = diGraph.richPushDeliveryTracker
     }
 
     func deleteDeviceToken() {
@@ -48,6 +31,9 @@ class MessagingPushImplementation: MessagingPushInstance {
         event: Metric,
         deviceToken: String
     ) {
-        richPushDeliveryTracker.trackMetric(token: deviceToken, event: event, deliveryId: deliveryID) { _ in }
+        // Access richPushDeliveryTracker from DIGraphShared.shared directly as it is only required for NSE.
+        // Keeping it as class property results in initialization of UserAgentUtil before SDK client is overridden by wrapper SDKs.
+        // In future, we can improve how we access SdkClient so that we don't need to worry about initialization order.
+        DIGraphShared.shared.richPushDeliveryTracker.trackMetric(token: deviceToken, event: event, deliveryId: deliveryID) { _ in }
     }
 }

--- a/Sources/MessagingPush/RichPush/RichPushHttpClient.swift
+++ b/Sources/MessagingPush/RichPush/RichPushHttpClient.swift
@@ -127,7 +127,7 @@ public class RichPushHttpClient: HttpClient {
         self.publicSession = Self.getBasicSession()
         self.cioApiSession = Self.getCIOApiSession(
             key: MessagingPush.moduleConfig.cdpApiKey,
-            userAgentHeaderValue: userAgentUtil.getUserAgentHeaderValue()
+            userAgentHeaderValue: userAgentUtil.getNSEUserAgentHeaderValue()
         )
     }
 

--- a/Tests/Common/Service/UserAgentUtilTest.swift
+++ b/Tests/Common/Service/UserAgentUtilTest.swift
@@ -78,4 +78,18 @@ class UserAgentUtilTest: UnitTest {
 
         XCTAssertEqual(expected, actual)
     }
+
+    func test_getUserAgent_givenDeviceInfoAvailable_expectLongNSEUserAgent() {
+        let expected = "Customer.io NSE Client/\(SdkVersion.version) (iPhone14; iOS 15.3) io.customer.nse/2.0.3"
+        deviceInfoMock.underlyingDeviceModel = "iPhone14"
+        deviceInfoMock.underlyingOsVersion = "15.3"
+        deviceInfoMock.underlyingOsName = "iOS"
+        deviceInfoMock.underlyingCustomerAppName = "NSEPush"
+        deviceInfoMock.underlyingCustomerBundleId = "io.customer.nse"
+        deviceInfoMock.underlyingCustomerAppVersion = "2.0.3"
+
+        let actual = userAgentUtil.getNSEUserAgentHeaderValue()
+
+        XCTAssertEqual(expected, actual)
+    }
 }


### PR DESCRIPTION
part of [MBL-540](https://linear.app/customerio/issue/MBL-540/react-native)

### Changes

- Updated `UserAgentUtil` to provide separate user agents for main target and NSE
- Added a separate NSE `SdkClient` to generate user agent from client using the same code
- Updated `RichPushHttpClient` to use NSE-specific user agent
- Removed unused methods
- Added tests for NSE headers
