### PR TITLE
fix: build issues on xcode 26 beta

### DIFF
--- a/Sources/Common/autogenerated/AutoMockable.generated.swift
+++ b/Sources/Common/autogenerated/AutoMockable.generated.swift
@@ -331,6 +331,7 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
     public var identifyEncodableClosure: ((String, AnyEncodable) -> Void)?
 
     /// Mocked function for `identify<RequestBody: Codable>(userId: String, traits: RequestBody?)`. Your opportunity to return a mocked value and check result of mock in test code.
+    @available(*, deprecated, message: "Use 'identify(userId:traits:)' with [String: Any] traits parameter instead. Support for Codable traits will be removed in a future version.")
     public func identify<RequestBody: Codable>(userId: String, traits: RequestBody?) {
         mockCalled = true
         identifyCallsCount += 1
@@ -474,6 +475,7 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
     public var trackEncodableClosure: ((String, AnyEncodable) -> Void)?
 
     /// Mocked function for `track<RequestBody: Codable>(name: String, properties: RequestBody?)`. Your opportunity to return a mocked value and check result of mock in test code.
+    @available(*, deprecated, message: "Use 'track(name:properties:)' with [String: Any] properties parameter instead. Support for Codable properties will be removed in a future version.")
     public func track<RequestBody: Codable>(name: String, properties: RequestBody?) {
         mockCalled = true
         trackCallsCount += 1
@@ -521,6 +523,7 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
     public var screenEncodableClosure: ((String, AnyEncodable) -> Void)?
 
     /// Mocked function for `screen<RequestBody: Codable>(title: String, properties: RequestBody?)`. Your opportunity to return a mocked value and check result of mock in test code.
+    @available(*, deprecated, message: "Use 'screen(title:properties:)' with [String: Any] properties parameter instead. Support for Codable properties will be removed in a future version.")
     public func screen<RequestBody: Codable>(title: String, properties: RequestBody?) {
         mockCalled = true
         screenCallsCount += 1

--- a/Sources/MessagingPush/Integration/CioProviderAgnosticAppDelegate.swift
+++ b/Sources/MessagingPush/Integration/CioProviderAgnosticAppDelegate.swift
@@ -155,7 +155,7 @@ open class CioProviderAgnosticAppDelegate: CioAppDelegateType, UNUserNotificatio
     ) {
         // Cast to concrete type since method was removed from protocol
         if let concreteMessagingPush = messagingPush as? MessagingPushImplementation {
-          _ = concreteMessagingPush.userNotificationCenter(center, didReceive: response)
+            _ = concreteMessagingPush.userNotificationCenter(center, didReceive: response)
         }
 
         // `completionHandlerCalled` is used to overcome limitation of `responds(to:)` when working with optional methods from protocol.

--- a/Sources/MessagingPush/Integration/CioProviderAgnosticAppDelegate.swift
+++ b/Sources/MessagingPush/Integration/CioProviderAgnosticAppDelegate.swift
@@ -154,7 +154,7 @@ open class CioProviderAgnosticAppDelegate: CioAppDelegateType, UNUserNotificatio
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
         // Cast to concrete type since method was removed from protocol
-        if let implementation = messagingPush as? MessagingPushImplementation {
+        if let implementation = messagingPush as? MessagingPush {
             _ = implementation.userNotificationCenter(center, didReceive: response)
         }
 

--- a/Sources/MessagingPush/Integration/CioProviderAgnosticAppDelegate.swift
+++ b/Sources/MessagingPush/Integration/CioProviderAgnosticAppDelegate.swift
@@ -154,8 +154,8 @@ open class CioProviderAgnosticAppDelegate: CioAppDelegateType, UNUserNotificatio
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
         // Cast to concrete type since method was removed from protocol
-        if let concreteMessagingPush = messagingPush as? MessagingPushImplementation {
-            _ = concreteMessagingPush.userNotificationCenter(center, didReceive: response)
+        if let implementation = messagingPush as? MessagingPushImplementation {
+            _ = implementation.userNotificationCenter(center, didReceive: response)
         }
 
         // `completionHandlerCalled` is used to overcome limitation of `responds(to:)` when working with optional methods from protocol.

--- a/Sources/MessagingPush/Integration/CioProviderAgnosticAppDelegate.swift
+++ b/Sources/MessagingPush/Integration/CioProviderAgnosticAppDelegate.swift
@@ -153,7 +153,10 @@ open class CioProviderAgnosticAppDelegate: CioAppDelegateType, UNUserNotificatio
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
-        _ = messagingPush.userNotificationCenter(center, didReceive: response)
+        // Cast to concrete type since method was removed from protocol
+        if let concreteMessagingPush = messagingPush as? MessagingPushImplementation {
+          _ = concreteMessagingPush.userNotificationCenter(center, didReceive: response)
+        }
 
         // `completionHandlerCalled` is used to overcome limitation of `responds(to:)` when working with optional methods from protocol.
         // Component may implement the protocol, but not specific optional method. In this case `responds(to:)` will return true.

--- a/Sources/MessagingPush/MessagingPushInstance.swift
+++ b/Sources/MessagingPush/MessagingPushInstance.swift
@@ -33,30 +33,7 @@ public protocol MessagingPushInstance: AutoMockable {
     func serviceExtensionTimeWillExpire()
     #endif
 
-    #if canImport(UserNotifications) && canImport(UIKit)
-
-    /*
-     A push notification was interacted with.
-
-     - returns: If the SDK called the completion handler for you indicating if the SDK took care of the request or not.
-     */
-    // @available(iOSApplicationExtension, unavailable)
-    //
-    // sourcery:IfCanImport=UserNotifications,UIKit
-    // sourcery:Name=userNotificationCenter_withCompletion
-    func userNotificationCenter(
-        _ center: UNUserNotificationCenter,
-        didReceive response: UNNotificationResponse,
-        withCompletionHandler completionHandler: @escaping () -> Void
-    ) -> Bool
-
-    // @available(iOSApplicationExtension, unavailable)
-    //
-    // sourcery:IfCanImport=UserNotifications,UIKit
-    // sourcery:Name=userNotificationCenter
-    func userNotificationCenter(
-        _ center: UNUserNotificationCenter,
-        didReceive response: UNNotificationResponse
-    ) -> CustomerIOParsedPushPayload?
-    #endif
+    // Note: userNotificationCenter methods removed from protocol due to
+    // @available(iOSApplicationExtension, unavailable) compatibility issues.
+    // These methods are implemented as extensions on concrete types where needed.
 }

--- a/Sources/MessagingPush/MessagingPushInstance.swift
+++ b/Sources/MessagingPush/MessagingPushInstance.swift
@@ -32,8 +32,4 @@ public protocol MessagingPushInstance: AutoMockable {
     // sourcery:IfCanImport=UserNotifications
     func serviceExtensionTimeWillExpire()
     #endif
-
-    // Note: userNotificationCenter methods removed from protocol due to
-    // @available(iOSApplicationExtension, unavailable) compatibility issues.
-    // These methods are implemented as extensions on concrete types where needed.
 }

--- a/Sources/MessagingPush/PushHandling/ManualPushHandling+UserNotifications.swift
+++ b/Sources/MessagingPush/PushHandling/ManualPushHandling+UserNotifications.swift
@@ -28,7 +28,12 @@ public extension MessagingPush {
             return false
         }
 
-        return implementation.userNotificationCenter(
+        // Cast to concrete type since method was removed from protocol
+        guard let concreteImplementation = implementation as? MessagingPushImplementation else {
+            completionHandler()
+            return false
+        }
+        return concreteImplementation.userNotificationCenter(
             center,
             didReceive: response,
             withCompletionHandler: completionHandler
@@ -43,7 +48,11 @@ public extension MessagingPush {
             return nil
         }
 
-        return implementation.userNotificationCenter(center, didReceive: response)
+        // Cast to concrete type since method was removed from protocol
+        guard let concreteImplementation = implementation as? MessagingPushImplementation else {
+          return nil
+        }
+        return concreteImplementation.userNotificationCenter(center, didReceive: response)
     }
 }
 
@@ -54,13 +63,13 @@ extension MessagingPushImplementation {
 
      - returns: If the SDK called the completion handler for you indicating if the SDK took care of the request or not.
      */
-    func userNotificationCenter(
+    public func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
     ) -> Bool {
         // to keep this code DRY, forward the request to another function to perform all the logic:
-        guard let _ = userNotificationCenter(center, didReceive: response) else {
+        guard userNotificationCenter(center, didReceive: response) != nil else {
             // push did not come from CIO
             // Do not call completionHandler() because push did not come from CIO. Another service might have sent it so
             // allow another SDK

--- a/Sources/MessagingPush/PushHandling/ManualPushHandling+UserNotifications.swift
+++ b/Sources/MessagingPush/PushHandling/ManualPushHandling+UserNotifications.swift
@@ -57,7 +57,7 @@ public extension MessagingPush {
 }
 
 @available(iOSApplicationExtension, unavailable)
-public extension MessagingPushImplementation {
+extension MessagingPushImplementation {
     /**
      A push notification was interacted with.
 
@@ -105,7 +105,7 @@ public extension MessagingPushImplementation {
 
     // Function that contains the logic for when a customer is wanting to manual handle a push click event.
     // Function created for logic to be testable since automated test suite crashes when trying to access some UserNotification framework classes such as UNUserNotificationCenter.
-    internal func manualPushClickHandling(push: PushNotification) {
+    func manualPushClickHandling(push: PushNotification) {
         // A hack to get an instance of pushClickHandler without making it a property of the MessagingPushImplementation class. pushClickHandler is not available to app extensions but MessagingPushImplementation is.
         // We get around this by getting a instance in this function, only.
         let pushClickHandler = DIGraphShared.shared.pushClickHandler

--- a/Sources/MessagingPush/PushHandling/ManualPushHandling+UserNotifications.swift
+++ b/Sources/MessagingPush/PushHandling/ManualPushHandling+UserNotifications.swift
@@ -50,20 +50,20 @@ public extension MessagingPush {
 
         // Cast to concrete type since method was removed from protocol
         guard let concreteImplementation = implementation as? MessagingPushImplementation else {
-          return nil
+            return nil
         }
         return concreteImplementation.userNotificationCenter(center, didReceive: response)
     }
 }
 
 @available(iOSApplicationExtension, unavailable)
-extension MessagingPushImplementation {
+public extension MessagingPushImplementation {
     /**
      A push notification was interacted with.
 
      - returns: If the SDK called the completion handler for you indicating if the SDK took care of the request or not.
      */
-    public func userNotificationCenter(
+    func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
@@ -82,7 +82,7 @@ extension MessagingPushImplementation {
         return true
     }
 
-    public func userNotificationCenter(
+    func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse
     ) -> CustomerIOParsedPushPayload? {
@@ -105,7 +105,7 @@ extension MessagingPushImplementation {
 
     // Function that contains the logic for when a customer is wanting to manual handle a push click event.
     // Function created for logic to be testable since automated test suite crashes when trying to access some UserNotification framework classes such as UNUserNotificationCenter.
-    func manualPushClickHandling(push: PushNotification) {
+    internal func manualPushClickHandling(push: PushNotification) {
         // A hack to get an instance of pushClickHandler without making it a property of the MessagingPushImplementation class. pushClickHandler is not available to app extensions but MessagingPushImplementation is.
         // We get around this by getting a instance in this function, only.
         let pushClickHandler = DIGraphShared.shared.pushClickHandler

--- a/Sources/MessagingPush/PushHandling/ManualPushHandling+UserNotifications.swift
+++ b/Sources/MessagingPush/PushHandling/ManualPushHandling+UserNotifications.swift
@@ -23,17 +23,13 @@ public extension MessagingPush {
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
     ) -> Bool {
-        guard let implementation = implementation else {
+        // Cast to concrete type since method was removed from protocol
+        guard let implementation = implementation as? MessagingPushImplementation else {
             completionHandler()
             return false
         }
 
-        // Cast to concrete type since method was removed from protocol
-        guard let concreteImplementation = implementation as? MessagingPushImplementation else {
-            completionHandler()
-            return false
-        }
-        return concreteImplementation.userNotificationCenter(
+        return implementation.userNotificationCenter(
             center,
             didReceive: response,
             withCompletionHandler: completionHandler
@@ -44,15 +40,12 @@ public extension MessagingPush {
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse
     ) -> CustomerIOParsedPushPayload? {
-        guard let implementation = implementation else {
+        // Cast to concrete type since method was removed from protocol
+        guard let implementation = implementation as? MessagingPushImplementation else {
             return nil
         }
 
-        // Cast to concrete type since method was removed from protocol
-        guard let concreteImplementation = implementation as? MessagingPushImplementation else {
-            return nil
-        }
-        return concreteImplementation.userNotificationCenter(center, didReceive: response)
+        return implementation.userNotificationCenter(center, didReceive: response)
     }
 }
 

--- a/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
@@ -298,8 +298,6 @@ public class MessagingPushInstanceMock: MessagingPushInstance, Mock {
         serviceExtensionTimeWillExpireClosure?()
     }
     #endif
-
-    // Note: userNotificationCenter mocks removed due to protocol availability conflicts
 }
 
 /**

--- a/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
@@ -298,7 +298,7 @@ public class MessagingPushInstanceMock: MessagingPushInstance, Mock {
         serviceExtensionTimeWillExpireClosure?()
     }
     #endif
-    
+
     // Note: userNotificationCenter mocks removed due to protocol availability conflicts
 }
 

--- a/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingPush/autogenerated/AutoMockable.generated.swift
@@ -165,20 +165,6 @@ public class MessagingPushInstanceMock: MessagingPushInstance, Mock {
         #endif
 
         mockCalled = false // do last as resetting properties above can make this true
-        #if canImport(UserNotifications)
-        userNotificationCenter_withCompletionCallsCount = 0
-        userNotificationCenter_withCompletionReceivedArguments = nil
-        userNotificationCenter_withCompletionReceivedInvocations = []
-        #endif
-
-        mockCalled = false // do last as resetting properties above can make this true
-        #if canImport(UserNotifications)
-        userNotificationCenterCallsCount = 0
-        userNotificationCenterReceivedArguments = nil
-        userNotificationCenterReceivedInvocations = []
-        #endif
-
-        mockCalled = false // do last as resetting properties above can make this true
     }
 
     // MARK: - registerDeviceToken
@@ -312,72 +298,8 @@ public class MessagingPushInstanceMock: MessagingPushInstance, Mock {
         serviceExtensionTimeWillExpireClosure?()
     }
     #endif
-
-    // MARK: - userNotificationCenter
-
-    #if canImport(UserNotifications)
-    /// Number of times the function was called.
-    @Atomic public private(set) var userNotificationCenter_withCompletionCallsCount = 0
-    /// `true` if the function was ever called.
-    public var userNotificationCenter_withCompletionCalled: Bool {
-        userNotificationCenter_withCompletionCallsCount > 0
-    }
-
-    /// The arguments from the *last* time the function was called.
-    @Atomic public private(set) var userNotificationCenter_withCompletionReceivedArguments: (center: UNUserNotificationCenter, response: UNNotificationResponse, completionHandler: () -> Void)?
-    /// Arguments from *all* of the times that the function was called.
-    @Atomic public private(set) var userNotificationCenter_withCompletionReceivedInvocations: [(center: UNUserNotificationCenter, response: UNNotificationResponse, completionHandler: () -> Void)] = []
-    /// Value to return from the mocked function.
-    public var userNotificationCenter_withCompletionReturnValue: Bool!
-    /**
-     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
-     The closure has first priority to return a value for the mocked function. If the closure returns `nil`,
-     then the mock will attempt to return the value for `userNotificationCenter_withCompletionReturnValue`
-     */
-    public var userNotificationCenter_withCompletionClosure: ((UNUserNotificationCenter, UNNotificationResponse, @escaping () -> Void) -> Bool)?
-
-    /// Mocked function for `userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
-    public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) -> Bool {
-        mockCalled = true
-        userNotificationCenter_withCompletionCallsCount += 1
-        userNotificationCenter_withCompletionReceivedArguments = (center: center, response: response, completionHandler: completionHandler)
-        userNotificationCenter_withCompletionReceivedInvocations.append((center: center, response: response, completionHandler: completionHandler))
-        return userNotificationCenter_withCompletionClosure.map { $0(center, response, completionHandler) } ?? userNotificationCenter_withCompletionReturnValue
-    }
-    #endif
-
-    // MARK: - userNotificationCenter
-
-    #if canImport(UserNotifications)
-    /// Number of times the function was called.
-    @Atomic public private(set) var userNotificationCenterCallsCount = 0
-    /// `true` if the function was ever called.
-    public var userNotificationCenterCalled: Bool {
-        userNotificationCenterCallsCount > 0
-    }
-
-    /// The arguments from the *last* time the function was called.
-    @Atomic public private(set) var userNotificationCenterReceivedArguments: (center: UNUserNotificationCenter, response: UNNotificationResponse)?
-    /// Arguments from *all* of the times that the function was called.
-    @Atomic public private(set) var userNotificationCenterReceivedInvocations: [(center: UNUserNotificationCenter, response: UNNotificationResponse)] = []
-    /// Value to return from the mocked function.
-    public var userNotificationCenterReturnValue: CustomerIOParsedPushPayload?
-    /**
-     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
-     The closure has first priority to return a value for the mocked function. If the closure returns `nil`,
-     then the mock will attempt to return the value for `userNotificationCenterReturnValue`
-     */
-    public var userNotificationCenterClosure: ((UNUserNotificationCenter, UNNotificationResponse) -> CustomerIOParsedPushPayload?)?
-
-    /// Mocked function for `userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse)`. Your opportunity to return a mocked value and check result of mock in test code.
-    public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) -> CustomerIOParsedPushPayload? {
-        mockCalled = true
-        userNotificationCenterCallsCount += 1
-        userNotificationCenterReceivedArguments = (center: center, response: response)
-        userNotificationCenterReceivedInvocations.append((center: center, response: response))
-        return userNotificationCenterClosure.map { $0(center, response) } ?? userNotificationCenterReturnValue
-    }
-    #endif
+    
+    // Note: userNotificationCenter mocks removed due to protocol availability conflicts
 }
 
 /**

--- a/Sources/MessagingPushAPN/MessagingPushAPN.swift
+++ b/Sources/MessagingPushAPN/MessagingPushAPN.swift
@@ -134,7 +134,7 @@ public class MessagingPushAPN: MessagingPushAPNInstance {
         didReceive response: UNNotificationResponse
     ) -> CustomerIOParsedPushPayload? {
         // Use concrete MessagingPush instance since method was removed from protocol
-        return MessagingPush.shared.userNotificationCenter(center, didReceive: response)
+        MessagingPush.shared.userNotificationCenter(center, didReceive: response)
     }
 
     @available(iOSApplicationExtension, unavailable)
@@ -144,7 +144,7 @@ public class MessagingPushAPN: MessagingPushAPNInstance {
         withCompletionHandler completionHandler: @escaping () -> Void
     ) -> Bool {
         // Use concrete MessagingPush instance since method was removed from protocol
-        return MessagingPush.shared.userNotificationCenter(center, didReceive: response, withCompletionHandler: completionHandler)
+        MessagingPush.shared.userNotificationCenter(center, didReceive: response, withCompletionHandler: completionHandler)
     }
     #endif
 }

--- a/Sources/MessagingPushAPN/MessagingPushAPN.swift
+++ b/Sources/MessagingPushAPN/MessagingPushAPN.swift
@@ -133,7 +133,8 @@ public class MessagingPushAPN: MessagingPushAPNInstance {
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse
     ) -> CustomerIOParsedPushPayload? {
-        messagingPush.userNotificationCenter(center, didReceive: response)
+        // Use concrete MessagingPush instance since method was removed from protocol
+        return MessagingPush.shared.userNotificationCenter(center, didReceive: response)
     }
 
     @available(iOSApplicationExtension, unavailable)
@@ -142,7 +143,8 @@ public class MessagingPushAPN: MessagingPushAPNInstance {
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
     ) -> Bool {
-        messagingPush.userNotificationCenter(center, didReceive: response, withCompletionHandler: completionHandler)
+        // Use concrete MessagingPush instance since method was removed from protocol
+        return MessagingPush.shared.userNotificationCenter(center, didReceive: response, withCompletionHandler: completionHandler)
     }
     #endif
 }

--- a/Sources/MessagingPushFCM/MessagingPushFCM.swift
+++ b/Sources/MessagingPushFCM/MessagingPushFCM.swift
@@ -138,7 +138,7 @@ public class MessagingPushFCM: MessagingPushFCMInstance {
         didReceive response: UNNotificationResponse
     ) -> CustomerIOParsedPushPayload? {
         // Use concrete MessagingPush instance since method was removed from protocol
-        return MessagingPush.shared.userNotificationCenter(center, didReceive: response)
+        MessagingPush.shared.userNotificationCenter(center, didReceive: response)
     }
 
     @available(iOSApplicationExtension, unavailable)
@@ -148,7 +148,7 @@ public class MessagingPushFCM: MessagingPushFCMInstance {
         withCompletionHandler completionHandler: @escaping () -> Void
     ) -> Bool {
         // Use concrete MessagingPush instance since method was removed from protocol
-        return MessagingPush.shared.userNotificationCenter(center, didReceive: response, withCompletionHandler: completionHandler)
+        MessagingPush.shared.userNotificationCenter(center, didReceive: response, withCompletionHandler: completionHandler)
     }
     #endif
 }

--- a/Sources/MessagingPushFCM/MessagingPushFCM.swift
+++ b/Sources/MessagingPushFCM/MessagingPushFCM.swift
@@ -137,7 +137,8 @@ public class MessagingPushFCM: MessagingPushFCMInstance {
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse
     ) -> CustomerIOParsedPushPayload? {
-        messagingPush.userNotificationCenter(center, didReceive: response)
+        // Use concrete MessagingPush instance since method was removed from protocol
+        return MessagingPush.shared.userNotificationCenter(center, didReceive: response)
     }
 
     @available(iOSApplicationExtension, unavailable)
@@ -146,7 +147,8 @@ public class MessagingPushFCM: MessagingPushFCMInstance {
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
     ) -> Bool {
-        messagingPush.userNotificationCenter(center, didReceive: response, withCompletionHandler: completionHandler)
+        // Use concrete MessagingPush instance since method was removed from protocol
+        return MessagingPush.shared.userNotificationCenter(center, didReceive: response, withCompletionHandler: completionHandler)
     }
     #endif
 }

--- a/Tests/MessagingPush/Integration/CioProviderAgnosticAppDelegateTests.swift
+++ b/Tests/MessagingPush/Integration/CioProviderAgnosticAppDelegateTests.swift
@@ -238,9 +238,6 @@ class CioProviderAgnosticAppDelegateTests: XCTestCase {
     }
 
     func testUserNotificationCenterDidReceive_whenNotificationCenterIntegrationIsEnabled_thenWrappedDelegateAndMessagingPushAreCalled() {
-        // Configure mock return value
-        mockMessagingPush.userNotificationCenterReturnValue = nil
-
         var completionHandlerCalled = false
         let completionHandler = {
             completionHandlerCalled = true
@@ -251,7 +248,6 @@ class CioProviderAgnosticAppDelegateTests: XCTestCase {
         appDelegate.userNotificationCenter(UNUserNotificationCenter.current(), didReceive: UNNotificationResponse.testInstance, withCompletionHandler: completionHandler)
 
         // Verify behavior
-        XCTAssertTrue(mockMessagingPush.userNotificationCenterCalled)
         XCTAssertTrue(mockNotificationCenterDelegate.didReceiveNotificationResponseCalled)
         XCTAssertTrue(completionHandlerCalled)
     }
@@ -265,7 +261,6 @@ class CioProviderAgnosticAppDelegateTests: XCTestCase {
             config: { self.createMockConfig(autoTrackPushEvents: false) },
             logger: mockLogger
         )
-        mockMessagingPush.userNotificationCenterReturnValue = nil
         var completionHandlerCalled = false
         let completionHandler = {
             completionHandlerCalled = true

--- a/Tests/MessagingPushAPN/Integration/CioAppDelegateAPNTests.swift
+++ b/Tests/MessagingPushAPN/Integration/CioAppDelegateAPNTests.swift
@@ -120,7 +120,6 @@ class CioAppDelegateAPNTests: XCTestCase {
     func testUserNotificationCenterDidReceive_whenCalled_thenSuperIsCalled() {
         // Setup
         _ = appDelegateAPN.application(UIApplication.shared, didFinishLaunchingWithOptions: nil)
-        mockMessagingPush.userNotificationCenterReturnValue = nil
 
         var completionHandlerCalled = false
         let completionHandler = {
@@ -131,7 +130,6 @@ class CioAppDelegateAPNTests: XCTestCase {
         appDelegateAPN.userNotificationCenter(UNUserNotificationCenter.current(), didReceive: UNNotificationResponse.testInstance, withCompletionHandler: completionHandler)
 
         // Verify behavior
-        XCTAssertTrue(mockMessagingPush.userNotificationCenterCalled == true)
         XCTAssertTrue(mockNotificationCenterDelegate.didReceiveNotificationResponseCalled)
         XCTAssertTrue(completionHandlerCalled)
     }

--- a/Tests/MessagingPushFCM/Integration/CioAppDelegateFCMTests.swift
+++ b/Tests/MessagingPushFCM/Integration/CioAppDelegateFCMTests.swift
@@ -183,7 +183,6 @@ class CioAppDelegateFCMTests: XCTestCase {
 
     func testUserNotificationCenterDidReceive_whenCalled_thenSuperIsCalled() {
         // Setup
-        mockMessagingPush.userNotificationCenterReturnValue = nil
         _ = appDelegateFCM.application(UIApplication.shared, didFinishLaunchingWithOptions: nil)
 
         var completionHandlerCalled = false
@@ -195,7 +194,6 @@ class CioAppDelegateFCMTests: XCTestCase {
         appDelegateFCM.userNotificationCenter(UNUserNotificationCenter.current(), didReceive: UNNotificationResponse.testInstance, withCompletionHandler: completionHandler)
 
         // Verify behavior
-        XCTAssertTrue(mockMessagingPush.userNotificationCenterCalled == true)
         XCTAssertTrue(mockNotificationCenterDelegate.didReceiveNotificationResponseCalled)
         XCTAssertTrue(completionHandlerCalled)
     }

--- a/api-docs/internal/CioMessagingPush.api
+++ b/api-docs/internal/CioMessagingPush.api
@@ -39,15 +39,6 @@ public interface CioMessagingPush.MessagingPushInstance {
     withContentHandler contentHandler: @escaping (UNNotificationContent) -> Unit
 ) -> Boolean;
 	public fun func serviceExtensionTimeWillExpire();
-	public fun func userNotificationCenter(
-    _ center: UNUserNotificationCenter,
-    didReceive response: UNNotificationResponse,
-    withCompletionHandler completionHandler: @escaping () -> Unit
-) -> Boolean;
-	public fun func userNotificationCenter(
-    _ center: UNUserNotificationCenter,
-    didReceive response: UNNotificationResponse
-) -> CustomerIOParsedPushPayload?;
 }
 public final class CioMessagingPush.PushAttachment {
 	public final val identifier: String;


### PR DESCRIPTION
closes: https://linear.app/customerio/issue/MBL-1343/ios-26-xcode-26-beta-build-fails-messagingpush-does-not-conform-to

Problem:
Xcode 16 Beta has stricter protocol conformance validation that detected availability annotation mismatches between protocol definitions and implementations with @available(iOSApplicationExtension, unavailable) annotations.

Solution: Remove Protocol Methods and Update Callers
 
 Note: SPM is resolving it by itself but its an issue on the cocoapods version. 