### PR TITLE
fix: Sanitize unsupported numeric values

### DIFF
--- a/Sources/DataPipeline/CustomerIO+Events.swift
+++ b/Sources/DataPipeline/CustomerIO+Events.swift
@@ -37,6 +37,6 @@ public extension CustomerIO {
     ///   - category: A category to the type of screen if it applies.
     ///   - properties: Any extra metadata associated with the screen. e.g. method of access, size, etc.
     func screen(title: String, category: String? = nil, properties: [String: Any]? = nil) {
-        DataPipeline.shared.analytics.screen(title: title, category: category, properties: properties)
+        DataPipeline.shared.analytics.screen(title: title, category: category, properties: properties?.sanitizedForJSON())
     }
 }

--- a/Sources/DataPipeline/DataPipeline.swift
+++ b/Sources/DataPipeline/DataPipeline.swift
@@ -72,12 +72,12 @@ public class DataPipeline: ModuleTopLevelObject<DataPipelineInstance>, DataPipel
         set {
             guard var implementation = implementation else { return }
 
-            implementation.profileAttributes = newValue
+            implementation.profileAttributes = newValue.sanitizedForJSON()
         }
     }
 
     public func identify(userId: String, traits: [String: Any]?) {
-        implementation?.identify(userId: userId, traits: traits)
+        implementation?.identify(userId: userId, traits: traits?.sanitizedForJSON())
     }
 
     public func identify<RequestBody: Codable>(userId: String, traits: RequestBody?) {
@@ -93,7 +93,7 @@ public class DataPipeline: ModuleTopLevelObject<DataPipelineInstance>, DataPipel
         set {
             guard var implementation = implementation else { return }
 
-            implementation.deviceAttributes = newValue
+            implementation.deviceAttributes = newValue.sanitizedForJSON()
         }
     }
 
