### PR TITLE
chore: build primary sample app

### DIFF
--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -73,8 +73,8 @@ jobs:
         # Distribution group constants
         ALL_BUILDS_GROUP: all-builds
         FEATURE_BUILDS_GROUP: feature-branch
-        RELEASE_BUILDS_GROUP: public
-        STABLE_BUILDS_GROUP: next
+        NEXT_BUILDS_GROUP: next
+        PUBLIC_BUILDS_GROUP: public
         # Input variables
         IS_PRIMARY_APP: ${{ matrix.apn-or-fcm == 'APN' }}
         CURRENT_BRANCH: ${{ github.ref }}
@@ -85,8 +85,8 @@ jobs:
         # Append distribution groups based on branch and context if the app is primary
         if [[ "$IS_PRIMARY_APP" == "true" ]]; then
           [[ "$CURRENT_BRANCH" == "refs/heads/feature/"* ]] && distribution_groups+=("$FEATURE_BUILDS_GROUP")
-          [[ "$CURRENT_BRANCH" == "refs/heads/main" ]] && distribution_groups+=("$STABLE_BUILDS_GROUP")
-          [[ "$CURRENT_BRANCH" == "refs/heads/main" ]] && distribution_groups+=("$RELEASE_BUILDS_GROUP")
+          [[ "$CURRENT_BRANCH" == "refs/heads/main" ]] && distribution_groups+=("$NEXT_BUILDS_GROUP")
+          [[ "$CURRENT_BRANCH" == "refs/heads/main" ]] && distribution_groups+=("$PUBLIC_BUILDS_GROUP")
         fi
 
         # Export the groups as an environment variable

--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -67,6 +67,29 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Set Default Firebase Distribution Groups
+      run: |
+        # Define all the possible distribution groups
+        ALL_BUILDS_GROUP="all-builds"
+        FEATURE_BUILDS_GROUP="feature-branch"
+        STABLE_BUILDS_GROUP="next"
+
+        # Initialize with the default distribution group
+        distribution_groups=("$ALL_BUILDS_GROUP")
+
+        # Determine current app type and Git context
+        is_primary_app=$([[ "${{ matrix.apn-or-fcm }}" == "APN" ]] && echo "true" || echo "false")
+        current_branch="${GITHUB_REF}"
+
+        # Append distribution groups based on branch and context if the app is primary
+        if [[ "$is_primary_app" == "true" ]]; then
+          [[ "$current_branch" == "refs/heads/feature/"* ]] && distribution_groups+=("$FEATURE_BUILDS_GROUP")
+          [[ "$current_branch" == "refs/heads/main" ]] && distribution_groups+=("$STABLE_BUILDS_GROUP")
+        fi
+
+        # Export the groups as an environment variable
+        echo "firebase_distribution_groups=$(IFS=','; echo "${distribution_groups[*]}")" >> $GITHUB_ENV
+
     - name: Build and upload app build for QA testing 
       uses: ./.github/actions/build-sample-app
       with:
@@ -74,6 +97,7 @@ jobs:
         sample-app: ${{ matrix.sample-app }}
         customerio-workspace-siteid: ${{ secrets[format('CUSTOMERIO_{0}_WORKSPACE_SITE_ID', matrix.apn-or-fcm)] }}
         customerio-workspace-cdp-api-key: ${{ secrets[format('CUSTOMERIO_{0}_WORKSPACE_CDP_API_KEY', matrix.apn-or-fcm)] }}
+        fastlane-build-args: '{"distribution_groups": "${{ env.firebase_distribution_groups }}"}'
         GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64: ${{ secrets.GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64 }}
         FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64: ${{ secrets.FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64 }}
 

--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -68,23 +68,25 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set Default Firebase Distribution Groups
+      shell: bash
+      env:
+        # Distribution group constants
+        ALL_BUILDS_GROUP: all-builds
+        FEATURE_BUILDS_GROUP: feature-branch
+        RELEASE_BUILDS_GROUP: public
+        STABLE_BUILDS_GROUP: next
+        # Input variables
+        IS_PRIMARY_APP: ${{ matrix.apn-or-fcm == 'APN' }}
+        CURRENT_BRANCH: ${{ github.ref }}
       run: |
