### PR TITLE
fix: dismiss keyboard on showing in app message on CDP SDK

### DIFF
--- a/Sources/MessagingInApp/Gist/GistDelegate.swift
+++ b/Sources/MessagingInApp/Gist/GistDelegate.swift
@@ -41,7 +41,13 @@ class GistDelegateImpl: GistDelegate {
         if let deliveryId = message.campaignDeliveryId {
             eventBusHandler.postEvent(TrackInAppMetricEvent(deliveryID: deliveryId, event: InAppMetric.opened.rawValue))
         }
-
+        // To ensure the keyboard is dismissed on displaying an in-app message,
+        // Update UI on main thread only.
+        // Dismiss keyboard on showing the message to prevent gap between
+        // displaying the in-app message and dismissing the keyboard.
+        DispatchQueue.main.async {
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
         eventListener?.messageShown(message: InAppMessage(gistMessage: message))
     }
 

--- a/Sources/MessagingInApp/Gist/GistDelegate.swift
+++ b/Sources/MessagingInApp/Gist/GistDelegate.swift
@@ -21,12 +21,12 @@ public protocol GistDelegate: AnyObject {
 class GistDelegateImpl: GistDelegate {
     private let logger: Logger
     private let eventBusHandler: EventBusHandler
-
     private var eventListener: InAppEventListener?
-
+    private let threadUtil: ThreadUtil
     init(logger: Logger, eventBusHandler: EventBusHandler) {
         self.logger = logger
         self.eventBusHandler = eventBusHandler
+        self.threadUtil = DIGraphShared.shared.threadUtil
     }
 
     func setEventListener(_ eventListener: InAppEventListener?) {
@@ -45,7 +45,7 @@ class GistDelegateImpl: GistDelegate {
         // Update UI on main thread only.
         // Dismiss keyboard on showing the message to prevent gap between
         // displaying the in-app message and dismissing the keyboard.
-        DispatchQueue.main.async {
+        threadUtil.runMain {
             UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
         }
         eventListener?.messageShown(message: InAppMessage(gistMessage: message))


### PR DESCRIPTION
### Problem
- An in-app message is sent to an iOS device.
- User opens the keyboard and begins typing.
- Issue arises when the in-app message shows on the screen, as the user is either blocked from closing the message or continuing to type.

This behavior prevents interaction with the app, as displaying of the in-app message disrupts the current activity (e.g., typing or moving back to previous screen) and makes it difficult for the user to manage actions. 

### Solution
Dismiss keyboard when in-app message shows up on the screen.

### Testing
The change has been tested on :
- iOS CDP SDK (CDP)

### Video

https://github.com/user-attachments/assets/c4095ee4-c09a-42cb-96e0-3d9a5d937366



