### PR TITLE
chore: Added step to normalize whitespace in API docs

### DIFF
--- a/api-docs/CioDataPipelines.api
+++ b/api-docs/CioDataPipelines.api
@@ -4,10 +4,7 @@ public final class CioDataPipelines.AutoTrackingScreenViews {
 	public var diGraph: DIGraphShared;
 	public var filterAutoScreenViewEvents: ((UIViewController) -> Boolean)?;
 	public var autoScreenViewBody: (() -> Map<String, Any>)?;
-	public fun init(
-    filterAutoScreenViewEvents: ((UIViewController) -> Boolean)? = nil,
-    autoScreenViewBody: (() -> List<String: Any>)? = nil
-);
+	public fun init(filterAutoScreenViewEvents: ((UIViewController) -> Boolean)? = nil, autoScreenViewBody: (() -> List<String: Any>)? = nil);
 }
 public final class CioDataPipelines.CustomerIODestination {
 }
@@ -53,11 +50,7 @@ public interface CioDataPipelines.DataPipelineInstance {
 public final class CioDataPipelines.SDKConfigBuilder {
 	public fun init(cdpApiKey: String);
 	public fun func region(_ region: Region) -> SDKConfigBuilder;
-	public fun func autoTrackUIKitScreenViews(
-    enabled: Boolean = true,
-    autoScreenViewBody: (() -> List<String: Any>)? = nil,
-    filterAutoScreenViewEvents: ((UIViewController) -> Boolean)? = nil
-) -> SDKConfigBuilder;
+	public fun func autoTrackUIKitScreenViews(enabled: Boolean = true, autoScreenViewBody: (() -> List<String: Any>)? = nil, filterAutoScreenViewEvents: ((UIViewController) -> Boolean)? = nil) -> SDKConfigBuilder;
 	public fun func logLevel(_ logLevel: CioLogLevel) -> SDKConfigBuilder;
 	public fun func apiHost(_ apiHost: String) -> SDKConfigBuilder;
 	public fun func cdnHost(_ cdnHost: String) -> SDKConfigBuilder;

--- a/api-docs/CioMessagingInApp.api
+++ b/api-docs/CioMessagingInApp.api
@@ -84,17 +84,7 @@ public final class CioMessagingInApp.InboxMessage {
 	public final val priority: Int?;
 	public final val properties: Map<String, Any>;
 	public var description: String;
-	public fun init(
-    queueId: String,
-    deliveryId: String?,
-    expiry: Date?,
-    sentAt: Date,
-    topics: List<String>,
-    type: String,
-    opened: Boolean,
-    priority: Int?,
-    properties: List<String: Any>
-);
+	public fun init(queueId: String, deliveryId: String?, expiry: Date?, sentAt: Date, topics: List<String>, type: String, opened: Boolean, priority: Int?, properties: List<String: Any>);
 	public fun func == (lhs: InboxMessage, rhs: InboxMessage) -> Boolean;
 }
 public enum CioMessagingInApp.InboxMessageFactory {
@@ -114,9 +104,7 @@ public final class CioMessagingInApp.InlineMessageBridgeView {
 	public fun func onViewDetached();
 	public fun func onMessageRendered(width: CGFloat, height: CGFloat);
 	public fun func onNoMessageToDisplay();
-	public fun func onInlineButtonAction(
-    message: Message, currentRoute: String, action: String, name: String
-) -> Boolean;
+	public fun func onInlineButtonAction(message: Message, currentRoute: String, action: String, name: String) -> Boolean;
 	public fun func willChangeMessage(newTemplateId: String, onComplete: @escaping () -> Unit);
 }
 public interface CioMessagingInApp.InlineMessageBridgeViewDelegate {
@@ -142,12 +130,7 @@ public interface CioMessagingInApp.InlineMessageUIViewDelegate {
 public final class CioMessagingInApp.Message {
 	public var isEmbedded: Boolean;
 	public var elementId: String?;
-	public fun init(
-    messageId: String,
-    queueId: String? = nil,
-    priority: Int? = nil,
-    properties: List<String: Any>?
-);
+	public fun init(messageId: String, queueId: String? = nil, priority: Int? = nil, properties: List<String: Any>?);
 }
 public enum CioMessagingInApp.MessagePosition {
 }
@@ -197,6 +180,5 @@ public interface CioMessagingInApp.StoreSubscriber {
 public final class CioMessagingInApp.Subscription {
 	public var observer: ((State?, State) -> ())?;
 	public fun init(sink: @escaping (@escaping (State?, State) -> Unit) -> Unit);
-	public fun func skipRepeats(_ isRepeat: @escaping (_ oldState: State, _ newState: State) -> Boolean)
-    -> Subscription<State>;
+	public fun func skipRepeats(_ isRepeat: @escaping (_ oldState: State, _ newState: State) -> Boolean) -> Subscription<State>;
 }

--- a/api-docs/CioMessagingPushAPN.api
+++ b/api-docs/CioMessagingPushAPN.api
@@ -4,43 +4,18 @@ public final class CioMessagingPushAPN.MessagingPushAPN {
 	public fun func application(_ application: Any, didFailToRegisterForRemoteNotificationsWithError error: Error);
 	public fun func deleteDeviceToken();
 	public fun func trackMetric(deliveryID: String, event: Metric, deviceToken: String);
-	public fun func initialize(
-    withConfig config: MessagingPushConfigOptions = MessagingPushConfigBuilder().build()
-) -> MessagingPushInstance;
-	public fun func didReceive(
-    _ request: UNNotificationRequest,
-    withContentHandler contentHandler: @escaping (UNNotificationContent) -> Unit
-) -> Boolean;
+	public fun func initialize(withConfig config: MessagingPushConfigOptions = MessagingPushConfigBuilder().build()) -> MessagingPushInstance;
+	public fun func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Unit) -> Boolean;
 	public fun func serviceExtensionTimeWillExpire();
-	public fun func userNotificationCenter(
-    _ center: UNUserNotificationCenter,
-    didReceive response: UNNotificationResponse
-) -> CustomerIOParsedPushPayload?;
-	public fun func userNotificationCenter(
-    _ center: UNUserNotificationCenter,
-    didReceive response: UNNotificationResponse,
-    withCompletionHandler completionHandler: @escaping () -> Unit
-) -> Boolean;
+	public fun func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) -> CustomerIOParsedPushPayload?;
+	public fun func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Unit) -> Boolean;
 }
 public interface CioMessagingPushAPN.MessagingPushAPNInstance {
 	public fun func registerDeviceToken(apnDeviceToken: Data);
-	public fun func application(
-    _ application: Any,
-    didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
-);
-	public fun func application(
-    _ application: Any,
-    didFailToRegisterForRemoteNotificationsWithError error: Error
-);
+	public fun func application(_ application: Any, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data);
+	public fun func application(_ application: Any, didFailToRegisterForRemoteNotificationsWithError error: Error);
 	public fun func deleteDeviceToken();
-	public fun func trackMetric(
-    deliveryID: String,
-    event: Metric,
-    deviceToken: String
-);
-	public fun func didReceive(
-    _ request: UNNotificationRequest,
-    withContentHandler contentHandler: @escaping (UNNotificationContent) -> Unit
-) -> Boolean;
+	public fun func trackMetric(deliveryID: String, event: Metric, deviceToken: String);
+	public fun func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Unit) -> Boolean;
 	public fun func serviceExtensionTimeWillExpire();
 }

--- a/api-docs/CioMessagingPushFCM.api
+++ b/api-docs/CioMessagingPushFCM.api
@@ -12,44 +12,18 @@ public final class CioMessagingPushFCM.MessagingPushFCM {
 	public fun func application(_ application: Any, didFailToRegisterForRemoteNotificationsWithError error: Error);
 	public fun func deleteDeviceToken();
 	public fun func trackMetric(deliveryID: String, event: Metric, deviceToken: String);
-	public fun func internalSetup(
-    withConfig config: MessagingPushConfigOptions = MessagingPushConfigBuilder().build(),
-    firebaseService: FirebaseService
-) -> MessagingPushInstance;
-	public fun func didReceive(
-    _ request: UNNotificationRequest,
-    withContentHandler contentHandler: @escaping (UNNotificationContent) -> Unit
-) -> Boolean;
+	public fun func internalSetup(withConfig config: MessagingPushConfigOptions = MessagingPushConfigBuilder().build(), firebaseService: FirebaseService) -> MessagingPushInstance;
+	public fun func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Unit) -> Boolean;
 	public fun func serviceExtensionTimeWillExpire();
-	public fun func userNotificationCenter(
-    _ center: UNUserNotificationCenter,
-    didReceive response: UNNotificationResponse
-) -> CustomerIOParsedPushPayload?;
-	public fun func userNotificationCenter(
-    _ center: UNUserNotificationCenter,
-    didReceive response: UNNotificationResponse,
-    withCompletionHandler completionHandler: @escaping () -> Unit
-) -> Boolean;
+	public fun func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) -> CustomerIOParsedPushPayload?;
+	public fun func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Unit) -> Boolean;
 }
 public interface CioMessagingPushFCM.MessagingPushFCMInstance {
 	public fun func registerDeviceToken(fcmToken: String?);
-	public fun func messaging(
-    _ messaging: Any,
-    didReceiveRegistrationToken fcmToken: String?
-);
-	public fun func application(
-    _ application: Any,
-    didFailToRegisterForRemoteNotificationsWithError error: Error
-);
+	public fun func messaging(_ messaging: Any, didReceiveRegistrationToken fcmToken: String?);
+	public fun func application(_ application: Any, didFailToRegisterForRemoteNotificationsWithError error: Error);
 	public fun func deleteDeviceToken();
-	public fun func trackMetric(
-    deliveryID: String,
-    event: Metric,
-    deviceToken: String
-);
-	public fun func didReceive(
-    _ request: UNNotificationRequest,
-    withContentHandler contentHandler: @escaping (UNNotificationContent) -> Unit
-) -> Boolean;
+	public fun func trackMetric(deliveryID: String, event: Metric, deviceToken: String);
+	public fun func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Unit) -> Boolean;
 	public fun func serviceExtensionTimeWillExpire();
 }

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -50,12 +50,7 @@ public final class CioInternalCommon.CioAppGroupPendingPushDeliveryStore {
 	public fun func removeAll(ids: Set<UUID>) -> Boolean;
 }
 public final class CioInternalCommon.CioEventBusHandler {
-	public fun init(
-    eventBus: EventBus,
-    eventCache: EventCache,
-    eventStorage: EventStorage,
-    logger: Logger
-);
+	public fun init(eventBus: EventBus, eventCache: EventCache, eventStorage: EventStorage, logger: Logger);
 	public fun deinit;
 	public fun func loadEventsFromStorage() async;
 	public fun func addObserver<E: EventRepresentable>(_ eventType: E.Type, action: @escaping (E) -> Unit);
@@ -117,30 +112,15 @@ public interface CioInternalCommon.CustomerIOInstance {
 	public var registeredDeviceToken: String?;
 	public fun func setProfileAttributes(_ attributes: List<String: Any>);
 	public fun func identify(userId: String, traits: List<String: Any>?);
-	public fun func identify<RequestBody: Codable>(
-    userId: String,
-    // sourcery:Type=AnyEncodable
-    // sourcery:TypeCast="AnyEncodable(traits)"
-    traits: RequestBody?
-);
+	public fun func identify<RequestBody: Codable>(userId: String, // sourcery:Type=AnyEncodable // sourcery:TypeCast="AnyEncodable(traits)" traits: RequestBody?);
 	public fun func clearIdentify();
 	public fun func setDeviceAttributes(_ attributes: List<String: Any>);
 	public fun func registerDeviceToken(_ deviceToken: String);
 	public fun func deleteDeviceToken();
 	public fun func track(name: String, properties: List<String: Any>?);
-	public fun func track<RequestBody: Codable>(
-    name: String,
-    // sourcery:Type=AnyEncodable
-    // sourcery:TypeCast="AnyEncodable(properties)"
-    properties: RequestBody?
-);
+	public fun func track<RequestBody: Codable>(name: String, // sourcery:Type=AnyEncodable // sourcery:TypeCast="AnyEncodable(properties)" properties: RequestBody?);
 	public fun func screen(title: String, properties: List<String: Any>?);
-	public fun func screen<RequestBody: Codable>(
-    title: String,
-    // sourcery:Type=AnyEncodable
-    // sourcery:TypeCast="AnyEncodable(properties)"
-    properties: RequestBody?
-);
+	public fun func screen<RequestBody: Codable>(title: String, // sourcery:Type=AnyEncodable // sourcery:TypeCast="AnyEncodable(properties)" properties: RequestBody?);
 	public fun func trackMetric(deliveryID: String, event: Metric, deviceToken: String);
 }
 public interface CioInternalCommon.CustomerIOModule {
@@ -279,10 +259,7 @@ public interface CioInternalCommon.GlobalDataStore {
 	public fun func deleteAll();
 }
 public interface CioInternalCommon.HttpClient {
-	public fun func request(
-    _ params: HttpRequestParams,
-    onComplete: @escaping (Result<Data, HttpRequestError>) -> Unit
-);
+	public fun func request(_ params: HttpRequestParams, onComplete: @escaping (Result<Data, HttpRequestError>) -> Unit);
 	public fun func downloadFile(url: URL, fileType: DownloadFileType, onComplete: @escaping (URL?) -> Unit);
 	public fun func cancel(finishTasks: Boolean);
 }
@@ -297,11 +274,7 @@ public final class CioInternalCommon.HttpRequestParams {
 	public fun init(method: String, url: URL, headers: HttpHeaders?, body: Data?);
 }
 public interface CioInternalCommon.HttpRequestRunner {
-	public fun func request(
-    params: HttpRequestParams,
-    session: URLSession,
-    onComplete: @escaping (Data?, HTTPURLResponse?, Error?) -> Unit
-);
+	public fun func request(params: HttpRequestParams, session: URLSession, onComplete: @escaping (Data?, HTTPURLResponse?, Error?) -> Unit);
 	public fun func downloadFile(url: URL, fileType: DownloadFileType, session: URLSession, onComplete: @escaping (URL?) -> Unit);
 }
 public final class CioInternalCommon.IdentifyProfileQueueTaskData {
@@ -320,10 +293,7 @@ public final class CioInternalCommon.JsonAdapter {
 	public fun func fromJsonString(_ jsonString: String) -> List<String: Any>?;
 	public fun func fromJson<T: Decodable>(_ json: Data, logErrors: Boolean = true) -> T?;
 	public fun func toJson<T: Encodable>(_ obj: T) -> Data?;
-	public fun func toJsonString<T: Encodable>(
-    _ obj: T,
-    nilIfEmpty: Boolean = true
-) -> String?;
+	public fun func toJsonString<T: Encodable>(_ obj: T, nilIfEmpty: Boolean = true) -> String?;
 }
 public enum CioInternalCommon.KeyValueStorageKey {
 }
@@ -388,13 +358,7 @@ public final class CioInternalCommon.PendingPushDeliveryMetric {
 	public final val deviceToken: String;
 	public final val event: Metric;
 	public final val timestamp: Date;
-	public fun init(
-    id: UUID = UUID(),
-    deliveryId: String,
-    deviceToken: String,
-    event: Metric,
-    timestamp: Date
-);
+	public fun init(id: UUID = UUID(), deliveryId: String, deviceToken: String, event: Metric, timestamp: Date);
 }
 public interface CioInternalCommon.PendingPushDeliveryStore {
 	public var appGroupSuiteName: String?;
@@ -594,17 +558,8 @@ public final class CioInternalCommon.UIKitWrapperImpl {
 	public fun func continueNSUserActivity(webpageURL: URL) -> Boolean;
 }
 public final class CioInternalCommon.UrlRequestHttpRequestRunner {
-	public fun func request(
-    params: HttpRequestParams,
-    session: URLSession,
-    onComplete: @escaping (Data?, HTTPURLResponse?, Error?) -> Unit
-);
-	public fun func downloadFile(
-    url: URL,
-    fileType: DownloadFileType,
-    session: URLSession,
-    onComplete: @escaping (URL?) -> Unit
-);
+	public fun func request(params: HttpRequestParams, session: URLSession, onComplete: @escaping (Data?, HTTPURLResponse?, Error?) -> Unit);
+	public fun func downloadFile(url: URL, fileType: DownloadFileType, session: URLSession, onComplete: @escaping (URL?) -> Unit);
 }
 public interface CioInternalCommon.UserAgentUtil {
 	public fun func getUserAgentHeaderValue() -> String;

--- a/api-docs/internal/CioMessagingPush.api
+++ b/api-docs/internal/CioMessagingPush.api
@@ -5,15 +5,8 @@ public final class CioMessagingPush.MessagingPush {
 	public fun func initialize(withConfig config: MessagingPushConfigOptions = MessagingPushConfigBuilder().build()) -> MessagingPushInstance;
 	public fun func registerDeviceToken(_ deviceToken: String);
 	public fun func deleteDeviceToken();
-	public fun func trackMetric(
-    deliveryID: String,
-    event: Metric,
-    deviceToken: String
-);
-	public fun func didReceive(
-    _ request: UNNotificationRequest,
-    withContentHandler contentHandler: @escaping (UNNotificationContent) -> Unit
-) -> Boolean;
+	public fun func trackMetric(deliveryID: String, event: Metric, deviceToken: String);
+	public fun func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Unit) -> Boolean;
 	public fun func serviceExtensionTimeWillExpire();
 }
 public final class CioMessagingPush.MessagingPushConfigBuilder {
@@ -36,15 +29,8 @@ public final class CioMessagingPush.MessagingPushConfigOptions {
 public interface CioMessagingPush.MessagingPushInstance {
 	public fun func registerDeviceToken(_ deviceToken: String);
 	public fun func deleteDeviceToken();
-	public fun func trackMetric(
-    deliveryID: String,
-    event: Metric,
-    deviceToken: String
-);
-	public fun func didReceive(
-    _ request: UNNotificationRequest,
-    withContentHandler contentHandler: @escaping (UNNotificationContent) -> Unit
-) -> Boolean;
+	public fun func trackMetric(deliveryID: String, event: Metric, deviceToken: String);
+	public fun func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Unit) -> Boolean;
 	public fun func serviceExtensionTimeWillExpire();
 }
 public final class CioMessagingPush.PushAttachment {

--- a/scripts/format-api-docs.rb
+++ b/scripts/format-api-docs.rb
@@ -113,7 +113,14 @@ class SwiftApiFormatter
     
     # Convert Swift syntax to more generic format
     cleaned = convert_swift_types(cleaned)
-    
+
+    # Normalize whitespace: collapse newlines and runs of spaces so output is
+    # stable across Xcode versions (the compiler's AST printer wraps long
+    # signatures differently between releases). The paren passes remove the
+    # spaces that appear immediately after ( and before ) when a multi-line
+    # signature is collapsed — those spaces don't appear in single-line output.
+    cleaned = cleaned.gsub(/\s+/, ' ').gsub(/\( +/, '(').gsub(/ +\)/, ')').strip
+
     "public fun #{cleaned}"
   end
 


### PR DESCRIPTION
Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After code reviews are approved and you determine this PR is ready to merge, select *Squash and Merge* button on this screen, leave the title and description to the default values, then merge the PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the API-docs generation formatter to normalize whitespace, resulting in doc-only diffs (mostly collapsing multi-line method signatures). Low risk since it doesn’t affect shipped SDK behavior.
> 
> **Overview**
> **Stabilizes generated API docs output across Xcode versions.** The API docs formatter now normalizes whitespace in parsed Swift method declarations (collapsing newlines and extra spaces, trimming around parentheses) so long signatures no longer wrap differently between toolchains.
> 
> This regenerates `api-docs/*.api` files with the same APIs but consistently single-line method signatures and reduced whitespace-only churn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0815b3c53d52b724cccc2071d043de416138152d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->