-        # Define all the possible distribution groups
-        ALL_BUILDS_GROUP="all-builds"
-        FEATURE_BUILDS_GROUP="feature-branch"
-        STABLE_BUILDS_GROUP="next"
-
         # Initialize with the default distribution group
         distribution_groups=("$ALL_BUILDS_GROUP")
 
-        # Determine current app type and Git context
-        is_primary_app=$([[ "${{ matrix.apn-or-fcm }}" == "APN" ]] && echo "true" || echo "false")
-        current_branch="${GITHUB_REF}"
-
         # Append distribution groups based on branch and context if the app is primary
-        if [[ "$is_primary_app" == "true" ]]; then
-          [[ "$current_branch" == "refs/heads/feature/"* ]] && distribution_groups+=("$FEATURE_BUILDS_GROUP")
-          [[ "$current_branch" == "refs/heads/main" ]] && distribution_groups+=("$STABLE_BUILDS_GROUP")
+        if [[ "$IS_PRIMARY_APP" == "true" ]]; then
+          [[ "$CURRENT_BRANCH" == "refs/heads/feature/"* ]] && distribution_groups+=("$FEATURE_BUILDS_GROUP")
+          [[ "$CURRENT_BRANCH" == "refs/heads/main" ]] && distribution_groups+=("$STABLE_BUILDS_GROUP")
+          [[ "$CURRENT_BRANCH" == "refs/heads/main" ]] && distribution_groups+=("$RELEASE_BUILDS_GROUP")
         fi
 
         # Export the groups as an environment variable

--- a/Apps/fastlane/Fastfile
+++ b/Apps/fastlane/Fastfile
@@ -45,7 +45,7 @@ platform :ios do
     new_build_number = arguments[:build_number] || get_new_build_version()
     new_app_version = arguments[:app_version] || get_new_app_version()
     build_notes = get_build_notes()
-    test_groups = get_build_test_groups()
+    test_groups = get_build_test_groups(distribution_groups: arguments[:distribution_groups])
 
     # Modify the source code with the new app version and build number before we compile the iOS app. This is a good idea to do to make installing builds on a test device easier. 
     # The iOS OS might give errors when trying to install a build of an app if the app is already installed on the device. Having unique build number or app version can avoid those errors. 
@@ -214,25 +214,15 @@ lane :get_build_notes do
   build_notes # return value 
 end 
 
-lane :get_build_test_groups do 
-  test_groups = ['all-builds'] # send all builds to group 'all-builds'. Therefore, set it here and we will not remove it. 
-  test_groups.append("feature-branch") # Feature branch will be used when a PR is merged into a feature branch. We will need to add a check for this.
-  github = GitHub.new()
-    
-  # To avoid giving potentially unstable builds of our sample apps to certain members of the organization, we only send builds to "stable" group uncertain certain situations. 
-  # If a commit is merged into main, it's considered stable because we deploy to production on merges to main. 
-  if github.is_commit_pushed && github.push_branch == "main"
-    test_groups.append("stable-builds") 
-    test_groups.append("next") # Next group will depricate the 'stable` builds group'.
-    test_groups.append("public") # Temp send to public group until we actually build from the deployed SDK.
-  end
-
-  test_groups = test_groups.join(", ")
+lane :get_build_test_groups do |arguments|
+  # Firebase App Distribution expects a comma separated string of test group names.
+  # If no groups are passed in, then set test groups to an empty string.
+  test_groups = arguments[:distribution_groups] || ""
 
   UI.important("Test group names that will be added to this build: #{test_groups}")
 
-  test_groups # return value 
-end 
+  test_groups # return value
+end
 
 # Parse JSON out of GitHub Context JSON when being executed on GitHub Actions. 
 class GitHub 


### PR DESCRIPTION
part of: [MBL-710](https://linear.app/customerio/issue/MBL-710/single-app-per-platform-distributed-to-firebase)

### Changes

- Updated `Build Sample Apps` action to push only primary app to relevant channels
- Modified `get_build_test_groups` lane to decouple from GitHub and accept arguments for passing Firebase distribution groups when distributing sample apps

Please refer to linked ticket for detailed expectations regarding channel distribution.