### PR TITLE
chore: Use CioFirebaseWrapper published version

### DIFF
--- a/Apps/CocoaPods-FCM/Podfile
+++ b/Apps/CocoaPods-FCM/Podfile
@@ -16,8 +16,7 @@ target 'test cocoapods' do
   pod 'CustomerIOMessagingPushAPN', :path => sdk_local_path
   pod 'CustomerIOTrackingMigration', :path => sdk_local_path
 
-  # Add customerio-ios-fcm wrapper from GitHub
-  pod 'CioFirebaseWrapper', :git => 'https://github.com/customerio/customerio-ios-fcm.git', :branch => 'fix-min-deployment'
+  pod 'CioFirebaseWrapper', '~> 1.0.0'
 
   # The "CustomerIOMessagingPushFCM" SDK installs the FCM SDK for you, defaulting to the latest version. 
   # If your app needs to use a specific version of the FCM SDK, you can add the line below to your app's Podfile 


### PR DESCRIPTION
Use CioFirebaseWrapper published version for Cocopods FCM app

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `CioFirebaseWrapper` dependency from Git source to the published CocoaPods version `~> 1.0.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd08fe9520696aa7e873f47f47065e3afb885b1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->