### PR TITLE
chore: Swizzling removal - iOS SDK (Sample apps)

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
@@ -4,6 +4,8 @@ import CioMessagingPushAPN
 import UIKit
 
 @main
+class AppDelegateWithCioIntegration: CioAppDelegateWrapper<AppDelegate> {}
+
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var storage = DIGraphShared.shared.storage
     var deepLinkHandler = DIGraphShared.shared.deepLinksHandlerUtil
@@ -104,9 +106,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 extension AppDelegate: UNUserNotificationCenterDelegate {
     // Function called when a push notification is clicked or swiped away.
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-        // Track a Customer.io event for testing purposes to more easily track when this function is called.
+        // Track custom event with Customer.io.
+        // NOT required for basic PN tap tracking - that is done automatically with `CioAppDelegateWrapper`.
         CustomerIO.shared.track(
-            name: "push clicked",
+            name: "custom push-clicked event",
             properties: ["push": response.notification.request.content.userInfo]
         )
 

--- a/Apps/CocoaPods-FCM/src/App.swift
+++ b/Apps/CocoaPods-FCM/src/App.swift
@@ -1,8 +1,16 @@
+import CioMessagingPushFCM
 import SwiftUI
 
 @main
 struct MainApp: App {
-    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    // Default option, without CIO integration
+    //    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    // Use this option if you don't have a need to extend `CioAppDelegateWrapper`
+    //    @UIApplicationDelegateAdaptor(CioAppDelegateWrapper<AppDelegate>.self) private var appDelegate
+
+    // Use this option if you need to extend `CioAppDelegateWrapper`
+    @UIApplicationDelegateAdaptor(AppDelegateWithCioIntegration.self) private var appDelegate
 
     @StateObject var userManager: UserManager = .init()
 

--- a/Apps/CocoaPods-FCM/src/App.swift
+++ b/Apps/CocoaPods-FCM/src/App.swift
@@ -4,13 +4,13 @@ import SwiftUI
 @main
 struct MainApp: App {
     // Default option, without CIO integration
-    //    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+//    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
     // Use this option if you don't have a need to extend `CioAppDelegateWrapper`
-    //    @UIApplicationDelegateAdaptor(CioAppDelegateWrapper<AppDelegate>.self) private var appDelegate
+    @UIApplicationDelegateAdaptor(CioAppDelegateWrapper<AppDelegate>.self) private var appDelegate
 
-    // Use this option if you need to extend `CioAppDelegateWrapper`
-    @UIApplicationDelegateAdaptor(AppDelegateWithCioIntegration.self) private var appDelegate
+    // Use this option if you need to extend `CioAppDelegateWrapper`: class AppDelegateWithCioIntegration: CioAppDelegateWrapper<AppDelegate> {}
+//    @UIApplicationDelegateAdaptor(AppDelegateWithCioIntegration.self) private var appDelegate
 
     @StateObject var userManager: UserManager = .init()
 

--- a/Apps/CocoaPods-FCM/src/AppDelegate.swift
+++ b/Apps/CocoaPods-FCM/src/AppDelegate.swift
@@ -7,8 +7,6 @@ import Foundation
 import SampleAppsCommon
 import UIKit
 
-class AppDelegateWithCioIntegration: CioAppDelegateWrapper<AppDelegate> {}
-
 class AppDelegate: NSObject, UIApplicationDelegate {
     let anotherPushEventHandler = AnotherPushEventHandler()
 


### PR DESCRIPTION
Changes:
- Sample apps are updated to use new AppDelegates and Deep-Linking

Testing:
- the easiest way to get a device-token is to copy from Xcode console
- Basic PN: 
  - Expectation: This will send the default testing PN, which should work in & out of the app
  - Triggering:
    - APN: Send test PN from https://fly.customer.io/workspaces/122175/settings/actions/push/ios
    - FCM: Send test PN from https://fly.customer.io/workspaces/111525/settings/actions/push/ios
- PN with Deep-link: 
  - Expectation: This will send the PN payload with URL (google.com), which should work in & out of the app, and tap should open this URL in Safari or Google app
  - Triggering:
    - APN: Use button `Send test...` in test-campaign PN-config from https://fly.customer.io/workspaces/122175/journeys/composer/actions/365
    - FCM: Use button `Send test...` in test-campaign PN-config from https://fly.customer.io/workspaces/111525/journeys/composer/actions/250