### PR TITLE
feat: allow Firebase 12 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,15 @@ jobs:
         ruby-version: '3.2'
         bundler-cache: true # install dependencies in Gemfile, including Fastlane. 
 
+    - name: Install sd for script dependencies
+      run: brew install sd
+
+    # Firebase 12+ requires iOS 15+ minimum deployment target, but our SDK supports iOS 13+
+    # This script temporarily updates Package.swift to use iOS 15+ for CI testing only
+    # while keeping the SDK's public API at iOS 13+ for customers
+    - name: Update iOS deployment target for Firebase 12+ compatibility
+      run: ./scripts/update-ios-deployment-target-for-ci.sh
+
     - name: Run tests 
       uses: maierj/fastlane-action@5a3b971aaa26776459bb26894d6c1a1a84a311a7 # v3.1.0
       with:

--- a/Apps/APN-UIKit/APN UIKit.xcodeproj/project.pbxproj
+++ b/Apps/APN-UIKit/APN UIKit.xcodeproj/project.pbxproj
@@ -684,7 +684,7 @@
 				INFOPLIST_FILE = NotificationServiceExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = NotificationServiceExtension;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -714,7 +714,7 @@
 				INFOPLIST_FILE = NotificationServiceExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = NotificationServiceExtension;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -864,7 +864,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -898,7 +898,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Apps/CocoaPods-FCM/Podfile
+++ b/Apps/CocoaPods-FCM/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '13.0'
+platform :ios, '15.0'
 use_frameworks!
 
 # Always install the SDK from the local source code so the sample app tests this specific commit of the code. 

--- a/Apps/Common/Package.swift
+++ b/Apps/Common/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 
 import PackageDescription
 
 let package = Package(
     name: "SampleAppsCommon",
     platforms: [
-        .iOS(.v13)
+        .iOS(.v15)
     ],
     products: [
         // library name is the name given when installing the SDK.

--- a/CustomerIOMessagingPushFCM.podspec
+++ b/CustomerIOMessagingPushFCM.podspec
@@ -30,5 +30,5 @@ Pod::Spec.new do |spec|
   # Add FCM SDK as a dependency, as our SDK is designed to be compatible with it. 
   # No version is specified which means that by default, the latest version is installed for customers. 
   # Customers can override this by adding the pod to their Podfile themselves to specify a version they want to use. 
-  spec.dependency "FirebaseMessaging", ">= 8.7.0", "< 12.0.0"
+  spec.dependency "FirebaseMessaging", ">= 8.7.0", "< 13.0.0"
 end

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 
 /**
  Manifest file for Swift Package Manager. This file defines our Swift Package for customers to install our SDK modules into their app. 
@@ -42,7 +42,7 @@ let package = Package(
         // https://web.archive.org/web/20220525200227/https://www.timc.dev/posts/understanding-swift-packages/
         //
         // Update to exact version until wrapper SDKs become part of testing pipeline.
-        .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git", "8.7.0"..<"12.0.0"),
+        .package(name: "Firebase", url: "https://github.com/firebase/firebase-ios-sdk.git", "8.7.0"..<"13.0.0"),
         
 
         // Make sure the version number is same for DataPipelines cocoapods.

--- a/scripts/update-ios-deployment-target-for-ci.sh
+++ b/scripts/update-ios-deployment-target-for-ci.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Script to temporarily update iOS deployment target in Package.swift for CI testing
+# 
+# Context: Firebase 12+ requires iOS 15+ minimum deployment target, but our SDK supports iOS 13+.
+# This script allows CI to run tests with iOS 15+ while keeping SDK's public API at iOS 13+.
+# 
+# This script:
+# 1. Validates that Package.swift currently has exactly ".iOS(.v13)" 
+# 2. Temporarily updates it to ".iOS(.v15)" for CI testing
+# 3. Fails if the current value is anything other than ".iOS(.v13)" to prevent accidental changes
+#
+# Usage: ./scripts/update-ios-deployment-target-for-ci.sh
+
+set -e  # Exit on any error
+
+PACKAGE_SWIFT="Package.swift"
+EXPECTED_CURRENT=".iOS(.v13)"
+NEW_TARGET=".iOS(.v15)"
+# Escape special regex characters for sd
+EXPECTED_CURRENT_ESCAPED="\.iOS\(\.v13\)"
+# Escaped new target is the same as the new target since it doesn't need escaping
+NEW_TARGET_ESCAPED="$NEW_TARGET"
+
+echo "🔍 Checking current iOS deployment target in Package.swift..."
+
+# Check if Package.swift exists
+if [[ ! -f "$PACKAGE_SWIFT" ]]; then
+    echo "❌ Error: Package.swift not found!"
+    exit 1
+fi
+
+# Check if the expected pattern exists
+if ! grep -q "platforms: \[" "$PACKAGE_SWIFT"; then
+    echo "❌ Error: Could not find 'platforms: [' in Package.swift"
+    exit 1
+fi
+
+# Extract the current iOS deployment target
+CURRENT_TARGET=$(grep -A 2 "platforms: \[" "$PACKAGE_SWIFT" | grep "\.iOS" | xargs)
+
+echo "📋 Current iOS deployment target: $CURRENT_TARGET"
+
+# Validate that current target is exactly what we expect
+if [[ "$CURRENT_TARGET" != "$EXPECTED_CURRENT" ]]; then
+    echo "❌ Error: Expected iOS deployment target to be '$EXPECTED_CURRENT' but found '$CURRENT_TARGET'"
+    echo ""
+    echo "This script only works when the deployment target is exactly '$EXPECTED_CURRENT'."
+    echo "If you've intentionally changed the deployment target, please update this script accordingly."
+    echo "This safeguard prevents accidental modification of Package.swift."
+    exit 1
+fi
+
+echo "✅ Current target matches expected value"
+echo "🔄 Updating iOS deployment target from $EXPECTED_CURRENT to $NEW_TARGET for CI testing..."
+
+# Perform the replacement using sd with escaped regex
+sd "$EXPECTED_CURRENT_ESCAPED" "$NEW_TARGET_ESCAPED" "$PACKAGE_SWIFT"
+
+# Verify the change was made
+if grep -q "$NEW_TARGET" "$PACKAGE_SWIFT"; then
+    echo "✅ Successfully updated iOS deployment target to $NEW_TARGET"
+    
+    # Show the change for verification
+    echo ""
+    echo "📋 Updated platforms section:"
+    grep -A 3 "platforms: \[" "$PACKAGE_SWIFT"
+else
+    echo "❌ Error: Failed to update iOS deployment target"
+    exit 1
+fi
+
+echo ""
+echo "🎯 iOS deployment target temporarily updated for CI testing"
+echo "⚠️  Remember: This change is only for CI testing Firebase 12+ compatibility"
+echo "⚠️  The SDK still supports iOS 13+ for end users"


### PR DESCRIPTION
### Changes

- Updated `CustomerIOMessagingPushFCM.podspec` to allow Firebase version up to `<13`
- Updated `Package.swift` to allow Firebase version up to `<13`

### Testing (Using Firebase `12.0`)

- FCM sample app compiled successfully without dependency conflicts
- Device token generation worked as expected
- Push notifications were delivered, and metrics were tracked correctly
- Push including universal links and images worked as expected


### Breaking Changes

⚠️ [Firebase 12 requires a minimum iOS deployment target of 15](https://firebase.google.com/support/release-notes/ios#version_1200_-_july_15_2025)

### References

- #929 
- [Slack thread](https://customerio.slack.com/archives/C06H7MMLH6C/p1753110172433819?thread_ts=1753108436.450109&cid=C06H7MMLH6C)