### PR TITLE
chore: SSE Heartbeat handling

### DIFF
--- a/Sources/MessagingInApp/Gist/Network/SSE/HeartbeatTimer.swift
+++ b/Sources/MessagingInApp/Gist/Network/SSE/HeartbeatTimer.swift
@@ -1,0 +1,138 @@
+import CioInternalCommon
+import Foundation
+
+/// Heartbeat timer that monitors server heartbeats and emits timeout events
+/// when the server stops sending heartbeats within the expected timeframe.
+/// Corresponds to Android's `HeartbeatTimer` class.
+actor HeartbeatTimer {
+    /// Default heartbeat timeout in seconds (matches Android's DEFAULT_HEARTBEAT_TIMEOUT_MS / 1000)
+    static let defaultHeartbeatTimeoutSeconds: TimeInterval = 30
+
+    /// Buffer added to heartbeat timeout to account for network delays
+    static let heartbeatBufferSeconds: TimeInterval = 5
+
+    /// Initial timeout used when connection opens before receiving server heartbeat config
+    static let initialTimeoutSeconds: TimeInterval = defaultHeartbeatTimeoutSeconds + heartbeatBufferSeconds
+
+    /// Maximum timeout in seconds to prevent overflow when converting to nanoseconds
+    /// UInt64.max nanoseconds ≈ 584 years, but we cap at 1 hour for practical purposes
+    private static let maxTimeoutSeconds: TimeInterval = 3600
+
+    private let logger: Logger
+    private var onTimeout: (@Sendable () async -> Void)?
+    private var currentTimerTask: Task<Void, Never>?
+
+    /// Creates a HeartbeatTimer
+    /// - Parameter logger: Logger for debug output
+    init(logger: Logger) {
+        self.logger = logger
+        self.onTimeout = nil
+    }
+
+    /// Sets the timeout callback. Must be called before starting the timer.
+    /// - Parameter callback: Callback invoked when the heartbeat timer expires without being reset
+    func setCallback(_ callback: @escaping @Sendable () async -> Void) {
+        onTimeout = callback
+    }
+
+    /// Starts the heartbeat timer with the specified timeout.
+    ///
+    /// If a timer is already running, it will be cancelled and replaced with the new timer.
+    /// This is the expected behavior when receiving heartbeat events from the server.
+    ///
+    /// - Parameter timeoutSeconds: Timeout in seconds after which the timer will expire
+    func startTimer(timeoutSeconds: TimeInterval) {
+        // Cancel existing timer if running
+        if currentTimerTask != nil {
+            logger.logWithModuleTag("[HeartbeatTimer] Cancelling previous timer", level: .debug)
+            currentTimerTask?.cancel()
+        }
+
+        // Clamp timeout to valid range to prevent overflow when converting to nanoseconds
+        let clampedTimeout = min(max(timeoutSeconds, 0), Self.maxTimeoutSeconds)
+        let nanoseconds = UInt64(clampedTimeout * 1000000000)
+
+        logger.logWithModuleTag("[HeartbeatTimer] Starting timer with \(clampedTimeout)s timeout", level: .debug)
+
+        // Use var so the closure captures by reference - by the time the Task body
+        // executes, newTask will be assigned (Task body runs asynchronously)
+        var newTask: Task<Void, Never>?
+
+        newTask = Task { [weak self] in
+            // Capture the task reference for later comparison
+            guard let task = newTask else { return }
+
+            do {
+                await self?.logTimerWaiting(timeoutSeconds: clampedTimeout)
+
+                // Task.sleep with nanoseconds required for iOS 13+ compatibility
+                try await Task.sleep(nanoseconds: nanoseconds)
+
+                // Check cancellation after sleep completes
+                if Task.isCancelled {
+                    await self?.logTimerCancelledAfterSleep()
+                    return
+                }
+
+                // Timer expired - pass task reference to verify it's still current
+                await self?.handleTimerExpired(task: task, timeoutSeconds: clampedTimeout)
+            } catch is CancellationError {
+                // Task was cancelled during sleep - expected behavior
+                await self?.logTimerCancelledDuringSleep()
+                return
+            } catch {
+                // Unexpected error - log but don't crash
+                await self?.logUnexpectedError(error)
+            }
+        }
+
+        currentTimerTask = newTask
+    }
+
+    /// Resets the heartbeat timer.
+    /// Cancels any running timer without triggering the timeout callback.
+    /// Should be called when connection is stopped or fails.
+    func reset() {
+        if currentTimerTask != nil {
+            logger.logWithModuleTag("[HeartbeatTimer] Reset called - cancelling active timer", level: .debug)
+            currentTimerTask?.cancel()
+            currentTimerTask = nil
+        } else {
+            logger.logWithModuleTag("[HeartbeatTimer] Reset called - no active timer", level: .debug)
+        }
+    }
+
+    // MARK: - Private Actor-Isolated Logging Methods
+
+    private func logTimerWaiting(timeoutSeconds: TimeInterval) {
+        logger.logWithModuleTag("[HeartbeatTimer] Timer waiting for \(timeoutSeconds)s...", level: .debug)
+    }
+
+    private func logTimerCancelledAfterSleep() {
+        logger.logWithModuleTag("[HeartbeatTimer] Timer cancelled (detected after sleep)", level: .debug)
+    }
+
+    private func logTimerCancelledDuringSleep() {
+        logger.logWithModuleTag("[HeartbeatTimer] Timer cancelled (during sleep)", level: .debug)
+    }
+
+    private func handleTimerExpired(task: Task<Void, Never>, timeoutSeconds: TimeInterval) async {
+        // Only proceed if this is still the current timer (guards against race condition
+        // where a new timer was started before this callback executed)
+        guard currentTimerTask == task else {
+            logger.logWithModuleTag("[HeartbeatTimer] Stale timer expired, ignoring (new timer already started)", level: .debug)
+            return
+        }
+
+        // Clear the timer to reflect "no active timer" state
+        currentTimerTask = nil
+
+        logger.logWithModuleTag("[HeartbeatTimer] ⚠️ Timer EXPIRED after \(timeoutSeconds)s - triggering timeout callback", level: .error)
+        await onTimeout?()
+        logger.logWithModuleTag("[HeartbeatTimer] Timeout callback completed", level: .debug)
+    }
+
+    private func logUnexpectedError(_ error: Error) {
+        logger.logWithModuleTag("[HeartbeatTimer] Unexpected error: \(error.localizedDescription)", level: .error)
+    }
+}