@@ -110,7 +110,7 @@ public class DataPipeline: ModuleTopLevelObject<DataPipelineInstance>, DataPipel
     }
 
     public func track(name: String, properties: [String: Any]?) {
-        implementation?.track(name: name, properties: properties)
+        implementation?.track(name: name, properties: properties?.sanitizedForJSON())
     }
 
     public func track<RequestBody: Codable>(name: String, properties: RequestBody?) {
@@ -118,7 +118,7 @@ public class DataPipeline: ModuleTopLevelObject<DataPipelineInstance>, DataPipel
     }
 
     public func screen(title: String, properties: [String: Any]?) {
-        implementation?.screen(title: title, properties: properties)
+        implementation?.screen(title: title, properties: properties?.sanitizedForJSON())
     }
 
     public func screen<RequestBody: Codable>(title: String, properties: RequestBody?) {

--- a/Sources/DataPipeline/Util/DictionarySanitizer.swift
+++ b/Sources/DataPipeline/Util/DictionarySanitizer.swift
@@ -1,0 +1,102 @@
+import CioInternalCommon
+import Foundation
+
+extension Dictionary where Key == String, Value == Any {
+    /**
+     Sanitizes a dictionary by removing JSON-incompatible values like NaN and infinities.
+     This prevents JSON serialization errors when sending events with these values.
+
+     - Parameter logger: Logger to log removed values
+     - Returns: A new dictionary with all JSON-incompatible values removed
+     */
+    func sanitizedForJSON(logger: Logger = DIGraphShared.shared.logger) -> [String: Any] {
+        var result: [String: Any] = [:]
+
+        for (key, value) in self {
+            // If sanitizeValue returns nil, the value is invalid for JSON and we skip it
+            if let sanitizedValue = sanitizeValue(value, logger: logger) {
+                result[key] = sanitizedValue
+            }
+        }
+
+        return result
+    }
+
+    /**
+     Sanitizes a value for JSON serialization.
+
+     - Parameter value: The value to sanitize
+     - Returns: The sanitized value, or nil if the value is invalid for JSON (NaN, infinity)
+     */
+    private func sanitizeValue(_ value: Any, logger: Logger) -> Any? {
+        switch value {
+        case let number as Double:
+            if number.isNaN || number.isInfinite {
+                logger.error("Removed unsupported numeric value")
+                return nil
+            } else {
+                return number
+            }
+        case let number as Float:
+            if number.isNaN || number.isInfinite {
+                logger.error("Removed unsupported numeric value")
+                return nil
+            } else {
+                return number
+            }
+        case let dict as [String: Any]:
+            let sanitized = dict.sanitizedForJSON(logger: logger)
+            return sanitized.isEmpty ? nil : sanitized
+        case let array as [Any]:
+            let sanitized = sanitizeArray(array, logger: logger)
+            return sanitized.isEmpty ? nil : sanitized
+        default:
+            return value
+        }
+    }
+
+    /**
+     Sanitizes an array by removing JSON-incompatible values.
+
+     - Parameter array: The array to sanitize
+     - Returns: A new array with all JSON-incompatible values removed
+     */
+    private func sanitizeArray(_ array: [Any], logger: Logger) -> [Any] {
+        array.compactMap { value in
+            sanitizeValue(value, logger: logger)
+        }
+    }
+}
+
+extension Array where Element == Any {
+    /**
+     Sanitizes an array by removing JSON-incompatible values like NaN and infinities.
+
+     - Returns: A new array with all JSON-incompatible values removed
+     */
+    func sanitizedForJSON(logger: Logger = DIGraphShared.shared.logger) -> [Any] {
+        compactMap { value in
+            if let dict = value as? [String: Any] {
+                let sanitized = dict.sanitizedForJSON(logger: logger)
+                return sanitized.isEmpty ? nil : sanitized
+            } else if let array = value as? [Any] {
+                let sanitized = array.sanitizedForJSON(logger: logger)
+                return sanitized.isEmpty ? nil : sanitized
+            } else if let number = value as? Double {
+                if number.isNaN || number.isInfinite {
+                    logger.error("Removed unsupported numeric value")
+                    return nil
+                }
+                return number
+            } else if let number = value as? Float {
+                if number.isNaN || number.isInfinite {
+                    logger.error("Removed unsupported numeric value")
+                    return nil
+                }
+                return number
+            } else {
+                return value
+            }
+        }
+    }
+}

--- a/Tests/DataPipeline/Util/DictionarySanitizerTests.swift
+++ b/Tests/DataPipeline/Util/DictionarySanitizerTests.swift
@@ -1,0 +1,253 @@
+@testable import CioDataPipelines
+@testable import CioInternalCommon
+import Foundation
+import SharedTests
+import XCTest
+
+class DictionarySanitizerTests: UnitTest {
+    private var loggerMock = LoggerMock()
+
+    func test_sanitizedForJSON_givenDictionaryWithNaN_expectNaNValuesRemoved() {
+        // Given
+        let dictionary: [String: Any] = [
+            "validKey": "validValue",
+            "nanKey": Double.nan,
+            "anotherValidKey": 42
+        ]
+
+        // When
+        let sanitized = dictionary.sanitizedForJSON(logger: loggerMock)
+
+        // Then
+        XCTAssertEqual(sanitized.count, 2)
+        XCTAssertEqual(sanitized["validKey"] as? String, "validValue")
+        XCTAssertEqual(sanitized["anotherValidKey"] as? Int, 42)
+        XCTAssertNil(sanitized["nanKey"])
+
+        // Verify logging
+        XCTAssertEqual(loggerMock.errorCallsCount, 1)
+        XCTAssertEqual(loggerMock.errorReceivedArguments?.message, "Removed unsupported numeric value")
+    }
+
+    func test_sanitizedForJSON_givenDictionaryWithInfinity_expectInfinityValuesRemoved() {
+        // Given
+        let dictionary: [String: Any] = [
+            "validKey": "validValue",
+            "positiveInfinityKey": Double.infinity,
+            "negativeInfinityKey": -Double.infinity,
+            "anotherValidKey": 42
+        ]
+
+        // When
+        let sanitized = dictionary.sanitizedForJSON(logger: loggerMock)
+
+        // Then
+        XCTAssertEqual(sanitized.count, 2)
+        XCTAssertEqual(sanitized["validKey"] as? String, "validValue")
+        XCTAssertEqual(sanitized["anotherValidKey"] as? Int, 42)
+        XCTAssertNil(sanitized["positiveInfinityKey"])
+        XCTAssertNil(sanitized["negativeInfinityKey"])
+
+        // Verify logging
+        XCTAssertEqual(loggerMock.errorCallsCount, 2)
+        XCTAssertEqual(loggerMock.errorReceivedArguments?.message, "Removed unsupported numeric value")
+    }
+
+    func test_sanitizedForJSON_givenDictionaryWithNestedDictionary_expectNestedNaNAndInfinityValuesRemoved() {
+        // Given
+        let dictionary: [String: Any] = [
+            "validKey": "validValue",
+            "nestedDict": [
+                "validNestedKey": 123,
+                "nanNestedKey": Double.nan,
+                "infinityNestedKey": Double.infinity
+            ],
+            "anotherValidKey": 42
+        ]
+
+        // When
+        let sanitized = dictionary.sanitizedForJSON(logger: loggerMock)
+
+        // Then
+        XCTAssertEqual(sanitized.count, 3)
+        XCTAssertEqual(sanitized["validKey"] as? String, "validValue")
+        XCTAssertEqual(sanitized["anotherValidKey"] as? Int, 42)
+
+        if let nestedDict = sanitized["nestedDict"] as? [String: Any] {
+            XCTAssertEqual(nestedDict.count, 1)
+            XCTAssertEqual(nestedDict["validNestedKey"] as? Double, 123)
+            XCTAssertNil(nestedDict["nanNestedKey"])
+            XCTAssertNil(nestedDict["infinityNestedKey"])
+        } else {
+            XCTFail("Expected nestedDict to be a dictionary")
+        }
+
+        // Verify logging
+        XCTAssertGreaterThanOrEqual(loggerMock.errorCallsCount, 2)
+        XCTAssertEqual(loggerMock.errorReceivedArguments?.message, "Removed unsupported numeric value")
+    }
+
+    func test_sanitizedForJSON_givenDictionaryWithArray_expectArrayItemsWithNaNAndInfinityRemoved() {
+        // Given
+        let dictionary: [String: Any] = [
+            "validKey": "validValue",
+            "arrayKey": [1, Double.nan, "valid", Double.infinity, 5],
+            "anotherValidKey": 42
+        ]
+
+        // When
+        let sanitized = dictionary.sanitizedForJSON(logger: loggerMock)
+
+        // Then
+        XCTAssertEqual(sanitized.count, 3)
+        XCTAssertEqual(sanitized["validKey"] as? String, "validValue")
+        XCTAssertEqual(sanitized["anotherValidKey"] as? Int, 42)
+
+        if let array = sanitized["arrayKey"] as? [Any] {
+            XCTAssertEqual(array.count, 3)
+            XCTAssertEqual(array[0] as? Int, 1)
+            XCTAssertEqual(array[1] as? String, "valid")
+            XCTAssertEqual(array[2] as? Int, 5)
+        } else {
+            XCTFail("Expected arrayKey to be an array")
+        }
+
+        // Verify logging
+        XCTAssertGreaterThanOrEqual(loggerMock.errorCallsCount, 2)
+        XCTAssertEqual(loggerMock.errorReceivedArguments?.message, "Removed unsupported numeric value")
+    }
+
+    func test_sanitizedForJSON_givenDictionaryWithNestedArrayContainingDictionaries_expectInvalidValuesRemoved() {
+        // Given
+        let dictionary: [String: Any] = [
+            "validKey": "validValue",
+            "arrayOfDicts": [
+                ["key1": "value1", "key2": Double.nan],
+                ["key3": Double.infinity, "key4": 42],
+                ["key5": "value5"]
+            ],
+            "anotherValidKey": 42
+        ]
+
+        // When
+        let sanitized = dictionary.sanitizedForJSON(logger: loggerMock)
+
+        // Then
+        XCTAssertEqual(sanitized.count, 3)
+        XCTAssertEqual(sanitized["validKey"] as? String, "validValue")
+        XCTAssertEqual(sanitized["anotherValidKey"] as? Int, 42)
+
+        if let arrayOfDicts = sanitized["arrayOfDicts"] as? [Any] {
+            XCTAssertEqual(arrayOfDicts.count, 3)
+
+            if let dict1 = arrayOfDicts[0] as? [String: Any] {
+                XCTAssertEqual(dict1.count, 1)
+                XCTAssertEqual(dict1["key1"] as? String, "value1")
+                XCTAssertNil(dict1["key2"])
+            } else {
+                XCTFail("Expected first item to be a dictionary")
+            }
+
+            if let dict2 = arrayOfDicts[1] as? [String: Any] {
+                XCTAssertEqual(dict2.count, 1)
+                XCTAssertEqual(dict2["key4"] as? Int, 42)
+                XCTAssertNil(dict2["key3"])
+            } else {
+                XCTFail("Expected second item to be a dictionary")
+            }
+
+            if let dict3 = arrayOfDicts[2] as? [String: Any] {
+                XCTAssertEqual(dict3.count, 1)
+                XCTAssertEqual(dict3["key5"] as? String, "value5")
+            } else {
+                XCTFail("Expected third item to be a dictionary")
+            }
+        } else {
+            XCTFail("Expected arrayOfDicts to be an array")
+        }
+    }
+
+    func test_sanitizedForJSON_givenDictionaryWithFloatNaNAndInfinity_expectInvalidValuesRemoved() {
+        // Given
+        let dictionary: [String: Any] = [
+            "validKey": "validValue",
+            "nanKey": Float.nan,
+            "positiveInfinityKey": Float.infinity,
+            "negativeInfinityKey": -Float.infinity,
+            "anotherValidKey": 42
+        ]
+
+        // When
+        let sanitized = dictionary.sanitizedForJSON(logger: loggerMock)
+
+        // Then
+        XCTAssertEqual(sanitized.count, 2)
+        XCTAssertEqual(sanitized["validKey"] as? String, "validValue")
+        XCTAssertEqual(sanitized["anotherValidKey"] as? Int, 42)
+        XCTAssertNil(sanitized["nanKey"])
+        XCTAssertNil(sanitized["positiveInfinityKey"])
+        XCTAssertNil(sanitized["negativeInfinityKey"])
+
+        // Verify logging
+        XCTAssertEqual(loggerMock.errorCallsCount, 3)
+        XCTAssertEqual(loggerMock.errorReceivedArguments?.message, "Removed unsupported numeric value")
+    }
+
+    func test_sanitizedForJSON_givenEmptyNestedStructures_expectEmptyStructuresRemoved() {
+        // Given
+        let dictionary: [String: Any] = [
+            "validKey": "validValue",
+            "emptyDictAfterSanitization": ["nanKey": Double.nan],
+            "arrayWithEmptyDict": [["nanKey": Double.nan]],
+            "anotherValidKey": 42
+        ]
+
+        // When
+        let sanitized = dictionary.sanitizedForJSON(logger: loggerMock)
+
+        // Then
+        XCTAssertEqual(sanitized.count, 2)
+        XCTAssertEqual(sanitized["validKey"] as? String, "validValue")
+        XCTAssertEqual(sanitized["anotherValidKey"] as? Int, 42)
+        XCTAssertNil(sanitized["emptyDictAfterSanitization"])
+        XCTAssertNil(sanitized["arrayWithEmptyDict"])
+
+        // Verify logging
+        XCTAssertGreaterThanOrEqual(loggerMock.errorCallsCount, 1)
+        XCTAssertEqual(loggerMock.errorReceivedArguments?.message, "Removed unsupported numeric value")
+    }
+
+    func test_sanitizedForJSON_givenValidDictionary_expectNoChanges() {
+        // Given
+        let dictionary: [String: Any] = [
+            "stringKey": "stringValue",
+            "intKey": 42,
+            "doubleKey": 3.14,
+            "boolKey": true,
+            "arrayKey": [1, 2, 3],
+            "dictKey": ["nestedKey": "nestedValue"]
+        ]
+
+        // When
+        let sanitized = dictionary.sanitizedForJSON(logger: loggerMock)
+
+        // Then
+        XCTAssertEqual(sanitized.count, dictionary.count)
+        XCTAssertEqual(sanitized["stringKey"] as? String, "stringValue")
+        XCTAssertEqual(sanitized["intKey"] as? Int, 42)
+        XCTAssertEqual(sanitized["doubleKey"] as? Double, 3.14)
+        XCTAssertEqual(sanitized["boolKey"] as? Bool, true)
+
+        if let array = sanitized["arrayKey"] as? [Int] {
+            XCTAssertEqual(array, [1, 2, 3])
+        } else {
+            XCTFail("Expected arrayKey to be an array of integers")
+        }
+
+        if let dict = sanitized["dictKey"] as? [String: String] {
+            XCTAssertEqual(dict, ["nestedKey": "nestedValue"])
+        } else {
+            XCTFail("Expected dictKey to be a dictionary")
+        }
+    }
+}


### PR DESCRIPTION
Fixes: [MBL-1196](https://linear.app/customerio/issue/MBL-1196/floating-point-nan-or-infinity-values-should-be-managed-on-android)

## Problem
- We allow customers to attach arbitrary `Map` of properties with events and screen tracking. The input is defined as `Map<String, Any>`. That means that customers can pass any value as value in a map entry
- These values need to be serialized into a JSON format to be transmitted to our servers
- Customers can pass values that are not supported by JSON. For example, a `Double` value of `Double.NaN` or the result of dividing 0/0 or smth similar. These values are not supported by JSON

This causes the serialization process to fail by crashing on Android and it defaults to an incorrect value of `0` on iOS


## Solution
- We are creating a sanitization step for those types of arbitrary inputs to _exclude_ values that are not supported by 
JSON
- An error log is logged to the console informing them of the problematic values
- We will be adding documentation letting customers know that these unsupported values should not be passed and if they are, they will be ignored.

## Testing
- I've added extensive unit tests for unsupported values embedded at different levels of nesting
- I've tested passing unsupported values in our sample apps and it works fine
  - You can add something like `CustomerIO.shared.screen(title: "Test", properties: ["test": Double.nan])` to the sample app and it will trigger the issue