### PR TITLE
fix: simplify region parsing in wrapper in-app initialization

### DIFF
--- a/Sources/MessagingInApp/Config/MessagingInAppConfigBuilder.swift
+++ b/Sources/MessagingInApp/Config/MessagingInAppConfigBuilder.swift
@@ -72,17 +72,7 @@ public extension MessagingInAppConfigBuilder {
         // This prevents users from having to specify region more than once in the configuration.
         // Therefore, we retrieve the region from top-level configuration here.
         // If the region is not present, the default region is used.
-        let regionStr: String
-        if let regionRawValue = sdkConfig[Keys.region.rawValue] {
-            // This check ensures region is always provided as a string, and throwing an error can help
-            // identify potential bugs when passing configuration values from wrappers.
-            guard let rawValueAsString = regionRawValue as? String else {
-                throw MessagingInAppConfigBuilderError.invalidRegionType
-            }
-            regionStr = rawValueAsString
-        } else {
-            regionStr = ""
-        }
+        let regionStr = sdkConfig[Keys.region.rawValue] as? String ?? ""
         let region = Region.getRegion(from: regionStr)
 
         return MessagingInAppConfigBuilder(siteId: siteId, region: region).build()

--- a/Sources/MessagingInApp/Config/MessagingInAppConfigBuilder.swift
+++ b/Sources/MessagingInApp/Config/MessagingInAppConfigBuilder.swift
@@ -41,7 +41,6 @@ public class MessagingInAppConfigBuilder {
 public enum MessagingInAppConfigBuilderError: Error {
     case malformedConfig
     case missingSiteId
-    case invalidRegionType
 }
 
 public extension MessagingInAppConfigBuilder {

--- a/Tests/MessagingInApp/Config/MessagingInAppConfigBuilderTest.swift
+++ b/Tests/MessagingInApp/Config/MessagingInAppConfigBuilderTest.swift
@@ -93,18 +93,20 @@ class MessagingInAppConfigBuilderTest: UnitTest {
         }
     }
 
-    func test_initializeFromDictionaryWithIncorrectRegionType_expectThrowError() {
+    func test_initializeFromDictionaryWithIncorrectRegionType_expectDefaultValues() {
         let givenSiteId = String.random
         let givenDict: [String: Any] = [
-            "region": Region.US,
+            "region": NSNull(),
             "inApp": [
                 "siteId": givenSiteId
             ]
         ]
 
-        XCTAssertThrowsError(try MessagingInAppConfigBuilder.build(from: givenDict)) { error in
-            XCTAssertEqual(error as? MessagingInAppConfigBuilderError, MessagingInAppConfigBuilderError.invalidRegionType)
-        }
+        let config = try? MessagingInAppConfigBuilder.build(from: givenDict)
+
+        XCTAssertNotNil(config)
+        XCTAssertEqual(config?.siteId, givenSiteId)
+        XCTAssertEqual(config?.region, Region.US)
     }
 
     func test_initializeFromDictionaryWithIncorrectRegionValue_expectDefaultValues() {


### PR DESCRIPTION
part of: [MBL-1052](https://linear.app/customerio/issue/MBL-1052/flutter-sdk-region-is-not-set-correctly-by-default)

### Changes

- Updated `MessagingInAppConfigBuilder.build([String: Any?])` to parse region leniently and fall back to default region if parsing fails instead of blocking initialization
- Updated tests to validate the behavior