### PR TITLE
fix: re-export CioInternalCommon to allow CustomerIO extensions

### DIFF
--- a/Sources/DataPipeline/Type/Aliases.swift
+++ b/Sources/DataPipeline/Type/Aliases.swift
@@ -1,5 +1,7 @@
 import CioAnalytics
-import CioInternalCommon
+// Re-exported so consumers can retroactively conform `CustomerIO` (declared in CioInternalCommon)
+// without an extra `import CioInternalCommon`. Required by Member Import Visibility (Xcode 16.3+).
+@_exported import CioInternalCommon
 import Foundation
 
 /*


### PR DESCRIPTION
## Summary

Adds `@_exported import CioInternalCommon` to `Sources/DataPipeline/Type/Aliases.swift` so consumers of `CioDataPipelines` can retroactively conform `CustomerIO` (and other types declared in `CioInternalCommon`) to their own protocols without an explicit `import CioInternalCommon`.

Fixes https://linear.app/customerio/issue/MBL-1387/package-setup-often-creates-compiler-errors / #952.

## Why this is needed

The `CustomerIO` class is declared in `CioInternalCommon`, which is intentionally not a public SPM library product. `CioDataPipelines` re-exposes the type only via a typealias:

```swift
public typealias CustomerIO = CioInternalCommon.CustomerIO
```

Under **Member Import Visibility** (Xcode 16.3+ / Swift 6, default-on in Xcode 26), the compiler requires the *defining* module of a type to be importable when extending it. The typealias makes the *name* visible but not the members, so:

```swift
import CioDataPipelines

protocol PushServiceProtocol {
    func identify(userId: String, traits: [String: Any]?)
}

extension CustomerIO: PushServiceProtocol {}
```

…fails with:

```
error: type 'CustomerIO' does not conform to protocol 'PushServiceProtocol'
note:  protocol requires function 'identify(userId:traits:)' ...
```

even though `CustomerIO` does have that method — the consumer's import scope just can't see members declared in `CioInternalCommon`. Customers reported the build only succeeds after a full clean, and breaks entirely under Xcode 26.

## Why `@_exported import` (and not the alternatives)

| Option | Verdict |
|---|---|
| **Make `CioInternalCommon` a public SPM product** | Rejected — exposes the entire internal module surface against the project's "do not expose internal modules" rule. |
| **Move `CustomerIO` (and friends) out of `CioInternalCommon`** | Rejected — large multi-module refactor (`MessagingPush`, `MessagingInApp`, `MessagingPushAPN/FCM`, `Location` all depend on these types in `CioInternalCommon`). |
| **`@_exported import CioInternalCommon` in `CioDataPipelines`** ✅ | Minimal: 1 line of code + 2 of comment. The internal module stays hidden from the public products list, but its symbols become reachable transitively for retroactive conformance. Same pattern Apple uses (e.g. `import SwiftUI` re-exports Combine). |

Note on the underscored attribute: `@_exported` is a Swift-internal attribute that has been the de-facto re-export mechanism for years. If a future toolchain ever changes the rules, the escape hatch is to expose `CioInternalCommon` as a public product (which the Cocoapods distribution already does via `CustomerIOCommon`).

## Validation

Verified end-to-end with a temporary consumer SPM package that mirrors the customer's setup (separate target that imports only `CioDataPipelines`, with `MemberImportVisibility` upcoming-feature flag enabled to simulate Xcode 26 behavior on Xcode 16.3+):

| Dependency under test | Result |
|---|---|
| Released SDK `4.4.1` (no fix) | ❌ `BUILD FAILED` — reproduces the exact `does not conform to protocol` error from the bug report |
| This branch (with fix) | ✅ `BUILD SUCCEEDED` |

The full SDK package itself (`Customer.io-Package` scheme) also builds cleanly against Xcode 17 / iOS 26.4 SDK after the change — no impact to existing modules.

## How to test this PR yourself

Build a throwaway SPM consumer package anywhere outside this repo:

1. **Create the package** with these two files:

   `Package.swift`:
   ```swift
   // swift-tools-version:5.9
   import PackageDescription

   let package = Package(
       name: "VerifyMBL1387",
       platforms: [.iOS(.v13)],
       products: [.library(name: "Consumer", targets: ["Consumer"])],
       dependencies: [
           // [A] Released SDK without fix -> expect BUILD FAILED.
           // .package(url: "https://github.com/customerio/customerio-ios.git", exact: "4.4.1"),

           // [B] This PR branch -> expect BUILD SUCCEEDED.
           .package(url: "https://github.com/customerio/customerio-ios.git", branch: "mbl-1387-package-errors")
       ],
       targets: [
           .target(
               name: "Consumer",
               dependencies: [.product(name: "DataPipelines", package: "customerio-ios")],
               swiftSettings: [.enableUpcomingFeature("MemberImportVisibility")]
           )
       ]
   )
   ```

   `Sources/Consumer/Reproduction.swift`:
   ```swift
   import CioDataPipelines

   protocol PushServiceProtocol {
       func identify(userId: String, traits: [String: Any]?)
   }

   extension CustomerIO: PushServiceProtocol {}
   ```

2. **Run the build** (use a real simulator UDID from `xcrun simctl list devices available`):
   ```bash
   xcodebuild -scheme VerifyMBL1387 \
       -destination 'platform=iOS Simulator,id=<SIMULATOR_ID>' \
       -allowProvisioningUpdates build
   ```

3. **Toggle `[A]`/`[B]`** in `Package.swift` to compare. After each toggle, clear caches before rebuilding:
   ```bash
   rm -rf .swiftpm ~/Library/Developer/Xcode/DerivedData/VerifyMBL1387-*
   ```

   Expected:
   - `[A]` v4.4.1: `BUILD FAILED` with `type 'CustomerIO' does not conform to protocol 'PushServiceProtocol'`
   - `[B]` this branch: `BUILD SUCCEEDED`

## Test plan

- [x] Customer.io-Package scheme builds against Xcode 17 / iOS 26.4 SDK
- [x] CioDataPipelines / CioInternalCommon individual schemes build standalone
- [x] Bug reproduced against released v4.4.1 (consumer package + MemberImportVisibility)
- [x] Fix verified against this branch (same harness, same flag, same code)
- [x] CI passes
- [ ] Reviewer reproduces the verification using the steps above

## Out of scope

- `CioMessagingPushAPN`/`CioMessagingPushFCM` re-export `CioMessagingPush` types via the same typealias pattern. Customers extending `MessagingPush` (rather than `CustomerIO`) would hit a similar issue — happy to address as a follow-up if reported.
- No changes to `Package.swift`, podspecs, or other modules. Nothing affecting the public product list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)