### PR TITLE
chore: Update push token identify logs

### DIFF
--- a/Sources/DataPipeline/Util/DataPipelinesLogger.swift
+++ b/Sources/DataPipeline/Util/DataPipelinesLogger.swift
@@ -5,6 +5,9 @@ protocol DataPipelinesLogger: AutoMockable {
     func logStoringBlankPushToken()
     func logRegisteringPushToken(token: String, userId: String?)
     func logPushTokenRefreshed()
+    func automaticTokenRegistrationForNewProfile(token: String, userId: String)
+    func logDeletingTokenDueToNewProfileIdentification()
+    func logTrackingDevicesAttributesWithoutValidToken()
 }
 
 // sourcery: InjectRegisterShared = "DataPipelinesLogger"
@@ -31,5 +34,17 @@ class DataPipelinesLoggerImpl: DataPipelinesLogger {
 
     public func logPushTokenRefreshed() {
         logger.debug("Token refreshed, deleting old token to avoid registering same device multiple times", Self.PUSH_TAG)
+    }
+
+    public func automaticTokenRegistrationForNewProfile(token: String, userId: String) {
+        logger.debug("Automatically registering device token: \(token) to newly identified profile: \(userId)", Self.PUSH_TAG)
+    }
+
+    public func logDeletingTokenDueToNewProfileIdentification() {
+        logger.debug("Deleting device token before identifying new profile", Self.PUSH_TAG)
+    }
+
+    public func logTrackingDevicesAttributesWithoutValidToken() {
+        logger.debug("No device token found. ignoring request to track device attributes", Self.PUSH_TAG)
     }
 }

--- a/Sources/DataPipeline/autogenerated/AutoMockable.generated.swift
+++ b/Sources/DataPipeline/autogenerated/AutoMockable.generated.swift
@@ -112,6 +112,17 @@ class DataPipelinesLoggerMock: DataPipelinesLogger, Mock {
         logPushTokenRefreshedCallsCount = 0
 
         mockCalled = false // do last as resetting properties above can make this true
+        automaticTokenRegistrationForNewProfileCallsCount = 0
+        automaticTokenRegistrationForNewProfileReceivedArguments = nil
+        automaticTokenRegistrationForNewProfileReceivedInvocations = []
+
+        mockCalled = false // do last as resetting properties above can make this true
+        logDeletingTokenDueToNewProfileIdentificationCallsCount = 0
+
+        mockCalled = false // do last as resetting properties above can make this true
+        logTrackingDevicesAttributesWithoutValidTokenCallsCount = 0
+
+        mockCalled = false // do last as resetting properties above can make this true
     }
 
     // MARK: - logStoringDevicePushToken
@@ -208,6 +219,75 @@ class DataPipelinesLoggerMock: DataPipelinesLogger, Mock {
         mockCalled = true
         logPushTokenRefreshedCallsCount += 1
         logPushTokenRefreshedClosure?()
+    }
+
+    // MARK: - automaticTokenRegistrationForNewProfile
+
+    /// Number of times the function was called.
+    @Atomic private(set) var automaticTokenRegistrationForNewProfileCallsCount = 0
+    /// `true` if the function was ever called.
+    var automaticTokenRegistrationForNewProfileCalled: Bool {
+        automaticTokenRegistrationForNewProfileCallsCount > 0
+    }
+
+    /// The arguments from the *last* time the function was called.
+    @Atomic private(set) var automaticTokenRegistrationForNewProfileReceivedArguments: (token: String, userId: String)?
+    /// Arguments from *all* of the times that the function was called.
+    @Atomic private(set) var automaticTokenRegistrationForNewProfileReceivedInvocations: [(token: String, userId: String)] = []
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     */
+    var automaticTokenRegistrationForNewProfileClosure: ((String, String) -> Void)?
+
+    /// Mocked function for `automaticTokenRegistrationForNewProfile(token: String, userId: String)`. Your opportunity to return a mocked value and check result of mock in test code.
+    func automaticTokenRegistrationForNewProfile(token: String, userId: String) {
+        mockCalled = true
+        automaticTokenRegistrationForNewProfileCallsCount += 1
+        automaticTokenRegistrationForNewProfileReceivedArguments = (token: token, userId: userId)
+        automaticTokenRegistrationForNewProfileReceivedInvocations.append((token: token, userId: userId))
+        automaticTokenRegistrationForNewProfileClosure?(token, userId)
+    }
+
+    // MARK: - logDeletingTokenDueToNewProfileIdentification
+
+    /// Number of times the function was called.
+    @Atomic private(set) var logDeletingTokenDueToNewProfileIdentificationCallsCount = 0
+    /// `true` if the function was ever called.
+    var logDeletingTokenDueToNewProfileIdentificationCalled: Bool {
+        logDeletingTokenDueToNewProfileIdentificationCallsCount > 0
+    }
+
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     */
+    var logDeletingTokenDueToNewProfileIdentificationClosure: (() -> Void)?
+
+    /// Mocked function for `logDeletingTokenDueToNewProfileIdentification()`. Your opportunity to return a mocked value and check result of mock in test code.
+    func logDeletingTokenDueToNewProfileIdentification() {
+        mockCalled = true
+        logDeletingTokenDueToNewProfileIdentificationCallsCount += 1
+        logDeletingTokenDueToNewProfileIdentificationClosure?()
+    }
+
+    // MARK: - logTrackingDevicesAttributesWithoutValidToken
+
+    /// Number of times the function was called.
+    @Atomic private(set) var logTrackingDevicesAttributesWithoutValidTokenCallsCount = 0
+    /// `true` if the function was ever called.
+    var logTrackingDevicesAttributesWithoutValidTokenCalled: Bool {
+        logTrackingDevicesAttributesWithoutValidTokenCallsCount > 0
+    }
+
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     */
+    var logTrackingDevicesAttributesWithoutValidTokenClosure: (() -> Void)?
+
+    /// Mocked function for `logTrackingDevicesAttributesWithoutValidToken()`. Your opportunity to return a mocked value and check result of mock in test code.
+    func logTrackingDevicesAttributesWithoutValidToken() {
+        mockCalled = true
+        logTrackingDevicesAttributesWithoutValidTokenCallsCount += 1
+        logTrackingDevicesAttributesWithoutValidTokenClosure?()
     }
 }
 

