### PR TITLE
fix: Preserve numeric types when doing sanitization for JSON

### DIFF
--- a/Sources/DataPipeline/Util/DictionarySanitizer.swift
+++ b/Sources/DataPipeline/Util/DictionarySanitizer.swift
@@ -35,14 +35,14 @@ extension Dictionary where Key == String, Value == Any {
                 logger.error("Removed unsupported numeric value")
                 return nil
             } else {
-                return number
+                return value
             }
         case let number as Float:
             if number.isInvalidJsonNumber() {
                 logger.error("Removed unsupported numeric value")
                 return nil
             } else {
-                return number
+                return value
             }
         case let dict as [String: Any]:
             let sanitized = dict.sanitizedForJSON(logger: logger)
@@ -87,13 +87,13 @@ extension Array where Element == Any {
                     logger.error("Removed unsupported numeric value")
                     return nil
                 }
-                return number
+                return value
             } else if let number = value as? Float {
                 if number.isInvalidJsonNumber() {
                     logger.error("Removed unsupported numeric value")
                     return nil
                 }
-                return number
+                return value
             } else {
                 return value
             }


### PR DESCRIPTION
## Overview

There was a mistake in the sanitization logic we created for JSON values. When checking numeric values, if they were valid we were returning the casted value not the original ones. This caused booleans to be converted to numeric values.


## Solution

Use the original value when value doesn't need to be sanitized