### PR TITLE
chore: add uikit inline message sample

### DIFF
--- a/Apps/APN-UIKit/APN UIKit.xcodeproj/project.pbxproj
+++ b/Apps/APN-UIKit/APN UIKit.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		9443F22C2A66CD650019E744 /* MetadataUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9443F22B2A66CD650019E744 /* MetadataUtil.swift */; };
 		94AF7C9F2A44BE9B004880BD /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94AF7C9E2A44BE9B004880BD /* BaseViewController.swift */; };
 		94C5C26C2A718E970066A072 /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94C5C26B2A718E970066A072 /* DateExtension.swift */; };
+		A76FCBF62D48AE5000625DD9 /* InlineInAppMessageUikitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A76FCBF52D48AE5000625DD9 /* InlineInAppMessageUikitViewController.swift */; };
 		A776886C2B9875B5004F2A49 /* DataPipelines in Frameworks */ = {isa = PBXBuildFile; productRef = A776886B2B9875B5004F2A49 /* DataPipelines */; };
 		A776886E2B9875D0004F2A49 /* DataPipelines in Frameworks */ = {isa = PBXBuildFile; productRef = A776886D2B9875D0004F2A49 /* DataPipelines */; };
 		F74F41F92A168316000D61B9 /* BuildEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = F74F41F82A168316000D61B9 /* BuildEnvironment.swift */; };
@@ -147,6 +148,7 @@
 		9443F22B2A66CD650019E744 /* MetadataUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataUtil.swift; sourceTree = "<group>"; };
 		94AF7C9E2A44BE9B004880BD /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		94C5C26B2A718E970066A072 /* DateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtension.swift; sourceTree = "<group>"; };
+		A76FCBF52D48AE5000625DD9 /* InlineInAppMessageUikitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineInAppMessageUikitViewController.swift; sourceTree = "<group>"; };
 		F74F41F82A168316000D61B9 /* BuildEnvironment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildEnvironment.swift; sourceTree = SOURCE_ROOT; };
 		F7820EA92A15631000B346A9 /* DIGraphShared.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DIGraphShared.swift; sourceTree = "<group>"; };
 		F78934232A168E08005D3DF7 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -275,6 +277,7 @@
 				46D5D9C629E59A5E00EAF40B /* CustomDataViewController.swift */,
 				46D5D9CB29E830AD00EAF40B /* SettingsViewController.swift */,
 				4650331029F696B8001B6552 /* DeepLinkViewController.swift */,
+				A76FCBF52D48AE5000625DD9 /* InlineInAppMessageUikitViewController.swift */,
 				94AF7C9E2A44BE9B004880BD /* BaseViewController.swift */,
 			);
 			path = View;
@@ -561,6 +564,7 @@
 				46D5D9B229E56E0E00EAF40B /* LoginViewController.swift in Sources */,
 				46D5D98529E459D600EAF40B /* ViewController.swift in Sources */,
 				46D5D9BC29E58D2000EAF40B /* StoryboardExtension.swift in Sources */,
+				A76FCBF62D48AE5000625DD9 /* InlineInAppMessageUikitViewController.swift in Sources */,
 				4650331329F69845001B6552 /* DeepLinksHandlerUtil.swift in Sources */,
 				46D5D98129E459D600EAF40B /* AppDelegate.swift in Sources */,
 				94AF7C9F2A44BE9B004880BD /* BaseViewController.swift in Sources */,

--- a/Apps/APN-UIKit/APN UIKit/Base.lproj/Main.storyboard
+++ b/Apps/APN-UIKit/APN UIKit/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="37F-6d-U3o">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="37F-6d-U3o">
     <device id="retina6_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -56,7 +56,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iXp-Fu-ehx">
-                                        <rect key="frame" x="20" y="240.00000000000003" width="344" height="38.333333333333343"/>
+                                        <rect key="frame" x="20" y="240.00000000000003" width="344" height="34.333333333333343"/>
                                         <color key="tintColor" red="0.44313725490196076" green="0.19215686274509802" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" title="Generate Random Login"/>
