### PR TITLE
chore: Detect SSE flag and switch between polling and SSE connection

### DIFF
--- a/Sources/MessagingInApp/Gist/Network/SSE/SseConnectionManager.swift
+++ b/Sources/MessagingInApp/Gist/Network/SSE/SseConnectionManager.swift
@@ -1,0 +1,43 @@
+import CioInternalCommon
+import Foundation
+
+// sourcery: InjectRegisterShared = "SseConnectionManager"
+// sourcery: InjectSingleton
+/// Manages SSE (Server-Sent Events) connections for real-time in-app message delivery.
+/// This class handles connection lifecycle, event parsing, heartbeat monitoring, and automatic reconnection.
+actor SseConnectionManager {
+    private let logger: Logger
+    private let inAppMessageManager: InAppMessageManager
+
+    init(
+        logger: Logger,
+        inAppMessageManager: InAppMessageManager
+    ) {
+        self.logger = logger
+        self.inAppMessageManager = inAppMessageManager
+        logger.logWithModuleTag("SseConnectionManager initialized", level: .debug)
+    }
+
+    /// Starts an SSE connection to the queue consumer API.
+    /// This method is idempotent - calling it multiple times while connected is safe.
+    func startConnection(state: InAppMessageState) {
+        logger.logWithModuleTag("SSE startConnection called", level: .info)
+
+        logger.logWithModuleTag("  - useSse: \(state.useSse)", level: .debug)
+        logger.logWithModuleTag("  - userId: \(state.userId ?? "nil")", level: .debug)
+        logger.logWithModuleTag("  - anonymousId: \(state.anonymousId ?? "nil")", level: .debug)
+        logger.logWithModuleTag("  - environment: \(state.environment)", level: .debug)
+
+        // TODO: Phase 2 - Implement actual SSE connection logic
+        logger.logWithModuleTag("SSE connection logic not yet implemented (Phase 2)", level: .debug)
+    }
+
+    /// Stops the active SSE connection.
+    /// This method is idempotent - calling it multiple times is safe.
+    func stopConnection() {
+        logger.logWithModuleTag("SSE stopConnection called", level: .info)
+
+        // TODO: Phase 2 - Implement connection cleanup logic
+        logger.logWithModuleTag("SSE cleanup logic not yet implemented (Phase 2)", level: .debug)
+    }
+}

