### PR TITLE
chore: process next inline message on dismiss

### DIFF
--- a/Sources/MessagingInApp/Gist/Managers/InlineMessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/InlineMessageManager.swift
@@ -45,7 +45,7 @@ class InlineMessageManager: BaseMessageManager {
 
     /// Called when the in-app state changes to `.displayed`.
     /// Inline typically means the content is ready and the `inlineMessageView` is or can be added to the UI.
-    override public func onMessageDisplayed() {
+    func onMessageDisplayed() {
         logger.logWithModuleTag(
             "Inline message displayed: \(currentMessage.describeForLogs)",
             level: .debug
@@ -56,7 +56,7 @@ class InlineMessageManager: BaseMessageManager {
 
     /// Called when the message is dismissed (or reset).
     /// Typically remove the web engine, unsubscribe, and optionally remove the inline view.
-    override func onMessageDismissed(messageState: ModalMessageState) {
+    func onMessageDismissed(messageState: InlineMessageState) {
         logger.logWithModuleTag(
             "Inline message dismissed: \(currentMessage.describeForLogs)",
             level: .debug

--- a/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
@@ -82,19 +82,6 @@ open class BaseMessageManager {
         engine.delegate = nil
     }
 
-    // MARK: - Callbacks to be overridden by Subclasses
-
-    /// Called when the state changes to `.displayed`.
-    /// Subclasses decide how to show the UI (inline or modal).
-    open func onMessageDisplayed() {
-        // Subclasses override for their own show logic
-    }
-
-    // Internal, for internal usage:
-    func onMessageDismissed(messageState: ModalMessageState) {
-        // Subclasses overridea
-    }
-
     // MARK: - Helpers
 
     public func showNewMessage(url: URL) {

--- a/Sources/MessagingInApp/Gist/Managers/ModalMessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/ModalMessageManager.swift
@@ -41,7 +41,7 @@ public class ModalMessageManager: BaseMessageManager {
     }
 
     // Show the modal when the message is displayed
-    override public func onMessageDisplayed() {
+    func onMessageDisplayed() {
         guard isMessageLoaded else {
             logger.logWithModuleTag(
                 "Message not loaded yet. Skipping loadModalMessage for \(currentMessage.describeForLogs).",
@@ -70,7 +70,7 @@ public class ModalMessageManager: BaseMessageManager {
     // Called when the message is dismissed (or reset).
     // Because onMessageDismissed(...) is internal in BaseMessageManager,
     // we can override it here in the same module.
-    override func onMessageDismissed(messageState: ModalMessageState) {
+    func onMessageDismissed(messageState: ModalMessageState) {
         logger.logWithModuleTag(
             "Dismissing message: \(currentMessage.describeForLogs) from ModalMessageManager",
             level: .debug


### PR DESCRIPTION
### Changes

- Simplified `onMessageDisplayed` and `onMessageDismissed` for both modal and inline message managers
- Added handling for `InlineMessageState` in `GistInlineMessageUIView`