@@ -154,13 +154,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="What would you like to test?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gm6-Cg-tg6">
-                                <rect key="frame" x="10" y="124.66666666666667" width="394" height="27.333333333333329"/>
+                                <rect key="frame" x="10" y="91.666666666666671" width="394" height="27.333333333333329"/>
                                 <fontDescription key="fontDescription" name="Avenir-Book" family="Avenir" pointSize="20"/>
                                 <color key="textColor" red="0.24313725489999999" green="0.24313725489999999" blue="0.24313725489999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalCentering" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="AIH-WX-Xne">
-                                <rect key="frame" x="20" y="192" width="374" height="512"/>
+                                <rect key="frame" x="20" y="159" width="374" height="578"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yOE-0O-ICW" customClass="ThemeButton" customModule="APN_UIKit" customModuleProvider="target">
                                         <rect key="frame" x="94.666666666666686" y="0.0" width="185" height="50"/>
@@ -229,7 +229,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QCc-aF-w6r" userLabel="Send local push" customClass="ThemeButton" customModule="APN_UIKit" customModuleProvider="target">
-                                        <rect key="frame" x="94.666666666666686" y="336" width="185" height="38.333333333333314"/>
+                                        <rect key="frame" x="94.666666666666686" y="338" width="185" height="34.333333333333314"/>
                                         <color key="backgroundColor" red="0.23529411759999999" green="0.26274509800000001" blue="0.49019607840000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <constraints>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="185" id="nRx-fT-Ki2"/>
@@ -242,20 +242,33 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lb4-oP-0VA" userLabel="Inline examples (UiKit)" customClass="ThemeButton" customModule="APN_UIKit" customModuleProvider="target">
-                                        <rect key="frame" x="81.333333333333329" y="402" width="211.66666666666669" height="38.333333333333314"/>
+                                        <rect key="frame" x="80.666666666666671" y="404" width="212.66666666666663" height="34.333333333333314"/>
                                         <color key="backgroundColor" red="0.2352941036" green="0.26274511220000002" blue="0.49019610879999997" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <constraints>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="185" id="R99-5x-1ES"/>
                                         </constraints>
                                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <state key="normal" title="Button"/>
-                                        <buttonConfiguration key="configuration" style="plain" title="Inline examples (SwiftUi)"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="Inline Examples (SwiftUI)"/>
                                         <connections>
                                             <action selector="openInlineSwiftUiExamples:" destination="0ax-47-4zI" eventType="touchUpInside" id="n9s-20-5vO"/>
                                         </connections>
                                     </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xg6-ZV-bDY" customClass="ThemeButton" customModule="APN_UIKit" customModuleProvider="target">
+                                        <rect key="frame" x="89.666666666666671" y="470" width="194.66666666666663" height="34.333333333333314"/>
+                                        <color key="backgroundColor" red="0.23529411759999999" green="0.26274509800000001" blue="0.49019607840000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="185" id="CXH-fW-VDm"/>
+                                        </constraints>
+                                        <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="Inline Examples (UIKit)"/>
+                                        <connections>
+                                            <action selector="openInlineUikitExamples:" destination="0ax-47-4zI" eventType="touchUpInside" id="BOs-sF-hvl"/>
+                                        </connections>
+                                    </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gSy-pH-Zuu" customClass="ThemeButton" customModule="APN_UIKit" customModuleProvider="target">
-                                        <rect key="frame" x="94.666666666666686" y="462" width="185" height="50"/>
+                                        <rect key="frame" x="94.666666666666686" y="528" width="185" height="50"/>
                                         <color key="backgroundColor" red="0.23529411759999999" green="0.26274509800000001" blue="0.49019607840000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <constraints>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="185" id="uv2-HN-pr3"/>
@@ -284,7 +297,7 @@
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="What would you like to test?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mIk-22-9js">
-                                <rect key="frame" x="10" y="97.333333333333329" width="394" height="27.333333333333329"/>
+                                <rect key="frame" x="10" y="64.333333333333329" width="394" height="27.333333333333329"/>
                                 <fontDescription key="fontDescription" name="Avenir-Heavy" family="Avenir" pointSize="20"/>
                                 <color key="textColor" red="0.24313725489999999" green="0.24313725489999999" blue="0.24313725489999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <nil key="highlightedColor"/>