--- a/Sources/MessagingInApp/State/InAppMessageAction.swift
+++ b/Sources/MessagingInApp/State/InAppMessageAction.swift
@@ -5,6 +5,7 @@ import Foundation
 enum InAppMessageAction: Equatable {
     case initialize(siteId: String, dataCenter: String, environment: GistEnvironment)
     case setPollingInterval(interval: Double)
+    case setSseEnabled(enabled: Bool)
     case setUserIdentifier(user: String)
     case setAnonymousIdentifier(anonymousId: String)
     case setPageRoute(route: String)
@@ -33,6 +34,9 @@ enum InAppMessageAction: Equatable {
 
         case (.setPollingInterval(let lhsInterval), .setPollingInterval(let rhsInterval)):
             return lhsInterval == rhsInterval
+
+        case (.setSseEnabled(let lhsEnabled), .setSseEnabled(let rhsEnabled)):
+            return lhsEnabled == rhsEnabled
 
         case (.setUserIdentifier(let lhsUser), .setUserIdentifier(let rhsUser)):
             return lhsUser == rhsUser

--- a/Sources/MessagingInApp/State/InAppMessageReducer.swift
+++ b/Sources/MessagingInApp/State/InAppMessageReducer.swift
@@ -32,6 +32,9 @@ private func reducer(action: InAppMessageAction, state: InAppMessageState) -> In
     case .setPollingInterval(let interval):
         return state.copy(pollInterval: interval)
 
+    case .setSseEnabled(let enabled):
+        return state.copy(useSse: enabled)
+
     case .setUserIdentifier(let user):
         return state.copy(userId: user)
 

--- a/Sources/MessagingInApp/State/InAppMessageState.swift
+++ b/Sources/MessagingInApp/State/InAppMessageState.swift
@@ -12,6 +12,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
     let userId: String?
     let anonymousId: String?
     let currentRoute: String?
+    let useSse: Bool
     let modalMessageState: ModalMessageState
     let embeddedMessagesState: EmbeddedMessagesState
     let messagesInQueue: Set<Message>
@@ -25,6 +26,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
         userId: String? = nil,
         anonymousId: String? = nil,
         currentRoute: String? = nil,
+        useSse: Bool = false,
         modalMessageState: ModalMessageState = .initial,
         embeddedMessagesState: EmbeddedMessagesState = EmbeddedMessagesState(),
         messagesInQueue: Set<Message> = [],
@@ -37,6 +39,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
         self.userId = userId
         self.anonymousId = anonymousId
         self.currentRoute = currentRoute
+        self.useSse = useSse
         self.modalMessageState = modalMessageState
         self.embeddedMessagesState = embeddedMessagesState
         self.messagesInQueue = messagesInQueue
@@ -50,6 +53,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
         userId: String? = nil,
         anonymousId: String? = nil,
         currentRoute: String? = nil,
+        useSse: Bool? = nil,
         modalMessageState: ModalMessageState? = nil,
         embeddedMessagesState: EmbeddedMessagesState? = nil,
         messagesInQueue: Set<Message>? = nil,
@@ -63,6 +67,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
             userId: userId ?? self.userId,
             anonymousId: anonymousId ?? self.anonymousId,
             currentRoute: currentRoute ?? self.currentRoute,
+            useSse: useSse ?? self.useSse,
             modalMessageState: modalMessageState ?? self.modalMessageState,
             embeddedMessagesState: embeddedMessagesState ?? self.embeddedMessagesState,
             messagesInQueue: messagesInQueue ?? self.messagesInQueue,
@@ -78,6 +83,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
             lhs.userId == rhs.userId &&
             lhs.anonymousId == rhs.anonymousId &&
             lhs.currentRoute == rhs.currentRoute &&
+            lhs.useSse == rhs.useSse &&
             lhs.modalMessageState == rhs.modalMessageState &&
             lhs.messagesInQueue == rhs.messagesInQueue &&
             lhs.shownMessageQueueIds == rhs.shownMessageQueueIds
@@ -93,6 +99,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
             userId: \(String(describing: userId)),
             anonymousId: \(String(describing: anonymousId)),
             currentRoute: \(String(describing: currentRoute)),
+            useSse: \(String(describing: useSse)),
             modalMessageState: \(modalMessageState),
             embeddedMessagesState: \(embeddedMessagesState),
             messagesInQueue: \(messagesInQueue.map(\.describeForLogs)),
@@ -124,6 +131,7 @@ extension InAppMessageState {
         putIfDifferent(\.userId, as: "userId")
         putIfDifferent(\.anonymousId, as: "anonymousId")
         putIfDifferent(\.currentRoute, as: "currentRoute")
+        putIfDifferent(\.useSse, as: "useSse")
         putIfDifferent(\.modalMessageState, as: "currentMessageState")
         putIfDifferent(\.embeddedMessagesState, as: "embeddedMessagesState")
         putIfDifferent(\.messagesInQueue, as: "messagesInQueue")

--- a/Tests/MessagingInApp/Core/IntegrationTest.swift
+++ b/Tests/MessagingInApp/Core/IntegrationTest.swift
@@ -27,8 +27,12 @@ open class IntegrationTest: UnitTest {
     }
 
     func setupHttpResponse(code: Int, body: Data) {
+        setupHttpResponse(code: code, body: body, headers: nil)
+    }
+
+    func setupHttpResponse(code: Int, body: Data, headers: [String: String]?) {
         gistQueueNetworkMock.requestClosure = { _, _, completionHandler in
-            let response = HTTPURLResponse(url: URL(string: "https://test.com")!, statusCode: code, httpVersion: nil, headerFields: nil)!
+            let response = HTTPURLResponse(url: URL(string: "https://test.com")!, statusCode: code, httpVersion: nil, headerFields: headers)!
 
             completionHandler(.success((body, response)))
         }


### PR DESCRIPTION
Closes: [MBL-1443](https://linear.app/customerio/issue/MBL-1443/switch-to-sse-if-enabled-for-workspace)

The implementation is split into multiple parts:
- Switch to SSE from polling if enabled -> This PR
- Basic SSE connection -> Future PR
- SEE heartbeat handling -> Future PR
- SEE retry logic -> Future PR
- SSE respecting app lifecycle -> Future PR

This PR parses the headers from queue consumer API call that instructs client to enable/disable SSE to fetch in-app messages.
- If SSE is enabled, it starts the SSE connection and disables polling
- If SSE is disabled, it stops SSE connection and enables polling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Detects SSE enablement via response header and toggles between polling and a new SSE connection manager, adding `useSse` state and wiring throughout.
> 
> - **Core behavior**:
>   - Parse `x-cio-use-sse` response header in `QueueManager.updateSseFlag` to set `InAppMessageState.useSse` via new action `setSseEnabled`.
>   - `Gist` subscribes to `state.useSse` and switches between polling and SSE: invalidates polling timer when `true`, starts `SseConnectionManager`; stops SSE and resumes polling when `false`.
> - **State management**:
>   - Add `useSse` to `InAppMessageState` (init, copy, equality, diff, description).
>   - Add `InAppMessageAction.setSseEnabled` and handle in reducer.
> - **SSE infrastructure**:
>   - New `SseConnectionManager` actor (stubbed `startConnection`/`stopConnection`) and inject into `Gist`.
> - **Dependency Injection**:
>   - Update DI graph to provide `SseConnectionManager` and pass into `Gist`.
> - **Tests**:
>   - Extend `IntegrationTest.setupHttpResponse` to accept headers.
>   - Add tests for SSE flag state transitions and header detection; verify polling/SSE coordination in `InAppMessageStateTests`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80d41efc944c205e5e9d18ffb5fc5a843fcbffec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->