### PR TITLE
fix: Fixed duplicate completion handler call crash

### DIFF
--- a/Sources/MessagingPush/Integration/CioProviderAgnosticAppDelegate.swift
+++ b/Sources/MessagingPush/Integration/CioProviderAgnosticAppDelegate.swift
@@ -117,24 +117,22 @@ open class CioProviderAgnosticAppDelegate: CioAppDelegateType, UNUserNotificatio
         willPresent notification: UNNotification,
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
-        // `completionHandlerCalled` is used to overcome limitation of `responds(to:)` when working with optional methods from protocol.
-        // Component may implement the protocol, but not specific optional method. In this case `responds(to:)` will return true.
-        // Explicit flag, `completionHandlerCalled` in this case, allows us to detect if method is implemented, since it's required by Apple to
-        // call `completionHandler` before returning.
-        var completionHandlerCalled = false
         if let wrappedNotificationCenterDelegate = wrappedNotificationCenterDelegate,
            wrappedNotificationCenterDelegate.responds(to: #selector(UNUserNotificationCenterDelegate.userNotificationCenter(_:willPresent:withCompletionHandler:))) {
+            // Pass completionHandler directly to support async implementations (e.g. a React Native JS bridge that
+            // calls back from the JS thread). A previous wrapper-closure approach tracked whether the handler was
+            // called synchronously and provided a fallback if not; that broke async delegates by invoking the
+            // handler a second time with the SDK default options.
+            // Trade-off: a delegate that returns true from responds(to:) but never calls the handler will now leave
+            // it uncalled. No known SDK or framework exhibits this behaviour by default; it would represent a bug
+            // in the host app's delegate code.
             wrappedNotificationCenterDelegate.userNotificationCenter?(
                 center,
                 willPresent: notification,
-                withCompletionHandler: { options in
-                    completionHandler(options)
-                    completionHandlerCalled = true
-                }
+                withCompletionHandler: completionHandler
             )
+            return
         }
-
-        guard !completionHandlerCalled else { return }
 
         if config?().showPushAppInForeground ?? false {
             if #available(iOS 14.0, *) {
@@ -159,24 +157,22 @@ open class CioProviderAgnosticAppDelegate: CioAppDelegateType, UNUserNotificatio
             _ = implementation.userNotificationCenter(center, didReceive: response)
         }
 
-        // `completionHandlerCalled` is used to overcome limitation of `responds(to:)` when working with optional methods from protocol.
-        // Component may implement the protocol, but not specific optional method. In this case `responds(to:)` will return true.
-        // Explicit flag, `completionHandlerCalled` in this case, allows us to detect if method is implemented, since it's required by Apple to
-        // call `completionHandler` before returning.
-        var completionHandlerCalled = false
         if let wrappedNotificationCenterDelegate = wrappedNotificationCenterDelegate,
            wrappedNotificationCenterDelegate.responds(to: #selector(UNUserNotificationCenterDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:))) {
+            // Pass completionHandler directly to support async implementations (e.g. a React Native JS bridge that
+            // calls back from the JS thread). A previous wrapper-closure approach tracked whether the handler was
+            // called synchronously and provided a fallback if not; that broke async delegates by invoking the
+            // handler a second time.
+            // Trade-off: a delegate that returns true from responds(to:) but never calls the handler will now leave
+            // it uncalled. No known SDK or framework exhibits this behaviour by default; it would represent a bug
+            // in the host app's delegate code.
             wrappedNotificationCenterDelegate.userNotificationCenter?(
                 center,
                 didReceive: response,
-                withCompletionHandler: {
-                    completionHandler()
-                    completionHandlerCalled = true
-                }
+                withCompletionHandler: completionHandler
             )
+            return
         }
-
-        guard !completionHandlerCalled else { return }
 
         completionHandler()
     }

--- a/Tests/MessagingPush/Integration/CioProviderAgnosticAppDelegateTests.swift
+++ b/Tests/MessagingPush/Integration/CioProviderAgnosticAppDelegateTests.swift
@@ -208,6 +208,28 @@ class CioProviderAgnosticAppDelegateTests: XCTestCase {
         }
     }
 
