### PR TITLE
chore: encode loadPage action URL

### DIFF
--- a/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
@@ -171,7 +171,9 @@ class MessageManager: EngineWebDelegate {
                 logger.logWithModuleTag("Dismissing from action: \(action)", level: .info)
                 inAppMessageManager.dispatch(action: .dismissMessage(message: currentMessage, viaCloseAction: true))
             case "loadPage":
-                if let page = url.queryParameters?["url"],
+                // Encode '#' in url action string and creates encoded URL to handle fragments
+                let encodedUrl = URL(string: action.percentEncode(character: "#")) ?? url
+                if let page = encodedUrl.queryParameters?["url"],
                    let pageUrl = URL(string: page),
                    UIApplication.shared.canOpenURL(pageUrl) {
                     UIApplication.shared.open(pageUrl)

--- a/Sources/MessagingInApp/Gist/Utilities/String.swift
+++ b/Sources/MessagingInApp/Gist/Utilities/String.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+extension String {
+    /// Encodes a specific character in the string using percent encoding.
+    func percentEncode(character target: String, withAllowedCharacters allowedCharacters: CharacterSet = .urlPathAllowed) -> String {
+        replacingOccurrences(of: target, with: target.addingPercentEncoding(withAllowedCharacters: allowedCharacters) ?? target)
+    }
+}

--- a/Tests/MessagingInApp/Gist/Utilities/StringPercentEncodeTests.swift
+++ b/Tests/MessagingInApp/Gist/Utilities/StringPercentEncodeTests.swift
@@ -1,0 +1,69 @@
+@testable import CioMessagingInApp
+import XCTest
+
+class StringPercentEncodeTests: XCTestCase {
+    func test_givenValidCharacter_expectEncodedURL() {
+        let input = "https://example.com/path#fragment"
+
+        let encoded = input.percentEncode(character: "#")
+
+        XCTAssertEqual(encoded, "https://example.com/path%23fragment")
+    }
+
+    func test_givenMultipleOccurrences_expectAllEncoded() {
+        let input = "https://example.com/path#fragment#another"
+
+        let encoded = input.percentEncode(character: "#")
+
+        XCTAssertEqual(encoded, "https://example.com/path%23fragment%23another")
+    }
+
+    func test_givenMultipleCharacter_expectEncodedGivenOnly() {
+        let input = "https://example.com/path#source=link&medium=email"
+
+        let encoded = input.percentEncode(character: "#")
+
+        XCTAssertEqual(encoded, "https://example.com/path%23source=link&medium=email")
+    }
+
+    func test_givenCharacterInAllowedSet_expectUnchangedString() {
+        let input = "https://example.com/path/fragment"
+
+        // '/' is allowed in `.urlPathAllowed`
+        let encoded = input.percentEncode(character: "/")
+
+        XCTAssertEqual(encoded, input)
+    }
+
+    func test_givenCustomAllowedCharacterSet_expectEncodedSpaces() {
+        let input = "https://example.com/path with spaces"
+
+        let encoded = input.percentEncode(character: " ", withAllowedCharacters: .alphanumerics)
+
+        XCTAssertEqual(encoded, "https://example.com/path%20with%20spaces")
+    }
+
+    func test_givenNoTargetCharacter_expectUnchangedString() {
+        let input = "https://example.com/path/fragment"
+
+        let encoded = input.percentEncode(character: "#")
+
+        XCTAssertEqual(encoded, input)
+    }
+
+    func test_givenEmptyTargetCharacter_expectUnchangedString() {
+        let input = "https://example.com/path/fragment"
+
+        let encoded = input.percentEncode(character: "")
+
+        XCTAssertEqual(encoded, input)
+    }
+
+    func test_givenEmptyInput_expectEmptyString() {
+        let input = ""
+
+        let encoded = input.percentEncode(character: "#")
+
+        XCTAssertEqual(encoded, input)
+    }
+}


### PR DESCRIPTION
fixes: [MBL-762](https://linear.app/customerio/issue/MBL-762/[bug]-ios-sdk-strips-fragment-from-urls-in-legacy-in-app-messages)

### Changes

- Encoded action URL before extracting it for `loadPage` action to retain fragment URL part
- Added string extension to encode specific characters
- Added relevant tests

### Example

#### Input

```
gist://loadPage?url=https://docs.customer.io/sdk/ios/in-app/set-up-in-app/#set-up-in-app-messaging
```

#### Output `pageUrl`

**Before:**

```
https://docs.customer.io/sdk/ios/in-app/set-up-in-app/
```  

**After:**

```
https://docs.customer.io/sdk/ios/in-app/set-up-in-app/#set-up-in-app-messaging
```