### PR TITLE
feat: support for large in-app messages

### DIFF
--- a/Sources/MessagingInApp/Gist/EngineWeb/EngineWeb.swift
+++ b/Sources/MessagingInApp/Gist/EngineWeb/EngineWeb.swift
@@ -34,55 +34,64 @@ public class EngineWeb: NSObject, EngineWebInstance {
         webView
     }
 
+    private var currentConfiguration: EngineWebConfiguration?
+
     public private(set) var currentRoute: String {
-        get {
-            _currentRoute
-        }
-        set {
-            _currentRoute = newValue
-        }
+        get { _currentRoute }
+        set { _currentRoute = newValue }
     }
 
+    /// Initializes the EngineWeb instance with the given configuration, state, and message.
     init(configuration: EngineWebConfiguration, state: InAppMessageState, message: Message) {
         self.currentMessage = message
+        self.currentConfiguration = configuration
 
         super.init()
 
-        _elapsedTimer.start(title: "Engine render for message: \(configuration.messageId)")
+        setupWebView()
+        injectJavaScriptListener()
+        loadMessage(with: state)
+    }
+
+    /// Sets up the properties and appearance of the WKWebView.
+    private func setupWebView() {
+        _elapsedTimer.start(title: "Engine render for message: \(currentConfiguration?.messageId ?? "")")
 
         webView.translatesAutoresizingMaskIntoConstraints = false
         webView.navigationDelegate = self
         webView.isOpaque = false
-        webView.backgroundColor = UIColor.clear
-        webView.scrollView.backgroundColor = UIColor.clear
-
-        let js = "window.parent.postMessage = function(message) {webkit.messageHandlers.gist.postMessage(message)}"
-        let messageHandlerScript = WKUserScript(source: js, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
-
-        webView.configuration.userContentController.add(self, name: "gist")
-        webView.configuration.userContentController.addUserScript(messageHandlerScript)
+        webView.backgroundColor = .clear
+        webView.scrollView.backgroundColor = .clear
 
         if #available(iOS 11.0, *) {
             webView.scrollView.contentInsetAdjustmentBehavior = .never
         }
+    }
 
