### PR TITLE
docs: Foundational Documentation and ADRs

### DIFF
--- a/v5/CLAUDE.md
+++ b/v5/CLAUDE.md
@@ -1,0 +1,240 @@
+# Claude Code Instructions — CustomerIO iOS SDK Reimplementation
+
+> **SCOPE OVERRIDE — READ FIRST**
+> This file is the sole source of instructions for all work within `v5/`.
+> The `CLAUDE.md` at the repository root does **not** apply to any code,
+> file, or decision within this directory. If those instructions conflict
+> with or extend anything here, ignore them entirely while working in `v5/`.
+
+> This file is the entry point for AI-assisted development on this project.
+> All code generation, review, and refactoring must be grounded in the specs
+> referenced here. Code is a build artifact of the specification — not the
+> source of truth.
+
+---
+
+## Project Overview
+
+**Project:** CustomerIO iOS SDK Reimplementation
+**Type:** SDK
+**Primary Language:** Swift 6.2
+**Target Platform:** iOS 13+
+
+A clean-room Swift 6.2 reimplementation of the Customer.io iOS SDK. Replaces
+the `cdp-analytics-swift` dependency with an owned event pipeline, uses
+SqlCipher for all encrypted on-device storage, and introduces a server-driven
+event aggregation engine. Distributed via Swift Package Manager only.
+
+---
+
+## Spec Hierarchy
+
+All specifications live in `/spec`. Code must not diverge from these documents.
+If the code and spec conflict, the spec wins — update the code, not the spec,
+unless a spec change is explicitly intended and documented.
+
+```
+/spec
+  /domain          # Core domain model, entities, and relationships
+  /features        # Per-feature specifications
+  /decisions       # Architecture Decision Records (ADRs)
+  /interfaces      # API contracts, SDK interfaces, data models
+  GLOSSARY.md      # Canonical terminology — always use these terms
+
+/behavioral-scenarios
+  core.csv         # Given/When/Then scenarios for the core SDK (identity, events, aggregation, …)
+  push.csv         # Given/When/Then scenarios for the push module (token registration, NSE, deduplication, …)
+```
+
+Each CSV has columns: `#, Area, Given, When, Then, Environment, Setup Tags, Comparative, Tests`.
+The `Environment` column indicates where a scenario is validated:
+- **Demo App** — manual verification in the demo application
+- **Integration Testing** — automated test against real SDK internals (no UIKit/NSE mocking)
+- **Unit Testing** — isolated unit test
+- **Separate** — separate project or device required (e.g. fresh install, legacy migration)
+
+The `Tests` column lists the specific test function name(s) that cover that scenario, semicolon-separated.
+Scenarios with an empty `Tests` cell have no automated coverage yet.
+
+**Start here for context:**
+- Domain model: `/spec/domain/domain-model.md`
+- Glossary: `/spec/GLOSSARY.md`
+- Current active features: `/spec/features/`
+- Behavioral scenarios: `/behavioral-scenarios/`
+- Outstanding work and test coverage: `TODO.md`
+- Unresolved design questions: `OPEN_QUESTIONS.md`
+
+---
+
+## Engineering Principles
+
+This project follows **SOLID principles** strictly. When generating or reviewing
+code, apply these in order of priority:
+
+1. **Single Responsibility** — Every class, module, and function has one reason
+   to change. If you find yourself writing "and" to describe what something does,
+   it needs to be split.
+
+2. **Open/Closed** — Extend behavior through abstraction, not modification.
+   Prefer protocols/interfaces over concrete inheritance.
+
+3. **Liskov Substitution** — Subtypes must be substitutable for their base types
+   without altering correctness. Flag any violation explicitly.
+
+4. **Interface Segregation** — Prefer narrow, focused interfaces over broad ones.
+   No client should depend on methods it does not use.
+
+5. **Dependency Inversion** — Depend on abstractions, not concretions. All
+   dependencies should be injected, not instantiated internally.
+
+**Additional non-negotiable principles:**
+- No magic numbers or strings — all constants are named and documented
+- All public interfaces are documented before implementation
+- Error states are explicit — no silent failures
+- Side effects are isolated and clearly identified
+
+### String Constants — `CIOKeys` Namespace
+
+Repeated string literals (storage keys, table names, event names, payload
+headers) are collected in the `CIOKeys` namespace rather than scattered as
+inline literals.
+
+**Pattern:**
+- The root `public enum CIOKeys` lives in
+  `Sources/CustomerIO_Utilities/Keys/CIOKeys.swift`.
+- Constants shared between two or more modules are added to extensions in
+  `Sources/CustomerIO_Utilities/Keys/` (e.g. `CIOKeys+Storage.swift`).
+- Constants that belong entirely within one module are added to an `internal`
+  extension in that module's own `Keys/` subdirectory
+  (e.g. `Sources/MessagingPush/Keys/CIOKeys+MessagingPush.swift`).
+
+**Rules:**
+- Constants are organised by **intended use**, not by value. Two constants may
+  share the same string value if they represent different semantic concepts.
+  Do not alias one to the other; declare them independently.
+- Do not extract a string into `CIOKeys` if it appears only once in the codebase.
+- When a string gains a second use site *for the same purpose*, move it to the
+  appropriate extension.
+
+### Thread-Safe Shared State — `Synchronized<T>`
+
+`Synchronized<T>` in `Sources/CustomerIO_Utilities/Synchronized/Synchronized.swift` is
+the canonical lock-protected wrapper for mutable state that crosses concurrency
+boundaries.
+
+**Do not create:**
+- Custom actor types whose only purpose is to wrap a value (e.g. `actor Box<T>`,
+  `actor Counter`)
+- Ad-hoc `@unchecked Sendable` struct/class wrappers around a value + lock
+
+**Use `Synchronized<T>` instead:**
+
+```swift
+let counter = Synchronized<Int>(0)
+counter.mutating { $0 += 1 }          // atomic read-modify-write
+let n = counter.wrappedValue           // atomic read
+let n = counter.using { $0.count }    // read with transform
+```
+
+This applies in both production code and tests. Test helpers like `ActorCounter`
+or `ActorBox` should never be introduced — `Synchronized` covers the same need
+without an extra actor hop.
+
+---
+
+## What a Bug Means Here
+
+> A bug is a gap between the specification and the implementation — not bad code.
+
+Before writing a fix:
+1. Identify which spec document governs the affected behavior
+2. Determine whether the spec is ambiguous or the implementation diverged
+3. If the spec is ambiguous — update the spec first, then implement
+4. If the implementation diverged — correct the implementation to match the spec
+5. Never patch code to pass a test if the spec does not support the behavior
+
+---
+
+## Code Generation Rules
+
+When generating code from a spec:
+
+- **Read the relevant spec file in full before writing any code**
+- Use terminology from `spec/GLOSSARY.md` exactly — do not invent synonyms
+- Implement what the spec states, nothing more
+- If the spec has a gap that requires a judgment call, pause and state the
+  assumption explicitly before proceeding — do not silently fill gaps
+- Generate interfaces and contracts before implementations
+- If an implementation decision conflicts with a SOLID principle, flag it
+  rather than silently compromising
+
+### Architectural Decision Documentation
+
+Whenever a structural or architectural decision is made — including refactors,
+module splits, access-level changes, migration of code between targets, or any
+choice that affects how the codebase is organised — add an ADR to
+`/spec/decisions/` with:
+
+- **What** changed (the specific files, types, or boundaries affected)
+- **Why** it was done (the goal or problem being solved)
+- **Tradeoffs** considered, if any were non-obvious
+
+This applies to decisions made during implementation, not just up-front design.
+If a refactor reveals a better split, or a constraint changes the approach, that
+reasoning belongs in an ADR so the next reader understands the shape of the
+code without having to reverse-engineer it from git history.
+
+---
+
+## Pull Request Expectations
+
+Every PR that modifies source code must also:
+
+- [ ] Update the relevant `/spec/features/` document if behavior changed
+- [ ] Add an ADR in `/spec/decisions/` if an architectural decision was made
+- [ ] Update `/spec/GLOSSARY.md` if new terms were introduced
+- [ ] Update `TODO.md` to reflect completed or newly discovered work
+
+PRs that modify spec files without corresponding code changes are valid —
+spec refinement is legitimate work.
+
+---
+
+## Architectural Decisions
+
+Significant decisions are recorded as ADRs in `/spec/decisions/`.
+
+Format: `NNN-short-title.md`
+
+Each ADR captures:
+- **Status:** Proposed / Accepted / Superseded
+- **Context:** Why this decision was needed
+- **Decision:** What was decided
+- **Consequences:** What this enables and what it constrains
+- **Supersedes / Superseded by:** Links to related ADRs
+
+ADRs are append-only. Never edit an accepted ADR — write a new one that
+supersedes it.
+
+---
+
+## Glossary Discipline
+
+`/spec/GLOSSARY.md` is the canonical source for all domain terminology.
+
+- If a term appears in code that is not in the glossary, add it before the PR merges
+- If a term in code differs from the glossary, the code is wrong
+- Use glossary terms verbatim in generated code, comments, and variable names
+
+---
+
+## Out of Scope
+
+Do not generate the following without explicit instruction and a corresponding
+spec update:
+
+- New public interfaces or API surface
+- New dependencies or third-party integrations
+- Database schema changes
+- Changes to error handling contracts
+- Performance optimizations that change observable behavior