--- a/Tests/DataPipeline/Util/DataPipelinesLoggerTests.swift
+++ b/Tests/DataPipeline/Util/DataPipelinesLoggerTests.swift
@@ -63,4 +63,37 @@ class DataPipelinesLoggerTests: UnitTest {
             "Token refreshed, deleting old token to avoid registering same device multiple times"
         )
     }
+
+    func test_automaticTokenRegistrationForNewProfile_logsExpectedMessage() {
+        logger.automaticTokenRegistrationForNewProfile(token: "token", userId: "userId")
+
+        XCTAssertEqual(loggerMock.debugReceivedInvocations.count, 1)
+        XCTAssertEqual(loggerMock.debugReceivedInvocations.first?.tag, "Push")
+        XCTAssertEqual(
+            loggerMock.debugReceivedInvocations.first?.message,
+            "Automatically registering device token: token to newly identified profile: userId"
+        )
+    }
+
+    func test_logDeletingTokenDueToNewProfileIdentification_logsExpectedMessage() {
+        logger.logDeletingTokenDueToNewProfileIdentification()
+
+        XCTAssertEqual(loggerMock.debugReceivedInvocations.count, 1)
+        XCTAssertEqual(loggerMock.debugReceivedInvocations.first?.tag, "Push")
+        XCTAssertEqual(
+            loggerMock.debugReceivedInvocations.first?.message,
+            "Deleting device token before identifying new profile"
+        )
+    }
+
+    func test_logTrackingDevicesAttributesWithoutValidToken_logsExpectedMessage() {
+        logger.logTrackingDevicesAttributesWithoutValidToken()
+
+        XCTAssertEqual(loggerMock.debugReceivedInvocations.count, 1)
+        XCTAssertEqual(loggerMock.debugReceivedInvocations.first?.tag, "Push")
+        XCTAssertEqual(
+            loggerMock.debugReceivedInvocations.first?.message,
+            "No device token found. ignoring request to track device attributes"
+        )
+    }
 }


### PR DESCRIPTION
Part of: [MBL-1074](https://linear.app/customerio/issue/MBL-1074/update-push-notification-logging-for-ios)
Closes: [MBL-1112](https://linear.app/customerio/issue/MBL-1112/update-identify-logs)

### Overview
This PR implements log definitions as defined in the log definitions repo https://github.com/customerio/mobile-log-definitions/pull/8

- Adds logs for token profile registration

### Test
- Added unit test for the wrapper logger and call sites
- Logs after implementation are as follows
```
[Init] Creating new instance of CustomerIO SDK version: 3.8.2...

[Init] Initializing SDK module DataPipeline...
[Init] CustomerIO DataPipeline module is initialized and ready to use

[Init] CustomerIO SDK is initialized and ready to use


[Init] Initializing SDK module MessagingPush...
[Init] CustomerIO MessagingPush module is initialized and ready to use

[Push] Storing device token: {actualToken} for user profile: nil
[Push] Registering device token: {actualToken} for user profile: nil
Automatically registering device token: {{token}} to newly identified profile: momo@test.io
```