+    func testUserNotificationCenterWillPresent_whenWrappedDelegateCallsCompletionHandlerAsync_thenCompletionHandlerIsCalledExactlyOnce() {
+        // Regression test: previously the SDK called completionHandler a second time with its own default options
+        // when the wrapped delegate deferred the call (e.g. a React Native JS bridge calling back from the JS thread).
+        let expectation = XCTestExpectation(description: "Completion handler called")
+        expectation.assertForOverFulfill = true
+        var callCount = 0
+        let completionHandler: (UNNotificationPresentationOptions) -> Void = { _ in
+            callCount += 1
+            expectation.fulfill()
+        }
+
+        mockNotificationCenterDelegate.callWillPresentHandlerAsync = true
+
+        _ = appDelegate.application(UIApplication.shared, didFinishLaunchingWithOptions: nil)
+        appDelegate.userNotificationCenter(UNUserNotificationCenter.current(), willPresent: UNNotification.testInstance, withCompletionHandler: completionHandler)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertEqual(callCount, 1)
+        XCTAssertTrue(mockNotificationCenterDelegate.willPresentNotificationCalled)
+    }
+
     func testUserNotificationCenterWillPresent_whenWrappedDelegateDoesntImplementMethodAndShowPushAppInForegroundIsFalse_thenNotificationIsNotShown() {
         // Setup
         var presentationOptions: UNNotificationPresentationOptions?
@@ -251,6 +273,28 @@ class CioProviderAgnosticAppDelegateTests: XCTestCase {
         // Verify behavior
         XCTAssertTrue(mockNotificationCenterDelegate.didReceiveNotificationResponseCalled)
         XCTAssertTrue(completionHandlerCalled)
+    }
+
+    func testUserNotificationCenterDidReceive_whenWrappedDelegateCallsCompletionHandlerAsync_thenCompletionHandlerIsCalledExactlyOnce() {
+        // Regression test: previously the SDK called completionHandler a second time when the wrapped delegate
+        // deferred the call (e.g. a React Native JS bridge calling back from the JS thread).
+        let expectation = XCTestExpectation(description: "Completion handler called")
+        expectation.assertForOverFulfill = true
+        var callCount = 0
+        let completionHandler: () -> Void = {
+            callCount += 1
+            expectation.fulfill()
+        }
+
+        mockNotificationCenterDelegate.callDidReceiveHandlerAsync = true
+
+        _ = appDelegate.application(UIApplication.shared, didFinishLaunchingWithOptions: nil)
+        appDelegate.userNotificationCenter(UNUserNotificationCenter.current(), didReceive: UNNotificationResponse.testInstance, withCompletionHandler: completionHandler)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertEqual(callCount, 1)
+        XCTAssertTrue(mockNotificationCenterDelegate.didReceiveNotificationResponseCalled)
     }
 
     func testUserNotificationCenterDidReceive_whenWrappedNotificationCenterDelegateIsNil_thenNotificationCompletionHandlerIsCalled() {

--- a/Tests/Shared/Mocks/UIKitDelegateMocks.swift
+++ b/Tests/Shared/Mocks/UIKitDelegateMocks.swift
@@ -58,6 +58,10 @@ public class MockNotificationCenterDelegate: NSObject, UNUserNotificationCenterD
         #selector(UNUserNotificationCenterDelegate.userNotificationCenter(_:didReceive:withCompletionHandler:)): true,
         #selector(UNUserNotificationCenterDelegate.userNotificationCenter(_:openSettingsFor:)): true
     ]
+    /// When true, the completion handler is dispatched asynchronously to simulate a bridge (e.g. React Native JS
+    /// bridge) that holds the closure and calls it from a different thread or run-loop turn.
+    public var callWillPresentHandlerAsync: Bool = false
+    public var callDidReceiveHandlerAsync: Bool = false
 
     override public func responds(to aSelector: Selector!) -> Bool {
         if let shouldRespond = respondsToSelectors[aSelector] {
@@ -68,12 +72,20 @@ public class MockNotificationCenterDelegate: NSObject, UNUserNotificationCenterD
 
     public func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         willPresentNotificationCalled = true
-        completionHandler([])
+        if callWillPresentHandlerAsync {
+            DispatchQueue.main.async { completionHandler([]) }
+        } else {
+            completionHandler([])
+        }
     }
 
     public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         didReceiveNotificationResponseCalled = true
-        completionHandler()
+        if callDidReceiveHandlerAsync {
+            DispatchQueue.main.async { completionHandler() }
+        } else {
+            completionHandler()
+        }
     }
 
     public func userNotificationCenter(_ center: UNUserNotificationCenter, openSettingsFor notification: UNNotification?) {


### PR DESCRIPTION
This change fixes a crash in react native caused by the completin handler being called multiple times from `userNotificationCenter(_:willPresent:withCompletionHandler:)` and `userNotificationCenter(_:didReceive:withCompletionHandler:)`. This was caused by a workaround for handling broken implementation of this method in partner apps.

This specifically fixes MBL-1708 and [GitHub Issue #1038](https://github.com/customerio/customerio-ios/issues/1038).

As discussed in the comment in the PR, the problem is a workaround that was added at one point. That workaround is fundamentally incompatible with working async implementations. No known standard cases require that workaround and anyone who does need that workaround is broken code.

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After code reviews are approved and you determine this PR is ready to merge, select *Squash and Merge* button on this screen, leave the title and description to the default values, then merge the PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches push notification delegate forwarding; incorrect completion handler behavior can suppress foreground presentation or leave the handler uncalled if a host delegate misbehaves. Changes are localized and covered by new regression tests for async delegates.
> 
> **Overview**
> Fixes a crash/double-invocation bug by changing `CioProviderAgnosticAppDelegate` to **forward Apple completion handlers directly** to wrapped `UNUserNotificationCenterDelegate` implementations for `willPresent` and `didReceive`, instead of wrapping them and falling back to SDK defaults.
> 
> Adds regression coverage for **async delegate behavior** (e.g. React Native bridges) ensuring the completion handler is called *exactly once*, and updates the `MockNotificationCenterDelegate` to optionally dispatch completion handlers asynchronously.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfe79c8982331d199c9b67d144d49d0dde54648d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->