### PR TITLE
chore: add missing custom scheme url handling to app delegate wrapper

### DIFF
--- a/Sources/Common/autogenerated/AutoMockable.generated.swift
+++ b/Sources/Common/autogenerated/AutoMockable.generated.swift
@@ -331,6 +331,7 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
     public var identifyEncodableClosure: ((String, AnyEncodable) -> Void)?
 
     /// Mocked function for `identify<RequestBody: Codable>(userId: String, traits: RequestBody?)`. Your opportunity to return a mocked value and check result of mock in test code.
+    @available(*, deprecated, message: "Use 'identify(userId:traits:)' with [String: Any] traits parameter instead. Support for Codable traits will be removed in a future version.")
     public func identify<RequestBody: Codable>(userId: String, traits: RequestBody?) {
         mockCalled = true
         identifyCallsCount += 1
@@ -474,6 +475,7 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
     public var trackEncodableClosure: ((String, AnyEncodable) -> Void)?
 
     /// Mocked function for `track<RequestBody: Codable>(name: String, properties: RequestBody?)`. Your opportunity to return a mocked value and check result of mock in test code.
+    @available(*, deprecated, message: "Use 'track(name:properties:)' with [String: Any] properties parameter instead. Support for Codable properties will be removed in a future version.")
     public func track<RequestBody: Codable>(name: String, properties: RequestBody?) {
         mockCalled = true
         trackCallsCount += 1
@@ -521,6 +523,7 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
     public var screenEncodableClosure: ((String, AnyEncodable) -> Void)?
 
     /// Mocked function for `screen<RequestBody: Codable>(title: String, properties: RequestBody?)`. Your opportunity to return a mocked value and check result of mock in test code.
+    @available(*, deprecated, message: "Use 'screen(title:properties:)' with [String: Any] properties parameter instead. Support for Codable properties will be removed in a future version.")
     public func screen<RequestBody: Codable>(title: String, properties: RequestBody?) {
         mockCalled = true
         screenCallsCount += 1

--- a/Sources/MessagingPush/Integration/CioProviderAgnosticAppDelegate.swift
+++ b/Sources/MessagingPush/Integration/CioProviderAgnosticAppDelegate.swift
@@ -31,6 +31,7 @@ open class CioProviderAgnosticAppDelegate: CioAppDelegateType, UNUserNotificatio
         #selector(UIApplicationDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)),
         #selector(UIApplicationDelegate.application(_:didFailToRegisterForRemoteNotificationsWithError:)),
         #selector(UIApplicationDelegate.application(_:continue:restorationHandler:)),
+        #selector(UIApplicationDelegate.application(_:open:options:)),
         // UNUserNotificationCenterDelegate
         #selector(UNUserNotificationCenterDelegate.userNotificationCenter(_:willPresent:withCompletionHandler:)),
         #selector(UNUserNotificationCenterDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:)),
@@ -213,5 +214,13 @@ extension CioProviderAgnosticAppDelegate {
     @objc
     open func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([any UIUserActivityRestoring]?) -> Void) -> Bool {
         wrappedAppDelegate?.application?(application, continue: userActivity, restorationHandler: restorationHandler) ?? false
+    }
+
+    open func application(
+        _ app: UIApplication,
+        open url: URL,
+        options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+    ) -> Bool {
+        wrappedAppDelegate?.application?(app, open: url, options: options) ?? false
     }
 }

--- a/Tests/MessagingPush/Integration/CioProviderAgnosticAppDelegateTests.swift
+++ b/Tests/MessagingPush/Integration/CioProviderAgnosticAppDelegateTests.swift
@@ -335,4 +335,28 @@ class CioProviderAgnosticAppDelegateTests: XCTestCase {
         XCTAssertTrue(mockAppDelegate.continueUserActivityCalled)
         XCTAssertTrue(result)
     }
+
+    func testApplicationOpenUrl_whenCalled_thenWrappedDelegateIsCalled() {
+        // Setup
+        let testUrl = URL(string: "myapp://deeplink")!
+        let testOptions: [UIApplication.OpenURLOptionsKey: Any] = [.sourceApplication: "com.test.app"]
+
+        // Call the method
+        let result = appDelegate.application(UIApplication.shared, open: testUrl, options: testOptions)
+
+        // Verify behavior
+        XCTAssertTrue(mockAppDelegate.openUrlCalled)
+        XCTAssertEqual(mockAppDelegate.urlReceived, testUrl)
+        XCTAssertEqual(mockAppDelegate.optionsReceived?[.sourceApplication] as? String, "com.test.app")
+        XCTAssertTrue(result)
+    }
+
+    func testRespondsToApplicationOpenUrl_whenSelectorIsInImplementedMethods_thenReturnsTrue() {
+        // Test that the app delegate responds to the URL opening selector
+        let urlSelector = #selector(UIApplicationDelegate.application(_:open:options:))
+        XCTAssertTrue(appDelegate.responds(to: urlSelector), "AppDelegate should respond to application(_:open:options:) selector")
+
+        // More importantly, test that it's handled by CioAppDelegate itself, not just forwarded
+        XCTAssertEqual(appDelegate.forwardingTarget(for: urlSelector) as? CioProviderAgnosticAppDelegate, appDelegate, "URL handling should be handled by CioAppDelegate, not forwarded to wrapped delegate")
+    }
 }

--- a/Tests/Shared/Mocks/UIKitDelegateMocks.swift
+++ b/Tests/Shared/Mocks/UIKitDelegateMocks.swift
@@ -11,6 +11,9 @@ public class MockAppDelegate: NSObject, UIApplicationDelegate {
     public var launchOptionsReceived: [UIApplication.LaunchOptionsKey: Any]?
     public var deviceTokenReceived: Data?
     public var errorReceived: Error?
+    public var openUrlCalled = false
+    public var urlReceived: URL?
+    public var optionsReceived: [UIApplication.OpenURLOptionsKey: Any]?
 
     public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         didFinishLaunchingCalled = true
@@ -34,6 +37,13 @@ public class MockAppDelegate: NSObject, UIApplicationDelegate {
 
     public func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
         continueUserActivityCalled = true
+        return true
+    }
+
+    public func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+        openUrlCalled = true
+        urlReceived = url
+        optionsReceived = options
         return true
     }
 }


### PR DESCRIPTION
part of: [MBL-1277](https://linear.app/customerio/issue/MBL-1277/react-native-sdk-443-conflict-with-facebook-login-sdk)

### Summary

When using `CioAppDelegateWrapper` in FCM setup, the `application(_:open:options:)` method was not being triggered which broke custom scheme deep links and possibly other URL based flows (e.g., OAuth callbacks). This issue was caused by the selector not being declared in `implementedOptionalMethods`, preventing proper method forwarding from `UIApplication`.

### Changes

- Added the missing selector `application(_:open:options:)` to `implementedOptionalMethods` array in `CioProviderAgnosticAppDelegate`
- Implemented `application(_:open:options:)` in `CioProviderAgnosticAppDelegate` to forward custom scheme handling to customer app
- Ensured the method works with both APN and FCM integrations by delegating handling based on context

### Testing

- Unit tests now fail if the selector or method implementation is removed
- Custom scheme URLs (e.g., `myapp://callback`) were successfully routed when triggered using command

```bash
xcrun simctl openurl booted "myapp://callback"
```