@@ -731,7 +744,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="T4D-Xe-9R6">
-                                                <rect key="frame" x="83" y="730.33333333333337" width="205" height="38.333333333333371"/>
+                                                <rect key="frame" x="83" y="730.33333333333337" width="205" height="34.333333333333371"/>
                                                 <color key="tintColor" red="0.4431372549" green="0.19215686269999999" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                 <state key="normal" title="Button"/>
                                                 <buttonConfiguration key="configuration" style="plain" title="Restore default settings"/>
@@ -740,7 +753,7 @@
                                                 </connections>
                                             </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Note: You must restart the app to apply these changes" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q0h-un-phO">
-                                                <rect key="frame" x="10" y="778.66666666666663" width="350.66666666666669" height="19.333333333333371"/>
+                                                <rect key="frame" x="10" y="774.66666666666663" width="350.66666666666669" height="19.333333333333371"/>
                                                 <fontDescription key="fontDescription" name="Avenir-Book" family="Avenir" pointSize="14"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="0.55000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -897,6 +910,21 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="hZc-t9-INr" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="4912" y="8"/>
+        </scene>
+        <!--Inline In App Message Uikit View Controller-->
+        <scene sceneID="XvK-Jp-F9O">
+            <objects>
+                <viewController storyboardIdentifier="InlineInAppMessageUikitViewController" id="aGf-c1-OHL" userLabel="Inline In App Message Uikit View Controller" customClass="InlineInAppMessageUikitViewController" customModule="APN_UIKit" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8oU-G6-4m4">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="YGe-lJ-MdQ"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Jgv-iL-1eI" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="5651" y="7"/>
         </scene>
     </scenes>
     <resources>

