### PR TITLE
chore: Turn profileAttributes into setProfileAttributes

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/View/Customisation/CustomDataViewController.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/Customisation/CustomDataViewController.swift
@@ -85,7 +85,7 @@ class CustomDataViewController: BaseViewController {
             CustomerIO.shared.deviceAttributes = [propName: propValue]
             toastMessage = "Device attribute set successfully."
         } else if source == .profileAttributes {
-            CustomerIO.shared.profileAttributes = [propName: propValue]
+            CustomerIO.shared.setProfileAttributes([propName: propValue])
             toastMessage = "Profile attribute set successfully."
         }
         if canEventFail() {

--- a/Apps/CocoaPods-FCM/src/View/CustomAttributeView.swift
+++ b/Apps/CocoaPods-FCM/src/View/CustomAttributeView.swift
@@ -38,7 +38,7 @@ struct CustomAttributeView: View {
                     hideKeyboard() // makes all textfields lose focus so that @State variables are up-to-date with the textfield values.
 
                     if attributeType == .profile {
-                        CustomerIO.shared.profileAttributes = [name: value]
+                        CustomerIO.shared.setProfileAttributes([name: value])
                     }
 
                     if attributeType == .device {

--- a/Sources/Common/CustomerIOInstance.swift
+++ b/Sources/Common/CustomerIOInstance.swift
@@ -7,7 +7,14 @@ public protocol CustomerIOInstance: AutoMockable {
      Modify attributes to an already identified profile.
      Note: The getter of this field returns an empty dictionary. This is a setter only field.
      */
+    @available(*, deprecated, message: "Use setProfileAttributes() instead")
     var profileAttributes: [String: Any] { get set }
+
+    /**
+     Set profile attributes for the currently identified customer.
+     - Parameter attributes: Dictionary of attributes to set for the profile.
+     */
+    func setProfileAttributes(_ attributes: [String: Any])
 
     /**
      Identify a customer (aka: Add or update a profile).
@@ -214,9 +221,14 @@ public class CustomerIO: CustomerIOInstance {
 
     // MARK: - CustomerIOInstance implementation
 
+    @available(*, deprecated, message: "Use setProfileAttributes() instead")
     public var profileAttributes: [String: Any] {
-        get { implementation?.profileAttributes ?? [:] }
-        set { implementation?.profileAttributes = newValue }
+        get { [:] }
+        set { setProfileAttributes(newValue) }
+    }
+
+    public func setProfileAttributes(_ attributes: [String: Any]) {
+        implementation?.setProfileAttributes(attributes)
     }
 
     public func identify(userId: String, traits: [String: Any]? = nil) {

--- a/Sources/Common/CustomerIOInstance.swift
+++ b/Sources/Common/CustomerIOInstance.swift
@@ -223,7 +223,7 @@ public class CustomerIO: CustomerIOInstance {
 
     @available(*, deprecated, message: "Use setProfileAttributes() instead")
     public var profileAttributes: [String: Any] {
-        get { [:] }
+        get { implementation?.profileAttributes ?? [:] }
         set { setProfileAttributes(newValue) }
     }
 

--- a/Sources/Common/autogenerated/AutoMockable.generated.swift
+++ b/Sources/Common/autogenerated/AutoMockable.generated.swift
@@ -210,6 +210,11 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
         registeredDeviceToken = nil
         registeredDeviceTokenGetCallsCount = 0
         registeredDeviceTokenSetCallsCount = 0
+        setProfileAttributesCallsCount = 0
+        setProfileAttributesReceivedArguments = nil
+        setProfileAttributesReceivedInvocations = []
+
+        mockCalled = false // do last as resetting properties above can make this true
         identifyCallsCount = 0
         identifyReceivedArguments = nil
         identifyReceivedInvocations = []
@@ -253,6 +258,33 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
         trackMetricReceivedInvocations = []
 
         mockCalled = false // do last as resetting properties above can make this true
+    }
+
+    // MARK: - setProfileAttributes
+
+    /// Number of times the function was called.
+    @Atomic public private(set) var setProfileAttributesCallsCount = 0
+    /// `true` if the function was ever called.
+    public var setProfileAttributesCalled: Bool {
+        setProfileAttributesCallsCount > 0
+    }
+
+    /// The arguments from the *last* time the function was called.
+    @Atomic public private(set) var setProfileAttributesReceivedArguments: [String: Any]?
+    /// Arguments from *all* of the times that the function was called.
+    @Atomic public private(set) var setProfileAttributesReceivedInvocations: [[String: Any]] = []
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     */
+    public var setProfileAttributesClosure: (([String: Any]) -> Void)?
+
+    /// Mocked function for `setProfileAttributes(_ attributes: [String: Any])`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func setProfileAttributes(_ attributes: [String: Any]) {
+        mockCalled = true
+        setProfileAttributesCallsCount += 1
+        setProfileAttributesReceivedArguments = attributes
+        setProfileAttributesReceivedInvocations.append(attributes)
+        setProfileAttributesClosure?(attributes)
     }
 
     // MARK: - identify

--- a/Sources/DataPipeline/DataPipeline.swift
+++ b/Sources/DataPipeline/DataPipeline.swift
@@ -67,13 +67,14 @@ public class DataPipeline: ModuleTopLevelObject<DataPipelineInstance>, DataPipel
 
     // MARK: - DataPipelineInstance implementation
 
+    @available(*, deprecated, message: "Use setProfileAttributes() instead")
     public var profileAttributes: [String: Any] {
-        get { implementation?.profileAttributes ?? [:] }
-        set {
-            guard var implementation = implementation else { return }
+        get { [:] }
+        set { setProfileAttributes(newValue) }
+    }
 
-            implementation.profileAttributes = newValue.sanitizedForJSON()
-        }
+    public func setProfileAttributes(_ attributes: [String: Any]) {
+        implementation?.setProfileAttributes(attributes.sanitizedForJSON())
     }
 
     public func identify(userId: String, traits: [String: Any]?) {

--- a/Sources/DataPipeline/DataPipeline.swift
+++ b/Sources/DataPipeline/DataPipeline.swift
@@ -69,7 +69,7 @@ public class DataPipeline: ModuleTopLevelObject<DataPipelineInstance>, DataPipel
 
     @available(*, deprecated, message: "Use setProfileAttributes() instead")
     public var profileAttributes: [String: Any] {
-        get { [:] }
+        get { implementation?.profileAttributes ?? [:] }
         set { setProfileAttributes(newValue) }
     }
 

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -136,7 +136,7 @@ class DataPipelineImplementation: DataPipelineInstance {
 
     @available(*, deprecated, message: "Use setProfileAttributes() instead")
     var profileAttributes: [String: Any] {
-        get { [:] }
+        get { analytics.traits() ?? [:] }
         set { setProfileAttributes(newValue) }
     }
 

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -134,16 +134,19 @@ class DataPipelineImplementation: DataPipelineInstance {
         analytics.screen(title: title, properties: properties)
     }
 
+    @available(*, deprecated, message: "Use setProfileAttributes() instead")
     var profileAttributes: [String: Any] {
-        get { analytics.traits() ?? [:] }
-        set {
-            let userId = registeredUserId
-            guard let userId = userId else {
-                logger.error("No user identified. If you don't have a userId but want to record traits, please pass traits using identify(body: Codable)")
-                return
-            }
-            commonIdentifyProfile(userId: userId, attributesDict: newValue)
+        get { [:] }
+        set { setProfileAttributes(newValue) }
+    }
+
+    func setProfileAttributes(_ attributes: [String: Any]) {
+        let userId = registeredUserId
+        guard let userId = userId else {
+            logger.error("No user identified. If you don't have a userId but want to record traits, please pass traits using identify(body: Codable)")
+            return
         }
+        commonIdentifyProfile(userId: userId, attributesDict: attributes)
     }
 
     private func commonIdentifyProfile(userId: String, attributesDict: [String: Any]? = nil, attributesCodable: Codable? = nil) {

--- a/Tests/Common/APITest.swift
+++ b/Tests/Common/APITest.swift
@@ -64,6 +64,7 @@ class CommonAPITest: UnitTest {
 
         // profile attributes
         mock.profileAttributes = dictionaryData
+        mock.setProfileAttributes(dictionaryData)
 
         // device attributes
         mock.deviceAttributes = dictionaryData

--- a/Tests/DataPipeline/APITest.swift
+++ b/Tests/DataPipeline/APITest.swift
@@ -58,6 +58,7 @@ class DataPipelineAPITest: UnitTest {
 
         // profile attributes
         CustomerIO.shared.profileAttributes = dictionaryData
+        CustomerIO.shared.setProfileAttributes(dictionaryData)
 
         // device attributes
         CustomerIO.shared.deviceAttributes = dictionaryData

--- a/api-docs/CioDataPipelines.api
+++ b/api-docs/CioDataPipelines.api
@@ -21,6 +21,7 @@ public final class CioDataPipelines.DataPipeline {
 	public fun func setUpSharedInstanceForUnitTest(implementation: DataPipelineInstance, config: DataPipelineConfigOptions) -> DataPipelineInstance;
 	public fun func setUpSharedInstanceForIntegrationTest(diGraphShared: DIGraphShared, config: DataPipelineConfigOptions) -> DataPipelineInstance;
 	public fun func initialize(moduleConfig: DataPipelineConfigOptions) -> DataPipelineInstance;
+	public fun func setProfileAttributes(_ attributes: List<String: Any>);
 	public fun func identify(userId: String, traits: List<String: Any>?);
 	public fun func identify<RequestBody: Codable>(userId: String, traits: RequestBody?);
 	public fun func clearIdentify();

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -69,6 +69,7 @@ public final class CioInternalCommon.CustomerIO {
 	public var registeredDeviceToken: String?;
 	public fun func resetSharedTestEnvironment();
 	public fun func initializeSharedInstance(with implementation: CustomerIOInstance);
+	public fun func setProfileAttributes(_ attributes: List<String: Any>);
 	public fun func identify(userId: String, traits: List<String: Any>? = nil);
 	public fun func identify<RequestBody: Codable>(userId: String, traits: RequestBody?);
 	public fun func clearIdentify();
@@ -84,6 +85,7 @@ public interface CioInternalCommon.CustomerIOInstance {
 	public var profileAttributes: Map<String, Any>;
 	public var deviceAttributes: Map<String, Any>;
 	public var registeredDeviceToken: String?;
+	public fun func setProfileAttributes(_ attributes: List<String: Any>);
 	public fun func identify(userId: String, traits: List<String: Any>?);
 	public fun func identify<RequestBody: Codable>(
     userId: String,


### PR DESCRIPTION
Closes: [MBL-1299](https://linear.app/customerio/issue/MBL-1299/device-and-user-enrichment-api-alignment)

Tweaks public API `profileAttributes` to be `setProfileAttributes` for clarify and consistency with other SDKs