--- a/v5/spec/GLOSSARY.md
+++ b/v5/spec/GLOSSARY.md
@@ -1,0 +1,170 @@
+# CustomerIO iOS SDK — Glossary
+
+Canonical terminology for this project. All code, comments, and documentation
+must use these terms exactly. If a term appears in code that is not listed here,
+add it before the PR merges.
+
+---
+
+## Core Types
+
+**`Variant`**
+The typed discriminated-union value type used for all event properties, traits,
+and attributes. Replaces `[String: Any]` across the entire SDK. `Codable`,
+`Sendable`, and `Equatable`. Cases: `.string`, `.int`, `.float`, `.bool`,
+`.date`, `.data`, `.array`, `.object`, `.null`. Renamed from `Commuted` —
+`Variant` is the standard PL-theory term (see `std::variant`, Rust enum
+variants). Lives in `Sources/CustomerIO/Variant/`.
+
+**`VariantConvertible`**
+Protocol for types that can convert themselves to `Variant` via `asVariant()`.
+All standard Swift types (`String`, `Int`, `Double`, `Bool`, `Date`, `Data`,
+`Array`, `Dictionary`, `Optional`) conform. Lives in `Sources/CustomerIO/Variant/`.
+
+**`PendingEvent`**
+An enum representing an event that has been accepted by the public API but not
+yet enriched or queued. Cases: `.track`, `.trackSynthesized`, `.identify`,
+`.screen`, `.clearIdentify`, `.setProfileAttributes`, `.setDeviceAttributes`.
+`trackSynthesized` bypasses the aggregation stage; all others pass through it.
+
+**`EnrichedEvent`**
+An event that has passed through the enrichment stage: timestamp, anonymousId,
+and profile context have been resolved. Carries `type`, `name`, `category`,
+`properties`, `timestamp`, and `anonymousId`.
+
+**`PersistedEvent`**
+An `EnrichedEvent` that has been written to the `event_queue` SQLite table.
+Carries a `storageId: Int64` primary key in addition to the event data.
+
+**`AggregationResult`**
+The outcome of evaluating an `EnrichedEvent` against the active ruleset.
+Cases: `.passThrough` (event proceeds to the queue), `.aggregated` (event
+absorbed into an accumulator), `.discarded` (event silently dropped).
+
+**`AggregationRule`**
+A server-configured rule that intercepts events by name and applies one or more
+`AggregateOperation` values. Carries `id`, `eventRules`, `uploadInterval`,
+and `scope` (`.device` or `.profile`).
+
+**`AccumulatorValue`**
+A typed slot in an accumulator's state dictionary. Cases: `.int`, `.double`,
+`.string`, `.variant`, `.stringSet`, `.histogram`, `.never`. `Codable` for
+encrypted persistence across app restarts.
+
+**`Synchronized<T>`**
+A thread-safe wrapper for non-`Sendable` values. `@unchecked Sendable`. Provides
+`.using { }` for read-only access and `.mutating { }` for mutation. Used wherever
+actor-isolated state must be read from `nonisolated` contexts (e.g. `_log`,
+`_currentToken` on `MessagingPushModule`).
+
+---
+
+## Protocols
+
+**`CIOModule`**
+The protocol all feature modules conform to. Two startup phases:
+- Phase 1 (`preActivate`) — synchronous, before the first run-loop cycle
+- Phase 2 (`configure`) — async, after the database and pipeline are ready
+
+**`CIOTrackingClient`**
+A narrow public protocol abstracting the CustomerIO tracking surface.
+`CustomerIO` conforms via an empty extension. Used by sub-modules (e.g.
+`MessagingPushModule`) so they can emit metric events without holding a direct
+`CustomerIO` reference, enabling mock injection in tests.
+
+**`ProfileEnhancing`**
+Optional `CIOModule` protocol. The root calls conforming modules during every
+`identify()` to collect additional profile attributes to merge into the payload.
+
+**`PushTokenProvider`**
+Protocol abstracting push token delivery. `APNPushProvider` is the
+SDK-supplied implementation for APNs. Apps using Firebase implement their own
+conformance wrapping `Firebase.Messaging`. The SDK never imports Firebase.
+
+**`FirebaseService`**
+Protocol boundary between the FCM push module and Firebase. The app provides
+a conforming wrapper. Keeps `MessagingPushFCM` free of any Firebase dependency.
+
+**`DatabaseKeyProvider`**
+Protocol for supplying the SqlCipher encryption passphrase. Two implementations:
+`ApiKeyDatabaseKeyProvider` (default; uses the CDP API key verbatim) and
+`KeychainDatabaseKeyProvider` (generates a per-install 256-bit random key
+stored in the platform Keychain).
+
+**`EventBus`**
+Protocol for the type-keyed pub/sub bus. Implemented by `CommonEventBus`.
+Used for cross-module SDK-internal communication only. App code never
+interacts with it directly.
+
+---
+
+## Key Components
+
+**`StorageManager`**
+A `struct` (stateless gateway) in `CustomerIO_Utilities`. All data is written
+to an encrypted SqlCipher database. Module-specific query methods live in
+`extension StorageManager` files inside their owning module — not in the core
+struct. Its `db: Database` property is `package` access.
+
+**`AggregationEngine`**
+An `actor` that holds the active ruleset and all in-progress accumulators.
+Evaluates events, updates accumulator state, and emits synthesised flush events
+via an injected `@Sendable (PendingEvent) -> Void` closure.
+
+**`EventProcessor`**
+A stateless `struct` whose collaborators are injected as closures. Isolates
+the per-event dispatch logic (five branches) from the `AsyncStream`-driving
+loop in `CustomerIO`. Fully testable with lambda mocks.
+
+**`PushClickHandler`**
+Handles metric tracking when a CIO push notification is clicked or displayed.
+Depends on `CIOTrackingClient` (not `CustomerIO` directly) for testability.
+
+**`CommonEventBus`**
+The SDK-internal typed pub/sub bus. No logging. Observer handlers run
+off-actor. Used by modules to react to SDK lifecycle events (e.g. `ResetEvent`,
+`ProfileIdentifiedEvent`).
+
+**`ModuleRegistry`**
+An `actor` that stores `[ObjectIdentifier: any CIOModule]`. Modules are
+registered during `configure(_:)` and retrieved via `module(ofType:)`.
+
+---
+
+## Events (CIOEvent namespace)
+
+**`CIOEvent.ProfileIdentifiedEvent`** — Posted by `CustomerIO` when `identify()` is called.
+**`CIOEvent.AnonymousProfileIdentifiedEvent`** — Posted when anonymous identification occurs.
+**`CIOEvent.ScreenViewedEvent`** — Posted by `CustomerIO` when `screen()` is called.
+**`CIOEvent.ResetEvent`** — Posted by `CustomerIO` when `clearIdentify()` is called.
+
+---
+
+## Architecture Terms
+
+**`CIOKeys`**
+The namespace for all repeated string literals (event names, storage keys, table
+names, payload headers). Root enum in `CustomerIO_Utilities`; extended per-module.
+
+**`preActivate`**
+Phase 1 of module startup. Runs synchronously before
+`application(_:didFinishLaunchingWithOptions:)` returns. Only modules that must
+register OS-level delegates (currently `MessagingPushModule`) override the
+default no-op.
+
+**`startConfigure`**
+The preferred entry point for SDK initialization. Calls `activateModulesForLaunch`
+synchronously, then kicks off `configure(_:)` in a `Task`. Calls `onCompletion`
+when done (`nil` = success). Satisfies Apple's requirement that
+`UNUserNotificationCenter.delegate` be set before the app finishes launching.
+
+**`trackSynthesized`**
+A `PendingEvent` case for events emitted internally by the SDK (e.g. flush events
+from `AggregationEngine`, `"Device Deleted"` from `unregisterDevice()`). These
+bypass the aggregation evaluation stage and go directly to enrichment and the queue.
+
+**`unregisterDevice`**
+Public method on `MessagingPushModule`. Emits `"Device Deleted"` to the backend
+to disassociate this device from the current user's profile, without affecting
+local identity, the system push permission, or the stored token. The token is
+retained for automatic re-registration on the next `identify()` profile change.

