### PR TITLE
fix: improve apn sample settings screen theme

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/Base.lproj/Main.storyboard
+++ b/Apps/APN-UIKit/APN UIKit/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="37F-6d-U3o">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="24127" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="37F-6d-U3o">
     <device id="retina6_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24063"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Native iOS (APN UIKit)" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WZv-T2-RIj">
-                                <rect key="frame" x="20" y="123.99999999999999" width="374" height="38.333333333333329"/>
+                                <rect key="frame" x="20" y="168" width="374" height="38.333333333333343"/>
                                 <fontDescription key="fontDescription" name="Avenir-Heavy" family="Avenir" pointSize="28"/>
                                 <color key="textColor" red="0.24313725490196078" green="0.24313725490196078" blue="0.24313725490196078" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <nil key="highlightedColor"/>
@@ -83,14 +83,14 @@
                                 </constraints>
                             </view>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="settings" translatesAutoresizingMaskIntoConstraints="NO" id="HPL-cE-0Qb">
-                                <rect key="frame" x="344" y="44" width="50" height="50"/>
+                                <rect key="frame" x="344" y="88" width="50" height="50"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="5wR-Cr-URF"/>
                                     <constraint firstAttribute="width" constant="50" id="J4G-Bk-vVW"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jhw-4t-vdr">
-                                <rect key="frame" x="20" y="822.66666666666663" width="374" height="19.333333333333371"/>
+                                <rect key="frame" x="20" y="788.66666666666663" width="374" height="19.333333333333371"/>
                                 <fontDescription key="fontDescription" name="Avenir-Book" family="Avenir" pointSize="14"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="0.55000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -154,7 +154,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="rFT-X3-bBo" userLabel="Header">
-                                <rect key="frame" x="16" y="44" width="324" height="63.333333333333343"/>
+                                <rect key="frame" x="16" y="88" width="324" height="63.333333333333343"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Current User Info" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mIk-22-9js">
                                         <rect key="frame" x="0.0" y="0.0" width="162" height="27.333333333333332"/>
@@ -180,7 +180,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="TWs-x8-gts">
-                                        <rect key="frame" x="0.0" y="45.333333333333329" width="128" height="18"/>
+                                        <rect key="frame" x="0.0" y="45.333333333333343" width="128" height="18"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Device id:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W61-r6-LMJ">
                                                 <rect key="frame" x="0.0" y="0.0" width="70.333333333333329" height="18"/>
@@ -199,14 +199,14 @@
                                 </subviews>
                             </stackView>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="settings" translatesAutoresizingMaskIntoConstraints="NO" id="Kn0-pQ-K5D" userLabel="Settings Icon">
-                                <rect key="frame" x="348" y="44" width="50" height="50"/>
+                                <rect key="frame" x="348" y="88" width="50" height="50"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="eSH-XH-6Fk"/>
                                     <constraint firstAttribute="width" constant="50" id="nG0-2Z-Q9S"/>
                                 </constraints>
                             </imageView>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Luu-tc-cUj" userLabel="Buttons Scrollable View">
-                                <rect key="frame" x="16" y="123.33333333333331" width="382" height="703.33333333333348"/>
+                                <rect key="frame" x="16" y="167.33333333333331" width="382" height="625.33333333333348"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="AIH-WX-Xne">
                                         <rect key="frame" x="0.0" y="0.0" width="382" height="487.33333333333331"/>
@@ -218,7 +218,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yOE-0O-ICW" customClass="ThemeButton" customModule="APN_UIKit" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="50.333333333333329" width="382" height="34.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="50.333333333333314" width="382" height="34.333333333333343"/>
                                                 <color key="backgroundColor" red="0.23529411764705882" green="0.2627450980392157" blue="0.49019607843137253" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <state key="normal" title="Button"/>
@@ -228,7 +228,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rAK-3p-434" customClass="ThemeButton" customModule="APN_UIKit" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="100.66666666666667" width="382" height="34.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="100.66666666666666" width="382" height="34.333333333333343"/>
                                                 <color key="backgroundColor" red="0.23529411759999999" green="0.26274509800000001" blue="0.49019607840000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <state key="normal" title="Button"/>
@@ -238,7 +238,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nOP-Lf-TEx" customClass="ThemeButton" customModule="APN_UIKit" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="151" width="382" height="34.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="150.99999999999997" width="382" height="34.333333333333343"/>
                                                 <color key="backgroundColor" red="0.23529411759999999" green="0.26274509800000001" blue="0.49019607840000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <state key="normal" title="Button"/>
