### PR TITLE
feat: added ability to pause the in-app polling

### DIFF
--- a/Sources/MessagingInApp/MessagingInApp.swift
+++ b/Sources/MessagingInApp/MessagingInApp.swift
@@ -7,9 +7,9 @@ public protocol MessagingInAppInstance: AutoMockable {
 
     func dismissMessage()
 
-    func pausePolling()
+    func pauseMessageFetching()
 
-    func resumePolling()
+    func resumeMessageFetching()
 }
 
 public class MessagingInApp: ModuleTopLevelObject<MessagingInAppInstance>, MessagingInAppInstance {
@@ -79,15 +79,16 @@ public class MessagingInApp: ModuleTopLevelObject<MessagingInAppInstance>, Messa
         implementation?.dismissMessage()
     }
 
-    /// Pauses the polling for in-app messages. No new messages will be fetched from the server
-    /// until polling is resumed.
-    public func pausePolling() {
-        implementation?.pausePolling()
+    /// Pauses message fetching. The polling timer continues running but network requests
+    /// for new messages are suspended until message fetching is resumed. Messages already
+    /// in the queue will continue to be displayed.
+    public func pauseMessageFetching() {
+        implementation?.pauseMessageFetching()
     }
 
-    /// Resumes the polling for in-app messages. If polling was previously paused,
-    /// this will restart the periodic fetching of messages from the server.
-    public func resumePolling() {
-        implementation?.resumePolling()
+    /// Resumes message fetching. If message fetching was previously paused,
+    /// this will restart the periodic fetching of new messages from the server.
+    public func resumeMessageFetching() {
+        implementation?.resumeMessageFetching()
     }
 }

--- a/Sources/MessagingInApp/MessagingInApp.swift
+++ b/Sources/MessagingInApp/MessagingInApp.swift
@@ -6,6 +6,10 @@ public protocol MessagingInAppInstance: AutoMockable {
     func setEventListener(_ eventListener: InAppEventListener?)
 
     func dismissMessage()
+
+    func pausePolling()
+
+    func resumePolling()
 }
 
 public class MessagingInApp: ModuleTopLevelObject<MessagingInAppInstance>, MessagingInAppInstance {
@@ -73,5 +77,17 @@ public class MessagingInApp: ModuleTopLevelObject<MessagingInAppInstance>, Messa
     // Dismiss in-app message
     public func dismissMessage() {
         implementation?.dismissMessage()
+    }
+
+    /// Pauses the polling for in-app messages. No new messages will be fetched from the server
+    /// until polling is resumed.
+    public func pausePolling() {
+        implementation?.pausePolling()
+    }
+
+    /// Resumes the polling for in-app messages. If polling was previously paused,
+    /// this will restart the periodic fetching of messages from the server.
+    public func resumePolling() {
+        implementation?.resumePolling()
     }
 }

--- a/Sources/MessagingInApp/MessagingInAppImplementation.swift
+++ b/Sources/MessagingInApp/MessagingInAppImplementation.swift
@@ -62,11 +62,11 @@ class MessagingInAppImplementation: MessagingInAppInstance {
         gist.dismissMessage()
     }
 
-    func pausePolling() {
-        inAppMessageManager.dispatch(action: .pausePolling)
+    func pauseMessageFetching() {
+        inAppMessageManager.dispatch(action: .pauseMessageFetching)
     }
 
-    func resumePolling() {
-        inAppMessageManager.dispatch(action: .resumePolling)
+    func resumeMessageFetching() {
+        inAppMessageManager.dispatch(action: .resumeMessageFetching)
     }
 }

--- a/Sources/MessagingInApp/MessagingInAppImplementation.swift
+++ b/Sources/MessagingInApp/MessagingInAppImplementation.swift
@@ -61,4 +61,12 @@ class MessagingInAppImplementation: MessagingInAppInstance {
     func dismissMessage() {
         gist.dismissMessage()
     }
+
+    func pausePolling() {
+        inAppMessageManager.dispatch(action: .pausePolling)
+    }
+
+    func resumePolling() {
+        inAppMessageManager.dispatch(action: .resumePolling)
+    }
 }

--- a/Sources/MessagingInApp/State/InAppMessageAction.swift
+++ b/Sources/MessagingInApp/State/InAppMessageAction.swift
@@ -5,6 +5,8 @@ import Foundation
 enum InAppMessageAction: Equatable {
     case initialize(siteId: String, dataCenter: String, environment: GistEnvironment)
     case setPollingInterval(interval: Double)
+    case pausePolling
+    case resumePolling
     case setUserIdentifier(user: String)
     case setPageRoute(route: String)
     case processMessageQueue(messages: [Message])
@@ -32,6 +34,12 @@ enum InAppMessageAction: Equatable {
 
         case (.setPollingInterval(let lhsInterval), .setPollingInterval(let rhsInterval)):
             return lhsInterval == rhsInterval
+
+        case (.pausePolling, .pausePolling):
+            return true
+
+        case (.resumePolling, .resumePolling):
+            return true
 
         case (.setUserIdentifier(let lhsUser), .setUserIdentifier(let rhsUser)):
             return lhsUser == rhsUser

--- a/Sources/MessagingInApp/State/InAppMessageAction.swift
+++ b/Sources/MessagingInApp/State/InAppMessageAction.swift
@@ -5,8 +5,8 @@ import Foundation
 enum InAppMessageAction: Equatable {
     case initialize(siteId: String, dataCenter: String, environment: GistEnvironment)
     case setPollingInterval(interval: Double)
-    case pausePolling
-    case resumePolling
+    case pauseMessageFetching
+    case resumeMessageFetching
     case setUserIdentifier(user: String)
     case setPageRoute(route: String)
     case processMessageQueue(messages: [Message])
@@ -35,10 +35,10 @@ enum InAppMessageAction: Equatable {
         case (.setPollingInterval(let lhsInterval), .setPollingInterval(let rhsInterval)):
             return lhsInterval == rhsInterval
 
-        case (.pausePolling, .pausePolling):
+        case (.pauseMessageFetching, .pauseMessageFetching):
             return true
 
-        case (.resumePolling, .resumePolling):
+        case (.resumeMessageFetching, .resumeMessageFetching):
             return true
 
         case (.setUserIdentifier(let lhsUser), .setUserIdentifier(let rhsUser)):

--- a/Sources/MessagingInApp/State/InAppMessageMiddleware.swift
+++ b/Sources/MessagingInApp/State/InAppMessageMiddleware.swift
@@ -31,8 +31,8 @@ func userAuthenticationMiddleware() -> InAppMessageMiddleware {
              .setUserIdentifier,
              .setPageRoute,
              .resetState,
-             .pausePolling,
-             .resumePolling:
+             .pauseMessageFetching,
+             .resumeMessageFetching:
             return next(action)
 
         default:

--- a/Sources/MessagingInApp/State/InAppMessageMiddleware.swift
+++ b/Sources/MessagingInApp/State/InAppMessageMiddleware.swift
@@ -30,7 +30,9 @@ func userAuthenticationMiddleware() -> InAppMessageMiddleware {
         case .initialize,
              .setUserIdentifier,
              .setPageRoute,
-             .resetState:
+             .resetState,
+             .pausePolling,
+             .resumePolling:
             return next(action)
 
         default:

--- a/Sources/MessagingInApp/State/InAppMessageReducer.swift
+++ b/Sources/MessagingInApp/State/InAppMessageReducer.swift
@@ -32,11 +32,11 @@ private func reducer(action: InAppMessageAction, state: InAppMessageState) -> In
     case .setPollingInterval(let interval):
         return state.copy(pollInterval: interval)
 
-    case .pausePolling:
-        return state.copy(isPollingPaused: true)
+    case .pauseMessageFetching:
+        return state.copy(isMessageFetchingPaused: true)
 
-    case .resumePolling:
-        return state.copy(isPollingPaused: false)
+    case .resumeMessageFetching:
+        return state.copy(isMessageFetchingPaused: false)
 
     case .setUserIdentifier(let user):
         return state.copy(userId: user)

--- a/Sources/MessagingInApp/State/InAppMessageReducer.swift
+++ b/Sources/MessagingInApp/State/InAppMessageReducer.swift
@@ -32,6 +32,12 @@ private func reducer(action: InAppMessageAction, state: InAppMessageState) -> In
     case .setPollingInterval(let interval):
         return state.copy(pollInterval: interval)
 
+    case .pausePolling:
+        return state.copy(isPollingPaused: true)
+
+    case .resumePolling:
+        return state.copy(isPollingPaused: false)
+
     case .setUserIdentifier(let user):
         return state.copy(userId: user)
 

--- a/Sources/MessagingInApp/State/InAppMessageState.swift
+++ b/Sources/MessagingInApp/State/InAppMessageState.swift
@@ -9,7 +9,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
     let dataCenter: String
     let environment: GistEnvironment
     let pollInterval: Double
-    let isPollingPaused: Bool
+    let isMessageFetchingPaused: Bool
     let userId: String?
     let currentRoute: String?
     let modalMessageState: ModalMessageState
@@ -22,7 +22,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
         dataCenter: String = "",
         environment: GistEnvironment = .production,
         pollInterval: Double = 600,
-        isPollingPaused: Bool = false,
+        isMessageFetchingPaused: Bool = false,
         userId: String? = nil,
         currentRoute: String? = nil,
         modalMessageState: ModalMessageState = .initial,
@@ -34,7 +34,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
         self.dataCenter = dataCenter
         self.environment = environment
         self.pollInterval = pollInterval
-        self.isPollingPaused = isPollingPaused
+        self.isMessageFetchingPaused = isMessageFetchingPaused
         self.userId = userId
         self.currentRoute = currentRoute
         self.modalMessageState = modalMessageState
@@ -47,7 +47,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
     /// It is useful when updating state with only a few properties and keeping the rest as is.
     func copy(
         pollInterval: Double? = nil,
-        isPollingPaused: Bool? = nil,
+        isMessageFetchingPaused: Bool? = nil,
         userId: String? = nil,
         currentRoute: String? = nil,
         modalMessageState: ModalMessageState? = nil,
@@ -60,7 +60,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
             dataCenter: dataCenter,
             environment: environment,
             pollInterval: pollInterval ?? self.pollInterval,
-            isPollingPaused: isPollingPaused ?? self.isPollingPaused,
+            isMessageFetchingPaused: isMessageFetchingPaused ?? self.isMessageFetchingPaused,
             userId: userId ?? self.userId,
             currentRoute: currentRoute ?? self.currentRoute,
             modalMessageState: modalMessageState ?? self.modalMessageState,
@@ -75,7 +75,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
             lhs.dataCenter == rhs.dataCenter &&
             lhs.environment == rhs.environment &&
             lhs.pollInterval == rhs.pollInterval &&
-            lhs.isPollingPaused == rhs.isPollingPaused &&
+            lhs.isMessageFetchingPaused == rhs.isMessageFetchingPaused &&
             lhs.userId == rhs.userId &&
             lhs.currentRoute == rhs.currentRoute &&
             lhs.modalMessageState == rhs.modalMessageState &&
@@ -90,7 +90,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
             dataCenter: '\(dataCenter)',
             environment: \(environment),
             pollInterval: \(pollInterval),
-            isPollingPaused: \(isPollingPaused),
+            isMessageFetchingPaused: \(isMessageFetchingPaused),
             userId: \(String(describing: userId)),
             currentRoute: \(String(describing: currentRoute)),
             modalMessageState: \(modalMessageState),
@@ -121,7 +121,7 @@ extension InAppMessageState {
         putIfDifferent(\.dataCenter, as: "dataCenter")
         putIfDifferent(\.environment, as: "environment")
         putIfDifferent(\.pollInterval, as: "pollInterval")
-        putIfDifferent(\.isPollingPaused, as: "isPollingPaused")
+        putIfDifferent(\.isMessageFetchingPaused, as: "isMessageFetchingPaused")
         putIfDifferent(\.userId, as: "userId")
         putIfDifferent(\.currentRoute, as: "currentRoute")
         putIfDifferent(\.modalMessageState, as: "currentMessageState")

--- a/Sources/MessagingInApp/State/InAppMessageState.swift
+++ b/Sources/MessagingInApp/State/InAppMessageState.swift
@@ -9,6 +9,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
     let dataCenter: String
     let environment: GistEnvironment
     let pollInterval: Double
+    let isPollingPaused: Bool
     let userId: String?
     let currentRoute: String?
     let modalMessageState: ModalMessageState
@@ -21,6 +22,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
         dataCenter: String = "",
         environment: GistEnvironment = .production,
         pollInterval: Double = 600,
+        isPollingPaused: Bool = false,
         userId: String? = nil,
         currentRoute: String? = nil,
         modalMessageState: ModalMessageState = .initial,
@@ -32,6 +34,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
         self.dataCenter = dataCenter
         self.environment = environment
         self.pollInterval = pollInterval
+        self.isPollingPaused = isPollingPaused
         self.userId = userId
         self.currentRoute = currentRoute
         self.modalMessageState = modalMessageState
@@ -44,6 +47,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
     /// It is useful when updating state with only a few properties and keeping the rest as is.
     func copy(
         pollInterval: Double? = nil,
+        isPollingPaused: Bool? = nil,
         userId: String? = nil,
         currentRoute: String? = nil,
         modalMessageState: ModalMessageState? = nil,
@@ -56,6 +60,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
             dataCenter: dataCenter,
             environment: environment,
             pollInterval: pollInterval ?? self.pollInterval,
+            isPollingPaused: isPollingPaused ?? self.isPollingPaused,
             userId: userId ?? self.userId,
             currentRoute: currentRoute ?? self.currentRoute,
             modalMessageState: modalMessageState ?? self.modalMessageState,
@@ -70,6 +75,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
             lhs.dataCenter == rhs.dataCenter &&
             lhs.environment == rhs.environment &&
             lhs.pollInterval == rhs.pollInterval &&
+            lhs.isPollingPaused == rhs.isPollingPaused &&
             lhs.userId == rhs.userId &&
             lhs.currentRoute == rhs.currentRoute &&
             lhs.modalMessageState == rhs.modalMessageState &&
@@ -84,6 +90,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
             dataCenter: '\(dataCenter)',
             environment: \(environment),
             pollInterval: \(pollInterval),
+            isPollingPaused: \(isPollingPaused),
             userId: \(String(describing: userId)),
             currentRoute: \(String(describing: currentRoute)),
             modalMessageState: \(modalMessageState),
@@ -114,6 +121,7 @@ extension InAppMessageState {
         putIfDifferent(\.dataCenter, as: "dataCenter")
         putIfDifferent(\.environment, as: "environment")
         putIfDifferent(\.pollInterval, as: "pollInterval")
+        putIfDifferent(\.isPollingPaused, as: "isPollingPaused")
         putIfDifferent(\.userId, as: "userId")
         putIfDifferent(\.currentRoute, as: "currentRoute")
         putIfDifferent(\.modalMessageState, as: "currentMessageState")

--- a/Sources/MessagingInApp/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingInApp/autogenerated/AutoMockable.generated.swift
@@ -870,10 +870,10 @@ public class MessagingInAppInstanceMock: MessagingInAppInstance, Mock {
         dismissMessageCallsCount = 0
 
         mockCalled = false // do last as resetting properties above can make this true
-        pausePollingCallsCount = 0
+        pauseMessageFetchingCallsCount = 0
 
         mockCalled = false // do last as resetting properties above can make this true
-        resumePollingCallsCount = 0
+        resumeMessageFetchingCallsCount = 0
 
         mockCalled = false // do last as resetting properties above can make this true
     }
@@ -926,46 +926,46 @@ public class MessagingInAppInstanceMock: MessagingInAppInstance, Mock {
         dismissMessageClosure?()
     }
 
-    // MARK: - pausePolling
+    // MARK: - pauseMessageFetching
 
     /// Number of times the function was called.
-    @Atomic public private(set) var pausePollingCallsCount = 0
+    @Atomic public private(set) var pauseMessageFetchingCallsCount = 0
     /// `true` if the function was ever called.
-    public var pausePollingCalled: Bool {
-        pausePollingCallsCount > 0
+    public var pauseMessageFetchingCalled: Bool {
+        pauseMessageFetchingCallsCount > 0
     }
 
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    public var pausePollingClosure: (() -> Void)?
+    public var pauseMessageFetchingClosure: (() -> Void)?
 
-    /// Mocked function for `pausePolling()`. Your opportunity to return a mocked value and check result of mock in test code.
-    public func pausePolling() {
+    /// Mocked function for `pauseMessageFetching()`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func pauseMessageFetching() {
         mockCalled = true
-        pausePollingCallsCount += 1
-        pausePollingClosure?()
+        pauseMessageFetchingCallsCount += 1
+        pauseMessageFetchingClosure?()
     }
 
-    // MARK: - resumePolling
+    // MARK: - resumeMessageFetching
 
     /// Number of times the function was called.
-    @Atomic public private(set) var resumePollingCallsCount = 0
+    @Atomic public private(set) var resumeMessageFetchingCallsCount = 0
     /// `true` if the function was ever called.
-    public var resumePollingCalled: Bool {
-        resumePollingCallsCount > 0
+    public var resumeMessageFetchingCalled: Bool {
+        resumeMessageFetchingCallsCount > 0
     }
 
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    public var resumePollingClosure: (() -> Void)?
+    public var resumeMessageFetchingClosure: (() -> Void)?
 
-    /// Mocked function for `resumePolling()`. Your opportunity to return a mocked value and check result of mock in test code.
-    public func resumePolling() {
+    /// Mocked function for `resumeMessageFetching()`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func resumeMessageFetching() {
         mockCalled = true
-        resumePollingCallsCount += 1
-        resumePollingClosure?()
+        resumeMessageFetchingCallsCount += 1
+        resumeMessageFetchingClosure?()
     }
 }
 

--- a/Sources/MessagingInApp/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingInApp/autogenerated/AutoMockable.generated.swift
@@ -870,6 +870,12 @@ public class MessagingInAppInstanceMock: MessagingInAppInstance, Mock {
         dismissMessageCallsCount = 0
 
         mockCalled = false // do last as resetting properties above can make this true
+        pausePollingCallsCount = 0
+
+        mockCalled = false // do last as resetting properties above can make this true
+        resumePollingCallsCount = 0
+
+        mockCalled = false // do last as resetting properties above can make this true
     }
 
     // MARK: - setEventListener
@@ -918,6 +924,48 @@ public class MessagingInAppInstanceMock: MessagingInAppInstance, Mock {
         mockCalled = true
         dismissMessageCallsCount += 1
         dismissMessageClosure?()
+    }
+
+    // MARK: - pausePolling
+
+    /// Number of times the function was called.
+    @Atomic public private(set) var pausePollingCallsCount = 0
+    /// `true` if the function was ever called.
+    public var pausePollingCalled: Bool {
+        pausePollingCallsCount > 0
+    }
+
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     */
+    public var pausePollingClosure: (() -> Void)?
+
+    /// Mocked function for `pausePolling()`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func pausePolling() {
+        mockCalled = true
+        pausePollingCallsCount += 1
+        pausePollingClosure?()
+    }
+
+    // MARK: - resumePolling
+
+    /// Number of times the function was called.
+    @Atomic public private(set) var resumePollingCallsCount = 0
+    /// `true` if the function was ever called.
+    public var resumePollingCalled: Bool {
+        resumePollingCallsCount > 0
+    }
+
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     */
+    public var resumePollingClosure: (() -> Void)?
+
+    /// Mocked function for `resumePolling()`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func resumePolling() {
+        mockCalled = true
+        resumePollingCallsCount += 1
+        resumePollingClosure?()
     }
 }
 

--- a/Tests/MessagingInApp/Gist/GistTests.swift
+++ b/Tests/MessagingInApp/Gist/GistTests.swift
@@ -1,0 +1,147 @@
+@testable import CioInternalCommon
+@testable import CioMessagingInApp
+import Foundation
+import SharedTests
+import XCTest
+
+class GistTests: IntegrationTest {
+    var gist: Gist!
+    var inAppMessageManager: InAppMessageManager!
+    var queueManager: QueueManager!
+    private let engineWebMock = EngineWebInstanceMock()
+    private var engineWebProvider: EngineWebProvider {
+        EngineWebProviderStub(engineWebMock: engineWebMock)
+    }
+
+    override func setUp() {
+        super.setUp()
+        
+        // Set up required mocks
+        engineWebMock.underlyingView = UIView()
+        diGraphShared.override(value: engineWebProvider, forType: EngineWebProvider.self)
+
+        // Set up InAppMessageManager (real implementation for better integration testing)
+        inAppMessageManager = InAppMessageStoreManager(
+            logger: diGraphShared.logger,
+            threadUtil: diGraphShared.threadUtil,
+            logManager: diGraphShared.logManager,
+            gistDelegate: diGraphShared.gistDelegate
+        )
+
+        // Set up QueueManager with mocked network
+        queueManager = QueueManager(
+            keyValueStore: diGraphShared.sharedKeyValueStorage,
+            gistQueueNetwork: gistQueueNetworkMock,
+            inAppMessageManager: inAppMessageManager,
+            logger: diGraphShared.logger
+        )
+
+        // Set up Gist with all dependencies
+        gist = Gist(
+            logger: diGraphShared.logger,
+            gistDelegate: diGraphShared.gistDelegate,
+            inAppMessageManager: inAppMessageManager,
+            queueManager: queueManager,
+            threadUtil: diGraphShared.threadUtil
+        )
+
+        setupMocks()
+    }
+
+    override func tearDown() {
+        gist = nil
+        inAppMessageManager = nil
+        queueManager = nil
+
+        super.tearDown()
+    }
+
+    private func setupMocks() {
+        // Mock GistQueueNetwork to simulate successful network response
+        gistQueueNetworkMock.requestClosure = { _, _, completion in
+            let response = HTTPURLResponse(url: URL(string: "https://test.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = Data("[]".utf8)
+            completion(.success((data, response)))
+        }
+    }
+
+    // MARK: - Network Request Blocking Tests
+
+    func test_fetchUserMessages_whenMessageFetchingNotPaused_expectNetworkRequestMade() async {
+        // Given: User is identified and message fetching is not paused (default state)
+        await inAppMessageManager.dispatch(action: .setUserIdentifier(user: "test-user")).value
+        await inAppMessageManager.dispatch(action: .resumeMessageFetching).value
+        
+        // Reset the mock to clear any previous calls
+        gistQueueNetworkMock.resetMock()
+
+        // When: fetchUserMessages is called
+        gist.fetchUserMessages()
+
+        // Then: Network request should be made
+        await waitForAsync()
+        XCTAssertTrue(gistQueueNetworkMock.requestCalled, "Network request should be made when message fetching is not paused")
+    }
+
+    func test_fetchUserMessages_whenMessageFetchingPaused_expectNetworkRequestBlocked() async {
+        // Given: User is identified and message fetching is paused
+        await inAppMessageManager.dispatch(action: .setUserIdentifier(user: "test-user")).value
+        await inAppMessageManager.dispatch(action: .pauseMessageFetching).value
+        
+        // Reset the mock to clear any previous calls
+        gistQueueNetworkMock.resetMock()
+
+        // When: fetchUserMessages is called
+        gist.fetchUserMessages()
+
+        // Then: Network request should be blocked
+        await waitForAsync()
+        XCTAssertFalse(gistQueueNetworkMock.requestCalled, "Network request should be blocked when message fetching is paused")
+    }
+
+    func test_fetchUserMessages_whenMessageFetchingResumed_expectNetworkRequestMade() async {
+        // Given: User is identified and message fetching starts paused
+        await inAppMessageManager.dispatch(action: .setUserIdentifier(user: "test-user")).value
+        await inAppMessageManager.dispatch(action: .pauseMessageFetching).value
+        
+        // Reset the mock to clear any previous calls
+        gistQueueNetworkMock.resetMock()
+
+        // When: fetchUserMessages is called while paused
+        gist.fetchUserMessages()
+        await waitForAsync()
+        
+        // Then: Network request should be blocked initially
+        XCTAssertFalse(gistQueueNetworkMock.requestCalled, "Network request should be blocked when paused")
+        
+        // And when: Message fetching is resumed
+        await inAppMessageManager.dispatch(action: .resumeMessageFetching).value
+        gistQueueNetworkMock.resetMock()
+        
+        // And: fetchUserMessages is called again
+        gist.fetchUserMessages()
+        await waitForAsync()
+        
+        // Then: Network request should now be made
+        XCTAssertTrue(gistQueueNetworkMock.requestCalled, "Network request should be made after resuming")
+    }
+
+    func test_fetchUserMessages_whenNoUserId_expectNetworkRequestBlocked() async {
+        // Given: No user ID is set (default state)
+        // Reset the mock to clear any previous calls
+        gistQueueNetworkMock.resetMock()
+
+        // When: fetchUserMessages is called
+        gist.fetchUserMessages()
+
+        // Then: Network request should be blocked
+        await waitForAsync()
+        XCTAssertFalse(gistQueueNetworkMock.requestCalled, "Network request should be blocked when no user ID is set")
+    }
+
+    // MARK: - Helper Methods
+
+    private func waitForAsync(timeout: TimeInterval = 1.0) async {
+        try? await Task.sleep(nanoseconds: UInt64(timeout * 0.1 * 1_000_000_000))
+    }
+}

--- a/Tests/MessagingInApp/Gist/GistTests.swift
+++ b/Tests/MessagingInApp/Gist/GistTests.swift
@@ -15,7 +15,7 @@ class GistTests: IntegrationTest {
 
     override func setUp() {
         super.setUp()
-        
+
         // Set up required mocks
         engineWebMock.underlyingView = UIView()
         diGraphShared.override(value: engineWebProvider, forType: EngineWebProvider.self)
@@ -71,7 +71,7 @@ class GistTests: IntegrationTest {
         // Given: User is identified and message fetching is not paused (default state)
         await inAppMessageManager.dispatch(action: .setUserIdentifier(user: "test-user")).value
         await inAppMessageManager.dispatch(action: .resumeMessageFetching).value
-        
+
         // Reset the mock to clear any previous calls
         gistQueueNetworkMock.resetMock()
 
@@ -87,7 +87,7 @@ class GistTests: IntegrationTest {
         // Given: User is identified and message fetching is paused
         await inAppMessageManager.dispatch(action: .setUserIdentifier(user: "test-user")).value
         await inAppMessageManager.dispatch(action: .pauseMessageFetching).value
-        
+
         // Reset the mock to clear any previous calls
         gistQueueNetworkMock.resetMock()
 
@@ -103,25 +103,25 @@ class GistTests: IntegrationTest {
         // Given: User is identified and message fetching starts paused
         await inAppMessageManager.dispatch(action: .setUserIdentifier(user: "test-user")).value
         await inAppMessageManager.dispatch(action: .pauseMessageFetching).value
-        
+
         // Reset the mock to clear any previous calls
         gistQueueNetworkMock.resetMock()
 
         // When: fetchUserMessages is called while paused
         gist.fetchUserMessages()
         await waitForAsync()
-        
+
         // Then: Network request should be blocked initially
         XCTAssertFalse(gistQueueNetworkMock.requestCalled, "Network request should be blocked when paused")
-        
+
         // And when: Message fetching is resumed
         await inAppMessageManager.dispatch(action: .resumeMessageFetching).value
         gistQueueNetworkMock.resetMock()
-        
+
         // And: fetchUserMessages is called again
         gist.fetchUserMessages()
         await waitForAsync()
-        
+
         // Then: Network request should now be made
         XCTAssertTrue(gistQueueNetworkMock.requestCalled, "Network request should be made after resuming")
     }
@@ -142,6 +142,6 @@ class GistTests: IntegrationTest {
     // MARK: - Helper Methods
 
     private func waitForAsync(timeout: TimeInterval = 1.0) async {
-        try? await Task.sleep(nanoseconds: UInt64(timeout * 0.1 * 1_000_000_000))
+        try? await Task.sleep(nanoseconds: UInt64(timeout * 0.1 * 1000000000))
     }
 }

--- a/Tests/MessagingInApp/MessagingInAppImplementationTest.swift
+++ b/Tests/MessagingInApp/MessagingInAppImplementationTest.swift
@@ -199,33 +199,33 @@ class MessagingInAppImplementationTest: IntegrationTest {
         XCTAssertEqual(gistProviderMock.dismissMessageCallsCount, 1)
     }
 
-    // MARK: pause/resume polling
+    // MARK: pause/resume message fetching
 
-    func test_pausePolling_expectPauseActionDispatched() async {
+    func test_pauseMessageFetching_expectPauseActionDispatched() async {
         await waitForExpectations(initializeModule())
 
-        messagingInApp.pausePolling()
+        messagingInApp.pauseMessageFetching()
 
         // Verify that pause action was dispatched
         XCTAssertEqual(inAppMessageManagerMock.dispatchCallsCount, 2) // 1 for initialize, 1 for pause
 
         if let lastAction = inAppMessageManagerMock.dispatchReceivedInvocations.last?.action {
-            XCTAssertEqual(lastAction, .pausePolling)
+            XCTAssertEqual(lastAction, .pauseMessageFetching)
         } else {
             XCTFail("Expected pause action to be dispatched")
         }
     }
 
-    func test_resumePolling_expectResumeActionDispatched() async {
+    func test_resumeMessageFetching_expectResumeActionDispatched() async {
         await waitForExpectations(initializeModule())
 
-        messagingInApp.resumePolling()
+        messagingInApp.resumeMessageFetching()
 
         // Verify that resume action was dispatched
         XCTAssertEqual(inAppMessageManagerMock.dispatchCallsCount, 2) // 1 for initialize, 1 for resume
 
         if let lastAction = inAppMessageManagerMock.dispatchReceivedInvocations.last?.action {
-            XCTAssertEqual(lastAction, .resumePolling)
+            XCTAssertEqual(lastAction, .resumeMessageFetching)
         } else {
             XCTFail("Expected resume action to be dispatched")
         }

--- a/Tests/MessagingInApp/MessagingInAppImplementationTest.swift
+++ b/Tests/MessagingInApp/MessagingInAppImplementationTest.swift
@@ -198,6 +198,38 @@ class MessagingInAppImplementationTest: IntegrationTest {
         messagingInApp.dismissMessage()
         XCTAssertEqual(gistProviderMock.dismissMessageCallsCount, 1)
     }
+
+    // MARK: pause/resume polling
+
+    func test_pausePolling_expectPauseActionDispatched() async {
+        await waitForExpectations(initializeModule())
+
+        messagingInApp.pausePolling()
+
+        // Verify that pause action was dispatched
+        XCTAssertEqual(inAppMessageManagerMock.dispatchCallsCount, 2) // 1 for initialize, 1 for pause
+
+        if let lastAction = inAppMessageManagerMock.dispatchReceivedInvocations.last?.action {
+            XCTAssertEqual(lastAction, .pausePolling)
+        } else {
+            XCTFail("Expected pause action to be dispatched")
+        }
+    }
+
+    func test_resumePolling_expectResumeActionDispatched() async {
+        await waitForExpectations(initializeModule())
+
+        messagingInApp.resumePolling()
+
+        // Verify that resume action was dispatched
+        XCTAssertEqual(inAppMessageManagerMock.dispatchCallsCount, 2) // 1 for initialize, 1 for resume
+
+        if let lastAction = inAppMessageManagerMock.dispatchReceivedInvocations.last?.action {
+            XCTAssertEqual(lastAction, .resumePolling)
+        } else {
+            XCTFail("Expected resume action to be dispatched")
+        }
+    }
 }
 
 extension MessagingInAppImplementationTest {

--- a/Tests/MessagingInApp/State/InAppMessageStateTests.swift
+++ b/Tests/MessagingInApp/State/InAppMessageStateTests.swift
@@ -74,7 +74,7 @@ class InAppMessageStateTests: IntegrationTest {
         XCTAssertEqual(state.dataCenter, "")
         XCTAssertEqual(state.environment, .production)
         XCTAssertEqual(state.pollInterval, 600)
-        XCTAssertFalse(state.isPollingPaused)
+        XCTAssertFalse(state.isMessageFetchingPaused)
         XCTAssertNil(state.userId)
         XCTAssertNil(state.currentRoute)
         XCTAssertEqual(state.modalMessageState, .initial)
@@ -105,23 +105,23 @@ class InAppMessageStateTests: IntegrationTest {
         XCTAssertEqual(state.currentRoute, "testRoute")
     }
 
-    func test_pausePolling_expectPollingPausedStateUpdate() async {
-        await inAppMessageManager.dispatchAsync(action: .pausePolling)
+    func test_pauseMessageFetching_expectMessageFetchingPausedStateUpdate() async {
+        await inAppMessageManager.dispatchAsync(action: .pauseMessageFetching)
 
         let state = await inAppMessageManager.state
-        XCTAssertTrue(state.isPollingPaused)
+        XCTAssertTrue(state.isMessageFetchingPaused)
     }
 
-    func test_resumePolling_expectPollingResumedStateUpdate() async {
-        // First pause polling
-        await inAppMessageManager.dispatchAsync(action: .pausePolling)
+    func test_resumeMessageFetching_expectMessageFetchingResumedStateUpdate() async {
+        // First pause message fetching
+        await inAppMessageManager.dispatchAsync(action: .pauseMessageFetching)
         var state = await inAppMessageManager.state
-        XCTAssertTrue(state.isPollingPaused)
+        XCTAssertTrue(state.isMessageFetchingPaused)
 
-        // Then resume polling
-        await inAppMessageManager.dispatchAsync(action: .resumePolling)
+        // Then resume message fetching
+        await inAppMessageManager.dispatchAsync(action: .resumeMessageFetching)
         state = await inAppMessageManager.state
-        XCTAssertFalse(state.isPollingPaused)
+        XCTAssertFalse(state.isMessageFetchingPaused)
     }
 
     func test_processMessageQueue_expectMessagesAddedToQueue() async {

--- a/Tests/MessagingInApp/State/InAppMessageStateTests.swift
+++ b/Tests/MessagingInApp/State/InAppMessageStateTests.swift
@@ -74,6 +74,7 @@ class InAppMessageStateTests: IntegrationTest {
         XCTAssertEqual(state.dataCenter, "")
         XCTAssertEqual(state.environment, .production)
         XCTAssertEqual(state.pollInterval, 600)
+        XCTAssertFalse(state.isPollingPaused)
         XCTAssertNil(state.userId)
         XCTAssertNil(state.currentRoute)
         XCTAssertEqual(state.modalMessageState, .initial)
@@ -102,6 +103,25 @@ class InAppMessageStateTests: IntegrationTest {
 
         let state = await inAppMessageManager.state
         XCTAssertEqual(state.currentRoute, "testRoute")
+    }
+
+    func test_pausePolling_expectPollingPausedStateUpdate() async {
+        await inAppMessageManager.dispatchAsync(action: .pausePolling)
+
+        let state = await inAppMessageManager.state
+        XCTAssertTrue(state.isPollingPaused)
+    }
+
+    func test_resumePolling_expectPollingResumedStateUpdate() async {
+        // First pause polling
+        await inAppMessageManager.dispatchAsync(action: .pausePolling)
+        var state = await inAppMessageManager.state
+        XCTAssertTrue(state.isPollingPaused)
+
+        // Then resume polling
+        await inAppMessageManager.dispatchAsync(action: .resumePolling)
+        state = await inAppMessageManager.state
+        XCTAssertFalse(state.isPollingPaused)
     }
 
     func test_processMessageQueue_expectMessagesAddedToQueue() async {


### PR DESCRIPTION
##  Problem:

We currently keep on polling for in-app messages weather user expects it or not, if a user wants to temporarily stop the networking requests for the session, they should have the ability to do so. 

## Summary

  • Add `pauseMessageFetching()` and `resumeMessageFetching()` API methods to `MessagingInApp` module for controlling in-app message fetching
  • Enable developers to temporarily stop and restart periodic message polling from the server

## Test plan

  - Verify `pauseMessageFetching()` dispatches correct action and stops making network requests
  - Verify `resumeMessageFetching()` dispatches correct action and restarts making network requests
  - Test state management with `isMessageFetchingPaused` property
  - Run existing in-app messaging tests to ensure no regressions
  
##   How to test

  In the sample app, you can test the new polling control functionality:
  - Pause network requests: Call the `pauseMessageFetching()` behind the click the "Random Event" button 
  - Resume network requests: Call the `resumeMessageFetching()` behind the Click of "Custom Event" button 
  - Verify no network requests are being made when paused
