### PR TITLE
fix: FCM version upper and lower bound  

### DIFF
--- a/CustomerIOMessagingPushFCM.podspec
+++ b/CustomerIOMessagingPushFCM.podspec
@@ -30,5 +30,5 @@ Pod::Spec.new do |spec|
   # Add FCM SDK as a dependency, as our SDK is designed to be compatible with it. 
   # No version is specified which means that by default, the latest version is installed for customers. 
   # Customers can override this by adding the pod to their Podfile themselves to specify a version they want to use. 
-  spec.dependency "FirebaseMessaging", ">= 8.7.0"
+  spec.dependency "FirebaseMessaging", ">= 8.7.0", "< 12.0.0"
 end

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
         // https://web.archive.org/web/20220525200227/https://www.timc.dev/posts/understanding-swift-packages/
         //
         // Update to exact version until wrapper SDKs become part of testing pipeline.
-        .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git", from: "8.7.0"),
+        .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git", "8.7.0"..<"12.0.0"),
         
 
         // Make sure the version number is same for DataPipelines cocoapods.

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,5 +1,6 @@
 // File that Danger runs to catch potential errors during PR reviews: https://danger.systems/js/
 import {message, danger, warn} from "danger"
+import {readFileSync} from "fs"
 
 // Warn about possible breaking changes being introduced in a pull request. 
 // Breaking changes should be documented when making a pull request. This is a reminder. 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -31,3 +31,50 @@ if (isSPMFilesModified || isCococapodsFilesModified) {
   if (!isSPMFilesModified) { warn("Cocoapods files (*.podspec) were modified but Swift Package Manager files (Package.*) files were not. This is error-prone when updating dependencies in one service but not the other. Double-check that you updated all of the correct files.") }
   if (!isCococapodsFilesModified) { warn("Swift Package Manager files (Package.*) were modified but Cocoapods files (*.podspec) files were not. This is error-prone when updating dependencies in one service but not the other. Double-check that you updated all of the correct files.") }
 }
+
+// Check Firebase/FCM version consistency between Package.swift and CustomerIOMessagingPushFCM.podspec
+function checkFirebaseVersionConsistency() {
+  try {
+    // Read Package.swift and extract Firebase version range
+    const packageSwiftContent = readFileSync('Package.swift', 'utf8')
+    const firebasePackageMatch = packageSwiftContent.match(/\.package\(name: "Firebase".*?"(\d+\.\d+\.\d+)"\.\.< *"(\d+\.\d+\.\d+)"\)/)
+    
+    if (!firebasePackageMatch) {
+      warn("Could not parse Firebase version range from Package.swift")
+      return
+    }
+    
+    const spmMinVersion = firebasePackageMatch[1]
+    const spmMaxVersion = firebasePackageMatch[2]
+    
+    // Read CustomerIOMessagingPushFCM.podspec and extract FirebaseMessaging version range
+    const podspecContent = readFileSync('CustomerIOMessagingPushFCM.podspec', 'utf8')
+    const firebaseDepMatch = podspecContent.match(/spec\.dependency "FirebaseMessaging", ">= (\d+\.\d+\.\d+)", "< (\d+\.\d+\.\d+)"/)
+    
+    if (!firebaseDepMatch) {
+      warn("Could not parse FirebaseMessaging version range from CustomerIOMessagingPushFCM.podspec")
+      return
+    }
+    
+    const podspecMinVersion = firebaseDepMatch[1]
+    const podspecMaxVersion = firebaseDepMatch[2]
+    
+    // Compare versions
+    if (spmMinVersion !== podspecMinVersion) {
+      warn(`Firebase minimum version mismatch! Package.swift: ${spmMinVersion}, CustomerIOMessagingPushFCM.podspec: ${podspecMinVersion}`)
+    }
+    
+    if (spmMaxVersion !== podspecMaxVersion) {
+      warn(`Firebase maximum version mismatch! Package.swift: ${spmMaxVersion}, CustomerIOMessagingPushFCM.podspec: ${podspecMaxVersion}`)
+    }
+    
+    if (spmMinVersion === podspecMinVersion && spmMaxVersion === podspecMaxVersion) {
+      message(`✅ Firebase version bounds are consistent: ${spmMinVersion} to ${spmMaxVersion}`)
+    }
+  } catch (error) {
+    warn(`Error checking Firebase version consistency: ${error.message}`)
+  }
+}
+
+// Run the Firebase version consistency check
+checkFirebaseVersionConsistency()


### PR DESCRIPTION
This PR updates the Firebase SDK version constraints to ensure consistency between Swift Package Manager (SPM) and CocoaPods integrations. Both now explicitly support versions from 8.7.0 up to (but not including) 12.0.0.

Changes
	•	SPM (Package.swift):
Updated .package declaration to use a closed range:

```
.package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git", "8.7.0"..<"12.0.0")
```

	•	CocoaPods (.podspec):
Updated dependency constraint to:
```
spec.dependency "FirebaseMessaging", ">= 8.7.0", "< 12.0.0"
```

Testing:
- In order to ensure its working, you add latest FCM dependency version in sample apps and they should not conflict with CIO FCM dependency. 