@@ -248,7 +248,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5Np-Wp-Fd7" customClass="ThemeButton" customModule="APN_UIKit" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="201.33333333333337" width="382" height="34.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="201.33333333333334" width="382" height="34.333333333333343"/>
                                                 <color key="backgroundColor" red="0.23529411759999999" green="0.26274509800000001" blue="0.49019607840000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <state key="normal" title="Button"/>
@@ -258,7 +258,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XDM-Yu-1Sg" customClass="ThemeButton" customModule="APN_UIKit" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="251.66666666666671" width="382" height="34.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="251.66666666666666" width="382" height="34.333333333333343"/>
                                                 <color key="backgroundColor" red="0.23529411759999999" green="0.26274509800000001" blue="0.49019607840000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <state key="normal" title="Button"/>
@@ -278,7 +278,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lb4-oP-0VA" userLabel="Inline examples (UiKit)" customClass="ThemeButton" customModule="APN_UIKit" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="352.33333333333337" width="382" height="34.333333333333314"/>
+                                                <rect key="frame" x="0.0" y="352.33333333333326" width="382" height="34.333333333333314"/>
                                                 <color key="backgroundColor" red="0.2352941036" green="0.26274511220000002" blue="0.49019610879999997" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <state key="normal" title="Button"/>
@@ -288,7 +288,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xg6-ZV-bDY" customClass="ThemeButton" customModule="APN_UIKit" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="402.66666666666669" width="382" height="34.333333333333314"/>
+                                                <rect key="frame" x="0.0" y="402.66666666666663" width="382" height="34.333333333333314"/>
                                                 <color key="backgroundColor" red="0.23529411759999999" green="0.26274509800000001" blue="0.49019607840000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <state key="normal" title="Button"/>
@@ -298,7 +298,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gSy-pH-Zuu" customClass="ThemeButton" customModule="APN_UIKit" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="453.00000000000006" width="382" height="34.333333333333314"/>
+                                                <rect key="frame" x="0.0" y="453" width="382" height="34.333333333333314"/>
                                                 <color key="backgroundColor" red="0.23529411759999999" green="0.26274509800000001" blue="0.49019607840000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <state key="normal" title="Button"/>
@@ -320,7 +320,7 @@
                                 <viewLayoutGuide key="frameLayoutGuide" id="dN7-1y-zLI"/>
                             </scrollView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h1a-Rs-bAS" userLabel="Version Info">
-                                <rect key="frame" x="16" y="842.66666666666663" width="324" height="19.333333333333371"/>
+                                <rect key="frame" x="16" y="808.66666666666663" width="324" height="19.333333333333371"/>
                                 <fontDescription key="fontDescription" name="Avenir-Book" family="Avenir" pointSize="14"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="0.55000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -499,11 +499,11 @@
         <scene sceneID="mGj-Jk-jcM">
             <objects>
                 <viewController storyboardIdentifier="DeepLinkViewController" id="3ov-7B-9mY" customClass="DeepLinkViewController" customModule="APN_UIKit" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="V8X-sX-Mw7">
+                    <view key="view" contentMode="scaleToFill" ambiguous="YES" id="V8X-sX-Mw7">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iCN-CU-i7l">
+                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iCN-CU-i7l">
                                 <rect key="frame" x="0.0" y="269" width="414" height="358"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="You see this screen because you tapped on a push notification that had a deep link." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UTr-u2-NjR">
@@ -599,7 +599,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nfY-D4-qbH">
-                                <rect key="frame" x="0.0" y="88" width="414" height="808"/>
+                                <rect key="frame" x="0.0" y="142" width="414" height="754"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ohO-aG-PRY">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="1178.3333333333333"/>
@@ -642,7 +642,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZFn-ux-MwY" customClass="ThemeTextField" customModule="APN_UIKit" customModuleProvider="target">
-                                                                <rect key="frame" x="0.0" y="18" width="374" height="34"/>
+                                                                <rect key="frame" x="0.0" y="18.000000000000028" width="374" height="34"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                                 <connections>
@@ -652,7 +652,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="8N2-ZQ-F9M">
-                                                        <rect key="frame" x="0.0" y="128.66666666666666" width="374" height="76.666666666666657"/>
+                                                        <rect key="frame" x="0.0" y="128.66666666666669" width="374" height="76.666666666666686"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="region" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yw7-j8-WrG">
                                                                 <rect key="frame" x="0.0" y="0.0" width="374" height="34.333333333333336"/>
