### PR TITLE
chore: Enable SSE only for authenticated users

### DIFF
--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -27,8 +27,9 @@ class Gist: GistProvider {
     private let threadUtil: ThreadUtil
     private let sseLifecycleManager: SseLifecycleManager
 
-    private var inAppMessageStoreSubscriber: InAppMessageStoreSubscriber?
-    private var sseFlagSubscriber: InAppMessageStoreSubscriber?
+    private var pollIntervalSubscriber: InAppMessageStoreSubscriber?
+    private var sseEnabledSubscriber: InAppMessageStoreSubscriber?
+    private var userIdSubscriber: InAppMessageStoreSubscriber?
     private var queueTimer: Timer?
 
     init(
@@ -57,50 +58,109 @@ class Gist: GistProvider {
     deinit {
         // Unsubscribe from in-app message state changes and release resources to stop polling
         // and prevent memory leaks.
-        if let subscriber = inAppMessageStoreSubscriber {
+        if let subscriber = pollIntervalSubscriber {
             inAppMessageManager.unsubscribe(subscriber: subscriber)
         }
-        inAppMessageStoreSubscriber = nil
-
-        if let subscriber = sseFlagSubscriber {
+        if let subscriber = sseEnabledSubscriber {
             inAppMessageManager.unsubscribe(subscriber: subscriber)
         }
-        sseFlagSubscriber = nil
+        if let subscriber = userIdSubscriber {
+            inAppMessageManager.unsubscribe(subscriber: subscriber)
+        }
+        pollIntervalSubscriber = nil
+        sseEnabledSubscriber = nil
+        userIdSubscriber = nil
 
         invalidateTimer()
     }
 
     private func subscribeToInAppMessageState() {
-        // Keep a strong reference to the subscriber to prevent deallocation and continue receiving updates
-        inAppMessageStoreSubscriber = {
-            let subscriber = InAppMessageStoreSubscriber { state in
-                self.setupPollingAndFetch(skipMessageFetch: true, pollingInterval: state.pollInterval)
+        // Subscribe to poll interval changes
+        pollIntervalSubscriber = {
+            let subscriber = InAppMessageStoreSubscriber { [weak self] state in
+                guard let self else { return }
+                // Only update polling if SSE is not active
+                if !state.shouldUseSse {
+                    setupPollingAndFetch(skipMessageFetch: true, pollingInterval: state.pollInterval)
+                }
             }
-            // Subscribe to changes in `pollInterval` property of `InAppMessageState`
             inAppMessageManager.subscribe(keyPath: \.pollInterval, subscriber: subscriber)
             return subscriber
         }()
 
-        // Subscribe to SSE flag changes to trigger immediate fetch when SSE is disabled
-        sseFlagSubscriber = {
+        // Subscribe to SSE flag changes (matching Android's subscribeToAttribute for sseEnabled)
+        sseEnabledSubscriber = {
             let subscriber = InAppMessageStoreSubscriber { [weak self] state in
                 guard let self else { return }
-
-                // When SSE is disabled, trigger an immediate fetch so users don't have to wait
-                // for the next polling timer tick (which could be up to 600 seconds)
-                if !state.useSse {
-                    logger.logWithModuleTag("SSE disabled - triggering immediate message fetch", level: .info)
-                    setupPollingAndFetch(skipMessageFetch: false, pollingInterval: state.pollInterval)
-                }
+                handleSseEnabledChange(state: state)
             }
             inAppMessageManager.subscribe(keyPath: \.useSse, subscriber: subscriber)
+            logger.logWithModuleTag("Gist: Subscribed to SSE flag changes", level: .debug)
+            return subscriber
+        }()
+
+        // Subscribe to user identification changes (matching Android's subscribeToAttribute for isUserIdentified)
+        userIdSubscriber = {
+            let subscriber = InAppMessageStoreSubscriber { [weak self] state in
+                guard let self else { return }
+                handleUserIdentificationChange(state: state)
+            }
+            inAppMessageManager.subscribe(keyPath: \.userId, subscriber: subscriber)
+            logger.logWithModuleTag("Gist: Subscribed to userId changes", level: .debug)
             return subscriber
         }()
     }
 
+    /// Handles SSE flag changes for polling control.
+    /// When SSE becomes active (enabled + identified user), stop polling.
+    /// When SSE becomes disabled, start polling.
+    private func handleSseEnabledChange(state: InAppMessageState) {
+        logger.logWithModuleTag(
+            "Gist: SSE flag changed - sseEnabled: \(state.useSse), isUserIdentified: \(state.isUserIdentified), shouldUseSse: \(state.shouldUseSse)",
+            level: .info
+        )
+
+        if state.shouldUseSse {
+            // SSE is now active - stop polling
+            logger.logWithModuleTag("Gist: SSE enabled for identified user - stopping polling timer", level: .info)
+            invalidateTimer()
+        } else if !state.useSse {
+            // SSE disabled - start polling
+            logger.logWithModuleTag("Gist: SSE disabled - starting polling with interval: \(state.pollInterval)s", level: .info)
+            setupPollingAndFetch(skipMessageFetch: false, pollingInterval: state.pollInterval)
+        } else {
+            // SSE enabled but user is anonymous - polling continues
+            logger.logWithModuleTag("Gist: SSE enabled but user anonymous - polling continues", level: .debug)
+        }
+    }
+
+    /// Handles user identification changes for polling control.
+    /// When user becomes identified and SSE is enabled, stop polling (SSE will take over).
+    /// When user becomes anonymous but SSE flag is still enabled, start polling.
+    private func handleUserIdentificationChange(state: InAppMessageState) {
+        logger.logWithModuleTag(
+            "Gist: User identification changed - isUserIdentified: \(state.isUserIdentified), sseEnabled: \(state.useSse), shouldUseSse: \(state.shouldUseSse)",
+            level: .info
+        )
+
+        if state.shouldUseSse {
+            // User became identified and SSE is enabled - stop polling (SSE will take over)
+            logger.logWithModuleTag("Gist: User identified with SSE enabled - stopping polling (SSE will handle messages)", level: .info)
+            invalidateTimer()
+        } else if !state.isUserIdentified, state.useSse {
+            // User became anonymous but SSE flag is still enabled - start polling
+            // (SSE won't be used for anonymous users)
+            logger.logWithModuleTag("Gist: User became anonymous with SSE enabled - starting polling (SSE not used for anonymous users)", level: .info)
+            setupPollingAndFetch(skipMessageFetch: false, pollingInterval: state.pollInterval)
+        } else {
+            logger.logWithModuleTag("Gist: No polling action needed for user identification change", level: .debug)
+        }
+    }
+
     private func invalidateTimer() {
         // Timer must be scheduled or modified on main.
-        logger.logWithModuleTag("Invalidating polling timer", level: .debug)
+        let timerWasActive = queueTimer != nil
+        logger.logWithModuleTag("Gist: Invalidating polling timer (wasActive: \(timerWasActive))", level: .debug)
         threadUtil.runMain {
             self.queueTimer?.invalidate()
             self.queueTimer = nil
@@ -173,7 +233,7 @@ class Gist: GistProvider {
     }
 
     private func setupPollingAndFetch(skipMessageFetch: Bool, pollingInterval: Double) {
-        logger.logWithModuleTag("Setting up polling with interval: \(pollingInterval) seconds and skipMessageFetch: \(skipMessageFetch)", level: .info)
+        logger.logWithModuleTag("Gist: Setting up polling timer - interval: \(pollingInterval)s, skipInitialFetch: \(skipMessageFetch)", level: .info)
         invalidateTimer()
 
         // Timer must be scheduled on the main thread
@@ -185,6 +245,7 @@ class Gist: GistProvider {
                 userInfo: nil,
                 repeats: true
             )
+            self.logger.logWithModuleTag("Gist: Polling timer started with interval: \(pollingInterval)s", level: .debug)
         }
 
         if !skipMessageFetch {
@@ -199,22 +260,28 @@ class Gist: GistProvider {
     /// Also, the method must be called on main thread since it checks the application state.
     @objc
     func fetchUserMessages() {
-        logger.logWithModuleTag("Attempting to fetch user messages from remote service", level: .info)
         guard UIApplication.shared.applicationState != .background else {
-            logger.logWithModuleTag("Application in background, skipping queue check.", level: .info)
+            logger.logWithModuleTag("Gist: Application in background, skipping queue check", level: .debug)
             return
         }
 
-        logger.logWithModuleTag("Checking Gist queue service", level: .info)
         inAppMessageManager.fetchState { [weak self] state in
             guard let self else { return }
 
-            // Skip polling if SSE is enabled - messages are delivered via SSE instead
-            guard !state.useSse else {
-                logger.logWithModuleTag("SSE enabled, skipping polling fetch", level: .debug)
+            // Skip polling only if SSE should be used (enabled + user is identified)
+            // Anonymous users always use polling even if SSE flag is enabled
+            guard !state.shouldUseSse else {
+                logger.logWithModuleTag(
+                    "Gist: Skipping polling - SSE active (sseEnabled: \(state.useSse), isUserIdentified: \(state.isUserIdentified))",
+                    level: .debug
+                )
                 return
             }
 
+            logger.logWithModuleTag(
+                "Gist: Polling for messages (sseEnabled: \(state.useSse), isUserIdentified: \(state.isUserIdentified))",
+                level: .info
+            )
             fetchUserQueue(state: state)
         }
     }

--- a/Sources/MessagingInApp/State/InAppMessageState.swift
+++ b/Sources/MessagingInApp/State/InAppMessageState.swift
@@ -107,6 +107,22 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
         )
         """
     }
+
+    // MARK: - SSE Eligibility
+
+    /// Returns true if user is identified (has a non-empty userId).
+    /// Anonymous users (only anonymousId) are not eligible for SSE.
+    var isUserIdentified: Bool {
+        guard let userId = userId else { return false }
+        return !userId.isEmpty
+    }
+
+    /// Returns true if SSE should be used for real-time message delivery.
+    /// SSE requires both: SSE flag enabled AND user is identified.
+    /// Anonymous users always use polling even if SSE flag is enabled.
+    var shouldUseSse: Bool {
+        useSse && isUserIdentified
+    }
 }
 
 extension InAppMessageState {

--- a/Tests/MessagingInApp/Gist/Utilities/SseLifecycleManagerTest.swift
+++ b/Tests/MessagingInApp/Gist/Utilities/SseLifecycleManagerTest.swift
@@ -43,27 +43,50 @@ class SseLifecycleManagerTest: XCTestCase {
         )
     }
 
-    private func setupDefaultState(useSse: Bool = false) {
+    /// Sets up the default state for the InAppMessageManager mock
+    /// - Parameters:
+    ///   - useSse: Whether SSE is enabled (from server header)
+    ///   - userId: The userId (nil for anonymous users)
+    private func setupDefaultState(useSse: Bool = false, userId: String? = "test-user") {
         inAppMessageManagerMock.underlyingState = InAppMessageState(
             siteId: "test-site-id",
             dataCenter: "us",
             environment: .production,
-            userId: "test-user",
+            userId: userId,
             useSse: useSse
         )
     }
 
-    /// Triggers the SSE flag change subscriber with a new state
-    private func triggerSseFlagChange(useSse: Bool) {
+    /// Triggers the SSE flag change subscriber with a new state.
+    /// The lifecycle manager registers subscribers in order: SSE flag (index 0), userId (index 1).
+    private func triggerSseFlagChange(useSse: Bool, userId: String? = "test-user") {
         let newState = InAppMessageState(
             siteId: "test-site-id",
             dataCenter: "us",
             environment: .production,
-            userId: "test-user",
+            userId: userId,
             useSse: useSse
         )
         inAppMessageManagerMock.underlyingState = newState
-        inAppMessageManagerMock.subscribeReceivedArguments?.subscriber.newState(state: newState)
+        // SSE flag subscriber is registered first (index 0)
+        guard !inAppMessageManagerMock.subscribeReceivedInvocations.isEmpty else { return }
+        inAppMessageManagerMock.subscribeReceivedInvocations[0].subscriber.newState(state: newState)
+    }
+
+    /// Triggers the userId change subscriber with a new state.
+    /// The lifecycle manager registers subscribers in order: SSE flag (index 0), userId (index 1).
+    private func triggerUserIdChange(userId: String?, useSse: Bool = false) {
+        let newState = InAppMessageState(
+            siteId: "test-site-id",
+            dataCenter: "us",
+            environment: .production,
+            userId: userId,
+            useSse: useSse
+        )
+        inAppMessageManagerMock.underlyingState = newState
+        // userId subscriber is registered second (index 1)
+        guard inAppMessageManagerMock.subscribeReceivedInvocations.count > 1 else { return }
+        inAppMessageManagerMock.subscribeReceivedInvocations[1].subscriber.newState(state: newState)
     }
 
     // MARK: - Initial State Tests (App Foreground at Startup)
@@ -241,7 +264,7 @@ class SseLifecycleManagerTest: XCTestCase {
         XCTAssertEqual(sseConnectionManagerMock.stopConnectionCallsCount, 1)
     }
 
-    func test_backgroundNotification_givenSseDisabled_expectNoStopConnection() async {
+    func test_backgroundNotification_givenSseDisabled_expectStopConnectionCalledAnyway() async {
         // Setup: SSE disabled
         setupDefaultState(useSse: false)
         sut = createLifecycleManager()
@@ -254,8 +277,10 @@ class SseLifecycleManagerTest: XCTestCase {
         // Allow time for async operations
         try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
 
-        // Assert: No stop should be called
-        XCTAssertFalse(sseConnectionManagerMock.stopConnectionCalled)
+        // Assert: stopConnection is always called when backgrounding (matching Android behavior)
+        // stopConnection() is idempotent, safe to call even if not connected
+        XCTAssertTrue(sseConnectionManagerMock.stopConnectionCalled)
+        XCTAssertEqual(sseConnectionManagerMock.stopConnectionCallsCount, 1)
     }
 
     func test_backgroundNotification_givenAlreadyBackgrounded_expectSkipped() async {
@@ -376,6 +401,201 @@ class SseLifecycleManagerTest: XCTestCase {
 
         // Verify: Connection started again
         XCTAssertEqual(sseConnectionManagerMock.startConnectionCallsCount, 2)
+        XCTAssertEqual(sseConnectionManagerMock.stopConnectionCallsCount, 1)
+    }
+
+    // MARK: - Anonymous User Tests (SSE requires identified user)
+
+    func test_start_givenSseEnabledButAnonymousUser_expectNoConnection() async {
+        // Setup: SSE enabled but user is anonymous (no userId)
+        setupDefaultState(useSse: true, userId: nil)
+        sut = createLifecycleManager()
+
+        // Action
+        await sut.start()
+
+        // Allow time for async operations
+        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+
+        // Assert: Connection should NOT be started for anonymous users
+        XCTAssertFalse(sseConnectionManagerMock.startConnectionCalled)
+    }
+
+    func test_foregroundNotification_givenSseEnabledButAnonymousUser_expectNoConnection() async {
+        // Setup: SSE enabled but user is anonymous
+        setupDefaultState(useSse: true, userId: nil)
+        sut = createLifecycleManager()
+        await sut.start()
+
+        // Simulate going to background and back to foreground
+        NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+        sseConnectionManagerMock.resetMock()
+
+        // Action: Simulate foreground notification
+        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+
+        // Allow time for async operations
+        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+
+        // Assert: No connection should be started for anonymous users
+        XCTAssertFalse(sseConnectionManagerMock.startConnectionCalled)
+    }
+
+    func test_sseFlagChangedToTrue_givenAnonymousUser_expectNoConnection() async {
+        // Setup: SSE initially disabled, user is anonymous
+        setupDefaultState(useSse: false, userId: nil)
+        sut = createLifecycleManager()
+        await sut.start()
+        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+
+        // Verify no connection started initially
+        XCTAssertFalse(sseConnectionManagerMock.startConnectionCalled)
+
+        // Action: Change SSE flag to true (simulating server enabling SSE)
+        triggerSseFlagChange(useSse: true, userId: nil)
+
+        // Allow time for async operations
+        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+
+        // Assert: Still no connection because user is anonymous
+        XCTAssertFalse(sseConnectionManagerMock.startConnectionCalled)
+    }
+
+    // MARK: - User Identification Change Tests
+
+    func test_userBecomesIdentified_givenSseEnabled_expectConnectionStarted() async {
+        // Setup: SSE enabled but user is initially anonymous
+        setupDefaultState(useSse: true, userId: nil)
+        sut = createLifecycleManager()
+        await sut.start()
+        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+
+        // Verify no connection started initially
+        XCTAssertFalse(sseConnectionManagerMock.startConnectionCalled)
+
+        // Action: User becomes identified
+        triggerUserIdChange(userId: "new-identified-user", useSse: true)
+
+        // Allow time for async operations
+        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+
+        // Assert: Connection should now be started
+        XCTAssertTrue(sseConnectionManagerMock.startConnectionCalled)
+        XCTAssertEqual(sseConnectionManagerMock.startConnectionCallsCount, 1)
+    }
+
+    func test_userBecomesAnonymous_givenSseEnabledAndConnected_expectConnectionStopped() async {
+        // Setup: SSE enabled and user is identified
+        setupDefaultState(useSse: true, userId: "test-user")
+        sut = createLifecycleManager()
+        await sut.start()
+        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+
+        // Verify connection started initially
+        XCTAssertTrue(sseConnectionManagerMock.startConnectionCalled)
+        XCTAssertEqual(sseConnectionManagerMock.startConnectionCallsCount, 1)
+
+        // Action: User becomes anonymous (e.g., logout)
+        triggerUserIdChange(userId: nil, useSse: true)
+
+        // Allow time for async operations
+        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+
+        // Assert: Connection should be stopped
+        XCTAssertTrue(sseConnectionManagerMock.stopConnectionCalled)
+        XCTAssertEqual(sseConnectionManagerMock.stopConnectionCallsCount, 1)
+    }
+
+    func test_userBecomesIdentified_givenSseDisabled_expectNoConnection() async {
+        // Setup: SSE disabled, user is anonymous
+        setupDefaultState(useSse: false, userId: nil)
+        sut = createLifecycleManager()
+        await sut.start()
+        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+
+        // Action: User becomes identified but SSE is still disabled
+        triggerUserIdChange(userId: "new-identified-user", useSse: false)
+
+        // Allow time for async operations
+        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+
+        // Assert: No connection because SSE flag is disabled
+        XCTAssertFalse(sseConnectionManagerMock.startConnectionCalled)
+    }
+
+    func test_userBecomesIdentified_givenBackgrounded_expectDeferredConnection() async {
+        // Setup: SSE enabled, user is anonymous
+        setupDefaultState(useSse: true, userId: nil)
+        sut = createLifecycleManager()
+        await sut.start()
+
+        // Go to background
+        NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+        sseConnectionManagerMock.resetMock()
+
+        // Action: User becomes identified while backgrounded
+        triggerUserIdChange(userId: "new-identified-user", useSse: true)
+
+        // Allow time for async operations
+        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+
+        // Assert: No connection while backgrounded
+        XCTAssertFalse(sseConnectionManagerMock.startConnectionCalled)
+
+        // Action: Return to foreground
+        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+
+        // Assert: Connection should now be started
+        XCTAssertTrue(sseConnectionManagerMock.startConnectionCalled)
+    }
+
+    // MARK: - Combined State Change Tests
+
+    func test_fullFlow_anonymousToIdentifiedToAnonymous() async {
+        // Setup: SSE enabled, user is anonymous
+        setupDefaultState(useSse: true, userId: nil)
+        sut = createLifecycleManager()
+        await sut.start()
+        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+
+        // Verify: No initial connection (anonymous user)
+        XCTAssertEqual(sseConnectionManagerMock.startConnectionCallsCount, 0)
+        XCTAssertEqual(sseConnectionManagerMock.stopConnectionCallsCount, 0)
+
+        // Action: User logs in (becomes identified)
+        triggerUserIdChange(userId: "logged-in-user", useSse: true)
+        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+
+        // Verify: Connection started
+        XCTAssertEqual(sseConnectionManagerMock.startConnectionCallsCount, 1)
+        XCTAssertEqual(sseConnectionManagerMock.stopConnectionCallsCount, 0)
+
+        // Action: User logs out (becomes anonymous)
+        triggerUserIdChange(userId: nil, useSse: true)
+        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+
+        // Verify: Connection stopped
+        XCTAssertEqual(sseConnectionManagerMock.startConnectionCallsCount, 1)
+        XCTAssertEqual(sseConnectionManagerMock.stopConnectionCallsCount, 1)
+    }
+
+    func test_backgroundNotification_givenAnonymousUser_expectStopConnectionCalledAnyway() async {
+        // Setup: SSE enabled but user is anonymous
+        setupDefaultState(useSse: true, userId: nil)
+        sut = createLifecycleManager()
+        await sut.start()
+        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+
+        // Action: Go to background
+        NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+
+        // Assert: stopConnection is always called when backgrounding (matching Android behavior)
+        // stopConnection() is idempotent, safe to call even if SSE was never started
+        XCTAssertTrue(sseConnectionManagerMock.stopConnectionCalled)
         XCTAssertEqual(sseConnectionManagerMock.stopConnectionCallsCount, 1)
     }
 }


### PR DESCRIPTION
This PR ensures that SSE connections are only enabled for authenticated users and not anonymous users.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns SSE usage with eligibility rules and streamlines polling control.
> 
> - Add `InAppMessageState.isUserIdentified` and `shouldUseSse` to centralize SSE eligibility
> - Update `Gist` to subscribe to `pollInterval`, `useSse`, and `userId`; start/stop polling based on `shouldUseSse` and user identification; skip polling when SSE is active
> - Enhance `SseLifecycleManager` to also subscribe to `userId`, check eligibility before starting SSE, and always stop SSE on background; refine foreground/background and flag change handling to avoid races
> - Improve logging for visibility into SSE/polling decisions
> - Expand tests in `SseLifecycleManagerTest` to cover anonymous vs identified users, foreground/background transitions, SSE flag changes, and combined flows
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bf1ff9987683ed8512aff5f05a2040a5c2825f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->