### PR TITLE
chore: Deprecating unnecessary tracking APIs

### DIFF
--- a/Sources/Common/CustomerIOInstance.swift
+++ b/Sources/Common/CustomerIOInstance.swift
@@ -44,6 +44,7 @@ public protocol CustomerIOInstance: AutoMockable {
     // swiftlint:enable orphaned_doc_comment
     // sourcery:Name=identifyEncodable
     // sourcery:DuplicateMethod=identify
+    @available(*, deprecated, message: "Use 'identify(userId:traits:)' with [String: Any] traits parameter instead. Support for Codable traits will be removed in a future version.")
     func identify<RequestBody: Codable>(
         userId: String,
         // sourcery:Type=AnyEncodable
@@ -128,6 +129,7 @@ public protocol CustomerIOInstance: AutoMockable {
     // swiftlint:enable orphaned_doc_comment
     // sourcery:Name=trackEncodable
     // sourcery:DuplicateMethod=track
+    @available(*, deprecated, message: "Use 'track(name:properties:)' with [String: Any] properties parameter instead. Support for Codable properties will be removed in a future version.")
     func track<RequestBody: Codable>(
         name: String,
         // sourcery:Type=AnyEncodable
@@ -157,6 +159,7 @@ public protocol CustomerIOInstance: AutoMockable {
     // swiftlint:enable orphaned_doc_comment
     // sourcery:Name=screenEncodable
     // sourcery:DuplicateMethod=screen
+    @available(*, deprecated, message: "Use 'screen(title:properties:)' with [String: Any] properties parameter instead. Support for Codable properties will be removed in a future version.")
     func screen<RequestBody: Codable>(
         title: String,
         // sourcery:Type=AnyEncodable
@@ -248,6 +251,7 @@ public class CustomerIO: CustomerIOInstance {
         implementation?.identify(userId: userId, traits: traits)
     }
 
+    @available(*, deprecated, message: "Use 'identify(userId:traits:)' with [String: Any] traits parameter instead. Support for Codable traits will be removed in a future version.")
     public func identify<RequestBody: Codable>(userId: String, traits: RequestBody?) {
         implementation?.identify(userId: userId, traits: traits)
     }
@@ -281,6 +285,7 @@ public class CustomerIO: CustomerIOInstance {
         implementation?.track(name: name, properties: properties)
     }
 
+    @available(*, deprecated, message: "Use 'track(name:properties:)' with [String: Any] properties parameter instead. Support for Codable properties will be removed in a future version.")
     public func track<RequestBody: Codable>(name: String, properties: RequestBody?) {
         implementation?.track(name: name, properties: properties)
     }
@@ -289,6 +294,7 @@ public class CustomerIO: CustomerIOInstance {
         implementation?.screen(title: title, properties: properties)
     }
 
+    @available(*, deprecated, message: "Use 'screen(title:properties:)' with [String: Any] properties parameter instead. Support for Codable properties will be removed in a future version.")
     public func screen<RequestBody: Codable>(title: String, properties: RequestBody?) {
         implementation?.screen(title: title, properties: properties)
     }

--- a/Sources/DataPipeline/CustomerIO+Events.swift
+++ b/Sources/DataPipeline/CustomerIO+Events.swift
@@ -11,10 +11,12 @@ public extension CustomerIO {
     /// Associate a user with their unique ID and record traits about them.
     /// - Parameters:
     ///   - traits: A dictionary of traits you know about the user. Things like: email, name, plan, etc.
+    @available(*, deprecated, message: "Use 'identify(userId:traits:)' with [String: Any] traits parameter instead. Support for Codable traits will be removed in a future version.")
     func identify<T: Codable>(traits: T) {
         DataPipeline.shared.analytics.identify(traits: traits)
     }
 
+    @available(*, deprecated, message: "Use 'screen(title:properties:)' with [String: Any] properties parameter instead. Support for Codable properties will be removed in a future version.")
     func screen<P: Codable>(title: String, category: String? = nil, properties: P?) {
         DataPipeline.shared.analytics.screen(title: title, category: category, properties: properties)
     }

--- a/Sources/DataPipeline/CustomerIO+Events.swift
+++ b/Sources/DataPipeline/CustomerIO+Events.swift
@@ -11,7 +11,7 @@ public extension CustomerIO {
     /// Associate a user with their unique ID and record traits about them.
     /// - Parameters:
     ///   - traits: A dictionary of traits you know about the user. Things like: email, name, plan, etc.
-    @available(*, deprecated, message: "Use 'identify(userId:traits:)' with [String: Any] traits parameter instead. Support for Codable traits will be removed in a future version.")
+    @available(*, deprecated, message: "Use 'setProfileAttributes(_:)' with [String: Any] instead. Support for Codable traits will be removed in a future version.")
     func identify<T: Codable>(traits: T) {
         DataPipeline.shared.analytics.identify(traits: traits)
     }

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -143,7 +143,11 @@ class DataPipelineImplementation: DataPipelineInstance {
     func setProfileAttributes(_ attributes: [String: Any]) {
         let userId = registeredUserId
         guard let userId = userId else {
-            logger.error("No user identified. If you don't have a userId but want to record traits, please pass traits using identify(body: Codable)")
+            if let jsonTraits = try? JSON(attributes) {
+                analytics.identify(traits: jsonTraits)
+            } else {
+                logger.error("Failed to convert attributes to JSON format for identify call")
+            }
             return
         }
         commonIdentifyProfile(userId: userId, attributesDict: attributes)


### PR DESCRIPTION
Closes: [MBL-1298](https://linear.app/customerio/issue/MBL-1298/tracking-api-alignment)

## Summary
Simplified the CustomerIO tracking API by removing all `Codable` parameter overloads for identify, track, and screen methods, keeping only the `[String: Any]` map-based versions.

## Changes
- Removed Codable overloads from:
  - CustomerIOInstance protocol and CustomerIO class implementation
  - CustomerIO+Events.swift extension methods
- Removed parameter-less overloads:
  - track(name:) without properties
  - screen(title:category:) without properties
  - identify<T: Codable>(traits:) without userId
  
## Benefits
- Simplified API: Single consistent method signature per function
- Better maintainability: Reduced code complexity and potential confusion