### PR TITLE
fix: Fix in-app messages not displaying when app returns from background when SSE enabled

### DIFF
--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -51,7 +51,9 @@ class Gist: GistProvider {
 
         // Start the SSE lifecycle manager to observe app foreground/background events
         Task {
-            await sseLifecycleManager.start()
+            await sseLifecycleManager.start { [weak self] state in
+                self?.fetchUserQueue(state: state)
+            }
         }
     }
 

--- a/Sources/MessagingInApp/Gist/Utilities/SseLifecycleManager.swift
+++ b/Sources/MessagingInApp/Gist/Utilities/SseLifecycleManager.swift
@@ -19,8 +19,8 @@ import UIKit
 /// Corresponds to Android's `SseLifecycleManager` class.
 protocol SseLifecycleManager: AutoMockable {
     /// Starts the lifecycle manager. Must be called after initialization.
-    /// Sets up notification observers and subscribes to SSE flag and userId changes.
-    func start() async
+    /// - Parameter foregroundFetchHandler: Called to fetch missed messages when app returns to foreground while SSE is active.
+    func start(foregroundFetchHandler: @escaping (InAppMessageState) -> Void) async
 }
 
 // sourcery: InjectRegisterShared = "SseLifecycleManager"
@@ -36,6 +36,7 @@ actor CioSseLifecycleManager: SseLifecycleManager {
     private var userIdSubscriber: InAppMessageStoreSubscriber?
 
     private var isForegrounded: Bool = false
+    private var foregroundFetchHandler: ((InAppMessageState) -> Void)?
 
     init(
         logger: Logger,
@@ -49,14 +50,8 @@ actor CioSseLifecycleManager: SseLifecycleManager {
         self.applicationStateProvider = applicationStateProvider
     }
 
-    /// Sets up the lifecycle manager. Must be called after initialization.
-    /// This is separate from init because actors cannot call async methods in init.
-    ///
-    /// The order of operations is important to avoid race conditions:
-    /// 1. Register notification observers first to catch any state transitions
-    /// 2. Subscribe to SSE flag changes
-    /// 3. Check initial state last - any transitions during setup will be caught by observers
-    func start() async {
+    func start(foregroundFetchHandler: @escaping (InAppMessageState) -> Void) async {
+        self.foregroundFetchHandler = foregroundFetchHandler
         logger.logWithModuleTag("SseLifecycleManager: Starting lifecycle manager", level: .debug)
 
         // Register observers FIRST to ensure no state transitions are missed
@@ -212,7 +207,17 @@ actor CioSseLifecycleManager: SseLifecycleManager {
         )
 
         // Check all 3 conditions: foregrounded + SSE enabled + user identified
-        await startSseIfEligible(state: state)
+        if state.shouldUseSse {
+            // SSE only delivers new events after reconnecting, so perform a one-time
+            // HTTP fetch to retrieve any messages sent while the app was backgrounded.
+            foregroundFetchHandler?(state)
+            await sseConnectionManager.startConnection()
+        } else {
+            logger.logWithModuleTag(
+                "SseLifecycleManager: SSE not used (sseEnabled: \(state.useSse), isUserIdentified: \(state.isUserIdentified))",
+                level: .debug
+            )
+        }
     }
 
     private func handleBackgrounded() async {

--- a/Sources/MessagingInApp/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingInApp/autogenerated/AutoMockable.generated.swift
@@ -1584,6 +1584,8 @@ class SseLifecycleManagerMock: SseLifecycleManager, Mock {
 
     public func resetMock() {
         startCallsCount = 0
+        startReceivedArguments = nil
+        startReceivedInvocations = []
 
         mockCalled = false // do last as resetting properties above can make this true
     }
@@ -1597,16 +1599,22 @@ class SseLifecycleManagerMock: SseLifecycleManager, Mock {
         startCallsCount > 0
     }
 
+    /// The arguments from the *last* time the function was called.
+    @Atomic private(set) var startReceivedArguments: ((InAppMessageState) -> Void)?
+    /// Arguments from *all* of the times that the function was called.
+    @Atomic private(set) var startReceivedInvocations: [(InAppMessageState) -> Void] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    var startClosure: (() -> Void)?
+    var startClosure: ((@escaping (InAppMessageState) -> Void) -> Void)?
 
-    /// Mocked function for `start()`. Your opportunity to return a mocked value and check result of mock in test code.
-    func start() {
+    /// Mocked function for `start(foregroundFetchHandler: @escaping (InAppMessageState) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
+    func start(foregroundFetchHandler: @escaping (InAppMessageState) -> Void) {
         mockCalled = true
         startCallsCount += 1
-        startClosure?()
+        startReceivedArguments = foregroundFetchHandler
+        startReceivedInvocations.append(foregroundFetchHandler)
+        startClosure?(foregroundFetchHandler)
     }
 }
 

--- a/Tests/MessagingInApp/Gist/Utilities/SseLifecycleManagerTest.swift
+++ b/Tests/MessagingInApp/Gist/Utilities/SseLifecycleManagerTest.swift
@@ -12,6 +12,7 @@ class SseLifecycleManagerTest: XCTestCase {
     private var applicationStateProviderMock: ApplicationStateProviderMock!
 
     private var sut: CioSseLifecycleManager!
+    private var foregroundFetchCallsCount = 0
 
     override func setUp() {
         super.setUp()
@@ -19,6 +20,7 @@ class SseLifecycleManagerTest: XCTestCase {
         inAppMessageManagerMock = InAppMessageManagerMock()
         sseConnectionManagerMock = SseConnectionManagerProtocolMock()
         applicationStateProviderMock = ApplicationStateProviderMock()
+        foregroundFetchCallsCount = 0
 
         // Default to foreground state for most tests (explicit control)
         applicationStateProviderMock.underlyingApplicationState = .active
@@ -35,12 +37,19 @@ class SseLifecycleManagerTest: XCTestCase {
     // MARK: - Helper Methods
 
     private func createLifecycleManager() -> CioSseLifecycleManager {
-        CioSseLifecycleManager(
+        let manager = CioSseLifecycleManager(
             logger: loggerMock,
             inAppMessageManager: inAppMessageManagerMock,
             sseConnectionManager: sseConnectionManagerMock,
             applicationStateProvider: applicationStateProviderMock
         )
+        return manager
+    }
+
+    private func startLifecycleManager(_ manager: CioSseLifecycleManager) async {
+        await manager.start { [weak self] _ in
+            self?.foregroundFetchCallsCount += 1
+        }
     }
 
     /// Sets up the default state for the InAppMessageManager mock
@@ -98,7 +107,7 @@ class SseLifecycleManagerTest: XCTestCase {
         sut = createLifecycleManager()
 
         // Action
-        await sut.start()
+        await startLifecycleManager(sut)
 
         // Allow time for async operations
         try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
@@ -115,7 +124,7 @@ class SseLifecycleManagerTest: XCTestCase {
         sut = createLifecycleManager()
 
         // Action
-        await sut.start()
+        await startLifecycleManager(sut)
 
         // Allow time for async operations
         try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
@@ -133,7 +142,7 @@ class SseLifecycleManagerTest: XCTestCase {
         sut = createLifecycleManager()
 
         // Action
-        await sut.start()
+        await startLifecycleManager(sut)
 
         // Allow time for async operations
         try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
@@ -149,7 +158,7 @@ class SseLifecycleManagerTest: XCTestCase {
         sut = createLifecycleManager()
 
         // Action
-        await sut.start()
+        await startLifecycleManager(sut)
 
         // Allow time for async operations
         try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
@@ -166,7 +175,7 @@ class SseLifecycleManagerTest: XCTestCase {
         sut = createLifecycleManager()
 
         // Action
-        await sut.start()
+        await startLifecycleManager(sut)
 
         // Allow time for async operations
         try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
@@ -178,57 +187,47 @@ class SseLifecycleManagerTest: XCTestCase {
     // MARK: - Foreground Transition Tests
 
     func test_foregroundNotification_givenSseEnabled_expectConnectionStarted() async {
-        // Setup: Start with SSE enabled
         setupDefaultState(useSse: true)
         sut = createLifecycleManager()
-        await sut.start()
+        await startLifecycleManager(sut)
 
-        // Reset mock to track only foreground-triggered calls
-        // First, the initial start() may have called startConnection, so we reset
         sseConnectionManagerMock.resetMock()
+        foregroundFetchCallsCount = 0
 
-        // Simulate app going to background first
         NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
-        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+        try? await Task.sleep(nanoseconds: 100000000)
         sseConnectionManagerMock.resetMock()
 
-        // Action: Simulate foreground notification
         NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+        try? await Task.sleep(nanoseconds: 100000000)
 
-        // Allow time for async operations
-        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
-
-        // Assert
         XCTAssertTrue(sseConnectionManagerMock.startConnectionCalled)
         XCTAssertEqual(sseConnectionManagerMock.startConnectionCallsCount, 1)
+        XCTAssertEqual(foregroundFetchCallsCount, 1)
     }
 
     func test_foregroundNotification_givenSseDisabled_expectNoConnection() async {
-        // Setup: SSE disabled
         setupDefaultState(useSse: false)
         sut = createLifecycleManager()
-        await sut.start()
+        await startLifecycleManager(sut)
 
-        // Simulate app going to background first
         NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
-        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+        try? await Task.sleep(nanoseconds: 100000000)
         sseConnectionManagerMock.resetMock()
+        foregroundFetchCallsCount = 0
 
-        // Action: Simulate foreground notification
         NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+        try? await Task.sleep(nanoseconds: 100000000)
 
-        // Allow time for async operations
-        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
-
-        // Assert: No connection should be started
         XCTAssertFalse(sseConnectionManagerMock.startConnectionCalled)
+        XCTAssertEqual(foregroundFetchCallsCount, 0)
     }
 
     func test_foregroundNotification_givenAlreadyForegrounded_expectSkipped() async {
         // Setup: SSE enabled
         setupDefaultState(useSse: true)
         sut = createLifecycleManager()
-        await sut.start()
+        await startLifecycleManager(sut)
 
         // Reset mock after initial start
         try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
@@ -250,7 +249,7 @@ class SseLifecycleManagerTest: XCTestCase {
         // Setup: SSE enabled
         setupDefaultState(useSse: true)
         sut = createLifecycleManager()
-        await sut.start()
+        await startLifecycleManager(sut)
         try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
 
         // Action: Simulate background notification
@@ -268,7 +267,7 @@ class SseLifecycleManagerTest: XCTestCase {
         // Setup: SSE disabled
         setupDefaultState(useSse: false)
         sut = createLifecycleManager()
-        await sut.start()
+        await startLifecycleManager(sut)
         try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
 
         // Action: Simulate background notification
@@ -287,7 +286,7 @@ class SseLifecycleManagerTest: XCTestCase {
         // Setup: SSE enabled
         setupDefaultState(useSse: true)
         sut = createLifecycleManager()
-        await sut.start()
+        await startLifecycleManager(sut)
 
         // First background
         NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
@@ -310,7 +309,7 @@ class SseLifecycleManagerTest: XCTestCase {
         // Setup: SSE initially disabled
         setupDefaultState(useSse: false)
         sut = createLifecycleManager()
-        await sut.start()
+        await startLifecycleManager(sut)
         try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
 
         // Verify no connection started initially
@@ -330,7 +329,7 @@ class SseLifecycleManagerTest: XCTestCase {
         // Setup: SSE initially enabled
         setupDefaultState(useSse: true)
         sut = createLifecycleManager()
-        await sut.start()
+        await startLifecycleManager(sut)
         try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
 
         // Reset mock after initial connection
@@ -350,7 +349,7 @@ class SseLifecycleManagerTest: XCTestCase {
         // Setup: SSE initially disabled
         setupDefaultState(useSse: false)
         sut = createLifecycleManager()
-        await sut.start()
+        await startLifecycleManager(sut)
 
         // Go to background
         NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
@@ -377,31 +376,27 @@ class SseLifecycleManagerTest: XCTestCase {
     // MARK: - Full Lifecycle Flow Tests
 
     func test_fullLifecycleFlow_foregroundBackgroundForeground() async {
-        // Setup: SSE enabled
         setupDefaultState(useSse: true)
         sut = createLifecycleManager()
-        await sut.start()
-        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+        await startLifecycleManager(sut)
+        try? await Task.sleep(nanoseconds: 100000000)
 
-        // Verify: Initial connection started
         XCTAssertEqual(sseConnectionManagerMock.startConnectionCallsCount, 1)
         XCTAssertEqual(sseConnectionManagerMock.stopConnectionCallsCount, 0)
+        XCTAssertEqual(foregroundFetchCallsCount, 0)
 
-        // Action: Go to background
         NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
-        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+        try? await Task.sleep(nanoseconds: 100000000)
 
-        // Verify: Connection stopped
         XCTAssertEqual(sseConnectionManagerMock.startConnectionCallsCount, 1)
         XCTAssertEqual(sseConnectionManagerMock.stopConnectionCallsCount, 1)
 
-        // Action: Return to foreground
         NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
-        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+        try? await Task.sleep(nanoseconds: 100000000)
 
-        // Verify: Connection started again
         XCTAssertEqual(sseConnectionManagerMock.startConnectionCallsCount, 2)
         XCTAssertEqual(sseConnectionManagerMock.stopConnectionCallsCount, 1)
+        XCTAssertEqual(foregroundFetchCallsCount, 1)
     }
 
     // MARK: - Anonymous User Tests (SSE requires identified user)
@@ -412,7 +407,7 @@ class SseLifecycleManagerTest: XCTestCase {
         sut = createLifecycleManager()
 
         // Action
-        await sut.start()
+        await startLifecycleManager(sut)
 
         // Allow time for async operations
         try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
@@ -422,31 +417,27 @@ class SseLifecycleManagerTest: XCTestCase {
     }
 
     func test_foregroundNotification_givenSseEnabledButAnonymousUser_expectNoConnection() async {
-        // Setup: SSE enabled but user is anonymous
         setupDefaultState(useSse: true, userId: nil)
         sut = createLifecycleManager()
-        await sut.start()
+        await startLifecycleManager(sut)
 
-        // Simulate going to background and back to foreground
         NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
-        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
+        try? await Task.sleep(nanoseconds: 100000000)
         sseConnectionManagerMock.resetMock()
+        foregroundFetchCallsCount = 0
 
-        // Action: Simulate foreground notification
         NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+        try? await Task.sleep(nanoseconds: 100000000)
 
-        // Allow time for async operations
-        try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
-
-        // Assert: No connection should be started for anonymous users
         XCTAssertFalse(sseConnectionManagerMock.startConnectionCalled)
+        XCTAssertEqual(foregroundFetchCallsCount, 0)
     }
 
     func test_sseFlagChangedToTrue_givenAnonymousUser_expectNoConnection() async {
         // Setup: SSE initially disabled, user is anonymous
         setupDefaultState(useSse: false, userId: nil)
         sut = createLifecycleManager()
-        await sut.start()
+        await startLifecycleManager(sut)
         try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
 
         // Verify no connection started initially
@@ -468,7 +459,7 @@ class SseLifecycleManagerTest: XCTestCase {
         // Setup: SSE enabled but user is initially anonymous
         setupDefaultState(useSse: true, userId: nil)
         sut = createLifecycleManager()
-        await sut.start()
+        await startLifecycleManager(sut)
         try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
 
         // Verify no connection started initially
@@ -489,7 +480,7 @@ class SseLifecycleManagerTest: XCTestCase {
         // Setup: SSE enabled and user is identified
         setupDefaultState(useSse: true, userId: "test-user")
         sut = createLifecycleManager()
-        await sut.start()
+        await startLifecycleManager(sut)
         try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
 
         // Verify connection started initially
@@ -511,7 +502,7 @@ class SseLifecycleManagerTest: XCTestCase {
         // Setup: SSE disabled, user is anonymous
         setupDefaultState(useSse: false, userId: nil)
         sut = createLifecycleManager()
-        await sut.start()
+        await startLifecycleManager(sut)
         try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
 
         // Action: User becomes identified but SSE is still disabled
@@ -528,7 +519,7 @@ class SseLifecycleManagerTest: XCTestCase {
         // Setup: SSE enabled, user is anonymous
         setupDefaultState(useSse: true, userId: nil)
         sut = createLifecycleManager()
-        await sut.start()
+        await startLifecycleManager(sut)
 
         // Go to background
         NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
@@ -558,7 +549,7 @@ class SseLifecycleManagerTest: XCTestCase {
         // Setup: SSE enabled, user is anonymous
         setupDefaultState(useSse: true, userId: nil)
         sut = createLifecycleManager()
-        await sut.start()
+        await startLifecycleManager(sut)
         try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
 
         // Verify: No initial connection (anonymous user)
@@ -586,7 +577,7 @@ class SseLifecycleManagerTest: XCTestCase {
         // Setup: SSE enabled but user is anonymous
         setupDefaultState(useSse: true, userId: nil)
         sut = createLifecycleManager()
-        await sut.start()
+        await startLifecycleManager(sut)
         try? await Task.sleep(nanoseconds: 100000000) // 0.1 seconds
 
         // Action: Go to background


### PR DESCRIPTION
### Reproducible

  - App in foreground → message displays immediately ✓
  - App closed, then opened → message displays on launch ✓
  - App in background, then foregrounded → message does NOT display until force-close and reopen ✗

### Root Cause

  Same bug as Android. When SSE support was introduced, a guard was added to fetchUserMessages() in Gist.swift that skips the HTTP fetch entirely when SSE is active (shouldUseSse = true). The
  SseLifecycleManager handles foreground transitions but only reconnects SSE — it never triggers an HTTP catch-up fetch.

  The sequence of events:

  1. App goes to background → SseLifecycleManager.handleBackgrounded() disconnects SSE
  2. Server sends an in-app message → nobody is listening
  3. App returns to foreground → handleForegrounded() calls startSseIfEligible()
  4. SSE reconnects but only delivers new real-time events, not missed messages
  5. fetchUserMessages() (polling) would skip the fetch due to the shouldUseSse guard
  6. The message is never retrieved

  On a cold start this doesn't happen because SSE hasn't been enabled yet (the flag comes from server response headers), so the first HTTP fetch runs before SSE is activated.

### Fix

  Added a foregroundFetchHandler closure parameter to SseLifecycleManager.start(). Gist passes its fetchUserQueue() method as the handler. When the app resumes from background and shouldUseSse is true,
   handleForegrounded() calls this handler to perform a one-time HTTP fetch before reconnecting SSE — catching up on any messages missed while the SSE connection was disconnected. All other code paths
  (polling, SSE flag changes, user identification changes) are unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes in-app message delivery behavior on app foreground by adding an extra HTTP catch-up fetch before reconnecting SSE; risk is moderate due to lifecycle timing/concurrency and potential for duplicate/extra fetches.
> 
> **Overview**
> Fixes a gap where in-app messages sent while the app was backgrounded were not retrieved when returning to foreground with SSE enabled.
> 
> `SseLifecycleManager.start` now accepts a `foregroundFetchHandler` callback; on foreground transitions *when `state.shouldUseSse` is true*, it triggers a one-time queue fetch before restarting the SSE connection. `Gist` wires this handler to `fetchUserQueue`, and mocks/tests are updated to cover the new callback and assert it fires only in the SSE-on-foreground path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98fdbecf79d2ce6eeda280aa9768171880334008. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->