### PR TITLE
fix: Analytics version updated to 1.7.3+cio.1

### DIFF
--- a/CustomerIODataPipelines.podspec
+++ b/CustomerIODataPipelines.podspec
@@ -28,5 +28,5 @@ Pod::Spec.new do |spec|
   spec.dependency "CustomerIOTrackingMigration", "= #{spec.version.to_s}"
 
   # Add Segment SDK as a dependency, as this module is designed to be compatible with it.
-  spec.dependency 'AnalyticsSwiftCIO', '= 1.5.14+cio.1'
+  spec.dependency 'AnalyticsSwiftCIO', '= 1.7.3+cio.1'
 end

--- a/CustomerIODataPipelines.podspec
+++ b/CustomerIODataPipelines.podspec
@@ -28,5 +28,5 @@ Pod::Spec.new do |spec|
   spec.dependency "CustomerIOTrackingMigration", "= #{spec.version.to_s}"
 
   # Add Segment SDK as a dependency, as this module is designed to be compatible with it.
-  spec.dependency 'AnalyticsSwiftCIO', '= 1.7.3+cio.1'
+  spec.dependency 'AnalyticsSwiftCIO', '1.7.3+cio.1'
 end

--- a/CustomerIODataPipelines.podspec
+++ b/CustomerIODataPipelines.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |spec|
   spec.author       = { "CustomerIO Team" => "win@customer.io" }
   spec.source       = { :git => 'https://github.com/customerio/customerio-ios.git', :tag => spec.version.to_s }
 
-  spec.swift_version = '5.3'
+  spec.swift_version = '5.9'
   spec.cocoapods_version = '>= 1.11.0'
 
   spec.platform = :ios # platforms SDK supports. Leave blank and it's assumed SDK supports all platforms.

--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
         
 
         // Make sure the version number is same for DataPipelines cocoapods.
-        .package(name: "CioAnalytics", url: "https://github.com/customerio/cdp-analytics-swift.git", .exact("1.5.14+cio.1"))
+        .package(name: "CioAnalytics", url: "https://github.com/customerio/cdp-analytics-swift.git", .exact("1.7.3+cio.1"))
     ],
     targets: [ 
         // Common - Code used by multiple modules in the SDK project.


### PR DESCRIPTION
Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [x] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [x] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [x] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After code reviews are approved and you determine this PR is ready to merge, select *Squash and Merge* button on this screen, leave the title and description to the default values, then merge the PR.

Testing:
- tested and verified SPM and CocoaPods config: 
  - cleaned local libraries, then installed them again, and confirmed the right versions are installed
- tested the building of apps `APN-UIKit` (uses SPM) and `CocoaPods-FCM` (uses CocoaPods)
- verified that `APN-UIKit` app reports multiple `Application Installed` events when uses library version `1.5.14+cio.1`, and that it doesn't do that after the version is updated to `1.7.3+cio.1`