--- a/Apps/APN-UIKit/APN UIKit/Router/DashboardRouter.swift
+++ b/Apps/APN-UIKit/APN UIKit/Router/DashboardRouter.swift
@@ -6,6 +6,7 @@ protocol DashboardRouting {
     func routeToCustomDataScreen(forSource source: CustomDataSource)
     func routeToSettings(_ withInfo: [String: String]?)
     func routeToInlineSwiftUiExamplesScreen()
+    func routeToInlineUikitExamplesScreen()
 }
 
 class DashboardRouter: DashboardRouting {
@@ -38,6 +39,11 @@ class DashboardRouter: DashboardRouting {
 
     func routeToInlineSwiftUiExamplesScreen() {
         let viewController = InlineInAppMessageSwiftUiViewController.newInstance()
+        dashboardViewController?.navigationController?.pushViewController(viewController, animated: true)
+    }
+
+    func routeToInlineUikitExamplesScreen() {
+        let viewController = InlineInAppMessageUikitViewController.newInstance()
         dashboardViewController?.navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/Apps/APN-UIKit/APN UIKit/View/DashboardViewController.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/DashboardViewController.swift
@@ -128,6 +128,10 @@ class DashboardViewController: BaseViewController {
         dashboardRouter?.routeToInlineSwiftUiExamplesScreen()
     }
 
+    @IBAction func openInlineUikitExamples(_ sender: UIButton) {
+        dashboardRouter?.routeToInlineUikitExamplesScreen()
+    }
+
     @IBAction func showPushPrompt(_ sender: UIButton) {
         notificationUtil.getPushPermission { status in
             if status == .notDetermined {

--- a/Apps/APN-UIKit/APN UIKit/View/InlineInAppMessageUikitViewController.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/InlineInAppMessageUikitViewController.swift
@@ -1,4 +1,9 @@
+import CioMessagingInApp
 import UIKit
+
+extension UIColor {
+    static let lightBlue = UIColor(red: 0.8, green: 0.9, blue: 1.0, alpha: 1.0)
+}
 
 class InlineInAppMessageUikitViewController: BaseViewController {
     static func newInstance() -> InlineInAppMessageUikitViewController {
@@ -8,5 +13,185 @@ class InlineInAppMessageUikitViewController: BaseViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.isNavigationBarHidden = false
+    }
+
+    private let stickyHeaderMessage = InlineMessageUIView(elementId: "sticky-header")
+    private let inlineMessage = InlineMessageUIView(elementId: "inline")
+    private let belowFoldMessage = InlineMessageUIView(elementId: "below-fold")
+
+    private let scrollView = UIScrollView()
+    private let contentStackView = UIStackView()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // 1. Add sticky header (non-scrollable)
+        view.addSubview(stickyHeaderMessage)
+        stickyHeaderMessage.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            stickyHeaderMessage.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            stickyHeaderMessage.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            stickyHeaderMessage.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+
+        // 2. Add scroll view for the remaining content
+        view.addSubview(scrollView)
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: stickyHeaderMessage.bottomAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+
+        // 3. Inside the scroll view, place a vertical stack view
+        scrollView.addSubview(contentStackView)
+
+        contentStackView.axis = .vertical
+        contentStackView.alignment = .fill
+        contentStackView.spacing = 10
+
+        contentStackView.isLayoutMarginsRelativeArrangement = true
+        contentStackView.layoutMargins = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 10)
+
+        contentStackView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            contentStackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            contentStackView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            contentStackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            contentStackView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+
+            // Match the stack view's width to the scroll view's visible width
+            contentStackView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor)
+        ])
+
+        // 4. Add content to stack view (scrollable portion)
+        contentStackView.addArrangedSubview(UICardView())
+        contentStackView.addArrangedSubview(UIRectangleView())
+        contentStackView.addArrangedSubview(UISquaresView())
+
+        contentStackView.addArrangedSubview(inlineMessage)
+
+        contentStackView.addArrangedSubview(UICardView())
+        contentStackView.addArrangedSubview(UIRectangleView())
+
+        contentStackView.addArrangedSubview(UICardView())
+        contentStackView.addArrangedSubview(UIRectangleView())
+
+        contentStackView.addArrangedSubview(belowFoldMessage)
+    }
+}
+
+private class UIRectangleView: UIView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .lightBlue
+
+        // Force height to 160
+        translatesAutoresizingMaskIntoConstraints = false
+        heightAnchor.constraint(equalToConstant: 160).isActive = true
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private class UICardView: UIStackView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        axis = .horizontal
+        alignment = .top
+        spacing = 20
+        distribution = .fill
+        translatesAutoresizingMaskIntoConstraints = false
+
+        let leftView = UIView()
+        leftView.backgroundColor = .lightBlue
+        leftView.layer.cornerRadius = 8
+        leftView.translatesAutoresizingMaskIntoConstraints = false
+        leftView.widthAnchor.constraint(equalToConstant: 150).isActive = true
+        leftView.heightAnchor.constraint(equalToConstant: 120).isActive = true
+
+        let rightStack = UIStackView()
+        rightStack.axis = .vertical
+        rightStack.alignment = .leading
+        rightStack.distribution = .fill
+        rightStack.spacing = 5
+        rightStack.translatesAutoresizingMaskIntoConstraints = false
+
+        let bar1 = makeBar(width: 120, height: 15)
+        let bar2 = makeBar(width: 100, height: 15)
+        let spacer = makeSpacer(height: 15)
+        let bar3 = makeBar(width: 80, height: 30)
+
+        rightStack.addArrangedSubview(bar1)
+        rightStack.addArrangedSubview(bar2)
+        rightStack.addArrangedSubview(spacer)
+        rightStack.addArrangedSubview(bar3)
+
+        addArrangedSubview(leftView)
+        addArrangedSubview(rightStack)
+
+        heightAnchor.constraint(equalToConstant: 120).isActive = true
+    }
+
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func makeBar(width: CGFloat, height: CGFloat) -> UIView {
+        let bar = UIView()
+        bar.backgroundColor = .lightBlue
+        bar.layer.cornerRadius = 4
+        bar.translatesAutoresizingMaskIntoConstraints = false
+
+        bar.widthAnchor.constraint(equalToConstant: width).isActive = true
+        bar.heightAnchor.constraint(equalToConstant: height).isActive = true
+        return bar
+    }
+
+    private func makeSpacer(height: CGFloat) -> UIView {
+        let spacer = UIView()
+        spacer.translatesAutoresizingMaskIntoConstraints = false
+        spacer.heightAnchor.constraint(equalToConstant: height).isActive = true
+        return spacer
+    }
+}
+
+private class UISquaresView: UIStackView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        axis = .horizontal
+        distribution = .fillEqually
+        alignment = .fill
+        spacing = 0
+        translatesAutoresizingMaskIntoConstraints = false
+
+        let square1 = UIView()
+        square1.backgroundColor = .lightBlue
+
+        let square2 = UIView()
+        square2.backgroundColor = .lightBlue
+
+        let square3 = UIView()
+        square3.backgroundColor = .lightBlue
+
+        addArrangedSubview(square1)
+        addArrangedSubview(square2)
+        addArrangedSubview(square3)
+
+        heightAnchor.constraint(equalToConstant: 160).isActive = true
+    }
+
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 }

