### PR TITLE
chore: switch deploy to App-bypass ruleset migration

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -42,7 +42,21 @@ jobs:
       new_release_published: ${{ steps.semantic-release.outputs.new_release_published }}
       new_release_version: ${{ steps.semantic-release.outputs.new_release_version }}
     steps:
+      # Mint the App installation token before checkout so we can pass it to actions/checkout.
+      # This is required because actions/checkout persists its token into local git config
+      # (http.https://github.com/.extraheader); whatever token the App-bypass ruleset trusts
+      # must be the one persisted, otherwise semantic-release's `git push` falls back to
+      # github-actions[bot] and is rejected with GH013.
+      - name: Generate App installation token
+        id: generate_token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.CIO_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CIO_APP_SECRET }}
+
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
 
       # CLI to replace strings in files. The CLI recommends using `cargo install` which is slow. This Action is fast because it downloads pre-built binaries.
       # If using sd on macos, "brew install" works great. for Linux, this is the recommended way.
@@ -50,7 +64,7 @@ jobs:
         # uses: kenji-miyake/setup-sd@59a1bd7bba077f6c491f04cd9d24b524ea2db4b6 # v1.1.1
         uses: levibostian/setup-sd@cbdeed93d4fe03f9e36b73bb6d9e7c3c4805e1f9 # add-file-extension # Using fork until upstream Action has bug fixed in it.
 
-      # We want to track the SDK binary size for each release. 
+      # We want to track the SDK binary size for each release.
       # The reports is pushed by semantic-release action below by including files listed in the `assets` array in the `.releaserc` file.
       - name: Write SDK size reports to file to include in the release
         run: |
@@ -61,17 +75,9 @@ jobs:
           echo "Verifying the reports got written to the file system. If the files are not empty, they were generated successfully..."
           echo "SDK binary size report:"
           head reports/sdk-binary-size.txt
-    
+
           echo "SDK binary size including dependencies report:"
           head reports/sdk-binary-size-including-dependencies.txt
-          
-          
-      - name: 'Generate token'
-        id: generate_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-        with:
-          app_id: ${{ secrets.CIO_APP_ID }}
-          private_key: ${{ secrets.CIO_APP_SECRET }}
     
       # Semantic-release tool is used to:
       # 1. Determine the next semantic version for the software during deployment.

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -20,7 +20,7 @@
         }],
         ["@semantic-release/git", {
             "assets": ["CHANGELOG.md", "Sources/Common/Version.swift", "*.podspec", "reports/*"],
-            "message": "chore: prepare for ${nextRelease.version}\n\n${nextRelease.notes}"
+            "message": "chore: prepare for ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
         }],
         ["@semantic-release/github", {
             "labels": false,


### PR DESCRIPTION
## Overview

Prep work for moving `main` from classic branch protection to a GitHub Ruleset where developers can't push directly and a designated GitHub App is the only bypass actor for deploy/release pushes.

The deploy workflow already mints an App token via `tibdex/github-app-token`, but the actual `git push` inside `@semantic-release/git` goes out as `github-actions[bot]` — not the App. That's because `actions/checkout@v4` defaults to `persist-credentials: true` and writes `GITHUB_TOKEN` into local git config (`http.https://github.com/.extraheader`); whatever creds we pass later via `env.GITHUB_TOKEN` are ignored by `git push`.

You can see this on the most recent release-prep commit (`2ff693b9 chore: prepare for 4.4.1`): committer is `semantic-release-bot` and the GitHub-side pusher identity is `github-actions[bot]`. Once the ruleset goes live, that pusher won't be on the bypass list and the push will be rejected with `GH013`.

## This PR

1. **Replace `tibdex/github-app-token` with `actions/create-github-app-token`** (SHA-pinned to v3.1.1). tibdex runs on Node 20, which GitHub Actions is deprecating; the official action is on Node 24.
2. **Switch the input from numeric `app_id` to `client-id`** — the deprecated `app-id` input warns in v3.x, and the Client ID is stable across App renames.
3. **Move the token-mint step before `actions/checkout`** and pass the App token via `with.token`, so the credentials persisted by checkout match the App identity that the ruleset will trust.
4. **Add a skip-ci directive to the `@semantic-release/git` commit-message template.** App-installation-token pushes do not inherit GitHub's recursion guard for `GITHUB_TOKEN`, so without this the deploy workflow self-triggers on its own release-prep commit.

Refers to it as "skip-ci directive" intentionally — writing the literal bracketed form anywhere in this PR's commit message or description would cause GitHub to suppress this very PR's CI runs (head-commit substring match — \"the bootstrap trap\"). The literal form belongs only inside `.releaserc.json`.

## Required before merge

A new repo secret must exist: `CIO_APP_CLIENT_ID` set to the App's Client ID (the public `Iv23…` string from the App's settings page). `CIO_APP_SECRET` (PEM) is unchanged. The numeric `CIO_APP_ID` becomes unused once this merges.

## Required after merge

1. Create the ruleset on `main` (Settings → Rules → Rulesets → New branch ruleset). Active enforcement, target `main`. **Bypass list: GitHub App → the App, Mode = Always.** Do NOT pick "For pull requests only" — direct `git push` from semantic-release will still hit `GH013`.
2. Trigger a release and verify (a) the push to `main` succeeds, (b) the pusher on the resulting workflow runs is `<app-slug>[bot]`, (c) the deploy workflow does not self-retrigger.
3. Then remove the existing classic branch protection on `main`.

Until step 3 is done, the classic protection and the new ruleset stack — most-restrictive wins, so `main` stays protected during transition.

## Test plan

- [ ] Confirm `CIO_APP_CLIENT_ID` secret is added in repo settings before merge.
- [ ] After merge, trigger a release (merge a `feat:`/`fix:` commit) and confirm the deploy push succeeds and the pusher is the App identity.
- [ ] Confirm only one deploy run kicks off on the release-prep commit (no recursion).
- [ ] After verification, create the ruleset and remove classic branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes release/deploy authentication and git push behavior; misconfigured App secrets or token persistence could break tagging/releases or cause unexpected workflow triggering.
> 
> **Overview**
> Updates the deploy workflow to mint a **GitHub App installation token** up front and pass it into `actions/checkout`, ensuring subsequent `semantic-release` `git push` operations use the App identity (for upcoming ruleset bypass) rather than the default `GITHUB_TOKEN`.
> 
> Adjusts release-prep commits from `@semantic-release/git` to include `[skip ci]` to prevent the deploy workflow from recursively triggering on its own version/changelog commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 237c74e15a0c26d3bfe6599281d149ac064e83fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->