### PR TITLE
chore: fix commits ahead count

### DIFF
--- a/.github/actions/build-sample-app/action.yml
+++ b/.github/actions/build-sample-app/action.yml
@@ -76,18 +76,22 @@ runs:
         COMMIT_HASH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
       run: |
         make setup_sample_app app=${{ inputs.sample-app }}
-        sd 'buildTimestamp: TimeInterval = .*' "buildTimestamp: TimeInterval = $(date +%s)" "Apps/${{ inputs.sample-app }}/BuildEnvironment.swift"
+        ENV_FILE="Apps/${{ inputs.sample-app }}/BuildEnvironment.swift"
+        sd 'buildTimestamp: TimeInterval = .*' "buildTimestamp: TimeInterval = $(date +%s)" "$ENV_FILE"
 
-        sd 'cdpApiKey: String = \".*\"' "cdpApiKey: String = \"${{ inputs.customerio-workspace-cdp-api-key }}\"" "Apps/${{ inputs.sample-app }}/BuildEnvironment.swift"
-        sd 'siteId: String = \".*\"' "siteId: String = \"${{ inputs.customerio-workspace-siteid }}\"" "Apps/${{ inputs.sample-app }}/BuildEnvironment.swift"
-        sd 'workspaceName: String = \".*\"' "workspaceName: String = \"${{ inputs.customerio-workspace-name }}\"" "Apps/${{ inputs.sample-app }}/BuildEnvironment.swift"
+        sd 'cdpApiKey: String = \".*\"' "cdpApiKey: String = \"${{ inputs.customerio-workspace-cdp-api-key }}\"" "$ENV_FILE"
+        sd 'siteId: String = \".*\"' "siteId: String = \"${{ inputs.customerio-workspace-siteid }}\"" "$ENV_FILE"
+        sd 'workspaceName: String = \".*\"' "workspaceName: String = \"${{ inputs.customerio-workspace-name }}\"" "$ENV_FILE"
         if [[ -n "${{ inputs.customerio-public-sdk-version }}" ]]; then
-          sd 'sdkVersion: String = \".*\"' "sdkVersion: String = \"${{ inputs.customerio-public-sdk-version }}\"" "Apps/${{ inputs.sample-app }}/BuildEnvironment.swift"
+          sd 'sdkVersion: String = \".*\"' "sdkVersion: String = \"${{ inputs.customerio-public-sdk-version }}\"" "$ENV_FILE"
         fi
 
-        sd 'branchName: String = \".*\"' "branchName: String = \"$BRANCH_NAME\"" "Apps/${{ inputs.sample-app }}/BuildEnvironment.swift"
-        sd 'commitHash: String = \".*\"' "commitHash: String = \"${COMMIT_HASH:0:7}\"" "Apps/${{ inputs.sample-app }}/BuildEnvironment.swift"
-        sd 'commitsAheadCount: String = \".*\"' "commitsAheadCount: String = \"$(git rev-list $(git describe --tags --abbrev=0)..HEAD --count)\"" "Apps/${{ inputs.sample-app }}/BuildEnvironment.swift"
+        sd 'branchName: String = \".*\"' "branchName: String = \"$BRANCH_NAME\"" "$ENV_FILE"
+        sd 'commitHash: String = \".*\"' "commitHash: String = \"${COMMIT_HASH:0:7}\"" "$ENV_FILE"
+
+        LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "untagged")
+        COMMITS_AHEAD=$(git rev-list $LAST_TAG..HEAD --count 2>/dev/null || echo "untracked")
+        sd 'commitsAheadCount: String = \".*\"' "commitsAheadCount: String = \"$COMMITS_AHEAD\"" "$ENV_FILE"
 
     - name: Does ${{ inputs.sample-app }} use CocoaPods? 
       id: check_podfile_exists

--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -67,7 +67,10 @@ jobs:
     runs-on: macos-14
     name: Building app...${{ matrix.sample-app }}
     steps:
-    - uses: actions/checkout@v4
+    - name: Check out code with conditional fetch-depth
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # Workaround for bug https://github.com/actions/checkout/issues/1471
 
     - name: Set Default Firebase Distribution Groups
       shell: bash


### PR DESCRIPTION
### Changes

- Fixed `commitsAheadCount` in `BuildInfoMetadata`
- Updated workflow to add fallback for cases where tags are not fetched properly

### Screenshots

| Before |  After |
|-|-|
| ![img_before](https://github.com/user-attachments/assets/1c9ec2a8-35be-42b1-a94b-ae2b94fe43e9) | ![img_after](https://github.com/user-attachments/assets/643843bd-6c57-4408-8e26-3fe9b434c347) |