--- a/v5/spec/decisions/001-sqlcipher-encrypted-storage.md
+++ b/v5/spec/decisions/001-sqlcipher-encrypted-storage.md
@@ -1,0 +1,54 @@
+# ADR 001 — SqlCipher for All On-Device Storage
+
+**Status:** Accepted
+
+---
+
+## Context
+
+The previous SDK stored its event queue and profile data in plain text
+(`UserDefaults` and `EventStorageManager` flat files). Events routinely carry
+PII — user identifiers, traits, and behavioral data. Storing this unencrypted
+is unacceptable; the SDK must encrypt all data at rest regardless of device
+encryption state.
+
+Encrypting on-device storage requires owning the storage layer entirely.
+`cdp-analytics-swift` writes its event queue to plain SQLite with no encryption
+path — it cannot be patched to use SqlCipher without forking the library. This
+is one of the requirements addressed in ADR 003.
+
+## Decision
+
+All data written to disk uses **SqlCipherKit**. `UserDefaults` and flat-file JSON
+storage are removed entirely from the new SDK.
+
+- The passphrase is supplied by a `DatabaseKeyProvider` protocol, configured at
+  SDK init time via `SdkConfigBuilder.databaseKeyProvider(_:)`.
+- Two implementations are provided out of the box:
+  - `ApiKeyDatabaseKeyProvider` (default) — uses the CDP API key verbatim.
+  - `KeychainDatabaseKeyProvider` — generates a 256-bit random key on first
+    launch, stored in the Keychain with `kSecAttrAccessibleAfterFirstUnlock`.
+- The database filename and Keychain account name are both scoped to the CDP API
+  key. Rotating the API key automatically produces a new database file and a new
+  Keychain entry; the old database is orphaned without an explicit cleanup step.
+
+## Consequences
+
+### What this enables
+
+- All PII stored by the SDK is encrypted at rest, regardless of device
+  encryption state.
+- `KeychainDatabaseKeyProvider` provides per-install, hardware-bound key
+  isolation, inaccessible even to someone with the app binary.
+- A single `StorageManager` struct serves as the stateless gateway for all
+  modules; module-specific query methods live in extensions inside their owning
+  module target.
+
+### What this constrains
+
+- SqlCipherKit is a required dependency for the entire SDK. Apps that do not
+  need encryption cannot opt out.
+- Database migrations must be managed explicitly via `MigrationRunner`. Each
+  module that adds tables must register a `Migration` conformance.
+- The `StorageManager.db` property is `package` access — visible within the
+  Swift package but not to external consumers.

