### PR TITLE
chore: Surface Cocopods publishing failures

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -207,24 +207,32 @@ jobs:
         run: gem install cocoapods
       - name: '⚠️ Note: Pushing to cocoapods is flaky. If you see some errors in these logs while deploying, re-run this GitHub Action to try deployment again and it might fix the issue.'
         run: echo ''
-      - name: Push CustomerIOCommon
-        run: ./scripts/push-cocoapod.sh CustomerIOCommon.podspec
-      - name: Push CustomerIOTrackingMigration
-        run: ./scripts/push-cocoapod.sh CustomerIOTrackingMigration.podspec
-      - name: Push CustomerIODataPipelines
-        run: ./scripts/push-cocoapod.sh CustomerIODataPipelines.podspec
-      - name: Push CustomerIOMessagingPush
-        run: ./scripts/push-cocoapod.sh CustomerIOMessagingPush.podspec
-      - name: Push CustomerIOMessagingPushAPN
-        run: ./scripts/push-cocoapod.sh CustomerIOMessagingPushAPN.podspec
-      - name: Push CustomerIOMessagingPushFCM
-        run: ./scripts/push-cocoapod.sh CustomerIOMessagingPushFCM.podspec
-      - name: Push CustomerIOMessagingInApp
-        run: ./scripts/push-cocoapod.sh CustomerIOMessagingInApp.podspec
-      - name: Push CustomerIOLocation
-        run: ./scripts/push-cocoapod.sh CustomerIOLocation.podspec
-      - name: Push CustomerIO
-        run: ./scripts/push-cocoapod.sh CustomerIO.podspec
+      - name: Push all podspecs to CocoaPods
+        run: |
+          podspecs=(
+            CustomerIOCommon.podspec
+            CustomerIOTrackingMigration.podspec
+            CustomerIODataPipelines.podspec
+            CustomerIOMessagingPush.podspec
+            CustomerIOMessagingPushAPN.podspec
+            CustomerIOMessagingPushFCM.podspec
+            CustomerIOMessagingInApp.podspec
+            CustomerIOLocation.podspec
+            CustomerIO.podspec
+          )
+
+          failed_pods=()
+          for podspec in "${podspecs[@]}"; do
+            if ! ./scripts/push-cocoapod.sh "$podspec"; then
+              failed_pods+=("$podspec")
+            fi
+          done
+
+          if [[ ${#failed_pods[@]} -gt 0 ]]; then
+            echo "::error::The following pods failed to publish: ${failed_pods[*]}"
+            exit 1
+          fi
+          echo "All pods published successfully."
 
       - name: Notify team of successful deployment
         uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0

--- a/scripts/push-cocoapod.sh
+++ b/scripts/push-cocoapod.sh
@@ -21,16 +21,23 @@ PODSPEC="$1"
 
 if ! [[ -f "$PODSPEC" ]]; then
     echo "File $PODSPEC does not exist. Please check the pod name."
+    exit 1
 fi
 
 echo "Pushing podspec: $PODSPEC."
-echo "Pushing to cocoapods is flaky and there might be errors that happen when pushing to cocoapods that might not mean the deployment failed."
-echo "If you do notice an error message when trying to push a pod,"
-echo "1. Check this github repo https://github.com/search?q=repo%3ACocoaPods%2FSpecs+customerio&type=commits to find the pods that successfully deployed. Dont trust cocoapods.org or the logs from this script if a deployment was successful or not."
-echo "2. Feel free to re-run a GitHub Action if you see errors. This script can be run many times and not cause issues with pods that have already been deployed."
+echo "If a pod version has already been published, it will be treated as success."
+echo "For any other failure, the script will exit with a non-zero code."
 
-# the '|| true' code makes it so the command never fails, even if an error is returned. 
-# CocoaPods deployments are flaky. Because of that, when you deploy to cocoapods it's best that you manually confirm 
-# that the pods all got deployed successfully. If not, just re-run the job on github actions to try pushing the pods again. 
-# If you try to re-run the github action without '|| true', the script would fail early and not allow you to retry pushing all pods. 
-pod trunk push "$PODSPEC" --allow-warnings --synchronous || true 
+OUTPUT=$(pod trunk push "$PODSPEC" --allow-warnings --synchronous 2>&1) || true
+echo "$OUTPUT"
+
+if echo "$OUTPUT" | grep -q "successfully published"; then
+  echo "Pod $PODSPEC published successfully."
+  exit 0
+elif echo "$OUTPUT" | grep -q "Unable to accept duplicate entry for"; then
+  echo "Pod $PODSPEC has already been published. Skipping."
+  exit 0
+else
+  echo "::error::Failed to push $PODSPEC."
+  exit 1
+fi


### PR DESCRIPTION
### Summary

  CocoaPods publish failures were silently swallowed by `|| true`, so a broken release looked green and had to be caught by manually checking logs. This PR makes the deploy job actually fail when a pod fails to publish, while
  still treating already-published pods as success so reruns stay safe.

### Expected behavior

  - Job fails loudly when any pod fails, with the failing pods named in the error
  - Reruns after a partial publish succeed (duplicates are skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes deployment pipeline behavior to fail on CocoaPods publish errors, which could block releases if the script misclassifies transient trunk output; functionality change is isolated to CI/release tooling.
> 
> **Overview**
> Makes CocoaPods publishing failures visible by **stopping the deploy job when any podspec push fails**.
> 
> The deploy workflow now pushes all podspecs in a loop, collects any failures, and exits non-zero with the failing podspec names. The `push-cocoapod.sh` script no longer silently swallows errors; it parses `pod trunk push` output to treat *already-published* versions as success but fails on other errors (and exits early if the podspec file is missing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc68ef52cd856984b87f29e6810e6a7b8bbbcd61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->