@@ -661,7 +661,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="OeP-jL-Kkb">
-                                                                <rect key="frame" x="0.0" y="42.333333333333343" width="374" height="34.333333333333343"/>
+                                                                <rect key="frame" x="0.0" y="42.333333333333314" width="374" height="34.333333333333343"/>
                                                                 <subviews>
                                                                     <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="STV-Qs-tNT" customClass="ThemeSelectedButton" customModule="APN_UIKit" customModuleProvider="target">
                                                                         <rect key="frame" x="0.0" y="0.0" width="182" height="34.333333333333336"/>
@@ -731,7 +731,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="mWe-HW-ZDc">
-                                                        <rect key="frame" x="0.0" y="358.66666666666669" width="374" height="76.666666666666686"/>
+                                                        <rect key="frame" x="0.0" y="358.66666666666663" width="374" height="76.666666666666686"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="trackApplicationLifecycleEvents" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0N9-h8-irs">
                                                                 <rect key="frame" x="0.0" y="0.0" width="374" height="34.333333333333336"/>
@@ -740,7 +740,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="xrD-tg-gFi">
-                                                                <rect key="frame" x="0.0" y="42.333333333333314" width="374" height="34.333333333333343"/>
+                                                                <rect key="frame" x="0.0" y="42.333333333333371" width="374" height="34.333333333333343"/>
                                                                 <subviews>
                                                                     <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KZO-iY-aAO" customClass="ThemeSelectedButton" customModule="APN_UIKit" customModuleProvider="target">
                                                                         <rect key="frame" x="0.0" y="0.0" width="182" height="34.333333333333336"/>
@@ -965,6 +965,8 @@
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DuB-VC-sfM" customClass="ThemeButton" customModule="APN_UIKit" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="0.0" width="374" height="34.333333333333336"/>
+                                                        <color key="backgroundColor" red="0.23529411759999999" green="0.26274509800000001" blue="0.49019607840000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                        <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="Restore Defaults"/>
                                                         <connections>
@@ -973,6 +975,8 @@
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cBa-8d-akP" customClass="ThemeButton" customModule="APN_UIKit" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="44.333333333333258" width="374" height="34.333333333333343"/>
+                                                        <color key="backgroundColor" red="0.23529411759999999" green="0.26274509800000001" blue="0.49019607840000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                        <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="Internal Settings"/>
                                                         <connections>
@@ -1085,10 +1089,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oRZ-dh-a9y">
-                                <rect key="frame" x="0.0" y="44" width="414" height="852"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="808"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6eC-nE-FMu">
-                                        <rect key="frame" x="21.666666666666657" y="0.0" width="370.66666666666674" height="852"/>
+                                        <rect key="frame" x="21.666666666666657" y="0.0" width="370.66666666666674" height="808"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="B0d-1D-KbW">
                                                 <rect key="frame" x="20" y="20" width="330.66666666666669" height="18"/>
@@ -1177,7 +1181,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Fyn-MJ-BIG">
-                                                <rect key="frame" x="20" y="787" width="330.66666666666669" height="17"/>
+                                                <rect key="frame" x="20" y="743" width="330.66666666666669" height="17"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Page rule name:" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tjb-1y-UiL">
                                                         <rect key="frame" x="0.0" y="0.0" width="163.33333333333334" height="17"/>

