### PR TITLE
chore(deps): resolve 3rd-party vulnerabilities (MBL-1696)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,11 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # gem "rails"
 
+# Security pins for transitive deps (MBL-1696)
+gem "addressable", "2.9.0"
+gem "faraday", "1.10.5"
+gem "aws-sdk-s3", "1.208.0"
+gem "rexml", "3.4.2"
+
 gem "fastlane"
 gem 'fastlane-plugin-firebase_app_distribution'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,30 +5,32 @@ GEM
       base64
       nkf
       rexml
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     artifactory (3.0.17)
     atomos (0.1.3)
     aws-eventstream (1.3.2)
     aws-partitions (1.1106.0)
-    aws-sdk-core (3.224.0)
+    aws-sdk-core (3.246.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
       base64
+      bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
     aws-sdk-kms (1.101.0)
       aws-sdk-core (~> 3, >= 3.216.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.186.1)
-      aws-sdk-core (~> 3, >= 3.216.0)
+    aws-sdk-s3 (1.208.0)
+      aws-sdk-core (~> 3, >= 3.234.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.11.0)
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     base64 (0.2.0)
+    bigdecimal (4.1.2)
     claide (1.1.0)
     colored (1.2)
     colored2 (3.1.2)
@@ -41,7 +43,7 @@ GEM
     dotenv (2.8.1)
     emoji_regex (3.2.3)
     excon (0.112.0)
-    faraday (1.10.4)
+    faraday (1.10.5)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -186,7 +188,7 @@ GEM
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.4.1)
+    rexml (3.4.2)
     rouge (3.28.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.4.1)
@@ -232,8 +234,12 @@ PLATFORMS
   x86_64-darwin-22
 
 DEPENDENCIES
+  addressable (= 2.9.0)
+  aws-sdk-s3 (= 1.208.0)
+  faraday (= 1.10.5)
   fastlane
   fastlane-plugin-firebase_app_distribution
+  rexml (= 3.4.2)
 
 BUNDLED WITH
    2.6.2


### PR DESCRIPTION
## Summary

Addresses [MBL-1696](https://linear.app/customerio/issue/MBL-1696) — Fix 3rd-party vulnerabilities (Non-Breaking) in `customerio-ios`.

Pins fastlane's transitive Ruby gem deps to patched versions per Socket advisories.

| Package | From | To | Advisory |
|---|---|---|---|
| addressable | 2.8.7 | **2.9.0** | GHSA-h27x-rffw-24p4 (CVE-2026-35611) |
| faraday | 1.10.4 | **1.10.5** | GHSA-33mh-2634-fwr2 (CVE-2026-25765) |
| aws-sdk-s3 | 1.186.1 | **1.208.0** | GHSA-2xgq-q749-89fq (CVE-2025-14762) |
| rexml | 3.4.1 | **3.4.2** | GHSA-c2f4-jgmc-q2r5 (CVE-2025-58767) |

### Notes

- Manifest-only change (Gemfile). `Gemfile.lock` will be regenerated by CI.
- These are fastlane build-tooling pins; the published Swift Package SDK is unaffected.

## Test plan

- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-tooling-only dependency pins with no application/runtime code changes; main risk is CI/build breakage from gem resolution changes.
> 
> **Overview**
> Pins vulnerable transitive Ruby gems used by `fastlane` to patched versions by explicitly adding them to the `Gemfile` (`addressable` 2.9.0, `faraday` 1.10.5, `aws-sdk-s3` 1.208.0, `rexml` 3.4.2).
> 
> Updates `Gemfile.lock` accordingly, including bumping `aws-sdk-core` and introducing `bigdecimal` as a resolved dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cac03fe695358fea95ee079b43be54d6f7518a48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->