### PR TITLE
chore: Mbl 1072 update logger interface

### DIFF
--- a/Sources/Common/Util/SystemLogger.swift
+++ b/Sources/Common/Util/SystemLogger.swift
@@ -1,0 +1,33 @@
+import Foundation
+#if canImport(os)
+import os.log
+#endif
+
+public protocol SystemLogger: AutoMockable {
+    func log(_ message: String, _ level: CioLogLevel)
+}
+
+// sourcery: InjectRegisterShared = "SystemLogger"
+public class SystemLoggerImpl: SystemLogger {
+    // allows filtering in Console mac app
+    public let logSubsystem = "io.customer.sdk"
+    public let logCategory = "CIO"
+
+    public func log(_ message: String, _ level: CioLogLevel) {
+        #if canImport(os)
+        // Unified logging for Swift. https://www.avanderlee.com/workflow/oslog-unified-logging/
+        // This means we can view logs in xcode console + Console app.
+        if #available(iOS 14, *) {
+            let logger = os.Logger(subsystem: logSubsystem, category: logCategory)
+            logger.log(level: level.osLogLevel, "\(message, privacy: .public)")
+        } else {
+            let logger = OSLog(subsystem: logSubsystem, category: logCategory)
+            os_log("%{public}@", log: logger, type: level.osLogLevel, message)
+        }
+        #else
+        // At this time, Linux cannot use `os.log` or `OSLog`. Instead, use: https://github.com/apple/swift-log/
+        // As we don't officially support Linux at this time, no need to add a dependency to the project.
+        // therefore, we are not logging if can't import os.log
+        #endif
+    }
+}

--- a/Sources/Common/autogenerated/AutoMockable.generated.swift
+++ b/Sources/Common/autogenerated/AutoMockable.generated.swift
@@ -1974,21 +1974,21 @@ public class LoggerMock: Logger, Mock {
     }
 
     /// The arguments from the *last* time the function was called.
-    @Atomic public private(set) var debugReceivedArguments: String?
+    @Atomic public private(set) var debugReceivedArguments: (message: String, tag: String?)?
     /// Arguments from *all* of the times that the function was called.
