### PR TITLE
fix: Fixed issue with duplicate internal call for setting device token

### DIFF
--- a/Sources/MessagingPush/Integration/CioProviderAgnosticAppDelegate.swift
+++ b/Sources/MessagingPush/Integration/CioProviderAgnosticAppDelegate.swift
@@ -73,7 +73,7 @@ open class CioProviderAgnosticAppDelegate: CioAppDelegateType, UNUserNotificatio
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        MessagingPush.appDelegateIntegratedExplicitely = true
+        MessagingPush.appDelegateIntegratedExplicitly = true
 
         let result = wrappedAppDelegate?.application?(application, didFinishLaunchingWithOptions: launchOptions)
 

--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -6,7 +6,7 @@ import Foundation
  So, performing an HTTP request to the API with a device token goes here.
   */
 public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, MessagingPushInstance {
-    @_spi(Internal) public static var appDelegateIntegratedExplicitely: Bool = false
+    @_spi(Internal) public static var appDelegateIntegratedExplicitly: Bool = false
 
     @Atomic public private(set) static var shared = MessagingPush()
     @Atomic public private(set) static var moduleConfig: MessagingPushConfigOptions = MessagingPushConfigBuilder().build()
@@ -59,7 +59,7 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
             Self.moduleConfig = config
             // Some part of the initialize is specific only to non-NSE targets.
             // Put those parts in this non-NSE initialize method.
-            if config.autoTrackPushEvents, !Self.appDelegateIntegratedExplicitely {
+            if config.autoTrackPushEvents, !Self.appDelegateIntegratedExplicitly {
                 DIGraphShared.shared.automaticPushClickHandling.start()
             }
 

--- a/Sources/MessagingPushAPN/MessagingPushAPN.swift
+++ b/Sources/MessagingPushAPN/MessagingPushAPN.swift
@@ -1,5 +1,5 @@
 import CioInternalCommon
-import CioMessagingPush
+@_spi(Internal) import CioMessagingPush
 import Foundation
 #if canImport(UserNotifications)
 import UserNotifications
@@ -88,7 +88,7 @@ public class MessagingPushAPN: MessagingPushAPNInstance {
         let implementation = MessagingPush.initialize(withConfig: config)
 
         let pushConfigOptions = MessagingPush.moduleConfig
-        if pushConfigOptions.autoFetchDeviceToken {
+        if pushConfigOptions.autoFetchDeviceToken, !MessagingPush.appDelegateIntegratedExplicitly {
             shared.setupAutoFetchDeviceToken()
         }
 

--- a/Sources/MessagingPushFCM/MessagingPushFCM.swift
+++ b/Sources/MessagingPushFCM/MessagingPushFCM.swift
@@ -92,7 +92,7 @@ public class MessagingPushFCM: MessagingPushFCMInstance {
         let implementation = MessagingPush.initialize(withConfig: config)
 
         let pushConfigOptions = MessagingPush.moduleConfig
-        if pushConfigOptions.autoFetchDeviceToken, !MessagingPush.appDelegateIntegratedExplicitely {
+        if pushConfigOptions.autoFetchDeviceToken, !MessagingPush.appDelegateIntegratedExplicitly {
             shared.setupAutoFetchDeviceToken()
         }
 

--- a/Tests/MessagingPush/Integration/CioProviderAgnosticAppDelegateTests.swift
+++ b/Tests/MessagingPush/Integration/CioProviderAgnosticAppDelegateTests.swift
@@ -63,7 +63,7 @@ class CioProviderAgnosticAppDelegateTests: XCTestCase {
 
         UNUserNotificationCenter.unswizzleNotificationCenter()
 
-        MessagingPush.appDelegateIntegratedExplicitely = false
+        MessagingPush.appDelegateIntegratedExplicitly = false
 
         super.tearDown()
     }
@@ -75,7 +75,7 @@ class CioProviderAgnosticAppDelegateTests: XCTestCase {
         let result = appDelegate.application(UIApplication.shared, didFinishLaunchingWithOptions: nil)
 
         // Verify behavior
-        XCTAssertTrue(MessagingPush.appDelegateIntegratedExplicitely)
+        XCTAssertTrue(MessagingPush.appDelegateIntegratedExplicitly)
         XCTAssertTrue(result)
         XCTAssertTrue(mockAppDelegate.didFinishLaunchingCalled)
         XCTAssertTrue(mockLogger.debugCallsCount == 1)

--- a/Tests/MessagingPushAPN/Integration/CioAppDelegateAPNTests.swift
+++ b/Tests/MessagingPushAPN/Integration/CioAppDelegateAPNTests.swift
@@ -61,7 +61,7 @@ class CioAppDelegateAPNTests: XCTestCase {
 
         UNUserNotificationCenter.unswizzleNotificationCenter()
 
-        MessagingPush.appDelegateIntegratedExplicitely = false
+        MessagingPush.appDelegateIntegratedExplicitly = false
 
         super.tearDown()
     }

--- a/Tests/MessagingPushFCM/Integration/CioAppDelegateFCMTests.swift
+++ b/Tests/MessagingPushFCM/Integration/CioAppDelegateFCMTests.swift
@@ -74,7 +74,7 @@ class CioAppDelegateFCMTests: XCTestCase {
         Messaging.unswizzleMessaging()
         UNUserNotificationCenter.unswizzleNotificationCenter()
 
-        MessagingPush.appDelegateIntegratedExplicitely = false
+        MessagingPush.appDelegateIntegratedExplicitly = false
 
         super.tearDown()
     }


### PR DESCRIPTION
Task: [MBL-1159](https://linear.app/customerio/issue/MBL-1159/bug-in-no-swizzling-interaction-with-messagingpushapn)

## Issue:
- The condition for enabling the AppDelegate that replaces swizzling wasn't properly checked
- This produced a duplicate call to the internal API for registering the device token
- Our internal API checks if the token has changed and calls the backend only if it has, so we do not have duplicate calls to the backend

## Solution:
- The missing condition is added

### Original plan
The original plan was to add full coverage for classes where this problem happened, classes MessagingPushAPN and MessagingPushFCM, which has been done in this PR: https://github.com/customerio/customerio-ios/pull/921/files#diff-d322168af6d12b45ff1a57021d6a686396fe280ff72e00f2c1872bc9e4abff3f
- but as layers of swizzling have been refactored for testability, to finish the work, I'll need to rewrite ~100% of the code
- this has a risk of not covering some aspect of original swizzling and producing new issues

### Final plan
I decided to first solve the issue I originally noticed, without making any changes to the swizzling code.
I'll later revisit the original PR and new ticket created to cover it: [MBL-1166](https://linear.app/customerio/issue/MBL-1166/improve-coverage-for-swizzling-part-of-the-code)


## Testing plan:
Manual Testing setup:
- The easiest way to get a device token is to copy from the Xcode console
- Basic PN: 
  - Expectation: This will send the default testing PN, which should work in & out of the app
  - Triggering:
    - APN: Send test PN from https://fly.customer.io/workspaces/122175/settings/actions/push/ios
    - FCM: Send test PN from https://fly.customer.io/workspaces/111525/settings/actions/push/ios
- PN with Deep-link: 
  - Expectation: This will send the PN payload with URL (google.com), which should work in & out of the app, and tap should open this URL in Safari or Google app
  - Triggering:
    - APN: Use button `Send test...` in test-campaign PN-config from https://fly.customer.io/workspaces/122175/journeys/composer/actions/365
    - FCM: Use button `Send test...` in test-campaign PN-config from https://fly.customer.io/workspaces/111525/journeys/composer/actions/250