### PR TITLE
chore: Fix GistView constaints to avoid incorrectly scrolling content for message positioned top/bottom

### DIFF
--- a/Sources/MessagingInApp/Gist/Views/GistModalViewController.swift
+++ b/Sources/MessagingInApp/Gist/Views/GistModalViewController.swift
@@ -33,11 +33,11 @@ class GistModalViewController: UIViewController, GistViewDelegate, DoNotTrackScr
 
         switch position {
         case .top:
-            verticalConstraint = gistView.topAnchor.constraint(equalTo: view.topAnchor)
+            verticalConstraint = gistView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)
         case .center:
             verticalConstraint = gistView.centerYAnchor.constraint(equalTo: view.centerYAnchor)
         case .bottom:
-            verticalConstraint = gistView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            verticalConstraint = gistView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         case .none:
             verticalConstraint = gistView.centerYAnchor.constraint(equalTo: view.centerYAnchor)
         }


### PR DESCRIPTION
Fixes: [MBL-866](https://linear.app/customerio/issue/MBL-866/[ios]-fix-incorrect-message-height-for-topbottom-positioning)

## Issue
For some modal in-app messages, when positioned at the top/bottom, the content is not shown fully and is scrollable for top/bottom positions but not for centered content.

https://github.com/user-attachments/assets/04086f32-c08a-4e37-9320-a2070f9cc9b6

## Fix
The `GistView` that contains the webiew that shows the message was being constraint to the top of the screen, making our height calculation incorrect because it didn't take into account the safe area.

Here are examples after the fix:

https://github.com/user-attachments/assets/855660ab-8c1d-44e4-9cc2-aba439ce83f5 

https://github.com/user-attachments/assets/19ff5edf-d05a-4b0a-af4c-703e0bdd2b7d