-        if let jsonData = try? JSONEncoder().encode(configuration),
-           let jsonString = String(data: jsonData, encoding: .utf8),
-           let options = jsonString.data(using: .utf8)?.base64EncodedString()
-           .addingPercentEncoding(withAllowedCharacters: .alphanumerics) {
-            let url = "\(state.environment.networkSettings.renderer)/index.html?options=\(options)"
-            logger.logWithModuleTag("Loading URL: \(url)", level: .info)
-            if let link = URL(string: url) {
-                self._timeoutTimer = Timer.scheduledTimer(
-                    timeInterval: 5.0,
-                    target: self,
-                    selector: #selector(forcedTimeout),
-                    userInfo: nil,
-                    repeats: false
-                )
-                let request = URLRequest(url: link)
-                webView.load(request)
-            }
+    /// Injects a JavaScript listener to handle messages from the web content.
+    private func injectJavaScriptListener() {
+        let js = """
+        window.addEventListener('message', function(event) {
+            webkit.messageHandlers.gist.postMessage(event.data);
+        });
+        """
+        let messageHandlerScript = WKUserScript(source: js, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
+
+        webView.configuration.userContentController.add(self, name: "gist")
+        webView.configuration.userContentController.addUserScript(messageHandlerScript)
+    }
+
+    private func loadMessage(with state: InAppMessageState) {
+        let messageUrl = "\(state.environment.networkSettings.renderer)/index.html"
+        logger.debug("Rendering message with URL: \(messageUrl)")
+
+        if let url = URL(string: messageUrl) {
+            _timeoutTimer?.invalidate()
+            _timeoutTimer = Timer.scheduledTimer(timeInterval: 5.0, target: self, selector: #selector(forcedTimeout), userInfo: nil, repeats: false)
+            webView.load(URLRequest(url: url))
+        } else {
+            logger.error("Invalid URL: \(messageUrl)")
+            delegate?.error()
         }
     }
 
@@ -104,10 +113,7 @@ public class EngineWeb: NSObject, EngineWebInstance {
 
 // swiftlint:disable cyclomatic_complexity
 extension EngineWeb: WKScriptMessageHandler {
-    public func userContentController(
-        _ userContentController: WKUserContentController,
-        didReceive message: WKScriptMessage
-    ) {
+    public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         guard let dict = message.body as? [String: AnyObject],
               let eventProperties = dict["gist"] as? [String: AnyObject],
               let method = eventProperties["method"] as? String,
@@ -116,6 +122,10 @@ extension EngineWeb: WKScriptMessageHandler {
             return
         }
 
+        handleEngineEvent(engineEventMethod, eventProperties: eventProperties)
+    }
+
+    private func handleEngineEvent(_ engineEventMethod: EngineEvent, eventProperties: [String: AnyObject]) {
         switch engineEventMethod {
         case .bootstrapped:
             _timeoutTimer?.invalidate()
@@ -150,27 +160,49 @@ extension EngineWeb: WKScriptMessageHandler {
 }
 
 // swiftlint:enable cyclomatic_complexity
-
 extension EngineWeb: WKNavigationDelegate {
-    public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {}
+    public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        guard let configuration = currentConfiguration else {
+            logger.error("Configuration not available")
+            delegate?.error()
+            return
+        }
+
+        injectConfiguration(configuration)
+    }
+
+    private func injectConfiguration(_ configuration: EngineWebConfiguration) {
+        do {
+            let jsonData = try JSONEncoder().encode(["options": configuration])
+            guard let jsonString = String(data: jsonData, encoding: .utf8) else {
+                throw NSError(domain: "EngineWeb", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to create JSON string"])
+            }
+
+            let js = "window.postMessage(\(jsonString), '*');"
+
+            webView.evaluateJavaScript(js) { [weak self] _, error in
+                if let error = error {
+                    self?.logger.error("JavaScript execution error: \(error)")
+                    self?.delegate?.error()
+                } else {
+                    self?.logger.debug("Configuration injected successfully")
+                }
+            }
+        } catch {
+            logger.error("Failed to encode configuration: \(error)")
+            delegate?.error()
+        }
+    }
 
     public func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
         delegate?.error()
     }
 
-    public func webView(
-        _ webView: WKWebView,
-        didFail navigation: WKNavigation!,
-        withError error: Error
-    ) {
+    public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         delegate?.error()
     }
 
-    public func webView(
-        _ webView: WKWebView,
-        didFailProvisionalNavigation navigation: WKNavigation!,
-        withError error: Error
-    ) {
+    public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         delegate?.error()
     }
 }

--- a/Sources/MessagingInApp/Gist/Network/NetworkSettings.swift
+++ b/Sources/MessagingInApp/Gist/Network/NetworkSettings.swift
@@ -7,13 +7,13 @@ protocol NetworkSettings {
 struct NetworkSettingsProduction: NetworkSettings {
     let queueAPI = "https://gist-queue-consumer-api.cloud.gist.build"
     let engineAPI = "https://engine.api.gist.build"
-    let renderer = "https://renderer.gist.build/2.0"
+    let renderer = "https://renderer.gist.build/3.0"
 }
 
 struct NetworkSettingsDevelopment: NetworkSettings {
     let queueAPI = "https://gist-queue-consumer-api.cloud.dev.gist.build"
     let engineAPI = "https://engine.api.dev.gist.build"
-    let renderer = "https://renderer.gist.build/2.0"
+    let renderer = "https://renderer.gist.build/3.0"
 }
 
 struct NetworkSettingsLocal: NetworkSettings {


### PR DESCRIPTION
closes: [MBL-547: Bug: Large in-app messages not getting delivered](https://linear.app/customerio/issue/MBL-547/bug-large-in-app-messages-not-getting-delivered)

changes:
- Make JS post request for sending is message payload rather than query params
- Updated how we used to post messages to JS
Before: You were overriding window.parent.postMessage, which altered how postMessage worked, potentially affecting other code on the page.
Now: You are listening for messages, allowing all normal JavaScript behavior to continue while capturing the data you need.