--- a/Sources/MessagingInApp/Views/GistInlineInAppMessageView.swift
+++ b/Sources/MessagingInApp/Views/GistInlineInAppMessageView.swift
@@ -177,7 +177,7 @@ public class GistInlineMessageUIView: UIView {
 //            return
 //        }
 
-        if let messageAvailableToDisplay = currentMessageState?.message {
+        if let messageAvailableToDisplay = currentMessageState?.message, case .readyToEmbed = currentMessageState {
             displayInAppMessage(state: state, message: messageAvailableToDisplay)
         }
     }

--- a/Sources/MessagingInApp/Views/UIKitInline.swift
+++ b/Sources/MessagingInApp/Views/UIKitInline.swift
@@ -105,7 +105,11 @@ public class InlineMessageUIView: UIView, GistInlineMessageUIViewDelegate {
         }
 
         inAppMessageView.isHidden = false
-        animateHeight(to: height)
+        // If current height is same, we don't need to animate as repeated animations can cause flicker
+        // and may result in view never showing up.
+        if height != frame.size.height {
+            animateHeight(to: height)
+        }
 
         if let messageRenderingLoadingView = messageRenderingLoadingView {
             animateFadeInOutInlineView(fromView: messageRenderingLoadingView, toView: inAppMessageView) {

--- a/Sources/MessagingInApp/Views/UIKitInline.swift
+++ b/Sources/MessagingInApp/Views/UIKitInline.swift
@@ -26,7 +26,7 @@ public protocol InlineMessageUIViewDelegate: AnyObject, AutoMockable {
  */
 public class InlineMessageUIView: UIView, GistInlineMessageUIViewDelegate {
     // Can set in the constructor or can set later (like if you use Storyboards)
-    public var elementId: String? {
+    @IBInspectable public var elementId: String? {
         didSet {
             setupView()
         }
@@ -60,6 +60,10 @@ public class InlineMessageUIView: UIView, GistInlineMessageUIViewDelegate {
 
         setupView()
         // An element id will not be set yet. No need to check for messages to display.
+    }
+
+    deinit {
+        inAppMessageView?.teardownView()
     }
 
     private func setupView() {


### PR DESCRIPTION
part of: [MBL-826](https://linear.app/customerio/issue/MBL-826/create-placeholder-ui-for-swiftui-and-uikit), [MBL-827](https://linear.app/customerio/issue/MBL-827/integrate-inline-in-app-message-in-placeholder-screen)

### Changes

- Updated APN sample app to include UIKit examples for inline in-app messages
- Made `elementId` in `InlineMessageUIView` configurable from Storyboard by marking it as `@IBInspectable`
- Updated `InlineMessageUIView` to automatically dismiss inline messages on `deinit`

### Screenshots

![Simulator Screenshot - iPhone 16 - 2025-01-28 at 13 37 01](https://github.com/user-attachments/assets/e15620af-7d42-4247-8f64-fbaec3e10f32)
![Simulator Screenshot - iPhone 16 - 2025-01-28 at 13 40 21](https://github.com/user-attachments/assets/7924be45-c640-45c1-bded-ff9e71053ab2)
