### PR TITLE
chore: Implement SSE connection

### DIFF
--- a/CustomerIOMessagingInApp.podspec
+++ b/CustomerIOMessagingInApp.podspec
@@ -26,4 +26,5 @@ Pod::Spec.new do |spec|
   spec.module_name = "CioMessagingInApp"  # the `import X` name when using SDK in Swift files
   
   spec.dependency "CustomerIOCommon", "= #{spec.version.to_s}"
+  spec.dependency "LDSwiftEventSource", "~> 3.3"
  end

--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,10 @@ let package = Package(
         
 
         // Make sure the version number is same for DataPipelines cocoapods.
-        .package(name: "CioAnalytics", url: "https://github.com/customerio/cdp-analytics-swift.git", .exact("1.7.3+cio.1"))
+        .package(name: "CioAnalytics", url: "https://github.com/customerio/cdp-analytics-swift.git", .exact("1.7.3+cio.1")),
+        
+        // SSE (Server-Sent Events) client for real-time in-app messaging
+        .package(url: "https://github.com/LaunchDarkly/swift-eventsource.git", .upToNextMajor(from: "3.3.0"))
     ],
     targets: [ 
         // Common - Code used by multiple modules in the SDK project.
@@ -113,7 +116,10 @@ let package = Package(
 
         // Messaging in-app
         .target(name: "CioMessagingInApp",
-                dependencies: ["CioInternalCommon"],
+                dependencies: [
+                    "CioInternalCommon",
+                    .product(name: "LDSwiftEventSource", package: "swift-eventsource")
+                ],
                 path: "Sources/MessagingInApp",
                 resources: [
                     .process("Resources/PrivacyInfo.xcprivacy"),

--- a/Sources/MessagingInApp/Gist/Network/NetworkSettings.swift
+++ b/Sources/MessagingInApp/Gist/Network/NetworkSettings.swift
@@ -2,22 +2,26 @@ protocol NetworkSettings {
     var queueAPI: String { get }
     var engineAPI: String { get }
     var renderer: String { get }
+    var sseAPI: String { get }
 }
 
 struct NetworkSettingsProduction: NetworkSettings {
     let queueAPI = "https://consumer.inapp.customer.io"
     let engineAPI = "https://engine.api.gist.build"
     let renderer = "https://renderer.gist.build/3.0"
+    let sseAPI = "https://realtime.inapp.customer.io/api/v3/sse"
 }
 
 struct NetworkSettingsDevelopment: NetworkSettings {
     let queueAPI = "https://consumer.dev.inapp.customer.io"
     let engineAPI = "https://engine.api.dev.gist.build"
     let renderer = "https://renderer.gist.build/3.0"
+    let sseAPI = "https://realtime.inapp.customer.io/api/v3/sse"
 }
 
 struct NetworkSettingsLocal: NetworkSettings {
     let queueAPI = "http://queue.api.local.gist.build:86"
     let engineAPI = "http://engine.api.local.gist.build:82"
     let renderer = "http://app.local.gist.build:8080/web"
+    let sseAPI = "http://realtime.api.local.gist.build:86/api/v3/sse"
 }

--- a/Sources/MessagingInApp/Gist/Network/SSE/AsyncStreamBackport.swift
+++ b/Sources/MessagingInApp/Gist/Network/SSE/AsyncStreamBackport.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Backport of `AsyncStream.makeStream()` for iOS 13+.
+///
+/// `AsyncStream.makeStream()` was introduced in iOS 17 and provides a way to create
+/// an AsyncStream and access its continuation separately. This is useful when you need
+/// to set up resources that require the continuation before returning the stream.
+///
+/// This backport provides the same functionality for older iOS versions.
+enum AsyncStreamBackport {
+    /// Creates an AsyncStream and returns both the stream and its continuation separately.
+    ///
+    /// This allows setup code to access the continuation before the stream is consumed,
+    /// enabling synchronous setup patterns that avoid race conditions.
+    ///
+    /// Example:
+    /// ```swift
+    /// func connect() -> AsyncStream<Event> {
+    ///     let (stream, continuation) = AsyncStreamBackport.makeStream(of: Event.self)
+    ///
+    ///     // Use continuation immediately for setup
+    ///     let handler = EventHandler(continuation: continuation)
+    ///     self.connection = Connection(handler: handler)
+    ///     self.connection.start()
+    ///
+    ///     return stream
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - elementType: The type of elements in the stream.
+    ///   - bufferingPolicy: The buffering policy for the stream. Defaults to `.unbounded`.
+    /// - Returns: A tuple containing the stream and its continuation.
+    static func makeStream<Element>(
+        of elementType: Element.Type = Element.self,
+        bufferingPolicy: AsyncStream<Element>.Continuation.BufferingPolicy = .unbounded
+    ) -> (stream: AsyncStream<Element>, continuation: AsyncStream<Element>.Continuation) {
+        // Capture the continuation from the closure using an optional variable
+        var continuation: AsyncStream<Element>.Continuation?
+
+        let stream = AsyncStream<Element>(bufferingPolicy: bufferingPolicy) { cont in
+            // This closure is called synchronously during AsyncStream initialization
+            continuation = cont
+        }
+
+        // By the time AsyncStream's init returns, the closure has executed
+        // and continuation is guaranteed to be set
+        guard let continuation = continuation else {
+            // This should never happen - the closure is called synchronously
+            fatalError("AsyncStream continuation was not set during initialization")
+        }
+
+        return (stream, continuation)
+    }
+}

--- a/Sources/MessagingInApp/Gist/Network/SSE/SseConnectionManager.swift
+++ b/Sources/MessagingInApp/Gist/Network/SSE/SseConnectionManager.swift
@@ -4,40 +4,192 @@ import Foundation
 // sourcery: InjectRegisterShared = "SseConnectionManager"
 // sourcery: InjectSingleton
 /// Manages SSE (Server-Sent Events) connections for real-time in-app message delivery.
-/// This class handles connection lifecycle, event parsing, heartbeat monitoring, and automatic reconnection.
+/// Phase 2: Basic connection and event logging only.
+/// Translates service events into connection state.
 actor SseConnectionManager {
     private let logger: Logger
     private let inAppMessageManager: InAppMessageManager
+    private let sseService: SseService
+    private var connectionState: SseConnectionState = .disconnected
+    private var streamTask: Task<Void, Never>?
 
     init(
         logger: Logger,
-        inAppMessageManager: InAppMessageManager
+        inAppMessageManager: InAppMessageManager,
+        sseService: SseService
     ) {
         self.logger = logger
         self.inAppMessageManager = inAppMessageManager
+        self.sseService = sseService
         logger.logWithModuleTag("SseConnectionManager initialized", level: .debug)
     }
 
     /// Starts an SSE connection to the queue consumer API.
-    /// This method is idempotent - calling it multiple times while connected is safe.
-    func startConnection(state: InAppMessageState) {
-        logger.logWithModuleTag("SSE startConnection called", level: .info)
+    /// This method is idempotent - calling it multiple times while connected/connecting is safe.
+    func startConnection(state: InAppMessageState) async {
+        logger.logWithModuleTag("SSE Manager: startConnection called", level: .info)
+        logger.logWithModuleTag("SSE Manager: useSse=\(state.useSse), userId=\(state.userId ?? "nil"), anonymousId=\(state.anonymousId ?? "nil")", level: .debug)
 
-        logger.logWithModuleTag("  - useSse: \(state.useSse)", level: .debug)
-        logger.logWithModuleTag("  - userId: \(state.userId ?? "nil")", level: .debug)
-        logger.logWithModuleTag("  - anonymousId: \(state.anonymousId ?? "nil")", level: .debug)
-        logger.logWithModuleTag("  - environment: \(state.environment)", level: .debug)
+        if connectionState == .connecting || connectionState == .connected {
+            logger.logWithModuleTag("SSE Manager: Connection is connected or connecting, ignoring", level: .debug)
+            return
+        }
 
-        // TODO: Phase 2 - Implement actual SSE connection logic
-        logger.logWithModuleTag("SSE connection logic not yet implemented (Phase 2)", level: .debug)
+        // Validate user identifier before updating state (matching Android's establishConnection pattern)
+        // This prevents getting stuck in .connecting state if validation fails
+        let userIdentifier = state.userId ?? state.anonymousId
+        guard let userIdentifier = userIdentifier, !userIdentifier.isEmpty else {
+            logger.logWithModuleTag("SSE Manager: Cannot establish connection: no user token available", level: .error)
+            // This is a configuration issue, not a network issue - update state to disconnected like Android
+            handleConnectionFailed(SseError(message: "Cannot establish connection: no user token available"))
+            return
+        }
+
+        streamTask?.cancel()
+
+        // Build connection parameters (matching Android's establishConnection pattern)
+        // Use shared session ID that persists for app lifetime (same as polling API uses)
+        let sessionId = SessionManager.shared.sessionId
+        let userToken = Data(userIdentifier.utf8).base64EncodedString()
+        let connectionParams = SseConnectionParams(
+            sseApiUrl: state.environment.networkSettings.sseAPI,
+            sessionId: sessionId,
+            userToken: userToken,
+            siteId: state.siteId,
+            dataCenter: state.dataCenter,
+            isAnonymous: state.userId == nil
+        )
+
+        logger.logWithModuleTag("SSE Manager: Establishing connection for userToken=\(userIdentifier), sessionId=\(sessionId)", level: .debug)
+
+        updateConnectionState(.connecting)
+        streamTask = Task { [weak self] in
+            guard let self = self else { return }
+
+            let eventStream = await self.sseService.connect(params: connectionParams)
+            for await event in eventStream {
+                await self.handleEvent(event)
+            }
+
+            // Stream ended - only cleanup if not cancelled
+            // If cancelled, the canceller (stopConnection or new startConnection) handles cleanup
+            guard !Task.isCancelled else { return }
+            await self.clearStreamTask()
+            logger.logWithModuleTag("SSE Manager: Event stream ended normally", level: .info)
+        }
     }
 
     /// Stops the active SSE connection.
     /// This method is idempotent - calling it multiple times is safe.
-    func stopConnection() {
-        logger.logWithModuleTag("SSE stopConnection called", level: .info)
+    func stopConnection() async {
+        logger.logWithModuleTag("SSE Manager: stopConnection called", level: .info)
 
-        // TODO: Phase 2 - Implement connection cleanup logic
-        logger.logWithModuleTag("SSE cleanup logic not yet implemented (Phase 2)", level: .debug)
+        streamTask?.cancel()
+        streamTask = nil
+
+        await sseService.disconnect()
+
+        updateConnectionState(.disconnected)
+
+        logger.logWithModuleTag("SSE Manager: Connection stopped", level: .info)
+    }
+
+    // MARK: - Private Handlers
+
+    /// Handles SSE events matching Android's sealed interface pattern
+    private func handleEvent(_ event: SseEvent) {
+        switch event {
+        case .connectionOpen:
+            handleConnectionOpen()
+
+        case .serverEvent(let serverEvent):
+            handleServerEvent(serverEvent)
+
+        case .connectionFailed(let error):
+            handleConnectionFailed(error)
+
+        case .connectionClosed:
+            handleConnectionClosed()
+        }
+    }
+
+    private func clearStreamTask() {
+        streamTask = nil
+    }
+
+    // MARK: - Connection Lifecycle Handlers
+
+    private func handleConnectionOpen() {
+        logger.logWithModuleTag("SSE Manager: ✓ Connection opened", level: .info)
+        updateConnectionState(.connected)
+    }
+
+    private func handleConnectionClosed() {
+        logger.logWithModuleTag("SSE Manager: Connection closed", level: .info)
+        updateConnectionState(.disconnected)
+    }
+
+    private func handleConnectionFailed(_ error: SseError) {
+        logger.logWithModuleTag("SSE Manager: ✗ Connection error: \(error.message)", level: .error)
+        // Reset state to disconnected so future connection attempts can proceed
+        // Retry logic will be handled in a future change
+        updateConnectionState(.disconnected)
+    }
+
+    // MARK: - Server Event Handlers
+
+    private func handleServerEvent(_ event: ServerEvent) {
+        logger.logWithModuleTag("SSE Manager: ← Server event '\(event.eventType)'", level: .info)
+        logger.logWithModuleTag("SSE Manager: Event data: \(event.data.prefix(100))", level: .debug)
+
+        switch event.eventType {
+        case .connected:
+            logger.logWithModuleTag("SSE Manager: ✓ Server acknowledged connection", level: .info)
+            updateConnectionState(.connected)
+
+        case .heartbeat:
+            logger.logWithModuleTag("SSE Manager: ♥ Heartbeat received", level: .debug)
+
+        case .messages:
+            handleMessagesEvent(event)
+
+        case .ttlExceeded:
+            logger.logWithModuleTag("SSE Manager: TTL exceeded, connection will be refreshed", level: .info)
+
+        case .unknown:
+            logger.logWithModuleTag("SSE Manager: Unknown server event type '\(event.rawEventType ?? "nil")', ignoring", level: .debug)
+        }
+    }
+
+    private func handleMessagesEvent(_ event: ServerEvent) {
+        logger.logWithModuleTag("SSE Manager: Message event received", level: .info)
+
+        // Messages are already parsed by ServerEvent
+        guard let messages = event.messages, !messages.isEmpty else {
+            logger.logWithModuleTag("SSE Manager: No messages in event or failed to parse", level: .debug)
+            return
+        }
+
+        logger.logWithModuleTag("SSE Manager: ✓ Received \(messages.count) message(s) from SSE", level: .info)
+
+        // Dispatch to message queue processor (same as polling does)
+        inAppMessageManager.dispatch(action: .processMessageQueue(messages: messages))
+    }
+
+    private func updateConnectionState(_ newState: SseConnectionState) {
+        guard newState != connectionState else { return }
+
+        let oldState = connectionState.description
+        logger.logWithModuleTag("SSE Manager: State transition: \(oldState) → \(newState.description)", level: .info)
+        connectionState = newState
+
+        switch newState {
+        case .disconnected:
+            logger.logWithModuleTag("SSE Manager: Connection is now closed", level: .info)
+        case .connecting:
+            logger.logWithModuleTag("SSE Manager: Connection initiated, waiting for response", level: .info)
+        case .connected:
+            logger.logWithModuleTag("SSE Manager: ✓ Connection established, listening for events", level: .info)
+        }
     }
 }

--- a/Sources/MessagingInApp/Gist/Network/SSE/SseConnectionState.swift
+++ b/Sources/MessagingInApp/Gist/Network/SSE/SseConnectionState.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Represents the current state of the SSE connection
+enum SseConnectionState: Equatable {
+    case disconnected
+    case connecting
+    case connected
+
+    var description: String {
+        switch self {
+        case .disconnected:
+            return "disconnected"
+        case .connecting:
+            return "connecting"
+        case .connected:
+            return "connected"
+        }
+    }
+}

--- a/Sources/MessagingInApp/Gist/Network/SSE/SseEventParser.swift
+++ b/Sources/MessagingInApp/Gist/Network/SSE/SseEventParser.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+// MARK: - SSE Event (matches Android's sealed interface)
+
+/// Represents an SSE event from the server connection.
+/// Aligns with Android's `SseEvent` sealed interface.
+enum SseEvent: Equatable {
+    /// Connection opened event (emitted by library's onOpen callback).
+    /// Corresponds to Android's `ConnectionOpenEvent`.
+    case connectionOpen
+
+    /// Server event with type and data.
+    /// Corresponds to Android's `ServerEvent`.
+    case serverEvent(ServerEvent)
+
+    /// Connection failed event with error details.
+    /// Corresponds to Android's `ConnectionFailedEvent`.
+    case connectionFailed(SseError)
+
+    /// Connection closed event (emitted by library's onClosed callback).
+    /// Corresponds to Android's `ConnectionClosedEvent`.
+    case connectionClosed
+}
+
+// MARK: - Server Event
+
+/// Represents a server event with type and data.
+/// Corresponds to Android's `ServerEvent` data class.
+struct ServerEvent: Equatable {
+    /// Server event types (matches Android's ServerEvent companion object constants)
+    enum EventType: String, Equatable, CustomStringConvertible {
+        case connected
+        case heartbeat
+        case messages
+        case ttlExceeded = "ttl_exceeded"
+        case unknown
+
+        var description: String { rawValue }
+
+        init(rawValue: String) {
+            switch rawValue {
+            case "connected": self = .connected
+            case "heartbeat": self = .heartbeat
+            case "messages", "": self = .messages // Empty/nil defaults to messages per SSE spec
+            case "ttl_exceeded": self = .ttlExceeded
+            default: self = .unknown
+            }
+        }
+    }
+
+    let eventType: EventType
+    let data: String
+    let id: String? // Event ID for Last-Event-ID tracking
+
+    /// Parsed messages (only populated for message events)
+    let messages: [Message]?
+
+    /// Raw event type string (preserved for logging unknown types)
+    let rawEventType: String?
+
+    /// Creates a ServerEvent from raw SSE fields
+    /// Parsing is resilient - malformed data results in nil messages, not errors
+    init(id: String?, type: String?, data: String) {
+        self.id = id
+        self.rawEventType = type
+        self.eventType = EventType(rawValue: type ?? "")
+        self.data = data
+        self.messages = Self.parseMessages(eventType: eventType, data: data)
+    }
+
+    /// Parses message data from SSE event into Message objects (same as polling does)
+    /// This method is resilient - it returns nil for any parsing failure without throwing
+    /// Note: No logging here since this is called from background thread; caller handles logging
+    private static func parseMessages(eventType: EventType, data: String) -> [Message]? {
+        // Only parse messages for message events
+        guard eventType == .messages else { return nil }
+
+        // Empty data is valid (no messages)
+        guard !data.isEmpty else { return nil }
+
+        // Convert to UTF8 data
+        guard let jsonData = data.data(using: .utf8) else { return nil }
+
+        do {
+            // Parse JSON - expect array of dictionaries (same format as polling API)
+            let jsonObject = try JSONSerialization.jsonObject(with: jsonData, options: .allowFragments)
+
+            guard let messageArray = jsonObject as? [[String: Any?]] else { return nil }
+
+            // Convert dictionaries to UserQueueResponse, then to Message
+            // compactMap ensures invalid items are skipped without failing the whole batch
+            let userQueueResponses = messageArray.compactMap { UserQueueResponse(dictionary: $0) }
+            let messages = userQueueResponses.map { $0.toMessage() }
+
+            return messages.isEmpty ? nil : messages
+        } catch {
+            return nil
+        }
+    }
+}
+
+// MARK: - SSE Error
+
+/// Represents errors that occur during SSE connection or communication.
+/// Corresponds to Android's `SseError`.
+struct SseError: Equatable, Error {
+    let message: String
+    let underlyingError: Error?
+
+    init(message: String, underlyingError: Error? = nil) {
+        self.message = message
+        self.underlyingError = underlyingError
+    }
+
+    static func == (lhs: SseError, rhs: SseError) -> Bool {
+        lhs.message == rhs.message
+    }
+}

--- a/Sources/MessagingInApp/Gist/Network/SSE/SseService.swift
+++ b/Sources/MessagingInApp/Gist/Network/SSE/SseService.swift
@@ -1,0 +1,183 @@
+import CioInternalCommon
+import Foundation
+import LDSwiftEventSource
+
+/// Parameters required to establish an SSE connection.
+/// Matches Android's connectSse() parameters with additional header info.
+struct SseConnectionParams {
+    let sseApiUrl: String
+    let sessionId: String
+    let userToken: String // Base64 encoded user identifier
+    let siteId: String
+    let dataCenter: String
+    let isAnonymous: Bool
+}
+
+// sourcery: InjectRegisterShared = "SseService"
+// sourcery: InjectSingleton
+/// SSE service layer that wraps LDSwiftEventSource library and provides AsyncStream interface
+/// Responsibilities:
+/// - Build SSE URLs from connection parameters
+/// - Wrap library callbacks as AsyncStream
+/// - Provide clean async/await interface to SseConnectionManager
+actor SseService {
+    private let logger: Logger
+    private var eventSource: LDSwiftEventSource.EventSource?
+
+    init(logger: Logger) {
+        self.logger = logger
+        logger.logWithModuleTag("SseService initialized", level: .debug)
+    }
+
+    // MARK: - Public API
+
+    /// Starts SSE connection using validated connection parameters.
+    /// Returns AsyncStream of events for the caller to iterate over.
+    /// - Parameter params: Pre-validated connection parameters from SseConnectionManager
+    /// - Returns: AsyncStream of SSE events
+    /// - Note: Caller (SseConnectionManager) validates and builds params before calling this method
+    func connect(params: SseConnectionParams) -> AsyncStream<SseEvent> {
+        logger.logWithModuleTag("SseService: Initiating connection", level: .info)
+
+        // Build SSE URL from params
+        guard let url = buildSseUrl(params: params) else {
+            logger.logWithModuleTag("SseService: Failed to build connection URL", level: .error)
+            // Emit connectionFailed event so manager can reset state properly
+            return AsyncStream { continuation in
+                let error = SseError(message: "Failed to build SSE connection URL")
+                continuation.yield(.connectionFailed(error))
+                continuation.finish()
+            }
+        }
+
+        logger.logWithModuleTag("SseService: Connecting to \(url.absoluteString)", level: .info)
+
+        // Create stream and continuation separately to avoid race conditions
+        // (Using backport for iOS 13+ compatibility; native makeStream() requires iOS 17+)
+        let (stream, continuation) = AsyncStreamBackport.makeStream(of: SseEvent.self)
+
+        // Create event handler with continuation
+        let handler = StreamEventHandler(continuation: continuation, logger: logger)
+
+        // Configure EventSource
+        let headers = buildHeaders(params: params)
+        var config = LDSwiftEventSource.EventSource.Config(handler: handler, url: url)
+        config.headers = headers
+        config.idleTimeout = 300.0 // 5 minutes read timeout
+
+        // Disable automatic retry - we'll handle reconnection logic ourselves
+        config.connectionErrorHandler = { _ in .shutdown }
+
+        // Create EventSource and store reference synchronously (no race condition)
+        let newEventSource = LDSwiftEventSource.EventSource(config: config)
+        eventSource = newEventSource
+
+        // Start connection
+        newEventSource.start()
+        logger.logWithModuleTag("SseService: EventSource started", level: .debug)
+
+        // Handle stream termination (called when consumer stops iterating or Task is cancelled)
+        continuation.onTermination = { [weak newEventSource] _ in
+            newEventSource?.stop()
+        }
+
+        return stream
+    }
+
+    /// Stops the SSE connection
+    func disconnect() {
+        logger.logWithModuleTag("SseService: Disconnecting", level: .info)
+
+        eventSource?.stop()
+        eventSource = nil
+
+        logger.logWithModuleTag("SseService: Disconnected", level: .debug)
+    }
+
+    // MARK: - Private Helpers
+
+    private func buildSseUrl(params: SseConnectionParams) -> URL? {
+        guard var components = URLComponents(string: params.sseApiUrl) else {
+            logger.logWithModuleTag("SseService: Invalid SSE URL: \(params.sseApiUrl)", level: .error)
+            return nil
+        }
+
+        // Add query parameters (matching Android's createSseRequest)
+        components.queryItems = [
+            URLQueryItem(name: "sessionId", value: params.sessionId),
+            URLQueryItem(name: "siteId", value: params.siteId),
+            URLQueryItem(name: "userToken", value: params.userToken)
+        ]
+
+        logger.logWithModuleTag("SseService: Built URL with siteId=\(params.siteId), sessionId=\(params.sessionId)", level: .debug)
+
+        return components.url
+    }
+
+    /// Builds common headers for SSE connection (matching Android's addCommonHeaders with includeUserToken=false)
+    /// SSE uses userToken in URL query parameter, not in header
+    private func buildHeaders(params: SseConnectionParams) -> [String: String] {
+        let sdkClient = DIGraphShared.shared.sdkClient
+
+        return [
+            HTTPHeader.siteId.rawValue: params.siteId,
+            HTTPHeader.cioDataCenter.rawValue: params.dataCenter,
+            HTTPHeader.cioClientPlatform.rawValue: sdkClient.source.lowercased() + "-apple",
+            HTTPHeader.cioClientVersion.rawValue: sdkClient.sdkVersion,
+            HTTPHeader.userAnonymous.rawValue: String(params.isAnonymous)
+            // Note: userToken is NOT included in headers for SSE - it's in the URL query params
+        ]
+    }
+}
+
+// MARK: - LDSwiftEventSource Event Handler
+
+/// Bridges LDSwiftEventSource callbacks to our AsyncStream.
+/// Maps library callbacks to SseEvent types matching Android's sealed interface.
+private final class StreamEventHandler: EventHandler {
+    private let continuation: AsyncStream<SseEvent>.Continuation
+    private let logger: Logger
+
+    init(continuation: AsyncStream<SseEvent>.Continuation, logger: Logger) {
+        self.continuation = continuation
+        self.logger = logger
+    }
+
+    func onOpened() {
+        logger.logWithModuleTag("SseService: ✓ Connection opened", level: .info)
+        // Emit ConnectionOpenEvent (matches Android's ConnectionOpenEvent)
+        continuation.yield(.connectionOpen)
+    }
+
+    func onClosed() {
+        logger.logWithModuleTag("SseService: Connection closed", level: .info)
+        // Emit ConnectionClosedEvent before finishing (matches Android's ConnectionClosedEvent)
+        continuation.yield(.connectionClosed)
+        continuation.finish()
+    }
+
+    func onMessage(eventType: String, messageEvent: MessageEvent) {
+        logger.logWithModuleTag("SseService: → Server event - type: '\(eventType)'", level: .info)
+        logger.logWithModuleTag("SseService:   data: \(messageEvent.data.prefix(100))\(messageEvent.data.count > 100 ? "..." : "")", level: .debug)
+
+        // Emit ServerEvent (matches Android's ServerEvent)
+        let serverEvent = ServerEvent(
+            id: messageEvent.lastEventId,
+            type: eventType.isEmpty ? nil : eventType,
+            data: messageEvent.data
+        )
+        continuation.yield(.serverEvent(serverEvent))
+    }
+
+    func onComment(comment: String) {
+        logger.logWithModuleTag("SseService: Comment received: \(comment.prefix(50))", level: .debug)
+    }
+
+    func onError(error: Error) {
+        logger.logWithModuleTag("SseService: ✗ Error: \(error.localizedDescription)", level: .error)
+
+        let sseError = SseError(message: error.localizedDescription, underlyingError: error)
+        continuation.yield(.connectionFailed(sseError))
+        continuation.finish()
+    }
+}

--- a/Tests/MessagingInApp/Gist/Network/SSE/ServerEventTest.swift
+++ b/Tests/MessagingInApp/Gist/Network/SSE/ServerEventTest.swift
@@ -1,0 +1,234 @@
+@testable import CioMessagingInApp
+import XCTest
+
+class ServerEventTest: XCTestCase {
+    // MARK: - EventType Parsing
+
+    func test_eventType_givenConnected_expectConnected() {
+        let eventType = ServerEvent.EventType(rawValue: "connected")
+        XCTAssertEqual(eventType, .connected)
+    }
+
+    func test_eventType_givenHeartbeat_expectHeartbeat() {
+        let eventType = ServerEvent.EventType(rawValue: "heartbeat")
+        XCTAssertEqual(eventType, .heartbeat)
+    }
+
+    func test_eventType_givenMessages_expectMessages() {
+        let eventType = ServerEvent.EventType(rawValue: "messages")
+        XCTAssertEqual(eventType, .messages)
+    }
+
+    func test_eventType_givenTtlExceeded_expectTtlExceeded() {
+        let eventType = ServerEvent.EventType(rawValue: "ttl_exceeded")
+        XCTAssertEqual(eventType, .ttlExceeded)
+    }
+
+    func test_eventType_givenEmptyString_expectMessages() {
+        // Per SSE spec, empty/nil event type defaults to "message"
+        let eventType = ServerEvent.EventType(rawValue: "")
+        XCTAssertEqual(eventType, .messages)
+    }
+
+    func test_eventType_givenUnknownValue_expectUnknown() {
+        let eventType = ServerEvent.EventType(rawValue: "some_future_event")
+        XCTAssertEqual(eventType, .unknown)
+    }
+
+    func test_eventType_givenRandomString_expectUnknown() {
+        let eventType = ServerEvent.EventType(rawValue: "xyz123")
+        XCTAssertEqual(eventType, .unknown)
+    }
+
+    // MARK: - ServerEvent Initialization
+
+    func test_serverEvent_givenConnectedType_expectConnectedEventType() {
+        let event = ServerEvent(id: nil, type: "connected", data: "{}")
+        XCTAssertEqual(event.eventType, .connected)
+        XCTAssertEqual(event.rawEventType, "connected")
+        XCTAssertNil(event.messages)
+    }
+
+    func test_serverEvent_givenNilType_expectMessagesEventType() {
+        let event = ServerEvent(id: nil, type: nil, data: "[]")
+        XCTAssertEqual(event.eventType, .messages)
+        XCTAssertNil(event.rawEventType)
+    }
+
+    func test_serverEvent_givenEventId_expectIdPreserved() {
+        let event = ServerEvent(id: "event-123", type: "heartbeat", data: "{}")
+        XCTAssertEqual(event.id, "event-123")
+    }
+
+    // MARK: - Message Parsing - Valid Cases
+
+    func test_parseMessages_givenValidJsonArray_expectMessages() {
+        // UserQueueResponse requires: queueId (String), priority (Int), messageId (String)
+        let jsonData = """
+        [{"queueId": "q1", "priority": 1, "messageId": "m1"}, {"queueId": "q2", "priority": 2, "messageId": "m2"}]
+        """
+        let event = ServerEvent(id: nil, type: "messages", data: jsonData)
+
+        XCTAssertNotNil(event.messages)
+        XCTAssertEqual(event.messages?.count, 2)
+    }
+
+    func test_parseMessages_givenSingleMessage_expectOneMessage() {
+        let jsonData = """
+        [{"queueId": "q1", "priority": 1, "messageId": "m1"}]
+        """
+        let event = ServerEvent(id: nil, type: "messages", data: jsonData)
+
+        XCTAssertNotNil(event.messages)
+        XCTAssertEqual(event.messages?.count, 1)
+    }
+
+    // MARK: - Message Parsing - Empty/Nil Cases
+
+    func test_parseMessages_givenEmptyArray_expectNil() {
+        let event = ServerEvent(id: nil, type: "messages", data: "[]")
+        XCTAssertNil(event.messages)
+    }
+
+    func test_parseMessages_givenEmptyString_expectNil() {
+        let event = ServerEvent(id: nil, type: "messages", data: "")
+        XCTAssertNil(event.messages)
+    }
+
+    func test_parseMessages_givenWhitespaceOnly_expectNil() {
+        let event = ServerEvent(id: nil, type: "messages", data: "   ")
+        XCTAssertNil(event.messages)
+    }
+
+    // MARK: - Message Parsing - Non-Message Event Types
+
+    func test_parseMessages_givenConnectedType_expectNilMessages() {
+        // Even with valid message JSON, non-message event types should not parse messages
+        let jsonData = """
+        [{"queueId": "q1", "priority": 1, "messageId": "m1"}]
+        """
+        let event = ServerEvent(id: nil, type: "connected", data: jsonData)
+
+        // Should not parse messages for non-message event types
+        XCTAssertNil(event.messages)
+    }
+
+    func test_parseMessages_givenHeartbeatType_expectNilMessages() {
+        let event = ServerEvent(id: nil, type: "heartbeat", data: "{}")
+        XCTAssertNil(event.messages)
+    }
+
+    func test_parseMessages_givenUnknownType_expectNilMessages() {
+        let jsonData = """
+        [{"queueId": "q1", "priority": 1, "messageId": "m1"}]
+        """
+        let event = ServerEvent(id: nil, type: "future_event", data: jsonData)
+        XCTAssertNil(event.messages)
+    }
+
+    // MARK: - Message Parsing - Malformed JSON (Resilience Tests)
+
+    func test_parseMessages_givenInvalidJson_expectNil() {
+        let event = ServerEvent(id: nil, type: "messages", data: "not json at all")
+        XCTAssertNil(event.messages)
+    }
+
+    func test_parseMessages_givenMalformedJson_expectNil() {
+        let event = ServerEvent(id: nil, type: "messages", data: "{invalid json}")
+        XCTAssertNil(event.messages)
+    }
+
+    func test_parseMessages_givenJsonObject_expectNil() {
+        // JSON object instead of array
+        let event = ServerEvent(id: nil, type: "messages", data: "{\"key\": \"value\"}")
+        XCTAssertNil(event.messages)
+    }
+
+    func test_parseMessages_givenJsonString_expectNil() {
+        // JSON string instead of array
+        let event = ServerEvent(id: nil, type: "messages", data: "\"just a string\"")
+        XCTAssertNil(event.messages)
+    }
+
+    func test_parseMessages_givenJsonNumber_expectNil() {
+        // JSON number instead of array
+        let event = ServerEvent(id: nil, type: "messages", data: "12345")
+        XCTAssertNil(event.messages)
+    }
+
+    func test_parseMessages_givenArrayOfStrings_expectNil() {
+        // Array of strings instead of objects
+        let event = ServerEvent(id: nil, type: "messages", data: "[\"a\", \"b\", \"c\"]")
+        XCTAssertNil(event.messages)
+    }
+
+    func test_parseMessages_givenArrayOfNumbers_expectNil() {
+        // Array of numbers instead of objects
+        let event = ServerEvent(id: nil, type: "messages", data: "[1, 2, 3]")
+        XCTAssertNil(event.messages)
+    }
+
+    // MARK: - Message Parsing - Partial Validity
+
+    func test_parseMessages_givenMixedValidAndInvalidItems_expectOnlyValidMessages() {
+        // Array with some valid and some invalid items
+        // Valid items have: queueId, priority, messageId
+        // Invalid item is missing required fields
+        let jsonData = """
+        [{"queueId": "q1", "priority": 1, "messageId": "m1"}, {"invalid": "item"}, {"queueId": "q2", "priority": 2, "messageId": "m2"}]
+        """
+        let event = ServerEvent(id: nil, type: "messages", data: jsonData)
+
+        // Should parse valid items (2) and skip invalid one (1)
+        XCTAssertNotNil(event.messages)
+        XCTAssertEqual(event.messages?.count, 2)
+    }
+
+    // MARK: - SseEvent Equatable
+
+    func test_sseEvent_connectionOpen_equatable() {
+        let event1 = SseEvent.connectionOpen
+        let event2 = SseEvent.connectionOpen
+        XCTAssertEqual(event1, event2)
+    }
+
+    func test_sseEvent_connectionClosed_equatable() {
+        let event1 = SseEvent.connectionClosed
+        let event2 = SseEvent.connectionClosed
+        XCTAssertEqual(event1, event2)
+    }
+
+    func test_sseEvent_serverEvent_equatable() {
+        let serverEvent1 = ServerEvent(id: "1", type: "connected", data: "{}")
+        let serverEvent2 = ServerEvent(id: "1", type: "connected", data: "{}")
+        XCTAssertEqual(SseEvent.serverEvent(serverEvent1), SseEvent.serverEvent(serverEvent2))
+    }
+
+    func test_sseEvent_connectionFailed_equatable() {
+        let error1 = SseError(message: "error")
+        let error2 = SseError(message: "error")
+        XCTAssertEqual(SseEvent.connectionFailed(error1), SseEvent.connectionFailed(error2))
+    }
+
+    // MARK: - SseError
+
+    func test_sseError_givenSameMessage_expectEqual() {
+        let error1 = SseError(message: "Connection failed")
+        let error2 = SseError(message: "Connection failed")
+        XCTAssertEqual(error1, error2)
+    }
+
+    func test_sseError_givenDifferentMessage_expectNotEqual() {
+        let error1 = SseError(message: "Error 1")
+        let error2 = SseError(message: "Error 2")
+        XCTAssertNotEqual(error1, error2)
+    }
+
+    func test_sseError_givenUnderlyingError_expectMessagePreserved() {
+        let underlyingError = NSError(domain: "test", code: 123)
+        let sseError = SseError(message: "Wrapper error", underlyingError: underlyingError)
+
+        XCTAssertEqual(sseError.message, "Wrapper error")
+        XCTAssertNotNil(sseError.underlyingError)
+    }
+}

--- a/Tests/MessagingInApp/Gist/Network/SSE/SseConnectionStateTest.swift
+++ b/Tests/MessagingInApp/Gist/Network/SSE/SseConnectionStateTest.swift
@@ -1,0 +1,35 @@
+@testable import CioMessagingInApp
+import XCTest
+
+class SseConnectionStateTest: XCTestCase {
+    // MARK: - State Values
+
+    func test_disconnected_description() {
+        let state = SseConnectionState.disconnected
+        XCTAssertEqual(state.description, "disconnected")
+    }
+
+    func test_connecting_description() {
+        let state = SseConnectionState.connecting
+        XCTAssertEqual(state.description, "connecting")
+    }
+
+    func test_connected_description() {
+        let state = SseConnectionState.connected
+        XCTAssertEqual(state.description, "connected")
+    }
+
+    // MARK: - Equatable
+
+    func test_equatable_sameStates_expectEqual() {
+        XCTAssertEqual(SseConnectionState.disconnected, SseConnectionState.disconnected)
+        XCTAssertEqual(SseConnectionState.connecting, SseConnectionState.connecting)
+        XCTAssertEqual(SseConnectionState.connected, SseConnectionState.connected)
+    }
+
+    func test_equatable_differentStates_expectNotEqual() {
+        XCTAssertNotEqual(SseConnectionState.disconnected, SseConnectionState.connecting)
+        XCTAssertNotEqual(SseConnectionState.connecting, SseConnectionState.connected)
+        XCTAssertNotEqual(SseConnectionState.connected, SseConnectionState.disconnected)
+    }
+}


### PR DESCRIPTION
Closes: [MBL-1440](https://linear.app/customerio/issue/MBL-1440/basic-sse-connection-and-receiving-messages-copy)

The implementation is split into multiple parts:
- Switch to SSE from polling if enabled -> https://github.com/customerio/customerio-ios/pull/965
- Basic SSE connection -> This PR
- SEE heartbeat handling -> Future PR
- SEE retry logic -> Future PR
- SSE respecting app lifecycle -> Future PR

Implements `SseConnectionManager` to handle Server-Sent Events connections for real-time in-app message delivery.
Changes:

- `SseConnectionManager` - manages connection lifecycle (start/stop), handles SSE events
- `SseService` - wraps LDSwiftEventSource library, provides AsyncStream interface
- `SseEventParser` - parses SSE events (connected, heartbeat, messages, ttl_exceeded)
- `SseConnectionState` - connection state enum (disconnected/connecting/connected)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces SSE-based in-app messaging using LDSwiftEventSource with a new service, connection manager, event parsing, and tests.
> 
> - **Messaging In-App**:
>   - **SSE Connection**: Add `SseService` (wrapping `LDSwiftEventSource`) exposing `AsyncStream<SseEvent>` and `SseConnectionManager` to manage lifecycle, translate events to `SseConnectionState`, and dispatch messages to the queue.
>   - **Event Parsing/State**: Add `SseEvent`/`ServerEvent` parsing and `SseConnectionState` enum; include `AsyncStreamBackport` for iOS 13+.
> - **Networking**:
>   - Extend `NetworkSettings` with `sseAPI` and define URLs for prod/dev/local.
> - **Dependencies**:
>   - Add `LDSwiftEventSource` to CocoaPods (`CustomerIOMessagingInApp.podspec`) and SPM (`Package.swift`), and link it in `CioMessagingInApp` target.
> - **Dependency Injection**:
>   - Register `SseService` as a singleton and inject into `SseConnectionManager` in the autogenerated DI graph.
> - **Tests**:
>   - Add unit tests for `ServerEvent` parsing and `SseConnectionState` equality/descriptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f2349c7ea542d87abd9e5fd02962c957f7f744e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->