### PR TITLE
chore: Add coordinator to prevent push delivery metrics loss

### DIFF
--- a/Sources/Common/Util/Synchronized.swift
+++ b/Sources/Common/Util/Synchronized.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// An object that manages the execution of tasks atomically.
+/// Thread-safe wrapper for read/write access to a value using concurrent queue with barriers.
+public struct Synchronized<Value> {
+    private let mutex = DispatchQueue(label: "io.customer.SDK.Utils.Synchronized", attributes: .concurrent)
+    private var _value: Value
+
+    public init(_ value: Value) {
+        self._value = value
+    }
+
+    /// Returns the thread-safe value.
+    public var value: Value { mutex.sync { _value } }
+
+    /// Submits a block for synchronous, thread-safe execution with write access.
+    public mutating func value<T>(execute task: (inout Value) throws -> T) rethrows -> T {
+        try mutex.sync(flags: .barrier) { try task(&_value) }
+    }
+}

--- a/Sources/MessagingPush/MessagingPushImplementation.swift
+++ b/Sources/MessagingPush/MessagingPushImplementation.swift
@@ -1,5 +1,8 @@
 import CioInternalCommon
 import Foundation
+#if canImport(UserNotifications)
+import UserNotifications
+#endif
 
 class MessagingPushImplementation: MessagingPushInstance {
     let moduleConfig: MessagingPushConfigOptions
@@ -7,6 +10,11 @@ class MessagingPushImplementation: MessagingPushInstance {
     let pushLogger: PushNotificationLogger
     let jsonAdapter: JsonAdapter
     let eventBusHandler: EventBusHandler
+
+    #if canImport(UserNotifications)
+    // Store current coordinator for timeout handling in NSE context
+    var currentCoordinator: NSEOperationCoordinator?
+    #endif
 
     init(diGraph: DIGraphShared, moduleConfig: MessagingPushConfigOptions) {
         self.moduleConfig = moduleConfig

--- a/Sources/MessagingPush/RichPush/NSEOperationCoordinator.swift
+++ b/Sources/MessagingPush/RichPush/NSEOperationCoordinator.swift
@@ -1,0 +1,183 @@
+import CioInternalCommon
+import Foundation
+#if canImport(UserNotifications)
+import UserNotifications
+#endif
+
+/**
+ Coordinates both metrics tracking and rich push processing in NSE context.
+ Ensures contentHandler is called exactly once when both operations complete or timeout occurs.
+ */
+#if canImport(UserNotifications)
+class NSEOperationCoordinator {
+    // MARK: - Private Properties
+
+    private let push: UNNotificationWrapper
+    private let contentHandler: (UNNotificationContent) -> Void
+    private let richPushHandler: RichPushRequestHandler
+    private let pushDeliveryTracker: RichPushDeliveryTracker
+    private let logger: Logger
+
+    private let state: OperationState
+
+    // MARK: - Initialization
+
+    init(
+        push: UNNotificationWrapper,
+        contentHandler: @escaping (UNNotificationContent) -> Void,
+        richPushHandler: RichPushRequestHandler,
+        pushDeliveryTracker: RichPushDeliveryTracker,
+        logger: Logger
+    ) {
+        self.push = push
+        self.contentHandler = contentHandler
+        self.richPushHandler = richPushHandler
+        self.pushDeliveryTracker = pushDeliveryTracker
+        self.logger = logger
+
+        // Initialize with original notification content
+        let originalContent = push.notificationContent
+        self.state = OperationState(originalContent: originalContent)
+    }
+
+    // MARK: - Public Interface
+
+    func start() {
+        logger.debug("Starting coordinated NSE operations for deliveryId: \(String(describing: push.cioDelivery?.id))")
+
+        // Start both operations concurrently
+        startMetricsTracking()
+        startRichPushProcessing()
+    }
+
+    func handleTimeWillExpire() {
+        logger.info("NSE time will expire. Stopping all operations and using current content.")
+
+        // Cancel any pending operations
+        richPushHandler.stopAll()
+
+        // Force completion with whatever content we have
+        let finalContent = state.forceComplete()
+        callContentHandler(with: finalContent, reason: "timeWillExpire")
+    }
+
+    /// Current notification content. Useful for testing thread safety.
+    var currentContent: UNNotificationContent {
+        state.currentContent
+    }
+
+    // MARK: - Private Methods
+
+    private func startMetricsTracking() {
+        // Note: push.cioDelivery is guaranteed to exist because coordinator is only created
+        // when the extension has already verified cioDelivery exists
+        let deliveryInfo = push.cioDelivery!
+
+        logger.debug("Starting metrics tracking for deliveryId: \(deliveryInfo.id)")
+
+        pushDeliveryTracker.trackMetric(token: deliveryInfo.token, event: .delivered, deliveryId: deliveryInfo.id, timestamp: nil) { [weak self] result in
+            self?.handleMetricsCompletion(result: result)
+        }
+    }
+
+    private func startRichPushProcessing() {
+        logger.debug("Starting rich push processing")
+
+        richPushHandler.startRequest(push: push) { [weak self] modifiedPush in
+            self?.handleRichPushCompletion(modifiedPush: modifiedPush)
+        }
+    }
+
+    private func handleMetricsCompletion(result: Result<Void, HttpRequestError>) {
+        switch result {
+        case .success:
+            logger.debug("Metrics tracking completed successfully for deliveryId: \(String(describing: push.cioDelivery?.id))")
+        case .failure(let error):
+            logger.error("Metrics tracking failed for deliveryId: \(String(describing: push.cioDelivery?.id)): \(error)")
+        }
+
+        if let finalContent = state.markMetricsComplete() {
+            callContentHandler(with: finalContent, reason: "bothOperationsComplete")
+        }
+    }
+
+    private func handleRichPushCompletion(modifiedPush: PushNotification) {
+        logger.debug("Rich push processing completed for deliveryId: \(String(describing: push.cioDelivery?.id))")
+
+        let content = (modifiedPush as? UNNotificationWrapper)?.notificationContent ?? state.currentContent
+
+        if let finalContent = state.markRichPushComplete(with: content) {
+            callContentHandler(with: finalContent, reason: "bothOperationsComplete")
+        }
+    }
+
+    private func callContentHandler(with content: UNNotificationContent, reason: String) {
+        logger.info("NSE operations complete (\(reason)). Calling content handler.")
+
+        contentHandler(content)
+    }
+}
+
+// MARK: - Thread-Safe State Management
+
+private struct OperationData {
+    var metricsCompleted = false
+    var richPushCompleted = false
+    var handlerCalled = false
+    var currentContent: UNNotificationContent
+
+    init(originalContent: UNNotificationContent) {
+        self.currentContent = originalContent
+    }
+}
+
+private class OperationState {
+    private var state: Synchronized<OperationData>
+
+    init(originalContent: UNNotificationContent) {
+        self.state = Synchronized(OperationData(originalContent: originalContent))
+    }
+
+    /// Marks metrics as complete and returns final content if both operations are done
+    func markMetricsComplete() -> UNNotificationContent? {
+        state.value { data in
+            data.metricsCompleted = true
+
+            // Check if both operations complete and handler not called yet
+            if data.metricsCompleted, data.richPushCompleted, !data.handlerCalled {
+                data.handlerCalled = true
+                return data.currentContent
+            }
+            return nil
+        }
+    }
+
+    /// Marks rich push as complete and returns final content if both operations are done
+    func markRichPushComplete(with content: UNNotificationContent) -> UNNotificationContent? {
+        state.value { data in
+            data.currentContent = content
+            data.richPushCompleted = true
+
+            // Check if both operations complete and handler not called yet
+            if data.metricsCompleted, data.richPushCompleted, !data.handlerCalled {
+                data.handlerCalled = true
+                return data.currentContent
+            }
+            return nil
+        }
+    }
+
+    /// Returns current content without modifying state
+    var currentContent: UNNotificationContent {
+        state.value.currentContent
+    }
+
+    /// Forces completion and returns current content (for timeout scenarios)
+    func forceComplete() -> UNNotificationContent {
+        state.value { data in
+            data.handlerCalled = true
+            return data.currentContent
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Why?
Some delivery metrics are lost because we don't wait for that request to finish. The previous implementation had two independent async operations (metrics tracking and rich push processing) and only rich push processing called `contentHandler` upon completion. When rich push is faster, it would call `contentHandler` and terminate the NSE, killing the in-flight metrics request even when plenty of NSE time remained.

## How we solve?
Add `NSEOperationCoordinator` to wait for both async calls or NSE call that it will expire. The coordinator ensures `contentHandler` is called exactly once only after:
- Both operations complete (success or failure), OR
- `serviceExtensionTimeWillExpire` is called by iOS
This maximizes delivery metrics success by using the full available NSE execution time instead of terminating prematurely when only one operation completes.

Note: Moved `Synchronized<T>` utility to Common module for reuse