### PR TITLE
fix: Fix in-app messages overlay color ignored from message payload

### DIFF
--- a/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
@@ -126,8 +126,9 @@ class MessageManager: EngineWebDelegate {
             return
         }
 
+        let gistProperties = currentMessage.gistProperties
         logger.logWithModuleTag("Loading modal message: \(currentMessage.describeForLogs)", level: .debug)
-        modalViewManager = ModalViewManager(gistView: gistView, position: currentMessage.gistProperties.position)
+        modalViewManager = ModalViewManager(gistView: gistView, position: gistProperties.position, overlayColor: gistProperties.overlayColor)
         modalViewManager?.showModalView { [weak self] in
             guard let self = self else { return }
 

--- a/Sources/MessagingInApp/Gist/Managers/ModalViewManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/ModalViewManager.swift
@@ -39,7 +39,7 @@ class ModalViewManager {
             finalPosition = viewController.view.center.y - viewController.view.bounds.height
         }
 
-        let overlayColor = UIColor.fromHex(color: overlayColor) ?? UIColor.black.withAlphaComponent(0.2)
+        let overlayColor = UIColor.fromHex(overlayColor) ?? UIColor.black.withAlphaComponent(0.2)
         UIView.animate(withDuration: 0.3, delay: 0, options: [.curveEaseIn], animations: {
             self.viewController.view.center.y = finalPosition
         }, completion: { _ in

--- a/Sources/MessagingInApp/Gist/Managers/ModalViewManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/ModalViewManager.swift
@@ -10,12 +10,14 @@ class ModalViewManager {
     var window: UIWindow?
     var viewController: GistModalViewController!
     var position: MessagePosition
+    var overlayColor: String?
 
-    init(gistView: GistView, position: MessagePosition) {
+    init(gistView: GistView, position: MessagePosition, overlayColor: String?) {
         self.viewController = GistModalViewController()
         viewController.gistView = gistView
         viewController.setup(position: position)
         self.position = position
+        self.overlayColor = overlayColor
     }
 
     func showModalView(completionHandler: @escaping () -> Void) {
@@ -37,11 +39,12 @@ class ModalViewManager {
             finalPosition = viewController.view.center.y - viewController.view.bounds.height
         }
 
+        let overlayColor = UIColor.fromHex(color: overlayColor) ?? UIColor.black.withAlphaComponent(0.2)
         UIView.animate(withDuration: 0.3, delay: 0, options: [.curveEaseIn], animations: {
             self.viewController.view.center.y = finalPosition
         }, completion: { _ in
             UIView.animate(withDuration: 0.1, delay: 0, options: [.curveEaseIn], animations: {
-                self.viewController.view.backgroundColor = UIColor.black.withAlphaComponent(0.2)
+                self.viewController.view.backgroundColor = overlayColor
             }, completion: nil)
             completionHandler()
         })

--- a/Sources/MessagingInApp/Gist/Managers/Models/Message.swift
+++ b/Sources/MessagingInApp/Gist/Managers/Models/Message.swift
@@ -9,12 +9,14 @@ public class GistProperties {
     public let persistent: Bool?
     public let overlayColor: String?
 
-    init(routeRule: String?,
-         elementId: String?,
-         campaignId: String?,
-         position: MessagePosition,
-         persistent: Bool?,
-         overlayColor: String?) {
+    init(
+        routeRule: String?,
+        elementId: String?,
+        campaignId: String?,
+        position: MessagePosition,
+        persistent: Bool?,
+        overlayColor: String?
+    ) {
         self.routeRule = routeRule
         self.elementId = elementId
         self.position = position

--- a/Sources/MessagingInApp/Gist/Managers/Models/Message.swift
+++ b/Sources/MessagingInApp/Gist/Managers/Models/Message.swift
@@ -7,13 +7,20 @@ public class GistProperties {
     public let campaignId: String?
     public let position: MessagePosition
     public let persistent: Bool?
+    public let overlayColor: String?
 
-    init(routeRule: String?, elementId: String?, campaignId: String?, position: MessagePosition, persistent: Bool?) {
+    init(routeRule: String?,
+         elementId: String?,
+         campaignId: String?,
+         position: MessagePosition,
+         persistent: Bool?,
+         overlayColor: String?) {
         self.routeRule = routeRule
         self.elementId = elementId
         self.position = position
         self.campaignId = campaignId
         self.persistent = persistent
+        self.overlayColor = overlayColor
     }
 }
 
@@ -45,7 +52,7 @@ public class Message {
     private static func parseGistProperties(from gist: [String: Any]?) -> GistProperties {
         let defaultPosition = MessagePosition.center
         guard let gist = gist else {
-            return GistProperties(routeRule: nil, elementId: nil, campaignId: nil, position: defaultPosition, persistent: false)
+            return GistProperties(routeRule: nil, elementId: nil, campaignId: nil, position: defaultPosition, persistent: false, overlayColor: nil)
         }
 
         let position = (gist["position"] as? String).flatMap(MessagePosition.init) ?? defaultPosition
@@ -53,13 +60,15 @@ public class Message {
         let elementId = gist["elementId"] as? String
         let campaignId = gist["campaignId"] as? String
         let persistent = gist["persistent"] as? Bool ?? false
+        let overlayColor = gist["overlayColor"] as? String
 
         return GistProperties(
             routeRule: routeRule,
             elementId: elementId,
             campaignId: campaignId,
             position: position,
-            persistent: persistent
+            persistent: persistent,
+            overlayColor: overlayColor
         )
     }
 }

--- a/Sources/MessagingInApp/Gist/Utilities/UIColor+Hex.swift
+++ b/Sources/MessagingInApp/Gist/Utilities/UIColor+Hex.swift
@@ -1,0 +1,35 @@
+import UIKit
+
+extension UIColor {
+    static func fromHex(color: String?) -> UIColor? {
+        guard var hexColor = color else { return nil }
+        if hexColor.hasPrefix("#") {
+            hexColor.removeFirst()
+        }
+
+        let scanner = Scanner(string: hexColor)
+
+        var rgbValue: UInt64 = 0
+        guard scanner.scanHexInt64(&rgbValue) else {
+            return nil
+        }
+
+        var red, green, blue, alpha: UInt64
+        switch hexColor.count {
+        case 6:
+            red = (rgbValue >> 16)
+            green = (rgbValue >> 8 & 0xFF)
+            blue = (rgbValue & 0xFF)
+            alpha = 255
+        case 8:
+            red = (rgbValue >> 16)
+            green = (rgbValue >> 8 & 0xFF)
+            blue = (rgbValue & 0xFF)
+            alpha = rgbValue >> 24
+        default:
+            return nil
+        }
+
+        return UIColor(red: CGFloat(red) / 255, green: CGFloat(green) / 255, blue: CGFloat(blue) / 255, alpha: CGFloat(alpha) / 255)
+    }
+}

--- a/Sources/MessagingInApp/Gist/Utilities/UIColor+Hex.swift
+++ b/Sources/MessagingInApp/Gist/Utilities/UIColor+Hex.swift
@@ -1,35 +1,29 @@
 import UIKit
 
 extension UIColor {
-    static func fromHex(color: String?) -> UIColor? {
-        guard var hexColor = color else { return nil }
-        if hexColor.hasPrefix("#") {
-            hexColor.removeFirst()
-        }
+    static func fromHex(_ hex: String?) -> UIColor? {
+        guard let hex = hex else { return nil }
 
-        let scanner = Scanner(string: hexColor)
+        let cleanHex = hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
+
+        // Validate hex string length
+        guard cleanHex.count == 6 || cleanHex.count == 8 else {
+            return nil
+        }
 
         var rgbValue: UInt64 = 0
-        guard scanner.scanHexInt64(&rgbValue) else {
+        guard Scanner(string: cleanHex).scanHexInt64(&rgbValue) else {
             return nil
         }
 
-        var red, green, blue, alpha: UInt64
-        switch hexColor.count {
-        case 6:
-            red = (rgbValue >> 16)
-            green = (rgbValue >> 8 & 0xFF)
-            blue = (rgbValue & 0xFF)
-            alpha = 255
-        case 8:
-            red = (rgbValue >> 16)
-            green = (rgbValue >> 8 & 0xFF)
-            blue = (rgbValue & 0xFF)
-            alpha = rgbValue >> 24
-        default:
-            return nil
-        }
+        // Extract color components
+        let red = CGFloat((rgbValue >> 16) & 0xFF) / 255.0
+        let green = CGFloat((rgbValue >> 8) & 0xFF) / 255.0
+        let blue = CGFloat(rgbValue & 0xFF) / 255.0
+        let alpha = cleanHex.count == 8
+            ? CGFloat((rgbValue >> 24) & 0xFF) / 255.0
+            : 1.0
 
-        return UIColor(red: CGFloat(red) / 255, green: CGFloat(green) / 255, blue: CGFloat(blue) / 255, alpha: CGFloat(alpha) / 255)
+        return UIColor(red: red, green: green, blue: blue, alpha: alpha)
     }
 }

--- a/Sources/MessagingInApp/Gist/Utilities/UIColor+Hex.swift
+++ b/Sources/MessagingInApp/Gist/Utilities/UIColor+Hex.swift
@@ -11,8 +11,10 @@ extension UIColor {
             return nil
         }
 
+        let correctHex = correctColorFormatIfNeeded(cleanHex)
+
         var rgbValue: UInt64 = 0
-        guard Scanner(string: cleanHex).scanHexInt64(&rgbValue) else {
+        guard Scanner(string: correctHex).scanHexInt64(&rgbValue) else {
             return nil
         }
 
@@ -25,5 +27,16 @@ extension UIColor {
             : 1.0
 
         return UIColor(red: red, green: green, blue: blue, alpha: alpha)
+    }
+
+    private static func correctColorFormatIfNeeded(_ color: String) -> String {
+        guard color.count == 8 else { return color }
+
+        let red = color[color.index(color.startIndex, offsetBy: 0) ..< color.index(color.startIndex, offsetBy: 2)]
+        let green = color[color.index(color.startIndex, offsetBy: 2) ..< color.index(color.startIndex, offsetBy: 4)]
+        let blue = color[color.index(color.startIndex, offsetBy: 4) ..< color.index(color.startIndex, offsetBy: 6)]
+        let alpha = color[color.index(color.startIndex, offsetBy: 6) ..< color.endIndex]
+
+        return "\(alpha)\(red)\(green)\(blue)"
     }
 }

--- a/Tests/MessagingInApp/Utilities/UIColor+HexTest.swift
+++ b/Tests/MessagingInApp/Utilities/UIColor+HexTest.swift
@@ -1,0 +1,74 @@
+@testable import CioMessagingInApp
+
+import UIKit
+import XCTest
+
+class UIColorFromHexTests: UnitTest {
+    func test_parseColor_givenInputColorIsNull_expectNullAsResult() {
+        let result = UIColor.fromHex(nil)
+
+        XCTAssertNil(result)
+    }
+
+    func test_parseColor_givenInputColorIsEmpty_expectNullAsResult() {
+        let result = UIColor.fromHex("")
+
+        XCTAssertNil(result)
+    }
+
+    func test_parseColor_givenInputColorHasUnexpectedCharCount_expectNullAsResult() {
+        // Only colors with 6 or 8 chars are accepted
+        XCTAssertNil(UIColor.fromHex("#"))
+        XCTAssertNil(UIColor.fromHex("#FF11F"))
+        XCTAssertNil(UIColor.fromHex("#FF11FF1"))
+        XCTAssertNil(UIColor.fromHex("#FF11FF11F"))
+    }
+
+    func test_parseColor_givenValidInputColorWithoutAlpha_expectCorrectResult() {
+        let result = UIColor.fromHex("#007AFF") // R:0, G:122, B:255
+
+        var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
+        result?.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        XCTAssertEqual(red, 0.0, accuracy: 0.01)
+        XCTAssertEqual(green, 0.48, accuracy: 0.01)
+        XCTAssertEqual(blue, 1.00, accuracy: 0.01)
+        XCTAssertEqual(alpha, 1.0, "Alpha should be 1.0 for 6-character hex.")
+    }
+
+    func test_parseColor_givenValidInputColorWithoutHashAndWithoutAlpha_expectCorrectResult() {
+        let result = UIColor.fromHex("007AFF") // R:0, G:122, B:255
+
+        var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
+        result?.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        XCTAssertEqual(red, 0.0, accuracy: 0.01)
+        XCTAssertEqual(green, 0.48, accuracy: 0.01)
+        XCTAssertEqual(blue, 1.00, accuracy: 0.01)
+        XCTAssertEqual(alpha, 1.0, "Alpha should be 1.0 for 6-character hex.")
+    }
+
+    func test_parseColor_givenValidInputColorWithAlpha_expectCorrectResult() {
+        let result = UIColor.fromHex("#007AFF80") // R:0, G:122, B:255, Alpha:50%
+
+        var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
+        result?.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        XCTAssertEqual(red, 0.0, accuracy: 0.01)
+        XCTAssertEqual(green, 0.48, accuracy: 0.01)
+        XCTAssertEqual(blue, 1.00, accuracy: 0.01)
+        XCTAssertEqual(alpha, 0.5, accuracy: 0.01)
+    }
+
+    func test_parseColor_givenValidInputColorWithoutHashAndWithAlpha_expectCorrectResult() {
+        let result = UIColor.fromHex("007AFF80") // R:0, G:122, B:255, Alpha:50%
+
+        var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
+        result?.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        XCTAssertEqual(red, 0.0, accuracy: 0.01)
+        XCTAssertEqual(green, 0.48, accuracy: 0.01)
+        XCTAssertEqual(blue, 1.00, accuracy: 0.01)
+        XCTAssertEqual(alpha, 0.5, accuracy: 0.01)
+    }
+}

--- a/Tests/MessagingInApp/Utilities/UIColor+HexTest.swift
+++ b/Tests/MessagingInApp/Utilities/UIColor+HexTest.swift
@@ -21,7 +21,10 @@ class UIColorFromHexTests: UnitTest {
         XCTAssertNil(UIColor.fromHex("#"))
         XCTAssertNil(UIColor.fromHex("#FF11F"))
         XCTAssertNil(UIColor.fromHex("#FF11FF1"))
-        XCTAssertNil(UIColor.fromHex("#FF11FF11F"))
+    }
+
+    func test_parseColor_givenInputColorWithNonHexChars_expectNullResult() {
+        XCTAssertNil(UIColor.fromHex("#MMXXMMYY"))
     }
 
     func test_parseColor_givenValidInputColorWithoutAlpha_expectCorrectResult() {


### PR DESCRIPTION
## Motivation
When sending an in-app message to the mobile apps, the specified `Overlay Color` in the in-app message editor is not reflected on the message shown on the app.

## Root cause
The value `overlayColor` sent to the mobile SDK from the server along with the in-app message payload is ignored and not used to set the in-app message overlay color.

Instead a hard-coded color is used for all message.

## Testing the fix

https://github.com/user-attachments/assets/ed33529a-cc7c-4aba-ba97-a8f7a20135bb