--- a/v5/spec/decisions/002-actor-based-concurrency.md
+++ b/v5/spec/decisions/002-actor-based-concurrency.md
@@ -1,0 +1,49 @@
+# ADR 002 — Swift 6.2 Actor-Based Concurrency Throughout
+
+**Status:** Accepted
+
+---
+
+## Context
+
+The previous SDK was not written with `Sendable` enforcement or actor isolation.
+`cdp-analytics-swift` produced `@preconcurrency` wrappers or suppressed warnings
+that hid real data races. The reimplementation targets Swift 6.2 with strict
+concurrency enabled, which is structurally incompatible with the previous
+library's concurrency model. This is one of the requirements addressed in ADR 003.
+
+## Decision
+
+Adopt **Swift 6.2 strict concurrency** throughout:
+
+- All public-facing mutable state lives in `actor` types.
+- All cross-boundary types conform to `Sendable`.
+- Event-tracking methods (`track`, `identify`, `screen`, etc.) on `CustomerIO`
+  are `nonisolated` — callable from any thread or isolation domain without `await`.
+- Pre-configure event buffering is handled by `AsyncStream`'s built-in buffer
+  (capped at 100 events, oldest-first). No separate two-mode buffer is needed.
+- `Synchronized<T>` bridges actor-owned state to `nonisolated` access sites
+  (e.g. module loggers, push token mirrors) without crossing actor boundaries.
+
+## Consequences
+
+### What this enables
+
+- No data races possible in the SDK's own code under strict checking.
+- `nonisolated` tracking methods allow the SDK to be called from `@MainActor`
+  views, background threads, and notification extensions without `await`.
+- Pre-configure events are buffered automatically and drained in order once
+  `configure()` completes.
+- Modules that need `@MainActor` (e.g. `MessagingInApp`) dispatch internally
+  without requiring the root actor to be `@MainActor`.
+
+### What this constrains
+
+- iOS 13+ minimum deployment target required (Swift concurrency embedded runtime).
+- `os.Logger` structured logging (iOS 14+) and `Clock`/`ContinuousClock`
+  (iOS 16+) are not used. Flush timing relies on app lifecycle events, not
+  background timers.
+- `URLSession` async APIs (iOS 15+) are not used. The HTTP client wraps the
+  completion-handler API in `withCheckedContinuation` for iOS 13/14 compatibility.
+- `@preconcurrency` annotations are used sparingly and only where Swift's region
+  checker produces a known false positive (documented inline).