--- a/Sources/MessagingInApp/Gist/Network/SSE/SseConnectionManager.swift
+++ b/Sources/MessagingInApp/Gist/Network/SSE/SseConnectionManager.swift
@@ -12,6 +12,8 @@ actor SseConnectionManager {
     private let sseService: SseService
     private var connectionState: SseConnectionState = .disconnected
     private var streamTask: Task<Void, Never>?
+    private let heartbeatTimer: HeartbeatTimer
+    private var heartbeatCallbackInitialized = false
 
     init(
         logger: Logger,
@@ -21,12 +23,28 @@ actor SseConnectionManager {
         self.logger = logger
         self.inAppMessageManager = inAppMessageManager
         self.sseService = sseService
+        self.heartbeatTimer = HeartbeatTimer(logger: logger)
+
         logger.logWithModuleTag("SseConnectionManager initialized", level: .debug)
+    }
+
+    /// Lazily initializes the heartbeat callback on first use.
+    /// Called automatically before any connection attempt.
+    private func ensureHeartbeatCallbackInitialized() async {
+        guard !heartbeatCallbackInitialized else { return }
+
+        await heartbeatTimer.setCallback { [weak self] in
+            await self?.handleHeartbeatTimeout()
+        }
+        heartbeatCallbackInitialized = true
     }
 
     /// Starts an SSE connection to the queue consumer API.
     /// This method is idempotent - calling it multiple times while connected/connecting is safe.
     func startConnection(state: InAppMessageState) async {
+        // Ensure heartbeat callback is initialized before any connection attempt
+        await ensureHeartbeatCallbackInitialized()
+
         logger.logWithModuleTag("SSE Manager: startConnection called", level: .info)
         logger.logWithModuleTag("SSE Manager: useSse=\(state.useSse), userId=\(state.userId ?? "nil"), anonymousId=\(state.anonymousId ?? "nil")", level: .debug)
 
@@ -41,7 +59,7 @@ actor SseConnectionManager {
         guard let userIdentifier = userIdentifier, !userIdentifier.isEmpty else {
             logger.logWithModuleTag("SSE Manager: Cannot establish connection: no user token available", level: .error)
             // This is a configuration issue, not a network issue - update state to disconnected like Android
-            handleConnectionFailed(SseError(message: "Cannot establish connection: no user token available"))
+            await handleConnectionFailed(SseError(message: "Cannot establish connection: no user token available"))
             return
         }
 
@@ -63,26 +81,36 @@ actor SseConnectionManager {
         logger.logWithModuleTag("SSE Manager: Establishing connection for userToken=\(userIdentifier), sessionId=\(sessionId)", level: .debug)
 
         updateConnectionState(.connecting)
-        streamTask = Task { [weak self] in
+        // Use var so the closure captures by reference - by the time the Task body
+        // executes, newTask will be assigned (Task body runs asynchronously)
+        var newTask: Task<Void, Never>?
+
+        newTask = Task { [weak self] in
             guard let self = self else { return }
+            // Capture the task reference for later comparison
+            guard let task = newTask else { return }
 
             let eventStream = await self.sseService.connect(params: connectionParams)
             for await event in eventStream {
                 await self.handleEvent(event)
             }
 
-            // Stream ended - only cleanup if not cancelled
-            // If cancelled, the canceller (stopConnection or new startConnection) handles cleanup
-            guard !Task.isCancelled else { return }
-            await self.clearStreamTask()
-            logger.logWithModuleTag("SSE Manager: Event stream ended normally", level: .info)
+            // Stream ended - pass task reference to verify it's still current
+            // This guards against race condition where a new connection started
+            // between stream ending and cleanup executing
+            await self.handleStreamEnded(task: task)
         }
+
+        streamTask = newTask
     }
 
     /// Stops the active SSE connection.
     /// This method is idempotent - calling it multiple times is safe.
     func stopConnection() async {
         logger.logWithModuleTag("SSE Manager: stopConnection called", level: .info)
+
+        // Reset heartbeat timer when stopping connection
+        await heartbeatTimer.reset()
 
         streamTask?.cancel()
         streamTask = nil
@@ -97,48 +125,76 @@ actor SseConnectionManager {
     // MARK: - Private Handlers
 
     /// Handles SSE events matching Android's sealed interface pattern
-    private func handleEvent(_ event: SseEvent) {
+    private func handleEvent(_ event: SseEvent) async {
         switch event {
         case .connectionOpen:
-            handleConnectionOpen()
+            await handleConnectionOpen()
 
         case .serverEvent(let serverEvent):
-            handleServerEvent(serverEvent)
+            await handleServerEvent(serverEvent)
 
         case .connectionFailed(let error):
-            handleConnectionFailed(error)
+            await handleConnectionFailed(error)
 
         case .connectionClosed:
-            handleConnectionClosed()
+            await handleConnectionClosed()
         }
     }
 
-    private func clearStreamTask() {
+    private func handleStreamEnded(task: Task<Void, Never>) async {
+        // Only proceed if this is still the current stream task (guards against race condition
+        // where a new connection was started before this cleanup executed)
+        guard streamTask == task else {
+            logger.logWithModuleTag("SSE Manager: Stale stream ended, ignoring (new connection already started)", level: .debug)
+            return
+        }
+
+        logger.logWithModuleTag("SSE Manager: Event stream ended normally", level: .info)
+
+        // Defensive cleanup - ensure timer is reset and state is correct
+        // These may have already been handled by connection event handlers,
+        // but we ensure consistency here to guard against edge cases
+        await heartbeatTimer.reset()
+        updateConnectionState(.disconnected)
+
         streamTask = nil
     }
 
     // MARK: - Connection Lifecycle Handlers
 
-    private func handleConnectionOpen() {
+    private func handleConnectionOpen() async {
         logger.logWithModuleTag("SSE Manager: ✓ Connection opened", level: .info)
         updateConnectionState(.connected)
+
+        // Start heartbeat timer with initial timeout (default + buffer)
+        // This will be updated when we receive the first heartbeat event with server config
+        await heartbeatTimer.startTimer(timeoutSeconds: HeartbeatTimer.initialTimeoutSeconds)
     }
 
-    private func handleConnectionClosed() {
+    private func handleConnectionClosed() async {
         logger.logWithModuleTag("SSE Manager: Connection closed", level: .info)
+
+        // Reset heartbeat timer when connection closes
+        await heartbeatTimer.reset()
+
         updateConnectionState(.disconnected)
     }
 
-    private func handleConnectionFailed(_ error: SseError) {
+    private func handleConnectionFailed(_ error: SseError) async {
         logger.logWithModuleTag("SSE Manager: ✗ Connection error: \(error.message)", level: .error)
         // Reset state to disconnected so future connection attempts can proceed
         // Retry logic will be handled in a future change
         updateConnectionState(.disconnected)
+
+        // Reset heartbeat timer on connection failure
+        await heartbeatTimer.reset()
+
+        // we will handle errors and retry in the next change
     }
 
     // MARK: - Server Event Handlers
 
-    private func handleServerEvent(_ event: ServerEvent) {
+    private func handleServerEvent(_ event: ServerEvent) async {
         logger.logWithModuleTag("SSE Manager: ← Server event '\(event.eventType)'", level: .info)
         logger.logWithModuleTag("SSE Manager: Event data: \(event.data.prefix(100))", level: .debug)
 
@@ -147,18 +203,55 @@ actor SseConnectionManager {
             logger.logWithModuleTag("SSE Manager: ✓ Server acknowledged connection", level: .info)
             updateConnectionState(.connected)
 
+            // Restart heartbeat timer with initial timeout when server confirms connection
+            await heartbeatTimer.startTimer(timeoutSeconds: HeartbeatTimer.initialTimeoutSeconds)
+
         case .heartbeat:
-            logger.logWithModuleTag("SSE Manager: ♥ Heartbeat received", level: .debug)
+            await handleHeartbeatEvent(event)
 
         case .messages:
             handleMessagesEvent(event)
 
         case .ttlExceeded:
             logger.logWithModuleTag("SSE Manager: TTL exceeded, connection will be refreshed", level: .info)
+            // Reset heartbeat timer before reconnection (matches Android's cleanupForReconnect)
+            await heartbeatTimer.reset()
+            // TODO: Trigger reconnection logic (will be implemented with error handling/retry)
 
         case .unknown:
             logger.logWithModuleTag("SSE Manager: Unknown server event type '\(event.rawEventType ?? "nil")', ignoring", level: .debug)
         }
+    }
+
+    private func handleHeartbeatEvent(_ event: ServerEvent) async {
+        // Use server-provided interval or default if parsing failed (nil for edge cases like empty data, malformed JSON)
+        let heartbeatInterval = event.heartbeatIntervalSeconds ?? HeartbeatTimer.defaultHeartbeatTimeoutSeconds
+        let timeoutWithBuffer = heartbeatInterval + HeartbeatTimer.heartbeatBufferSeconds
+
+        logger.logWithModuleTag("SSE Manager: ♥ Heartbeat received (interval: \(heartbeatInterval)s, timeout: \(timeoutWithBuffer)s)", level: .debug)
+
+        // Restart heartbeat timer with the parsed interval + buffer
+        await heartbeatTimer.startTimer(timeoutSeconds: timeoutWithBuffer)
+    }
+
+    /// Handles heartbeat timeout - called when no heartbeat is received within the expected timeframe
+    private func handleHeartbeatTimeout() async {
+        logger.logWithModuleTag("SSE Manager: ⚠️ Heartbeat timeout - connection appears stale", level: .error)
+
+        // Reset heartbeat timer
+        await heartbeatTimer.reset()
+
+        // Cancel and clear the stale stream task
+        streamTask?.cancel()
+        streamTask = nil
+
+        // Disconnect the underlying SSE service to release socket
+        await sseService.disconnect()
+
+        // Update connection state to disconnected
+        updateConnectionState(.disconnected)
+
+        // TODO: Trigger reconnection logic (will be implemented with error handling/retry)
     }
 
     private func handleMessagesEvent(_ event: ServerEvent) {

--- a/Tests/MessagingInApp/Gist/Network/SSE/HeartbeatTimerTest.swift
+++ b/Tests/MessagingInApp/Gist/Network/SSE/HeartbeatTimerTest.swift
@@ -1,0 +1,109 @@
+@testable import CioInternalCommon
+@testable import CioMessagingInApp
+import SharedTests
+import XCTest
+
+class HeartbeatTimerTest: XCTestCase {
+    private var loggerMock: LoggerMock!
+
+    override func setUp() {
+        super.setUp()
+        loggerMock = LoggerMock()
+    }
+
+    // MARK: - Constants
+
+    func test_constants_expectCorrectValues() {
+        XCTAssertEqual(HeartbeatTimer.defaultHeartbeatTimeoutSeconds, 30)
+        XCTAssertEqual(HeartbeatTimer.heartbeatBufferSeconds, 5)
+        XCTAssertEqual(HeartbeatTimer.initialTimeoutSeconds, 35)
+    }
+
+    // MARK: - Timer Start/Reset
+
+    func test_startTimer_expectTimerStarts() async {
+        var timeoutCalled = false
+        let timer = HeartbeatTimer(logger: loggerMock)
+        await timer.setCallback {
+            timeoutCalled = true
+        }
+
+        await timer.startTimer(timeoutSeconds: 100)
+
+        // Timer should not fire immediately
+        XCTAssertFalse(timeoutCalled)
+
+        // Cleanup
+        await timer.reset()
+    }
+
+    func test_reset_givenTimerRunning_expectTimerCancelled() async throws {
+        var timeoutCalled = false
+        let timer = HeartbeatTimer(logger: loggerMock)
+        await timer.setCallback {
+            timeoutCalled = true
+        }
+
+        // Start timer with short timeout
+        await timer.startTimer(timeoutSeconds: 0.1)
+
+        // Reset before it fires
+        await timer.reset()
+
+        // Wait longer than the timeout
+        try await Task.sleep(nanoseconds: 200000000) // 0.2 seconds
+
+        // Timeout should not have been called because we reset
+        XCTAssertFalse(timeoutCalled)
+    }
+
+    func test_startTimer_givenMultipleStarts_expectPreviousTimerCancelled() async throws {
+        var timeoutCount = 0
+        let timer = HeartbeatTimer(logger: loggerMock)
+        await timer.setCallback {
+            timeoutCount += 1
+        }
+
+        // Start timer with very short timeout
+        await timer.startTimer(timeoutSeconds: 0.05)
+
+        // Immediately start another timer with longer timeout
+        await timer.startTimer(timeoutSeconds: 0.5)
+
+        // Wait for first timer's timeout to pass
+        try await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+
+        // First timer should have been cancelled, so timeout count should still be 0
+        XCTAssertEqual(timeoutCount, 0)
+
+        // Cleanup
+        await timer.reset()
+    }
+
+    func test_timer_givenTimeoutExpires_expectCallbackInvoked() async throws {
+        let expectation = XCTestExpectation(description: "Timeout callback invoked")
+        var timeoutCalled = false
+
+        let timer = HeartbeatTimer(logger: loggerMock)
+        await timer.setCallback {
+            timeoutCalled = true
+            expectation.fulfill()
+        }
+
+        // Start timer with very short timeout
+        await timer.startTimer(timeoutSeconds: 0.05)
+
+        // Wait for timeout
+        await fulfillment(of: [expectation], timeout: 1.0)
+
+        XCTAssertTrue(timeoutCalled)
+    }
+
+    func test_reset_givenNoTimerRunning_expectNoError() async {
+        let timer = HeartbeatTimer(logger: loggerMock)
+
+        // Should not throw or crash
+        await timer.reset()
+        await timer.reset()
+    }
+}


### PR DESCRIPTION
Closes: [MBL-1444](https://linear.app/customerio/issue/MBL-1444/heart-beat-handling-and-timeout)

The implementation is split into multiple parts:
- Switch to SSE from polling if enabled -> https://github.com/customerio/customerio-ios/pull/965
- Basic SSE connection -> https://github.com/customerio/customerio-ios/pull/966
- SEE heartbeat handling -> This PR
- SEE retry logic -> Future PR
- SSE respecting app lifecycle -> Future PR

Implements `HeartbeatTimer` to detect stale SSE connections when server stops sending heartbeats.
Changes:
- `HeartbeatTimer` actor - monitors heartbeat timeout with configurable interval
- `ServerEvent.heartbeatIntervalSeconds` - parses heartbeat interval from {"heartbeat":30} JSON
- Integration in`SseConnectionManager` - starts/resets timer on connection events

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements a heartbeat timer and server interval parsing, integrating timeout/reset logic into the SSE connection manager to detect and clean up stale connections.
> 
> - **SSE Heartbeat Handling**
>   - Adds `HeartbeatTimer` actor (`Sources/.../SSE/HeartbeatTimer.swift`) to track heartbeats with buffer and cap, invoking an async timeout callback.
>   - Integrates heartbeat lifecycle in `SseConnectionManager` (`Sources/.../SSE/SseConnectionManager.swift`):
>     - Initializes timer and sets timeout callback; starts/resets timer on connection open/confirmed, heartbeat, close, and failure.
>     - Handles heartbeat events using `ServerEvent.heartbeatIntervalSeconds` + buffer; triggers cleanup on timeout (cancel stream, disconnect, set `disconnected`).
>     - Improves stream task management to avoid race conditions (`newTask` capture, `handleStreamEnded`).
>   - Extends `ServerEvent` (`Sources/.../SSE/SseEventParser.swift`) to parse `heartbeatIntervalSeconds` from heartbeat JSON, defaulting safely when invalid.
> - **Tests**
>   - Adds `HeartbeatTimerTest` covering constants, start/cancel/reset, and timeout callback behavior.
>   - Expands `ServerEventTest` with heartbeat-interval parsing cases and resilience tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a9b5e8de39585334f855a1033a99834ebe28d35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->