### PR TITLE
chore: move to v2 for user queue request and user agent in headers

### DIFF
--- a/Sources/MessagingInApp/Gist/Network/Endpoints/QueueEndpoint.swift
+++ b/Sources/MessagingInApp/Gist/Network/Endpoints/QueueEndpoint.swift
@@ -17,7 +17,7 @@ enum QueueEndpoint: GistNetworkRequest {
     var path: String {
         switch self {
         case .getUserQueue:
-            return "/api/v1/users"
+            return "/api/v2/users"
         }
     }
 }

--- a/Sources/MessagingInApp/Gist/Network/Endpoints/Utilities/Headers.swift
+++ b/Sources/MessagingInApp/Gist/Network/Endpoints/Utilities/Headers.swift
@@ -3,6 +3,8 @@ enum HTTPHeader: String {
     case siteId = "X-CIO-Site-Id"
     case cioDataCenter = "X-CIO-Datacenter"
     case userToken = "X-Gist-Encoded-User-Token"
+    case cioClientVersion = "X-CIO-Client-Version"
+    case cioClientPlatform = "X-CIO-Client-Platform"
 }
 
 enum ContentTypes: String {

--- a/Sources/MessagingInApp/Gist/Network/GistQueueNetwork.swift
+++ b/Sources/MessagingInApp/Gist/Network/GistQueueNetwork.swift
@@ -22,10 +22,14 @@ class GistQueueNetworkImpl: GistQueueNetwork {
             throw GistNetworkRequestError.invalidBaseURL
         }
 
+        let sdkClient = DIGraphShared.shared.sdkClient
+
         var urlRequest = URLRequest(url: baseURL.appendingPathComponent(request.path))
         urlRequest.httpMethod = request.method.rawValue
         urlRequest.addValue(state.siteId, forHTTPHeaderField: HTTPHeader.siteId.rawValue)
         urlRequest.addValue(state.dataCenter, forHTTPHeaderField: HTTPHeader.cioDataCenter.rawValue)
+        urlRequest.addValue(sdkClient.sdkVersion, forHTTPHeaderField: HTTPHeader.cioClientVersion.rawValue)
+        urlRequest.addValue(sdkClient.source.lowercased(), forHTTPHeaderField: HTTPHeader.cioClientPlatform.rawValue)
         if let userToken = state.userId {
             urlRequest.addValue(Data(userToken.utf8).base64EncodedString(), forHTTPHeaderField: HTTPHeader.userToken.rawValue)
         }


### PR DESCRIPTION
closes: https://linear.app/customerio/issue/MBL-495/move-to-v2-apis-of-gist-and-add-sdk-reporting

changes:
- Upgrade user queue endpoint path to v2
- Added SDK version and platform in request headers