--- a/Apps/APN-UIKit/APN UIKit/View/Customisation/ThemeSelectedButton.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/Customisation/ThemeSelectedButton.swift
@@ -2,14 +2,8 @@ import UIKit
 
 class ThemeSelectedButton: UIButton {
     // Default colors
-    var defaultBackgroundColor = UIColor(red: 60.0 / 255, green: 67.0 / 255, blue: 125.0 / 255, alpha: 0.7)
-    var defaultTitleColor: UIColor = .white
-
-    // Selected colors
-    var selectedBackgroundColor = UIColor(red: 60.0 / 255, green: 67.0 / 255, blue: 125.0 / 255, alpha: 1.0)
-
-    // Highlight color
-    var highlightTitleColor: UIColor = .white.withAlphaComponent(0.7)
+    private static var primaryColor = UIColor(red: 60.0 / 255, green: 67.0 / 255, blue: 125.0 / 255, alpha: 1.0)
+    private static var primaryTextColor: UIColor = .white
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -21,28 +15,88 @@ class ThemeSelectedButton: UIButton {
         setup()
     }
 
-    func setup() {
-        layer.cornerRadius = 5
-        frame.size.height = 50
+    private func setup() {
+        // Modern styling
+        layer.cornerRadius = 12
+        clipsToBounds = false
 
-        // Added to prevent automatic tinging for selected state
-        tintColor = .clear
+        // Beautiful shadow
+        applyShadow()
 
-        // Configure colors for all states
-        setTitleColor(defaultTitleColor, for: .normal)
-        setTitleColor(defaultTitleColor, for: .selected)
-        setTitleColor(highlightTitleColor, for: .highlighted)
-        setTitleColor(highlightTitleColor, for: [.highlighted, .selected])
+        // Typography
+        titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
+        titleLabel?.textAlignment = .center
 
-        // Set background color for normal state
-        backgroundColor = defaultBackgroundColor
+        // Configure initial appearance
+        configureAppearance(
+            backgroundColor: Self.primaryColor.withAlphaComponent(0.1),
+            titleColor: Self.primaryColor,
+            borderColor: Self.primaryColor.withAlphaComponent(0.3)
+        )
+
+        // Add touch animations
+        addTarget(self, action: #selector(touchDown), for: .touchDown)
+        addTarget(self, action: #selector(touchUp), for: [.touchUpInside, .touchUpOutside, .touchCancel])
+    }
+
+    private func configureAppearance(backgroundColor: UIColor, titleColor: UIColor, borderColor: UIColor) {
+        self.backgroundColor = backgroundColor
+        setTitleColor(titleColor, for: .normal)
+        layer.borderWidth = 1.5
+        layer.borderColor = borderColor.cgColor
     }
 
     override var isSelected: Bool {
         didSet {
-            backgroundColor = isSelected ? selectedBackgroundColor : defaultBackgroundColor
-            setBackgroundImage(nil, for: .normal)
-            setBackgroundImage(nil, for: .selected)
+            updateAppearance()
+        }
+    }
+
+    private func updateAppearance() {
+        UIView.animate(withDuration: 0.2, delay: 0, options: [.curveEaseInOut], animations: {
+            if self.isSelected {
+                self.backgroundColor = Self.primaryColor
+                self.layer.borderColor = Self.primaryColor.cgColor
+                self.transform = CGAffineTransform(scaleX: 0.98, y: 0.98)
+            } else {
+                self.backgroundColor = Self.primaryColor.withAlphaComponent(0.1)
+                self.layer.borderColor = Self.primaryColor.withAlphaComponent(0.3).cgColor
+                self.transform = .identity
+            }
+        }) { _ in
+            self.setTitleColors(self.isSelected ? Self.primaryTextColor : Self.primaryColor)
+        }
+    }
+
+    private func setTitleColors(_ color: UIColor) {
+        setTitleColor(color, for: .normal)
+        setTitleColor(color, for: .selected)
+        setTitleColor(color, for: .highlighted)
+        tintColor = color
+    }
+
+    private func applyShadow() {
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOffset = CGSize(width: 0, height: 2)
+        layer.shadowRadius = 8
+        layer.shadowOpacity = 0.15
+    }
+
+    @objc private func touchDown() {
+        UIView.animate(withDuration: 0.1) {
+            self.transform = CGAffineTransform(scaleX: 0.95, y: 0.95)
+            self.alpha = 0.8
+        }
+    }
+
+    @objc private func touchUp() {
+        UIView.animate(withDuration: 0.1) {
+            if self.isSelected {
+                self.transform = CGAffineTransform(scaleX: 0.98, y: 0.98)
+            } else {
+                self.transform = .identity
+            }
+            self.alpha = 1.0
         }
     }
 }


### PR DESCRIPTION
### Summary

Received feedback from support team about Settings screen buttons in APN sample app were hard to read due to color mismatches. The issue was reproducible and confirmed during testing.

### Changes

- Updated `ThemeSelectedButton` styles to ensure text is clearly readable against the button background
- Adjusted button colors in Settings screen to match rest of the app's design

### Screenshots

#### Before

<img width="1170" height="2532" alt="Screenshot 2025-09-22 at 7 55 29 PM" src="https://github.com/user-attachments/assets/42a31744-f277-4670-b019-72a2f7f73e4d" />

#### After

<img width="1170" height="2532" alt="Screenshot 2025-09-22 at 7 56 10 PM" src="https://github.com/user-attachments/assets/ee9980ca-ca4a-4b50-994d-f9b54128fbde" />