### PR TITLE
feat: add option to disable screen view usage

### DIFF
--- a/Sources/Common/Type/ScreenView.swift
+++ b/Sources/Common/Type/ScreenView.swift
@@ -11,7 +11,7 @@ public enum ScreenView: String {
     /// Returns the ScreenView enum case for the given name.
     /// Returns fallback if the specified enum type has no constant with the given name.
     /// Defaults to .all
-    static func getScreenView(_ screenView: String?, fallback: ScreenView = .all) -> ScreenView {
+    public static func getScreenView(_ screenView: String?, fallback: ScreenView = .all) -> ScreenView {
         guard let screenView = screenView,
               !screenView.isEmpty,
               let value = ScreenView(rawValue: screenView.lowercased())

--- a/Sources/Common/Type/ScreenView.swift
+++ b/Sources/Common/Type/ScreenView.swift
@@ -1,0 +1,23 @@
+/// Enum to define how CustomerIO SDK should handle screen view events.
+public enum ScreenView: String {
+    /// Screen view events are sent to destinations for analytics purposes.
+    /// They are also used to display in-app messages based on page rules.
+    case all
+
+    /// Screen view events are kept on device only. They are used to display in-app messages based on
+    /// page rules. Events are not sent to our back end servers.
+    case inApp = "inapp"
+
+    /// Returns the ScreenView enum case for the given name.
+    /// Returns fallback if the specified enum type has no constant with the given name.
+    /// Defaults to .all
+    static func getScreenView(_ screenView: String?, fallback: ScreenView = .all) -> ScreenView {
+        guard let screenView = screenView,
+              !screenView.isEmpty,
+              let value = ScreenView(rawValue: screenView.lowercased())
+        else {
+            return fallback
+        }
+        return value
+    }
+}

--- a/Sources/DataPipeline/Config/DataPipelineConfigOptions.swift
+++ b/Sources/DataPipeline/Config/DataPipelineConfigOptions.swift
@@ -28,6 +28,9 @@ public struct DataPipelineConfigOptions {
     /// Configuration options required for migration from earlier versions
     public let migrationSiteId: String?
 
+    /// Determines how SDK should handle screen view events
+    public let screenViewUse: ScreenView
+
     /// Plugins identified based on configuration provided by the user
     let autoConfiguredPlugins: [Plugin]
 }

--- a/Sources/DataPipeline/Config/SDKConfigBuilder.swift
+++ b/Sources/DataPipeline/Config/SDKConfigBuilder.swift
@@ -43,6 +43,7 @@ public class SDKConfigBuilder {
     private var trackApplicationLifecycleEvents: Bool = true
     private var autoTrackDeviceAttributes: Bool = true
     private var migrationSiteId: String?
+    private var screenViewUse: ScreenView = .all
 
     /// Initializes new `SDKConfigBuilder` with required configuration options.
     /// - Parameters:
@@ -149,6 +150,12 @@ public class SDKConfigBuilder {
         return self
     }
 
+    @discardableResult
+    public func screenViewUse(screenView: ScreenView) -> SDKConfigBuilder {
+        screenViewUse = screenView
+        return self
+    }
+
     @available(iOSApplicationExtension, unavailable)
     public func build() -> SDKConfigBuilderResult {
         // create `SdkConfig` from given configurations
@@ -180,6 +187,7 @@ public class SDKConfigBuilder {
             trackApplicationLifecycleEvents: trackApplicationLifecycleEvents,
             autoTrackDeviceAttributes: autoTrackDeviceAttributes,
             migrationSiteId: migrationSiteId,
+            screenViewUse: screenViewUse,
             autoConfiguredPlugins: configuredPlugins
         )
 

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -58,6 +58,9 @@ class DataPipelineImplementation: DataPipelineInstance {
         // plugin to publish data pipeline events
         analytics.add(plugin: DataPipelinePublishedEvents(diGraph: diGraph))
 
+        // Add plugin to filter events based on SDK configuration
+        analytics.add(plugin: ScreenFilterPlugin(screenViewUse: moduleConfig.screenViewUse))
+
         // subscribe to journey events emmitted from push/in-app module to send them via datapipelines
         subscribeToJourneyEvents()
         postProfileAlreadyIdentified()

--- a/Sources/DataPipeline/Plugins/ScreenFilterPlugin.swift
+++ b/Sources/DataPipeline/Plugins/ScreenFilterPlugin.swift
@@ -1,0 +1,25 @@
+import CioAnalytics
+import CioInternalCommon
+/// Plugin to filter screen events based on the configuration provided by customer app.
+/// This plugin is used to filter out screen events that should not be processed further.
+class ScreenFilterPlugin: EventPlugin {
+    private let screenViewUse: ScreenView
+    public let type = PluginType.enrichment
+    public weak var analytics: Analytics?
+
+    init(screenViewUse: ScreenView) {
+        self.screenViewUse = screenViewUse
+    }
+
+    func screen(event: ScreenEvent) -> ScreenEvent? {
+        // Filter out screen events based on the configuration provided by customer app
+        // Using switch statement to enforce exhaustive checking for all possible values of ScreenView
+        switch screenViewUse {
+        case .all:
+            return event
+        // Do not send screen events to server if ScreenView is not Analytics
+        case .inApp:
+            return nil
+        }
+    }
+}

--- a/Sources/DataPipeline/Type/Aliases.swift
+++ b/Sources/DataPipeline/Type/Aliases.swift
@@ -10,3 +10,4 @@ public typealias Metric = CioInternalCommon.Metric
 public typealias CustomerIO = CioInternalCommon.CustomerIO
 public typealias CioLogLevel = CioInternalCommon.CioLogLevel
 public typealias Region = CioInternalCommon.Region
+public typealias ScreenView = CioInternalCommon.ScreenView

--- a/Tests/Common/Type/ScreenViewTest.swift
+++ b/Tests/Common/Type/ScreenViewTest.swift
@@ -1,0 +1,40 @@
+@testable import CioInternalCommon
+import Foundation
+import SharedTests
+import XCTest
+
+class ScreenViewTest: UnitTest {
+    func test_getScreenView_givenNamesWithMatchingCase_expectCorrectScreenView() {
+        let screenViewAnalytics = ScreenView.getScreenView("All")
+        let screenViewInApp = ScreenView.getScreenView("InApp")
+
+        XCTAssertEqual(screenViewAnalytics, .all)
+        XCTAssertEqual(screenViewInApp, .inApp)
+    }
+
+    func test_getScreenView_givenNamesWithDifferentCase_expectCorrectScreenView() {
+        let screenViewAnalytics = ScreenView.getScreenView("all")
+        let screenViewInApp = ScreenView.getScreenView("inapp")
+
+        XCTAssertEqual(screenViewAnalytics, .all)
+        XCTAssertEqual(screenViewInApp, .inApp)
+    }
+
+    func test_getScreenView_givenInvalidValue_expectFallbackScreenView() {
+        let parsedValue = ScreenView.getScreenView("none")
+
+        XCTAssertEqual(parsedValue, .all)
+    }
+
+    func test_getScreenView_givenEmptyValue_expectFallbackScreenView() {
+        let parsedValue = ScreenView.getScreenView("", fallback: .inApp)
+
+        XCTAssertEqual(parsedValue, .inApp)
+    }
+
+    func test_getScreenView_givenNil_expectFallbackScreenView() {
+        let parsedValue = ScreenView.getScreenView(nil)
+
+        XCTAssertEqual(parsedValue, .all)
+    }
+}

--- a/Tests/DataPipeline/Plugin/ScreenViewsFilterPluginTest.swift
+++ b/Tests/DataPipeline/Plugin/ScreenViewsFilterPluginTest.swift
@@ -1,0 +1,70 @@
+@testable import CioAnalytics
+@testable import CioDataPipelines
+@testable import CioInternalCommon
+import Foundation
+@testable import SharedTests
+import XCTest
+
+class ScreenViewFilterPluginTests: IntegrationTest {
+    var outputReader: OutputReaderPlugin!
+
+    override func setUp() {}
+
+    private func setupWithConfig(screenViewUse: ScreenView, customConfig: ((inout SdkConfig) -> Void)? = nil) {
+        super.setUp(modifySdkConfig: { config in
+            config.screenViewUse(screenView: screenViewUse)
+        })
+        outputReader = (customerIO.add(plugin: OutputReaderPlugin()) as? OutputReaderPlugin)
+    }
+
+    func testProcessGivenScreenViewUseAnalyticsExpectScreenEventWithoutPropertiesProcessed() {
+        setupWithConfig(screenViewUse: .all)
+
+        let givenScreenTitle = String.random
+
+        customerIO.screen(title: givenScreenTitle)
+
+        guard let screenEvent = outputReader.screenEvents.first, outputReader.screenEvents.count == 1 else {
+            XCTFail("Expected exactly one screen event")
+            return
+        }
+
+        XCTAssertEqual(screenEvent.name, givenScreenTitle)
+        XCTAssertTrue(screenEvent.properties?.dictionaryValue?.isEmpty ?? true)
+    }
+
+    func testProcessGivenScreenViewUseAnalyticsExpectScreenEventWithPropertiesProcessed() {
+        setupWithConfig(screenViewUse: .all)
+
+        let givenScreenTitle = String.random
+        let givenProperties: [String: Any] = [
+            "source": "push",
+            "discount": 10
+        ]
+
+        customerIO.screen(title: givenScreenTitle, properties: givenProperties)
+
+        guard let screenEvent = outputReader.screenEvents.first, outputReader.screenEvents.count == 1 else {
+            XCTFail("Expected exactly one screen event")
+            return
+        }
+
+        XCTAssertEqual(screenEvent.name, givenScreenTitle)
+        XCTAssertMatches(
+            screenEvent.properties?.dictionaryValue,
+            givenProperties,
+            withTypeMap: [["discount"]: Int.self]
+        )
+    }
+
+    func testProcessGivenScreenViewUseInAppExpectAllScreenEventsIgnored() {
+        setupWithConfig(screenViewUse: .inApp)
+
+        // Track multiple screen events
+        for _ in 1 ... 5 {
+            customerIO.screen(title: String.random)
+        }
+
+        XCTAssertTrue(outputReader.events.isEmpty)
+    }
+}

--- a/Tests/DataPipeline/Support/Segment.swift
+++ b/Tests/DataPipeline/Support/Segment.swift
@@ -44,7 +44,7 @@ class OutputReaderPlugin: Plugin {
 extension OutputReaderPlugin {
     var identifyEvents: [IdentifyEvent] { events.compactMap { $0 as? IdentifyEvent } }
     var trackEvents: [RawEvent] { events.compactMap { $0 as? TrackEvent } }
-    var screenEvents: [RawEvent] { events.compactMap { $0 as? ScreenEvent } }
+    var screenEvents: [ScreenEvent] { events.compactMap { $0 as? ScreenEvent } }
 
     var deviceDeleteEvents: [TrackEvent] {
         events


### PR DESCRIPTION
closes: [MBL-756: Add config to iOS SDK](https://linear.app/customerio/issue/MBL-756/add-config-to-ios-sdk)

### Changes

- Added `screenViewUse` enum option to allow disable sending screen view events to server and use them locally only
- Added `ScreenFilterPlugin` to filter events based on the `screenViewUse` configuration
- Added tests to ensure functionality

### `ScreenView` Options

- `All` -> Sends all screen events to the server (same as before) - Default behavior
- `InApp` -> Retains screen events locally for in-app use only

### Sample Usage

```swift
let config = SDKConfigBuilder(cdpApiKey: cdpApiKey)
            .screenViewUse(screenView: .all)

CustomerIO.initialize(withConfig: config.build())
```