### PR TITLE
chore: Turn deviceAttributes into setDeviceAttributes

### DIFF
--- a/Sources/Common/CustomerIOInstance.swift
+++ b/Sources/Common/CustomerIOInstance.swift
@@ -62,8 +62,21 @@ public protocol CustomerIOInstance: AutoMockable {
      ```
      CustomerIO.shared.deviceAttributes = ["foo" : "bar"]
      ```
+     @deprecated Use `setDeviceAttributes` method instead. This property getter always returns an empty dictionary.
      */
+    @available(*, deprecated, message: "Use setDeviceAttributes method instead. This property getter always returns an empty dictionary.")
     var deviceAttributes: [String: Any] { get set }
+
+    /**
+     Set additional and custom device attributes apart from the ones the SDK is programmed to send to customer workspace.
+     Example use:
+     ```
+     CustomerIO.shared.setDeviceAttributes(["foo": "bar"])
+     ```
+     - Parameters:
+     - attributes: Dictionary of custom device attributes to set.
+     */
+    func setDeviceAttributes(_ attributes: [String: Any])
 
     /**
      Use `registeredDeviceToken` to fetch the current FCM/APN device token.
@@ -232,8 +245,12 @@ public class CustomerIO: CustomerIOInstance {
     }
 
     public var deviceAttributes: [String: Any] {
-        get { implementation?.deviceAttributes ?? [:] }
-        set { implementation?.deviceAttributes = newValue }
+        get { [:] }
+        set { implementation?.setDeviceAttributes(newValue) }
+    }
+
+    public func setDeviceAttributes(_ attributes: [String: Any]) {
+        implementation?.setDeviceAttributes(attributes)
     }
 
     public var registeredDeviceToken: String? {

--- a/Sources/Common/autogenerated/AutoMockable.generated.swift
+++ b/Sources/Common/autogenerated/AutoMockable.generated.swift
@@ -222,6 +222,11 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
         clearIdentifyCallsCount = 0
 
         mockCalled = false // do last as resetting properties above can make this true
+        setDeviceAttributesCallsCount = 0
+        setDeviceAttributesReceivedArguments = nil
+        setDeviceAttributesReceivedInvocations = []
+
+        mockCalled = false // do last as resetting properties above can make this true
         registerDeviceTokenCallsCount = 0
         registerDeviceTokenReceivedArguments = nil
         registerDeviceTokenReceivedInvocations = []
@@ -321,6 +326,33 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
         mockCalled = true
         clearIdentifyCallsCount += 1
         clearIdentifyClosure?()
+    }
+
+    // MARK: - setDeviceAttributes
+
+    /// Number of times the function was called.
+    @Atomic public private(set) var setDeviceAttributesCallsCount = 0
+    /// `true` if the function was ever called.
+    public var setDeviceAttributesCalled: Bool {
+        setDeviceAttributesCallsCount > 0
+    }
+
+    /// The arguments from the *last* time the function was called.
+    @Atomic public private(set) var setDeviceAttributesReceivedArguments: [String: Any]?
+    /// Arguments from *all* of the times that the function was called.
+    @Atomic public private(set) var setDeviceAttributesReceivedInvocations: [[String: Any]] = []
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     */
+    public var setDeviceAttributesClosure: (([String: Any]) -> Void)?
+
+    /// Mocked function for `setDeviceAttributes(_ attributes: [String: Any])`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func setDeviceAttributes(_ attributes: [String: Any]) {
+        mockCalled = true
+        setDeviceAttributesCallsCount += 1
+        setDeviceAttributesReceivedArguments = attributes
+        setDeviceAttributesReceivedInvocations.append(attributes)
+        setDeviceAttributesClosure?(attributes)
     }
 
     // MARK: - registerDeviceToken