-    @Atomic public private(set) var debugReceivedInvocations: [String] = []
+    @Atomic public private(set) var debugReceivedInvocations: [(message: String, tag: String?)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    public var debugClosure: ((String) -> Void)?
+    public var debugClosure: ((String, String?) -> Void)?
 
-    /// Mocked function for `debug(_ message: String)`. Your opportunity to return a mocked value and check result of mock in test code.
-    public func debug(_ message: String) {
+    /// Mocked function for `debug(_ message: String, _ tag: String?)`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func debug(_ message: String, _ tag: String?) {
         mockCalled = true
         debugCallsCount += 1
-        debugReceivedArguments = message
-        debugReceivedInvocations.append(message)
-        debugClosure?(message)
+        debugReceivedArguments = (message: message, tag: tag)
+        debugReceivedInvocations.append((message: message, tag: tag))
+        debugClosure?(message, tag)
     }
 
     // MARK: - info
@@ -2001,21 +2001,21 @@ public class LoggerMock: Logger, Mock {
     }
 
     /// The arguments from the *last* time the function was called.
-    @Atomic public private(set) var infoReceivedArguments: String?
+    @Atomic public private(set) var infoReceivedArguments: (message: String, tag: String?)?
     /// Arguments from *all* of the times that the function was called.
-    @Atomic public private(set) var infoReceivedInvocations: [String] = []
+    @Atomic public private(set) var infoReceivedInvocations: [(message: String, tag: String?)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    public var infoClosure: ((String) -> Void)?
+    public var infoClosure: ((String, String?) -> Void)?
 
-    /// Mocked function for `info(_ message: String)`. Your opportunity to return a mocked value and check result of mock in test code.
-    public func info(_ message: String) {
+    /// Mocked function for `info(_ message: String, _ tag: String?)`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func info(_ message: String, _ tag: String?) {
         mockCalled = true
         infoCallsCount += 1
-        infoReceivedArguments = message
-        infoReceivedInvocations.append(message)
-        infoClosure?(message)
+        infoReceivedArguments = (message: message, tag: tag)
+        infoReceivedInvocations.append((message: message, tag: tag))
+        infoClosure?(message, tag)
     }
 
     // MARK: - error
@@ -2028,21 +2028,21 @@ public class LoggerMock: Logger, Mock {
     }
 
     /// The arguments from the *last* time the function was called.
-    @Atomic public private(set) var errorReceivedArguments: String?
+    @Atomic public private(set) var errorReceivedArguments: (message: String, tag: String?, throwable: Error?)?
     /// Arguments from *all* of the times that the function was called.
-    @Atomic public private(set) var errorReceivedInvocations: [String] = []
+    @Atomic public private(set) var errorReceivedInvocations: [(message: String, tag: String?, throwable: Error?)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    public var errorClosure: ((String) -> Void)?
+    public var errorClosure: ((String, String?, Error?) -> Void)?
 
-    /// Mocked function for `error(_ message: String)`. Your opportunity to return a mocked value and check result of mock in test code.
-    public func error(_ message: String) {
+    /// Mocked function for `error(_ message: String, _ tag: String?, _ throwable: Error?)`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func error(_ message: String, _ tag: String?, _ throwable: Error?) {
         mockCalled = true
         errorCallsCount += 1
-        errorReceivedArguments = message
-        errorReceivedInvocations.append(message)
-        errorClosure?(message)
+        errorReceivedArguments = (message: message, tag: tag, throwable: throwable)
+        errorReceivedInvocations.append((message: message, tag: tag, throwable: throwable))
+        errorClosure?(message, tag, throwable)
     }
 }
 
@@ -2665,6 +2665,57 @@ class SingleScheduleTimerMock: SingleScheduleTimer, Mock {
         mockCalled = true
         cancelCallsCount += 1
         cancelClosure?()
+    }
+}
+
+/**
+ Class to easily create a mocked version of the `SystemLogger` class.
+ This class is equipped with functions and properties ready for you to mock!
+
+ Note: This file is automatically generated. This means the mocks should always be up-to-date and has a consistent API.
+ See the SDK documentation to learn the basics behind using the mock classes in the SDK.
+ */
+public class SystemLoggerMock: SystemLogger, Mock {
+    /// If *any* interactions done on mock. `true` if any method or property getter/setter called.
+    public var mockCalled: Bool = false //
+
+    public init() {
+        Mocks.shared.add(mock: self)
+    }
+
+    public func resetMock() {
+        logCallsCount = 0
+        logReceivedArguments = nil
+        logReceivedInvocations = []
+
+        mockCalled = false // do last as resetting properties above can make this true
+    }
+
+    // MARK: - log
+
+    /// Number of times the function was called.
+    @Atomic public private(set) var logCallsCount = 0
+    /// `true` if the function was ever called.
+    public var logCalled: Bool {
+        logCallsCount > 0
+    }
+
+    /// The arguments from the *last* time the function was called.
+    @Atomic public private(set) var logReceivedArguments: (message: String, level: CioLogLevel)?
+    /// Arguments from *all* of the times that the function was called.
+    @Atomic public private(set) var logReceivedInvocations: [(message: String, level: CioLogLevel)] = []
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     */
+    public var logClosure: ((String, CioLogLevel) -> Void)?
+
+    /// Mocked function for `log(_ message: String, _ level: CioLogLevel)`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func log(_ message: String, _ level: CioLogLevel) {
+        mockCalled = true
+        logCallsCount += 1
+        logReceivedArguments = (message: message, level: level)
+        logReceivedInvocations.append((message: message, level: level))
+        logClosure?(message, level)
     }
 }
 


### PR DESCRIPTION
Closes: [MBL-1072](https://linear.app/customerio/issue/MBL-1072/implement-unified-logging-interface-on-ios)

## Overview
This PR aligns the Customer IO iOS SDK `Logger` interface to the [unified interfaces definitions](https://www.notion.so/custio/Mobile-SDK-unified-logging-interfaces-1dc4302f4c2b80d08bacd478ca8bbf7e).

The main change in the interface is that logging functions now include a `tag` that will allow us to easily filter logs in the future by module.

Some notable changes in this PR:
- I made sure that the same `Logger` interface was used to avoid having two versions and go through deprecation process
- I've intentionally made `tag` parameter optional for now so we don't have to change any existing code that uses the existing `Logger` interface, I am using extension functions to ensure existing calls don't have to change
- The `Logger Dispatcher` closure was not updated to include the `tag` parameter, I will update it when I am working on updating the wrappers
- I've chosen to add all new parameters to the end of functions like `Logger#debug()`, so that we don't have to change any code of all modules using the interface

## A more testable logger
_This is implemented in the next PR #888_
I've changed how the `LoggerImpl` is initialized:
- `CioLogLevel` is now a required parameter and its usage is an implementation details
- I've wrapped calls to OS loggers in a `SystemLogger` so we can test the `Logger` message format
- Added tests for the logger implementation

## Test plan
I've ran the app both from this branch and the main branch with debug logging enabled and compared the logs between both versions and all log points were there before and after the change.

- You can run the same test yourself and compare with any diff tool
- I am attaching two files with cleaned up logs if you want to compare them without running app on multiple branches

[ios-before.txt](https://github.com/user-attachments/files/19957695/ios-before.txt)
[ios-after.txt](https://github.com/user-attachments/files/19957694/ios-after.txt)
