### PR TITLE
chore: Remove Code Climate Velocity Deployment

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -126,14 +126,6 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFY_RELEASES_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
-      - name: Send Velocity Deployment
-        uses: codeclimate/velocity-deploy-action@1b4a22f0db113bf8d85c14fd726cf0ec6d17cd13 # v1.0.0
-        if: steps.semantic-release.outputs.new_release_published == 'true' # only run if a git tag was made.
-        with:
-          token: ${{ secrets.VELOCITY_DEPLOYMENT_TOKEN }}
-          version: ${{ steps.semantic-release.outputs.new_release_version }}
-          environment: production
-
       - name: Notify team of failure
         uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         if: ${{ failure() }} # only run this if any previous step failed


### PR DESCRIPTION
`codeclimate/velocity-deploy-action` Github action started [failing](https://github.com/customerio/customerio-expo-plugin/actions/runs/14379532878/job/40319773344), which is blocking SDK release, we are temporarily disabling it to enables releasing