--- a/Sources/DataPipeline/DataPipeline.swift
+++ b/Sources/DataPipeline/DataPipeline.swift
@@ -89,12 +89,14 @@ public class DataPipeline: ModuleTopLevelObject<DataPipelineInstance>, DataPipel
     }
 
     public var deviceAttributes: [String: Any] {
-        get { implementation?.deviceAttributes ?? [:] }
+        get { [:] }
         set {
-            guard var implementation = implementation else { return }
-
-            implementation.deviceAttributes = newValue.sanitizedForJSON()
+            implementation?.setDeviceAttributes(newValue.sanitizedForJSON())
         }
+    }
+
+    public func setDeviceAttributes(_ attributes: [String: Any]) {
+        implementation?.setDeviceAttributes(attributes.sanitizedForJSON())
     }
 
     public var registeredDeviceToken: String? {

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -201,9 +201,13 @@ class DataPipelineImplementation: DataPipelineInstance {
     var deviceAttributes: [String: Any] {
         get { [:] }
         set {
-            logger.info("updating device attributes")
-            addDeviceAttributes(token: contextPlugin.deviceToken, attributes: newValue)
+            setDeviceAttributes(newValue)
         }
+    }
+
+    func setDeviceAttributes(_ attributes: [String: Any]) {
+        logger.info("updating device attributes")
+        addDeviceAttributes(token: contextPlugin.deviceToken, attributes: attributes)
     }
 
     /// Internal method for passing device token to the plugin and updating device attributes

--- a/Tests/Common/APITest.swift
+++ b/Tests/Common/APITest.swift
@@ -66,6 +66,7 @@ class CommonAPITest: UnitTest {
         mock.profileAttributes = dictionaryData
 
         // device attributes
+        mock.setDeviceAttributes(dictionaryData)
         mock.deviceAttributes = dictionaryData
     }
 

--- a/Tests/DataPipeline/APITest.swift
+++ b/Tests/DataPipeline/APITest.swift
@@ -60,6 +60,7 @@ class DataPipelineAPITest: UnitTest {
         CustomerIO.shared.profileAttributes = dictionaryData
 
         // device attributes
+        CustomerIO.shared.setDeviceAttributes(dictionaryData)
         CustomerIO.shared.deviceAttributes = dictionaryData
 
         // plugins

--- a/Tests/DataPipeline/DataPipelineCompatibilityTests.swift
+++ b/Tests/DataPipeline/DataPipelineCompatibilityTests.swift
@@ -180,7 +180,7 @@ class DataPipelineCompatibilityTests: IntegrationTest {
 
         customerIO.identify(userId: givenIdentifier)
         customerIO.registerDeviceToken(givenToken)
-        customerIO.deviceAttributes = customAttributes
+        customerIO.setDeviceAttributes(customAttributes)
 
         let allEvents = readTypeFromStorage(key: Storage.Constants.events)
         let filteredEvents = allEvents.filter { $0.eventType == "track" }

--- a/Tests/DataPipeline/DataPipelineInteractionTests.swift
+++ b/Tests/DataPipeline/DataPipelineInteractionTests.swift
@@ -294,7 +294,7 @@ class CDPInteractionDefaultConfigTests: DataPipelineInteractionTests {
         ]
         mockDeviceAttributes(defaultAttributes: givenDefaultAttributes)
 
-        customerIO.deviceAttributes = [:]
+        customerIO.setDeviceAttributes([:])
 
         customerIO.track(name: String.random)
 

--- a/Tests/MessagingPush/MessagingPushIntegrationTests.swift
+++ b/Tests/MessagingPush/MessagingPushIntegrationTests.swift
@@ -12,8 +12,8 @@ class MessagingPushIntegrationTests: IntegrationTest {
     // Test exists in non-tracking module because non-tracking modules are what read CustomerIO.shared in their
     // code-bases which causes the SDK crashes.
     func test_modifyingCustomerIO_expectNoError() {
-        CustomerIO.shared.deviceAttributes = [
+        CustomerIO.shared.setDeviceAttributes([
             "foo": "bar"
-        ]
+        ])
     }
 }

--- a/api-docs/CioDataPipelines.api
+++ b/api-docs/CioDataPipelines.api
@@ -24,6 +24,7 @@ public final class CioDataPipelines.DataPipeline {
 	public fun func identify(userId: String, traits: List<String: Any>?);
 	public fun func identify<RequestBody: Codable>(userId: String, traits: RequestBody?);
 	public fun func clearIdentify();
+	public fun func setDeviceAttributes(_ attributes: List<String: Any>);
 	public fun func registerDeviceToken(_ deviceToken: String);
 	public fun func deleteDeviceToken();
 	public fun func track(name: String, properties: List<String: Any>?);

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -72,6 +72,7 @@ public final class CioInternalCommon.CustomerIO {
 	public fun func identify(userId: String, traits: List<String: Any>? = nil);
 	public fun func identify<RequestBody: Codable>(userId: String, traits: RequestBody?);
 	public fun func clearIdentify();
+	public fun func setDeviceAttributes(_ attributes: List<String: Any>);
 	public fun func registerDeviceToken(_ deviceToken: String);
 	public fun func deleteDeviceToken();
 	public fun func track(name: String, properties: List<String: Any>? = nil);
@@ -92,6 +93,7 @@ public interface CioInternalCommon.CustomerIOInstance {
     traits: RequestBody?
 );
 	public fun func clearIdentify();
+	public fun func setDeviceAttributes(_ attributes: List<String: Any>);
 	public fun func registerDeviceToken(_ deviceToken: String);
 	public fun func deleteDeviceToken();
 	public fun func track(name: String, properties: List<String: Any>?);


### PR DESCRIPTION
Closes: [MBL-1299](https://linear.app/customerio/issue/MBL-1299/device-and-user-enrichment-api-alignment)

Tweaks public API `deviceAttributes` to be `setDeviceAttributes` for clarify and consistency with other SDKs