### PR TITLE
fix: v2 dismiss keyboard when inapp message shows

### DIFF
--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -91,6 +91,14 @@ public class Gist: GistDelegate {
         } else {
             Logger.instance.debug(message: "Persistent message shown, skipping logging view")
         }
+        
+        // To ensure the keyboard is dismissed on displaying an in-app message,
+        // Update UI on main thread only.
+        // Dismiss keyboard on showing the message to prevent gap between
+        // displaying the in-app message and dismissing the keyboard.
+        DispatchQueue.main.async {
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
         delegate?.messageShown(message: message)
     }
 


### PR DESCRIPTION
### Problem
- An in-app message is sent to an iOS device.
- User opens the keyboard and begins typing.
- Issue arises when the in-app message shows on the screen, as the user is either blocked from closing the message or continuing to type.

This behavior prevents interaction with the app, as displaying of the in-app message disrupts the current activity (e.g., typing or moving back to previous screen) and makes it difficult for the user to manage actions. 

### Solution
Dismiss keyboard when in-app message shows up on the screen.

### Testing
The change has been tested on :
- iOS v2 SDK (Journeys)
- Wrapper SDKs

### Video

https://github.com/user-attachments/assets/c4095ee4-c09a-42cb-96e0-3d9a5d937366