--- a/v5/spec/decisions/003-remove-analytics-swift.md
+++ b/v5/spec/decisions/003-remove-analytics-swift.md
@@ -1,0 +1,51 @@
+# ADR 003 — Remove cdp-analytics-swift Dependency
+
+**Status:** Accepted
+
+---
+
+## Context
+
+The previous SDK depended on `cdp-analytics-swift` (Segment's analytics library)
+for its event pipeline, upload scheduler, and retry logic. Two prior
+architectural requirements make this dependency untenable:
+
+- **ADR 001 — Encrypted storage**: All on-device data must be encrypted via
+  SqlCipher. `cdp-analytics-swift` writes its event queue to plain SQLite with
+  no encryption path. This cannot be addressed by configuration or extension —
+  it requires owning the storage layer entirely.
+
+- **ADR 002 — Swift 6.2 strict concurrency**: The SDK must compile cleanly
+  under Swift 6.2 with full `Sendable` enforcement. `cdp-analytics-swift` was
+  not written with actor isolation; it produces `@preconcurrency` suppressions
+  that hide real data races and is structurally incompatible with the required
+  concurrency model.
+
+A third requirement compounds this: the server-driven `AggregationEngine`
+(see ADR 005) evaluates events before they enter the upload queue and may absorb
+them into accumulators rather than forwarding them immediately. This does not
+map onto the drain-on-queue assumptions built into `analytics-swift`'s scheduler.
+Implementing the aggregation model requires controlling the full path from event
+receipt to upload.
+
+None of these requirements can be met by patching or wrapping the existing
+library. The dependency must be removed.
+
+## Decision
+
+Remove `cdp-analytics-swift` entirely. Own the full event pipeline:
+enrichment → aggregation → queue → upload/retry.
+
+## Consequences
+
+### What this constrains
+
+- The upload/retry pipeline must be reimplemented from scratch. The area of
+  `cdp-analytics-swift` most worth preserving as *reference* — not reinventing —
+  is the batch upload pipeline: exponential backoff with jitter, deduplication
+  across restarts, ordering guarantees, and partial-batch failure handling.
+  These have years of production hardening. Treat the `cdp-analytics-swift`
+  source as the specification for this layer.
+- Any plugin-based interception model (`analytics-swift`'s `Plugin` API) is not
+  carried forward. There is no public plugin protocol for customer code to
+  intercept the event pipeline.

--- a/v5/spec/decisions/004-spm-only-distribution.md
+++ b/v5/spec/decisions/004-spm-only-distribution.md
@@ -1,0 +1,37 @@
+# ADR 004 — Swift Package Manager as Sole Distribution Channel
+
+**Status:** Accepted
+
+---
+
+## Context
+
+The previous SDK supported CocoaPods as its primary distribution channel.
+CocoaPods has been officially deprecated; the trunk repository will become
+read-only in fall 2026.
+
+## Decision
+
+The SDK is distributed via **Swift Package Manager only**. No `.podspec` is
+maintained or published.
+
+## Consequences
+
+### What this enables
+
+- No dual-distribution maintenance burden (`.podspec` + `Package.swift`).
+- Wrapper SDK compatibility:
+  - **Flutter**: SPM plugin support has been available since Flutter 3.19 (early 2024).
+    The Flutter wrapper declares its iOS native dependency via `Package.swift`.
+  - **Expo**: Expo Modules API supports SPM for native modules. EAS Build handles resolution.
+
+### What this constrains
+
+- **React Native (bare)**: RN's iOS build system remains CocoaPods-centric at the
+  framework level as of this writing. This is the broader community's problem to
+  solve — CocoaPods deprecation affects every major iOS library, not just CIO.
+  If the RN wrapper temporarily requires a pre-built binary bridge (via
+  `swift-create-xcframework`), that is the wrapper team's concern and does not
+  affect the SDK's distribution model.
+- Apps that have not yet migrated from CocoaPods to SPM cannot adopt this SDK
+  until they do.

--- a/v5/spec/decisions/005-server-driven-aggregation.md
+++ b/v5/spec/decisions/005-server-driven-aggregation.md
@@ -1,0 +1,72 @@
+# ADR 005 — Server-Driven Event Aggregation Engine
+
+**Status:** Accepted
+
+---
+
+## Context
+
+The previous SDK forwarded every event individually to the upload queue. For
+high-frequency events (screen views, location pings, lifecycle events), this
+produces excessive server load and inflated analytics noise. Reducing volume
+client-side requires a configurable ruleset.
+
+## Decision
+
+Introduce a server-driven `AggregationEngine` that evaluates every event
+before it enters the queue. The engine fetches its ruleset from a static
+endpoint relative to the region base URL.
+
+### Rule evaluation
+
+Each `AggregationRule` specifies an event name and one or more `AggregateOperation`
+values. Supported operations: `count`, `sum`, `min`, `max`, `assign`,
+`assignIfNull`, `countUnique`, `histogram`, `discard`.
+
+Evaluation outcomes (`AggregationResult`):
+- `.passThrough` — event proceeds to the queue unchanged
+- `.aggregated` — event is absorbed into an accumulator; not queued individually
+- `.discarded` — event is silently dropped
+
+### Accumulator lifecycle
+
+- Accumulators are persisted encrypted to SqlCipher so partial counts survive
+  app kills.
+- On flush, the engine synthesises a `trackSynthesized` event (bypasses
+  aggregation re-evaluation), injects it into the pipeline via a stored
+  `@Sendable (PendingEvent) -> Void` closure, and resets the accumulator.
+- Flush checks occur only at app lifecycle events (startup, foreground,
+  background). No background timers are used.
+- Flush schedules in rule configs are **minimum durations** ("no sooner than").
+
+### Config refresh
+
+- Fetched on SDK startup and on app foreground.
+- Rate-limited to once per 24 hours (last fetch timestamp persisted to `sdk_meta`).
+- A new ruleset is applied atomically; in-progress accumulator state is preserved
+  for rules whose `id` is unchanged.
+
+### Back-reference pattern
+
+`AggregationEngine` injects synthesised events via a closure rather than holding
+a back-reference to `CustomerIO`. This avoids a retain cycle and makes the engine
+testable without SDK infrastructure.
+
+## Consequences
+
+### What this enables
+
+- High-frequency events can be aggregated client-side without app updates — the
+  server controls the rules.
+- Events matching `discard` rules never reach the server, reducing data noise.
+- The engine is fully testable: a `MockHttpClient` and a lambda enqueue closure
+  are sufficient; no real database or scheduler is needed.
+
+### What this constrains
+
+- The `predicate` field in rule configs is reserved but **not evaluated in v1**.
+  All v1 use cases require only event-name matching. Property-level filtering
+  (e.g. "count only purchases where currency == USD") requires a future CEL
+  interpreter (see OPEN_QUESTIONS.md item 2).
+- Flush timing is coarse — only at lifecycle checkpoints, not on a timer.
+  A flush overdue by hours will not fire until the next foreground event.

--- a/v5/spec/domain/domain-model.md
+++ b/v5/spec/domain/domain-model.md
@@ -1,0 +1,210 @@
+# CustomerIO iOS SDK — Domain Model
+
+---
+
+## Module Graph
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                   CustomerIO_Utilities                    │
+│  (internal — never imported directly by app developers)  │
+│                                                          │
+│  Synchronized                                             │
+│  CommonEventBus · RegistrationToken                      │
+│  HttpClient · JsonAdapter · DateUtil                     │
+│  StorageManager · MigrationRunner                        │
+│  CIOKeys                                                 │
+└─────────────────────────┬────────────────────────────────┘
+                          │ (internal dependency)
+           ┌──────────────▼──────────────────┐
+           │          CustomerIO              │
+           │  (root public module)            │
+           │                                 │
+           │  Variant / VariantConvertible    │
+           │  CIOTrackingClient               │
+           │  identify · track · screen       │
+           │  Event pipeline                 │
+           │  Aggregation engine             │
+           │  Upload scheduler               │
+           │  SdkConfig / SdkConfigBuilder   │
+           │  StorageManager extensions      │
+           │  Module registry                │
+           │  CIOLogger / CIOLogLevel        │
+           └──┬──────────┬──────────┬────────┘
+              │          │          │
+  ┌───────────▼──┐  ┌────▼────────────────┐  ┌────────────────────┐  ┌──────────────────────┐
+  │  Location    │  │  MessagingPush       │  │  MessagingInApp    │  │  LiveActivities      │
+  │  module      │  │  (APN or FCM via     │  │  (not yet impl.)   │  │  (iOS 16.1+ only)    │
+  │              │  │  PushTokenProvider)  │  │                    │  │  (not yet impl.)     │
+  └──────────────┘  └──────────────────────┘  └────────────────────┘  └──────────────────────┘
+        │
+  ┌─────▼──────────┐
+  │   Geofencing   │
+  │   module       │
+  └────────────────┘
+```
+
+`CustomerIO_Utilities` is the successor to `CioInternalCommon`. Its products are
+**not** exposed as a public library product. Sub-modules depend on it internally.
+App code never imports it directly.
+
+---
+
+## Event Pipeline
+
+```
+track / identify / screen / clearIdentify / setProfileAttributes / setDeviceAttributes
+        │  (nonisolated — callable from any thread; yields to AsyncStream)
+        ▼
+  [Enrichment Stage]   EventEnricher actor
+  • Timestamp, anonymousId
+  • Profile ID from IdentityStore
+  • ProfileEnhancing module contributions merged into identify payloads
+        │
+        ▼
+  [Aggregation Stage]  AggregationEngine actor
+  • .passThrough → event continues
+  • .aggregated  → absorbed into accumulator (not queued)
+  • .discarded   → silently dropped
+        │ (.passThrough only)
+        ▼
+  [Event Queue]        EventQueue actor  (SqlCipher-encrypted event_queue table)
+        │
+        ▼
+  [Upload Scheduler]   UploadScheduler actor
+  • Batch assembler (count- or byte-triggered)
+  • HTTP POST to CDP API
+  • Retry with exponential backoff
+  • Delete from queue on server acknowledgement
+```
+
+**Pre-configure buffering:** Events yielded before `configure()` completes sit in
+the `AsyncStream`'s internal buffer (capped at 100, oldest-first). The processing
+loop suspends until configuration is complete, then drains in order. No separate
+two-mode buffer logic is needed.
+
+**`trackSynthesized` bypass:** Events emitted internally by the SDK (flush events
+from `AggregationEngine`, `"Device Deleted"` from `unregisterDevice()`) use the
+`.trackSynthesized` case. These skip the aggregation evaluation stage and go
+directly to enrichment → queue → upload.
+
+---
+
+## Storage Schema
+
+All data is written to an encrypted SqlCipher database. `UserDefaults` and flat-file
+JSON are not used.
+
+| Table | Module | Contents |
+|-------|--------|----------|
+| `identity` | `CustomerIO` | Current profile ID, anonymous ID |
+| `device` | `CustomerIO` | Push token, device attributes |
+| `event_queue` | `CustomerIO` | Pending upload events (`Variant`-serialized) |
+| `aggregation_rules` | `CustomerIO` | Cached server aggregation rule config |
+| `aggregation_state` | `CustomerIO` | In-progress accumulator values |
+| `sdk_meta` | `CustomerIO` | SDK version, install date, migration flags |
+| `location_state` | `Location` | Last known coordinates and upload timestamp |
+| `geofences` | `Geofencing` | Geofence definitions from server sync |
+| `geofence_state` | `Geofencing` | Current monitoring cursor and active regions |
+| `live_activity_state` | `LiveActivities` | Active Live Activity tokens and metadata |
+
+### StorageManager Extension Pattern
+
+`StorageManager` is a `struct` in `CustomerIO_Utilities`. Module-specific query methods
+live in `extension StorageManager` files inside their owning module:
+
+| File | Module | Tables |
+|------|--------|--------|
+| `StorageManager+EventQueue.swift` | `CustomerIO` | `event_queue` |
+| `StorageManager+Aggregation.swift` | `CustomerIO` | `aggregation_rules`, `aggregation_state` |
+| `StorageManager+Push.swift` | `MessagingPush` | `device` (push token) |
+| `StorageManager+Geofences.swift` | `Geofencing` | `geofences`, `geofence_state` |
+| `StorageManager+LiveActivities.swift` | `LiveActivities` | `live_activity_state` |
+
+### Encryption Key
+
+| Provider | Key source | Security model |
+|----------|------------|----------------|
+| `ApiKeyDatabaseKeyProvider` *(default)* | CDP API key used verbatim | File-at-rest protection only |
+| `KeychainDatabaseKeyProvider` | 256-bit random key, generated on first launch, stored in Keychain with `kSecAttrAccessibleAfterFirstUnlock` | Per-install, hardware-bound |
+
+The database filename (`cio-<sanitizedKey>.db`) and Keychain account name
+(`cio-db-key-<cdpApiKey>`) are both scoped to the CDP API key. Rotating the
+API key automatically produces a new database and Keychain entry.
+
+---
+
+## Concurrency Model
+
+| Type | Concurrency | Rationale |
+|------|-------------|-----------|
+| `CustomerIO` | `actor` | Owns configuration and pipeline state; event methods are `nonisolated` |
+| `ModuleRegistry` | `actor` | Concurrent-safe module storage |
+| `AggregationEngine` | `actor` | Mutable accumulator state |
+| `EventQueue` | `actor` | Serialized queue operations |
+| `UploadScheduler` | `actor` | Coordinates batch assembly and upload |
+| `StorageManager` | `struct` (`Sendable`) | Stateless gateway; thread safety delegated to `Database` actor |
+| `CommonEventBus` | `Sendable` class | Internal operation queue; no logging |
+| Module implementations | `actor` | Each module owns its mutable state |
+| `Synchronized<T>` | `@unchecked Sendable` | Bridge for nonisolated access to actor-owned state |
+
+### nonisolated Event Methods
+
+Event-tracking methods (`track`, `identify`, `screen`, etc.) are `nonisolated`.
+They yield into an `AsyncStream<PendingEvent>` via a `nonisolated let` continuation.
+`AsyncStream.Continuation.yield()` is synchronous and `Sendable`-safe. An
+actor-isolated processing loop task consumes the stream for the SDK's lifetime.
+
+---
+
+## Module Startup Phases
+
+```swift
+public protocol CIOModule: AnyObject, Sendable {
+    nonisolated func preActivate(_ config: SdkConfig)   // Phase 1 — synchronous
+    func configure(_ config: SdkConfig, storage: StorageManager, root: CustomerIO) async throws  // Phase 2
+}
+```
+
+| Phase | When | Who overrides |
+|-------|------|---------------|
+| `preActivate` | Before first run-loop cycle; inside `activateModulesForLaunch` | Only `MessagingPushModule` (registers `UNUserNotificationCenter` delegate) |
+| `configure` | After database and pipeline are ready | All modules |
+
+Modules access the event bus via `root.eventBus` — a `nonisolated package let`
+readable from any context without `await`. It is not passed as a separate parameter.
+
+---
+
+## Anonymous ID Ownership
+
+`CustomerIO` (via its internal `IdentityStore`) is the sole owner of the anonymous
+ID. On first launch, a UUID is generated and persisted to the `identity` table.
+It survives for the lifetime of the app install — it is never rotated except by an
+explicit `clearIdentify()` call. No other module generates or stores an anonymous ID.
+
+---
+
+## SDK-Internal Event Bus
+
+`CommonEventBus` is used for cross-module communication within the SDK only.
+App code does not interact with it. Events posted on the bus:
+
+| Event | Poster | Subscribers |
+|-------|--------|-------------|
+| `ProfileIdentifiedEvent` | `CustomerIO.identify()` | `MessagingInApp` (engine profile token) |
+| `AnonymousProfileIdentifiedEvent` | `CustomerIO.identify()` | `MessagingInApp` (engine anonymous ID) |
+| `ScreenViewedEvent` | `CustomerIO.screen()` | `MessagingInApp` (trigger matching) |
+| `ResetEvent` | `CustomerIO.clearIdentify()` | `MessagingPush` (clear token), `MessagingInApp` (reset state), `LocationModule` (clear coordinates), `LiveActivities` (cancel tasks) |
+
+---
+
+## Legacy Migration
+
+On first launch after upgrade from the previous SDK:
+
+1. **Identity** (best-effort): Read `identifiedProfileId` from legacy `UserDefaults`; write to `identity` table.
+2. **Anonymous ID** (best-effort): Read from legacy `CioAnalytics` storage; write to `identity` table. Generate fresh UUID if not found.
+3. **Push token** (best-effort): Read from legacy `GlobalDataStore` (UserDefaults); write to `device` table.
+4. **Event queue**: **Not migrated.** In-flight queued events from the old SDK are abandoned.
+5. **Migration flag**: `sdk_meta.legacy_migration_complete = true` set after a successful pass.

--- a/v5/spec/features/utilities.md
+++ b/v5/spec/features/utilities.md
@@ -1,0 +1,270 @@
+# CustomerIO_Utilities — Feature Specification
+
+**Status:** Implemented
+**Last updated:** April 29, 2026
+
+---
+
+## Overview
+
+`CustomerIO_Utilities` is an internal Swift package target — not a public library
+product — that provides shared infrastructure consumed by the `CustomerIO` root
+module and all feature modules. App developers never import it directly.
+
+Because it sits at the bottom of the dependency graph, `CustomerIO_Utilities`
+must have no knowledge of SDK-level concepts (events, profiles, modules). It
+contains only general-purpose primitives that could plausibly live in any
+Swift project.
+
+---
+
+## What Does Not Live Here
+
+`DatabaseKeyProvider`, `ApiKeyDatabaseKeyProvider`, and `KeychainDatabaseKeyProvider`
+are defined in the `CustomerIO` module (`Sources/CustomerIO/Storage/`), not here.
+Although they are infrastructure, they are part of the public `SdkConfigBuilder`
+API and must be referenceable by app code that imports only `CustomerIO`. Moving
+them here would make them inaccessible to app developers since
+`CustomerIO_Utilities` is not a library product.
+
+---
+
+## Design Constraints
+
+- No SDK-level types may be imported here. `CustomerIO_Utilities` must remain a
+  leaf dependency.
+- All types must be `Sendable` or explicitly `@unchecked Sendable` with
+  documented isolation guarantees.
+- No static state. Every type is instantiated and injected; nothing is accessed
+  via a global or singleton.
+
+---
+
+## Components
+
+### `Synchronized<T>`
+
+**File:** `Synchronized/Synchronized.swift` and extensions
+
+A thread-safe wrapper for any value type, backed by `NSRecursiveLock`. Declared
+`@unchecked Sendable` because it enforces its own invariants rather than relying
+on Swift's type system.
+
+```swift
+public final class Synchronized<T>: @unchecked Sendable {
+    public var wrappedValue: T { get set }          // lock-protected
+    public func mutating<R>(_ body: (inout T) throws -> R) rethrows -> R
+    public func mutatingAsync<R>(_ body: @Sendable (inout T) throws -> sending R) async throws -> R
+    public func using<R>(_ body: (T) throws -> R) rethrows -> R
+    public func usingAsync<R>(_ body: @Sendable (T) throws -> sending R) async throws -> R
+    public func atomicSetAndFetch(_ newValue: T) -> T
+}
+```
+
+**Why `NSRecursiveLock`:** The SDK occasionally acquires the same lock from a
+re-entrant call path (e.g. an observer registered inside a `mutating` closure
+during early initialisation). A non-recursive lock would deadlock in those cases.
+
+**Extension files** add conditional conformances and convenience operators for
+common wrapped types: `Arithmetic`, `Bool`, `Comparable`, `Equatable`,
+`Hashable`, `Collections`, `Dictionaries`.
+
+---
+
+### `CommonEventBus` / `EventBus`
+
+**Files:** `EventBus/CommonEventBus.swift`, `EventBus/RegistrationToken.swift`
+
+A type-erased publish/subscribe bus. Events are any `Sendable` value. Observers
+register a typed closure; the bus filters by dynamic type cast at delivery time.
+
+```swift
+public protocol EventBus: Sendable {
+    func registerObserver<EventType: Sendable>(
+        listener: @Sendable @escaping (EventType) -> Void
+    ) -> RegistrationToken<UUID>
+    func post(_ event: any Sendable)
+}
+```
+
+**Delivery:** `post()` takes a snapshot of current observers synchronously, then
+dispatches `NotifyOperation` instances onto a background `OperationQueue`
+asynchronously. Observers that do not match the event type return `false` and
+are counted but not invoked. After all notifications complete, a
+`DeliverySummary` system message is posted (not recursed into).
+
+**`postAndWait`:** An async variant that suspends until all observers finish
+processing. Used in tests and in places where ordering guarantees are needed.
+
+**`RegistrationToken<UUID>`:** Returned by `registerObserver`. Holds a `deinit`
+cleanup closure that removes the observer when the token is released. Modules
+store the token as a `private var` for the lifetime of the object — dropping it
+unregisters automatically.
+
+**SDK-level event types** (defined in `CustomerIO`, not here):
+`ProfileIdentifiedEvent`, `AnonymousProfileIdentifiedEvent`,
+`ScreenViewedEvent`, `ResetEvent`.
+
+---
+
+### `StorageManager`
+
+**Files:** `Storage/StorageManager.swift` and module-specific extensions
+
+A `struct` (stateless, `Sendable`) gateway to the encrypted SQLite database.
+Thread safety is fully delegated to `Database` (a SqlCipherKit `actor`).
+
+The `db: Database` property is `package` access, allowing extension files in
+other targets within this Swift package to add typed query methods without
+making the raw database handle part of the public API.
+
+**Core methods:**
+
+| Method | Purpose |
+|---|---|
+| `runMigrations(extra:)` | Apply `CreateSDKSchema` plus any module-supplied migrations. Must be called once before any other method. |
+| `getString(_:from:)` / `setString(_:for:in:)` | Generic key/value read/write for any table with `(key TEXT, value TEXT)` shape. |
+| `getMetaValue(_:)` / `setMetaValue(_:for:)` | Convenience wrappers targeting the `sdk_meta` table. |
+
+**Core schema (`CreateSDKSchema`, migration id `001`):**
+
+| Table | Purpose |
+|---|---|
+| `identity` | Profile ID and anonymous ID |
+| `device` | Push token and device attributes |
+| `event_queue` | Pending upload events (JSON-serialised `EnrichedEvent`) |
+| `aggregation_rules` | Cached server aggregation ruleset (single row) |
+| `aggregation_state` | In-progress accumulator values per rule |
+| `sdk_meta` | SDK flags, version, migration markers |
+
+---
+
+### `MigrationRunner`
+
+**File:** `Storage/MigrationRunner.swift`
+
+Runs a one-time migration from the legacy SDK on first launch after upgrade.
+Reads `UserDefaults` keys used by the previous SDK, returns them as `LegacySeeds`,
+and marks completion in `sdk_meta` so it never runs again.
+
+```swift
+public actor MigrationRunner {
+    public nonisolated func legacySeeds() -> LegacySeeds
+    public func markComplete() async throws
+    public func isComplete() async -> Bool
+}
+
+public struct LegacySeeds: Sendable {
+    public let profileId: String?
+    public let anonymousId: String?
+    public let pushToken: String?
+}
+```
+
+`legacySeeds()` is `nonisolated` because it only reads `UserDefaults` — no
+actor-isolated state is touched. The caller is responsible for writing the seeds
+to the appropriate stores (e.g. `IdentityStore`, `DeviceStore`).
+
+---
+
+### `MigrationProviding`
+
+**File:** `Storage/MigrationProviding.swift`
+
+Protocol for modules that need to extend the database schema. The
+`CustomerIO` root collects `additionalMigrations` from all registered
+`MigrationProviding` modules and passes them to `StorageManager.runMigrations(extra:)`
+before any module's `configure()` is called.
+
+```swift
+public protocol MigrationProviding {
+    var additionalMigrations: [any Migration] { get }
+}
+```
+
+Migration types (`GeofenceStorageMigration`, `LocationStorageMigration`) are
+`internal` to their module. They escape only as `any Migration` existentials
+through this property.
+
+---
+
+### `CIOKeys`
+
+**Files:** `Keys/CIOKeys.swift` and module-specific extensions
+
+Namespace for all string constants (storage keys, table names, event names,
+payload header names) used across the SDK. Prevents magic strings from being
+scattered as inline literals.
+
+- The root `public enum CIOKeys` lives in `Keys/CIOKeys.swift`.
+- Constants shared between two or more modules are added to extensions in
+  `Keys/` (e.g. `CIOKeys+Storage.swift`).
+- Constants that belong entirely within one module are declared in an `internal`
+  extension in that module's own `Keys/` subdirectory.
+- Constants are organised by **intended use**, not by value.
+
+---
+
+### `HttpClient` / `HttpRequestRunner`
+
+**Files:** `Networking/HttpClient.swift`, `Networking/HttpRequestRunner.swift`
+
+```swift
+public protocol HttpClient: Sendable {
+    func performRequest(_ request: URLRequest) async throws -> (Data, URLResponse)
+}
+```
+
+`HttpRequestRunner` is the `URLSession`-backed production implementation.
+It wraps the completion-handler `dataTask(with:)` API in a
+`withCheckedThrowingContinuation` for iOS 13/14 compatibility
+(`URLSession.data(for:)` requires iOS 15+).
+
+Inject a mock `HttpClient` in tests. Register `HttpRequestRunner` in production.
+
+---
+
+### `JsonAdapter`
+
+**File:** `Util/JsonAdapter.swift`
+
+Thin wrapper around `JSONEncoder` / `JSONDecoder` with ISO 8601 date strategy
+configured by default. Provides `encode<T: Encodable>` and
+`decode<T: Decodable>` with consistent error behaviour across the SDK.
+
+---
+
+### `QuadKey`
+
+**File:** `QuadKey.swift`
+
+Encodes WGS-84 coordinates to the Bing Maps quadtree tile string format.
+
+```swift
+public enum QuadKey {
+    public static let defaultZoom: Int = 13
+
+    /// Encodes a coordinate pair to a QuadKey string at the given zoom level.
+    public static func encode(latitude: Double, longitude: Double, zoom: Int = defaultZoom) -> String
+
+    /// Returns the 9-tile Moore neighbourhood (centre + 8 neighbours) for a coordinate.
+    public static func neighborhoodTiles(latitude: Double, longitude: Double, zoom: Int = defaultZoom) -> [String]
+}
+```
+
+At zoom 13, each tile covers approximately 4.9 km × 4.9 km at the equator,
+scaling down by cos(latitude) at higher latitudes (~3.5 km at 45°N).
+
+Used exclusively by `GeofencingModule` for candidate selection and indexing.
+Lives in `CustomerIO_Utilities` so both the Geofencing module and its test
+target can access it without a cross-module import.
+
+---
+
+### `Logger` / `DateUtil`
+
+**Files:** `Util/Logger.swift`, `Util/DateUtil.swift`
+
+Thin wrappers over `swift-log`'s `Logger` type and `Date`/`ISO8601DateFormatter`
+respectively. `DateProviding` is a protocol for injecting a fixed date in tests
+(used by `EventEnricher` tests).

--- a/v5/spec/features/utilities.md
+++ b/v5/spec/features/utilities.md
@@ -54,9 +54,7 @@ on Swift's type system.
 public final class Synchronized<T>: @unchecked Sendable {
     public var wrappedValue: T { get set }          // lock-protected
     public func mutating<R>(_ body: (inout T) throws -> R) rethrows -> R
-    public func mutatingAsync<R>(_ body: @Sendable (inout T) throws -> sending R) async throws -> R
     public func using<R>(_ body: (T) throws -> R) rethrows -> R
-    public func usingAsync<R>(_ body: @Sendable (T) throws -> sending R) async throws -> R
     public func atomicSetAndFetch(_ newValue: T) -> T
 }
 ```


### PR DESCRIPTION
This PR is the foundational work for the v5 SDK. These files define the structure for all subsequent documents and code.

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After code reviews are approved and you determine this PR is ready to merge, select *Squash and Merge* button on this screen, leave the title and description to the default values, then merge the PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that introduce no runtime behavior changes; risk is limited to potential misalignment with future implementation if the specs are interpreted incorrectly.
> 
> **Overview**
> Establishes the `v5/` specification foundation for the CustomerIO iOS SDK reimplementation, including a scoped `CLAUDE.md` that defines AI/dev workflow rules and spec-as-source-of-truth expectations.
> 
> Adds core spec artifacts: a canonical `spec/GLOSSARY.md`, an initial `spec/domain/domain-model.md` describing the planned module graph/pipeline/schema, and ADRs (`001`–`005`) formalizing major architectural decisions (SqlCipher-encrypted storage, Swift 6.2 strict concurrency, removing `cdp-analytics-swift`, SPM-only distribution, and server-driven aggregation).
> 
> Introduces the `spec/features/utilities.md` feature spec defining the intended responsibilities and constraints of the internal `CustomerIO_Utilities` target (e.g., `Synchronized`, `StorageManager`, `CommonEventBus`, `HttpClient`, `CIOKeys`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 172f96eabec1ee955fca449907f744c365552940. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->