### PR TITLE
fix: multi screen views action handling

### DIFF
--- a/Sources/MessagingInApp/Gist/Managers/InlineMessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/InlineMessageManager.swift
@@ -141,7 +141,7 @@ extension InlineMessageManager: GistViewDelegate {
 
 extension InlineMessageManager: GistViewLifecycleDelegate {
     /// For inline messages, we want to dismiss the message when the view is removed from superview
-    func gistViewWillRemoveFromSuperview(_ gistView: GistView) {
+    public func gistViewWillRemoveFromSuperview(_ gistView: GistView) {
         logger.logWithModuleTag(
             "GistView being removed from superview for inline message: \(currentMessage.describeForLogs)",
             level: .debug

--- a/Sources/MessagingInApp/Gist/Managers/ModalMessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/ModalMessageManager.swift
@@ -54,6 +54,9 @@ public class ModalMessageManager: BaseMessageManager {
             "Displaying modal message: \(currentMessage.describeForLogs)",
             level: .debug
         )
+        
+        // Set lifecycle delegate to handle removeFromSuperview event correctly for modal context
+        gistView.lifecycleDelegate = self
 
         let gistProperties = currentMessage.gistProperties
         modalViewManager = ModalViewManager(
@@ -114,5 +117,19 @@ public class ModalMessageManager: BaseMessageManager {
         elapsedTimer.start(
             title: "Displaying modal for message: \(currentMessage.messageId)"
         )
+    }
+}
+
+// MARK: - GistViewLifecycleDelegate
+
+extension ModalMessageManager: GistViewLifecycleDelegate {
+    /// For modal messages, we don't want to automatically dismiss when the view is removed from superview
+    /// because the modal dismissal is handled by the ModalViewManager and state system
+    func gistViewWillRemoveFromSuperview(_ gistView: GistView) {
+        logger.logWithModuleTag(
+            "GistView being removed from superview for modal message: \(currentMessage.describeForLogs). No action taken.",
+            level: .debug
+        )
+        // Intentionally not triggering dismissMessage() since modal dismissal is managed differently
     }
 }

--- a/Sources/MessagingInApp/Gist/Managers/ModalMessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/ModalMessageManager.swift
@@ -125,7 +125,7 @@ public class ModalMessageManager: BaseMessageManager {
 extension ModalMessageManager: GistViewLifecycleDelegate {
     /// For modal messages, we don't want to automatically dismiss when the view is removed from superview
     /// because the modal dismissal is handled by the ModalViewManager and state system
-    func gistViewWillRemoveFromSuperview(_ gistView: GistView) {
+    public func gistViewWillRemoveFromSuperview(_ gistView: GistView) {
         logger.logWithModuleTag(
             "GistView being removed from superview for modal message: \(currentMessage.describeForLogs). No action taken.",
             level: .debug

--- a/Sources/MessagingInApp/Gist/Views/GistView.swift
+++ b/Sources/MessagingInApp/Gist/Views/GistView.swift
@@ -7,8 +7,15 @@ public protocol GistViewDelegate: AnyObject {
     func sizeChanged(message: Message, width: CGFloat, height: CGFloat)
 }
 
+/// Delegate protocol for handling view lifecycle events for GistView
+public protocol GistViewLifecycleDelegate: AnyObject {
+    /// Called when the GistView is about to be removed from its superview
+    func gistViewWillRemoveFromSuperview(_ gistView: GistView)
+}
+
 public class GistView: UIView {
     public weak var delegate: GistViewDelegate?
+    public weak var lifecycleDelegate: GistViewLifecycleDelegate?
     var message: Message?
 
     convenience init(message: Message, engineView: UIView) {
@@ -20,8 +27,10 @@ public class GistView: UIView {
 
     override public func removeFromSuperview() {
         super.removeFromSuperview()
-        if let _ = message {
-            DIGraphShared.shared.gistProvider.dismissMessage()
-        }
+        
+        // Notify lifecycle delegate that this view is being removed
+        // The delegate (InlineMessageManager or ModalMessageManager) can decide 
+        // what action to take based on the context
+        lifecycleDelegate?.gistViewWillRemoveFromSuperview(self)
     }
 }

--- a/Tests/MessagingInApp/Gist/GistDelegateImplTests.swift
+++ b/Tests/MessagingInApp/Gist/GistDelegateImplTests.swift
@@ -1,0 +1,161 @@
+import XCTest
+@testable import CioInternalCommon
+@testable import CioMessagingInApp
+import SharedTests
+
+class GistDelegateImplTests: UnitTest {
+    
+    var gistDelegate: GistDelegateImpl!
+    var mockLogger: LoggerMock!
+    var mockEventBusHandler: EventBusHandlerMock!
+    var mockEventListener: InAppEventListenerMock!
+    var mockThreadUtil: ThreadUtilStub!
+    
+    override func setUp() {
+        super.setUp()
+        
+        mockLogger = LoggerMock()
+        mockEventBusHandler = EventBusHandlerMock()
+        mockEventListener = InAppEventListenerMock()
+        mockThreadUtil = ThreadUtilStub()
+        
+        // Override the ThreadUtil in the DIGraphShared
+        let originalThreadUtil = diGraphShared.threadUtil
+        diGraphShared.override(value: mockThreadUtil, forType: ThreadUtil.self)
+        
+        gistDelegate = GistDelegateImpl(logger: mockLogger, eventBusHandler: mockEventBusHandler)
+        gistDelegate.setEventListener(mockEventListener)
+        
+        // Reset the original ThreadUtil after creating the gistDelegate
+        diGraphShared.override(value: originalThreadUtil, forType: ThreadUtil.self)
+    }
+    
+    override func tearDown() {
+        mockLogger = nil
+        mockEventBusHandler = nil
+        mockEventListener = nil
+        mockThreadUtil = nil
+        gistDelegate = nil
+        
+        super.tearDown()
+    }
+    
+    func testSetEventListener() {
+        let newMockEventListener = InAppEventListenerMock()
+        
+        gistDelegate.setEventListener(newMockEventListener)
+        
+        // Create a test message to verify the event listener is properly set
+        let message = Message(messageId: "test-message-id")
+        gistDelegate.messageShown(message: message)
+        
+        XCTAssertFalse(mockEventListener.messageShownCalled, "Old event listener should not be called")
+        XCTAssertTrue(newMockEventListener.messageShownCalled, "New event listener should be called")
+    }
+    
+    func testMessageShown() {
+        let message = Message(messageId: "test-message-id", campaignId: "test-delivery-id")
+        
+        gistDelegate.messageShown(message: message)
+        
+        XCTAssertTrue(mockEventBusHandler.postEventCalled, "EventBusHandler should post an event")
+        XCTAssertTrue(mockThreadUtil.runMainCalled, "ThreadUtil.runMain should be called to dismiss keyboard")
+        XCTAssertTrue(mockEventListener.messageShownCalled, "EventListener's messageShown should be called")
+        
+        // Verify event bus event details
+        if let postedEvent = mockEventBusHandler.postEventArguments as? TrackInAppMetricEvent {
+            XCTAssertEqual(postedEvent.deliveryID, "test-delivery-id", "DeliveryID should match campaign ID")
+            XCTAssertEqual(postedEvent.event, InAppMetric.opened.rawValue, "Event should be 'opened'")
+        } else {
+            XCTFail("Event posted should be TrackInAppMetricEvent")
+        }
+        
+        // Verify event listener details
+        XCTAssertEqual(mockEventListener.messageShownReceivedArguments?.messageId, "test-message-id", "Message ID should match")
+    }
+    
+    func testMessageDismissed() {
+        let message = Message(messageId: "test-message-id")
+        
+        gistDelegate.messageDismissed(message: message)
+        
+        XCTAssertTrue(mockEventListener.messageDismissedCalled, "EventListener's messageDismissed should be called")
+        XCTAssertEqual(mockEventListener.messageDismissedReceivedArguments?.messageId, "test-message-id", "Message ID should match")
+    }
+    
+    func testMessageError() {
+        let message = Message(messageId: "test-message-id")
+        
+        gistDelegate.messageError(message: message)
+        
+        XCTAssertTrue(mockEventListener.errorWithMessageCalled, "EventListener's errorWithMessage should be called")
+        XCTAssertEqual(mockEventListener.errorWithMessageReceivedArguments?.messageId, "test-message-id", "Message ID should match")
+    }
+    
+    func testActionWithNormalAction() {
+        let message = Message(messageId: "test-message-id", campaignId: "test-delivery-id")
+        let action = "https://customerio.com"
+        let name = "Visit Website"
+        
+        gistDelegate.action(message: message, currentRoute: "/test", action: action, name: name)
+        
+        XCTAssertTrue(mockEventBusHandler.postEventCalled, "EventBusHandler should post an event for non-close actions")
+        XCTAssertTrue(mockEventListener.messageActionTakenCalled, "EventListener's messageActionTaken should be called")
+        
+        // Verify event bus event details
+        if let postedEvent = mockEventBusHandler.postEventArguments as? TrackInAppMetricEvent {
+            XCTAssertEqual(postedEvent.deliveryID, "test-delivery-id", "DeliveryID should match campaign ID")
+            XCTAssertEqual(postedEvent.event, InAppMetric.clicked.rawValue, "Event should be 'clicked'")
+            
+            if let params = postedEvent.params as? [String: String] {
+                XCTAssertEqual(params["actionName"], "Visit Website", "Action name should match")
+                XCTAssertEqual(params["actionValue"], "https://customerio.com", "Action value should match")
+            } else {
+                XCTFail("Event params should be a dictionary of [String: String]")
+            }
+        } else {
+            XCTFail("Event posted should be TrackInAppMetricEvent")
+        }
+        
+        // Verify event listener details
+        XCTAssertEqual(mockEventListener.messageActionTakenReceivedArguments?.message.messageId, "test-message-id", "Message ID should match")
+        XCTAssertEqual(mockEventListener.messageActionTakenReceivedArguments?.actionValue, "https://customerio.com", "Action value should match")
+        XCTAssertEqual(mockEventListener.messageActionTakenReceivedArguments?.actionName, "Visit Website", "Action name should match")
+    }
+    
+    func testActionWithCloseAction() {
+        let message = Message(messageId: "test-message-id", campaignId: "test-delivery-id")
+        let action = "gist://close"
+        let name = "Close"
+        
+        gistDelegate.action(message: message, currentRoute: "/test", action: action, name: name)
+        
+        XCTAssertFalse(mockEventBusHandler.postEventCalled, "EventBusHandler should not post an event for close actions")
+        XCTAssertTrue(mockEventListener.messageActionTakenCalled, "EventListener's messageActionTaken should be called")
+        
+        // Verify event listener details
+        XCTAssertEqual(mockEventListener.messageActionTakenReceivedArguments?.message.messageId, "test-message-id", "Message ID should match")
+        XCTAssertEqual(mockEventListener.messageActionTakenReceivedArguments?.actionValue, "gist://close", "Action value should match")
+        XCTAssertEqual(mockEventListener.messageActionTakenReceivedArguments?.actionName, "Close", "Action name should match")
+    }
+    
+    
+    func testEmbedMessage() {
+        let message = Message(messageId: "test-message-id")
+        let elementId = "test-element-id"
+        
+        // Reset the mocks to ensure we start clean
+        mockEventBusHandler.resetMock()
+        mockEventListener.resetMock()
+        
+        gistDelegate.embedMessage(message: message, elementId: elementId)
+        
+        // Since this is a no-op implementation, verify no events are posted
+        // and that the event listener wasn't called
+        XCTAssertFalse(mockEventBusHandler.postEventCalled, "No events should be posted")
+        XCTAssertFalse(mockEventListener.messageShownCalled, "No event listener methods should be called")
+        XCTAssertFalse(mockEventListener.messageDismissedCalled, "No event listener methods should be called")
+        XCTAssertFalse(mockEventListener.errorWithMessageCalled, "No event listener methods should be called")
+        XCTAssertFalse(mockEventListener.messageActionTakenCalled, "No event listener methods should be called")
+    }
+}

--- a/Tests/MessagingInApp/Gist/Views/GistViewLifecycleDelegateTests.swift
+++ b/Tests/MessagingInApp/Gist/Views/GistViewLifecycleDelegateTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import CioInternalCommon
+@testable import CioMessagingInApp
+import SharedTests
+
+class GistViewLifecycleDelegateTests: UnitTest {
+    
+    class MockGistViewLifecycleDelegate: GistViewLifecycleDelegate {
+        var removeFromSuperviewCalled = false
+        var lastGistView: GistView?
+        
+        public func gistViewWillRemoveFromSuperview(_ gistView: GistView) {
+            removeFromSuperviewCalled = true
+            lastGistView = gistView
+        }
+    }
+    
+    var gistView: GistView!
+    var mockLifecycleDelegate: MockGistViewLifecycleDelegate!
+    var mockEngineView: UIView!
+    var mockGistProvider: GistProviderMock!
+    var originalGistProvider: GistProvider!
+    
+    override func setUp() {
+        super.setUp()
+        
+        mockLifecycleDelegate = MockGistViewLifecycleDelegate()
+        mockEngineView = UIView()
+        mockGistProvider = GistProviderMock()
+        
+        originalGistProvider = diGraphShared.gistProvider
+        diGraphShared.override(value: mockGistProvider, forType: GistProvider.self)
+        
+        let message = Message(messageId: "test-message")
+        gistView = GistView(message: message, engineView: mockEngineView)
+        gistView.lifecycleDelegate = mockLifecycleDelegate
+    }
+    
+    override func tearDown() {
+        diGraphShared.override(value: originalGistProvider, forType: GistProvider.self)
+        
+        mockLifecycleDelegate = nil
+        mockEngineView = nil
+        mockGistProvider = nil
+        gistView = nil
+        
+        super.tearDown()
+    }
+    
+    func testLifecycleDelegateCalledWhenRemovingFromSuperview() {
+        gistView.removeFromSuperview()
+        
+        XCTAssertTrue(mockLifecycleDelegate.removeFromSuperviewCalled, "Lifecycle delegate should be notified when removeFromSuperview is called")
+        XCTAssertTrue(mockLifecycleDelegate.lastGistView === gistView, "The correct GistView should be passed to the delegate")
+        XCTAssertFalse(mockGistProvider.dismissMessageCalled, "GistView should not directly call dismissMessage after our refactoring")
+    }
+    
+    func testInlineMessageManagerImplementation() {
+        let message = Message(messageId: "test-inline-message", elementId: "test-element")
+        XCTAssertTrue(message.isEmbedded, "Message should be identified as embedded/inline")
+        
+        let state = InAppMessageState()
+        let inlineManager = InlineMessageManager(state: state, message: message)
+        gistView.lifecycleDelegate = inlineManager
+        
+        gistView.removeFromSuperview()
+        
+        XCTAssertTrue(mockGistProvider.dismissMessageCalled, 
+                     "InlineMessageManager should call dismissMessage when GistView is removed from superview")
+    }
+    
+    func testModalMessageManagerImplementation() {
+        // Modal messages don't have an elementId
+        let message = Message(messageId: "test-modal-message")
+        XCTAssertFalse(message.isEmbedded, "Message should be identified as modal (not embedded/inline)")
+        
+        let state = InAppMessageState()
+        let modalManager = ModalMessageManager(state: state, message: message)
+        
+        mockGistProvider.resetMock()
+        gistView.lifecycleDelegate = modalManager
+        
+        gistView.removeFromSuperview()
+        
+        XCTAssertFalse(mockGistProvider.dismissMessageCalled, 
+                      "ModalMessageManager should NOT call dismissMessage when GistView is removed from superview")
+    }
+}

--- a/Tests/Shared/Stub/ThreadUtilStub.swift
+++ b/Tests/Shared/Stub/ThreadUtilStub.swift
@@ -2,11 +2,25 @@ import CioInternalCommon
 import Foundation
 
 public class ThreadUtilStub: ThreadUtil {
+    public var runMainCalled = false
+    public var runBackgroundCalled = false
+    
+    public init() {
+        // Public initializer
+    }
+    
     public func runMain(_ block: @escaping () -> Void) {
+        runMainCalled = true
         block()
     }
 
     public func runBackground(_ block: @escaping () -> Void) {
+        runBackgroundCalled = true
         block()
+    }
+    
+    public func reset() {
+        runMainCalled = false
+        runBackgroundCalled = false
     }
 }


### PR DESCRIPTION
  Summary:

  - Added a new GistViewLifecycleDelegate protocol to improve the handling of view lifecycle events
  - Refactored message view dismissal logic to respect different manager contexts
  - Enhanced test coverage for Gist components with comprehensive test suites

  Changes:

  - Created a new GistViewLifecycleDelegate protocol to properly handle view removal events
  - Moved dismissal logic from GistView to the appropriate message managers
  - Implemented context-specific handling:
    - InlineMessageManager: Automatically dismisses messages when views are removed
    - ModalMessageManager: Skips auto-dismissal since modals have their own dismissal flow. This was root cause of multi screen messages, when one would hinder the other dismissal flow.

  Testing:

  - Added GistViewLifecycleDelegateTests to verify the new lifecycle delegation system works correctly
  - Created GistDelegateImplTests to improve test coverage of event handling
  - Updated ThreadUtilStub to support better testing of UI operations

  Testing Instructions:

  1. Run the MessagingInApp test suite to verify all tests pass
  2. Test inline message embedding/dismissal to ensure they dismiss correctly when removed
  3. Test modal messages to verify they don't auto-dismiss when their view is removed