### PR TITLE
refactor: isolate CoreLocationGeofenceMonitor on @MainActor

### DIFF
--- a/Sources/Location/Geofence/Monitor/CoreLocationGeofenceMonitor.swift
+++ b/Sources/Location/Geofence/Monitor/CoreLocationGeofenceMonitor.swift
@@ -4,34 +4,24 @@ import Foundation
 
 /// CLLocationManager-backed geofence region monitor.
 ///
-/// Implemented as an actor so all mutable state is serialized without locks.
-/// Delegate callbacks are nonisolated and re-enter the actor via `Task { await ... }`,
-/// matching the existing `CoreLocationProvider` pattern in this module.
+/// `@MainActor`-isolated because CLLocationManager must be created and called on the main
+/// thread, and its delegate callbacks arrive on main. State and OS calls share one
+/// isolation domain, so the ownership-set update and the OS dispatch happen atomically with
+/// no reentrancy point between them — no locks, no fire-and-forget Tasks, no FIFO assumption.
 ///
 /// Tracks which regions this monitor owns so it does not interfere with regions
 /// registered by the host app or other SDKs (CLLocationManager.monitoredRegions is shared app-wide).
-///
-/// `init` is `@MainActor` so CLLocationManager creation and delegate wiring run on main
-/// (a CLLocationManager requirement). Subsequent CLLocationManager method calls are
-/// dispatched to the main actor via fire-and-forget `Task { @MainActor in ... }` so the
-/// ownership-set update and OS-call dispatch happen atomically on the actor executor with
-/// no reentrancy point between them.
-actor CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, CLLocationManagerDelegate {
+@MainActor
+final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preconcurrency CLLocationManagerDelegate {
     private let manager: CLLocationManager
     private let logger: Logger
-    private let maxRegionMonitoringDistance: CLLocationDistance
     private var onTransition: GeofenceTransitionHandler?
     private var hasLoggedPermissionWarning = false
     private var ownedRegionIdentifiers: Set<String> = []
 
-    @MainActor
     init(logger: Logger) {
-        let manager = CLLocationManager()
-        self.manager = manager
+        self.manager = CLLocationManager()
         self.logger = logger
-        // Constant for the platform (documented as 10 km on iOS); cache so we don't need
-        // an actor-suspending main-actor hop in startMonitoring.
-        self.maxRegionMonitoringDistance = manager.maximumRegionMonitoringDistance
         super.init()
         manager.delegate = self
     }
@@ -44,8 +34,8 @@ actor CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, CLLocatio
         onTransition = handler
     }
 
-    func startMonitoring(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) async {
-        guard await checkAlwaysAuthorization() else { return }
+    func startMonitoring(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) {
+        guard checkAlwaysAuthorization() else { return }
 
         let coordinate = CLLocationCoordinate2D(latitude: center.latitude, longitude: center.longitude)
         guard CLLocationCoordinate2DIsValid(coordinate) else {
@@ -53,84 +43,63 @@ actor CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, CLLocatio
             return
         }
 
-        let clampedRadius = min(radius, maxRegionMonitoringDistance)
+        let clampedRadius = min(radius, manager.maximumRegionMonitoringDistance)
         let region = CLCircularRegion(center: coordinate, radius: clampedRadius, identifier: identifier)
         region.notifyOnEntry = transitionTypes.contains(.enter)
         region.notifyOnExit = transitionTypes.contains(.exit)
 
-        // Atomic on the actor executor: insert into the ownership set and dispatch the OS
-        // call without any await between them. A concurrent stop cannot interleave here
-        // because there is no suspension point. The OS call itself runs later on the main
-        // actor; subsequent stop dispatches submitted afterwards run after it (FIFO).
         ownedRegionIdentifiers.insert(identifier)
-        let locationManager = manager
-        Task { @MainActor in locationManager.startMonitoring(for: region) }
+        manager.startMonitoring(for: region)
     }
 
-    func stopMonitoring(identifier: String) async {
+    func stopMonitoring(identifier: String) {
         guard ownedRegionIdentifiers.remove(identifier) != nil else { return }
-        let locationManager = manager
-        Task { @MainActor in
-            if let region = locationManager.monitoredRegions.first(where: { $0.identifier == identifier }) {
-                locationManager.stopMonitoring(for: region)
-            }
+        if let region = manager.monitoredRegions.first(where: { $0.identifier == identifier }) {
+            manager.stopMonitoring(for: region)
         }
     }
 
-    func stopMonitoringAll() async {
+    func stopMonitoringAll() {
         let identifiers = ownedRegionIdentifiers
         ownedRegionIdentifiers.removeAll()
-        let locationManager = manager
-        Task { @MainActor in
-            for identifier in identifiers {
-                if let region = locationManager.monitoredRegions.first(where: { $0.identifier == identifier }) {
-                    locationManager.stopMonitoring(for: region)
-                }
+        for identifier in identifiers {
+            if let region = manager.monitoredRegions.first(where: { $0.identifier == identifier }) {
+                manager.stopMonitoring(for: region)
             }
         }
     }
 
-    // MARK: - CLLocationManagerDelegate (nonisolated; re-enter actor via Task)
+    // MARK: - CLLocationManagerDelegate
 
-    nonisolated func locationManager(_ manager: CLLocationManager, didEnterRegion region: CLRegion) {
-        guard let circularRegion = region as? CLCircularRegion else { return }
-        let identifier = circularRegion.identifier
-        let location = locationDataFrom(manager)
-        Task { await self.handleTransition(identifier: identifier, transition: .enter, location: location) }
+    func locationManager(_ manager: CLLocationManager, didEnterRegion region: CLRegion) {
+        guard let circularRegion = region as? CLCircularRegion,
+              ownedRegionIdentifiers.contains(circularRegion.identifier)
+        else { return }
+        onTransition?(circularRegion.identifier, .enter, currentLocationData())
     }
 
-    nonisolated func locationManager(_ manager: CLLocationManager, didExitRegion region: CLRegion) {
-        guard let circularRegion = region as? CLCircularRegion else { return }
-        let identifier = circularRegion.identifier
-        let location = locationDataFrom(manager)
-        Task { await self.handleTransition(identifier: identifier, transition: .exit, location: location) }
+    func locationManager(_ manager: CLLocationManager, didExitRegion region: CLRegion) {
+        guard let circularRegion = region as? CLCircularRegion,
+              ownedRegionIdentifiers.contains(circularRegion.identifier)
+        else { return }
+        onTransition?(circularRegion.identifier, .exit, currentLocationData())
     }
 
-    nonisolated func locationManager(_ manager: CLLocationManager, monitoringDidFailFor region: CLRegion?, withError error: Error) {
-        guard let identifier = region?.identifier else { return }
-        Task { await self.handleMonitoringFailure(identifier: identifier, error: error) }
-    }
-
-    // MARK: - Private (actor-isolated)
-
-    private func handleTransition(identifier: String, transition: GeofenceTransition, location: LocationData?) {
-        guard ownedRegionIdentifiers.contains(identifier) else { return }
-        onTransition?(identifier, transition, location)
-    }
-
-    private func handleMonitoringFailure(identifier: String, error: Error) {
-        guard ownedRegionIdentifiers.remove(identifier) != nil else { return }
+    func locationManager(_ manager: CLLocationManager, monitoringDidFailFor region: CLRegion?, withError error: Error) {
+        guard let identifier = region?.identifier,
+              ownedRegionIdentifiers.remove(identifier) != nil
+        else { return }
         logger.geofenceMonitoringFailed(region: identifier, error: error)
     }
 
-    private func checkAlwaysAuthorization() async -> Bool {
-        let locationManager = manager
-        let status: CLAuthorizationStatus = await MainActor.run {
-            if #available(iOS 14.0, *) {
-                return locationManager.authorizationStatus
-            } else {
-                return CLLocationManager.authorizationStatus()
-            }
+    // MARK: - Private
+
+    private func checkAlwaysAuthorization() -> Bool {
+        let status: CLAuthorizationStatus
+        if #available(iOS 14.0, *) {
+            status = manager.authorizationStatus
+        } else {
+            status = CLLocationManager.authorizationStatus()
         }
 
         guard status == .authorizedAlways else {
@@ -143,7 +112,7 @@ actor CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, CLLocatio
         return true
     }
 
-    private nonisolated func locationDataFrom(_ manager: CLLocationManager) -> LocationData? {
+    private func currentLocationData() -> LocationData? {
         guard let location = manager.location,
               CLLocationCoordinate2DIsValid(location.coordinate)
         else {

--- a/Sources/Location/Geofence/Monitor/CoreLocationGeofenceMonitor.swift
+++ b/Sources/Location/Geofence/Monitor/CoreLocationGeofenceMonitor.swift
@@ -4,50 +4,46 @@ import Foundation
 
 /// CLLocationManager-backed geofence region monitor.
 ///
-/// Must be created on the main thread (CLLocationManager requirement).
-/// Delegate callbacks are forwarded to the `onTransition` handler along with the
-/// manager's current location so callers have a fresh fix at transition time.
+/// Implemented as an actor so all mutable state is serialized without locks.
+/// Delegate callbacks are nonisolated and re-enter the actor via `Task { await ... }`,
+/// matching the existing `CoreLocationProvider` pattern in this module.
 ///
 /// Tracks which regions this monitor owns so it does not interfere with regions
 /// registered by the host app or other SDKs (CLLocationManager.monitoredRegions is shared app-wide).
 ///
-/// All mutable state is protected by `lock` since CLLocationManager delegate callbacks
-/// may fire on a different thread than the caller of start/stop methods.
-final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, CLLocationManagerDelegate {
-    var onTransition: GeofenceTransitionHandler? {
-        get { lock.lock()
-            defer { lock.unlock() }
-            return _onTransition
-        }
-        set { lock.lock()
-            defer { lock.unlock() }
-            _onTransition = newValue
-        }
-    }
-
+/// Must be created on the main thread so CLLocationManager and delegate setup run on main.
+/// CLLocationManager method calls are dispatched to the main actor via fire-and-forget
+/// `Task { @MainActor in ... }` so the ownership-set update and OS-call dispatch happen
+/// atomically on the actor executor with no reentrancy point between them.
+actor CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, CLLocationManagerDelegate {
     private let manager: CLLocationManager
     private let logger: Logger
-    private let lock = NSLock()
-    private var _onTransition: GeofenceTransitionHandler?
+    private let maxRegionMonitoringDistance: CLLocationDistance
+    private var onTransition: GeofenceTransitionHandler?
     private var hasLoggedPermissionWarning = false
     private var ownedRegionIdentifiers: Set<String> = []
 
-    /// Must be called on the main thread so CLLocationManager and delegate setup run on main.
     init(logger: Logger) {
-        self.manager = CLLocationManager()
+        let manager = CLLocationManager()
+        self.manager = manager
         self.logger = logger
+        // Constant for the platform (documented as 10 km on iOS); cache so we don't need
+        // an actor-suspending main-actor hop in startMonitoring.
+        self.maxRegionMonitoringDistance = manager.maximumRegionMonitoringDistance
         super.init()
         manager.delegate = self
     }
 
     var monitoredRegionIdentifiers: Set<String> {
-        lock.lock()
-        defer { lock.unlock() }
-        return ownedRegionIdentifiers
+        ownedRegionIdentifiers
     }
 
-    func startMonitoring(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) {
-        guard checkAlwaysAuthorization() else { return }
+    func setOnTransition(_ handler: GeofenceTransitionHandler?) {
+        onTransition = handler
+    }
+
+    func startMonitoring(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) async {
+        guard await checkAlwaysAuthorization() else { return }
 
         let coordinate = CLLocationCoordinate2D(latitude: center.latitude, longitude: center.longitude)
         guard CLLocationCoordinate2DIsValid(coordinate) else {
@@ -55,95 +51,89 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, CLL
             return
         }
 
-        let clampedRadius = min(radius, manager.maximumRegionMonitoringDistance)
+        let clampedRadius = min(radius, maxRegionMonitoringDistance)
         let region = CLCircularRegion(center: coordinate, radius: clampedRadius, identifier: identifier)
         region.notifyOnEntry = transitionTypes.contains(.enter)
         region.notifyOnExit = transitionTypes.contains(.exit)
-        lock.lock()
+
+        // Atomic on the actor executor: insert into the ownership set and dispatch the OS
+        // call without any await between them. A concurrent stop cannot interleave here
+        // because there is no suspension point. The OS call itself runs later on the main
+        // actor; subsequent stop dispatches submitted afterwards run after it (FIFO).
         ownedRegionIdentifiers.insert(identifier)
-        lock.unlock()
-
-        manager.startMonitoring(for: region)
+        let locationManager = manager
+        Task { @MainActor in locationManager.startMonitoring(for: region) }
     }
 
-    func stopMonitoring(identifier: String) {
-        lock.lock()
-        let removed = ownedRegionIdentifiers.remove(identifier) != nil
-        lock.unlock()
-
-        guard removed else { return }
-        if let region = manager.monitoredRegions.first(where: { $0.identifier == identifier }) {
-            manager.stopMonitoring(for: region)
-        }
-    }
-
-    func stopMonitoringAll() {
-        lock.lock()
-        let identifiers = ownedRegionIdentifiers
-        ownedRegionIdentifiers.removeAll()
-        lock.unlock()
-
-        for identifier in identifiers {
-            if let region = manager.monitoredRegions.first(where: { $0.identifier == identifier }) {
-                manager.stopMonitoring(for: region)
+    func stopMonitoring(identifier: String) async {
+        guard ownedRegionIdentifiers.remove(identifier) != nil else { return }
+        let locationManager = manager
+        Task { @MainActor in
+            if let region = locationManager.monitoredRegions.first(where: { $0.identifier == identifier }) {
+                locationManager.stopMonitoring(for: region)
             }
         }
     }
 
-    // MARK: - CLLocationManagerDelegate
-
-    func locationManager(_ manager: CLLocationManager, didEnterRegion region: CLRegion) {
-        guard let circularRegion = region as? CLCircularRegion else { return }
-
-        lock.lock()
-        let isOwned = ownedRegionIdentifiers.contains(circularRegion.identifier)
-        let handler = _onTransition
-        lock.unlock()
-
-        guard isOwned else { return }
-        handler?(circularRegion.identifier, .enter, currentLocationData())
+    func stopMonitoringAll() async {
+        let identifiers = ownedRegionIdentifiers
+        ownedRegionIdentifiers.removeAll()
+        let locationManager = manager
+        Task { @MainActor in
+            for identifier in identifiers {
+                if let region = locationManager.monitoredRegions.first(where: { $0.identifier == identifier }) {
+                    locationManager.stopMonitoring(for: region)
+                }
+            }
+        }
     }
 
-    func locationManager(_ manager: CLLocationManager, didExitRegion region: CLRegion) {
+    // MARK: - CLLocationManagerDelegate (nonisolated; re-enter actor via Task)
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didEnterRegion region: CLRegion) {
         guard let circularRegion = region as? CLCircularRegion else { return }
-
-        lock.lock()
-        let isOwned = ownedRegionIdentifiers.contains(circularRegion.identifier)
-        let handler = _onTransition
-        lock.unlock()
-
-        guard isOwned else { return }
-        handler?(circularRegion.identifier, .exit, currentLocationData())
+        let identifier = circularRegion.identifier
+        let location = locationDataFrom(manager)
+        Task { await self.handleTransition(identifier: identifier, transition: .enter, location: location) }
     }
 
-    func locationManager(_ manager: CLLocationManager, monitoringDidFailFor region: CLRegion?, withError error: Error) {
+    nonisolated func locationManager(_ manager: CLLocationManager, didExitRegion region: CLRegion) {
+        guard let circularRegion = region as? CLCircularRegion else { return }
+        let identifier = circularRegion.identifier
+        let location = locationDataFrom(manager)
+        Task { await self.handleTransition(identifier: identifier, transition: .exit, location: location) }
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager, monitoringDidFailFor region: CLRegion?, withError error: Error) {
         guard let identifier = region?.identifier else { return }
+        Task { await self.handleMonitoringFailure(identifier: identifier, error: error) }
+    }
 
-        lock.lock()
-        let wasOwned = ownedRegionIdentifiers.remove(identifier) != nil
-        lock.unlock()
+    // MARK: - Private (actor-isolated)
 
-        guard wasOwned else { return }
+    private func handleTransition(identifier: String, transition: GeofenceTransition, location: LocationData?) {
+        guard ownedRegionIdentifiers.contains(identifier) else { return }
+        onTransition?(identifier, transition, location)
+    }
+
+    private func handleMonitoringFailure(identifier: String, error: Error) {
+        guard ownedRegionIdentifiers.remove(identifier) != nil else { return }
         logger.geofenceMonitoringFailed(region: identifier, error: error)
     }
 
-    // MARK: - Private
-
-    private func checkAlwaysAuthorization() -> Bool {
-        let status: CLAuthorizationStatus
-        if #available(iOS 14.0, *) {
-            status = manager.authorizationStatus
-        } else {
-            status = CLLocationManager.authorizationStatus()
+    private func checkAlwaysAuthorization() async -> Bool {
+        let locationManager = manager
+        let status: CLAuthorizationStatus = await MainActor.run {
+            if #available(iOS 14.0, *) {
+                return locationManager.authorizationStatus
+            } else {
+                return CLLocationManager.authorizationStatus()
+            }
         }
 
         guard status == .authorizedAlways else {
-            lock.lock()
-            let alreadyLogged = hasLoggedPermissionWarning
-            hasLoggedPermissionWarning = true
-            lock.unlock()
-
-            if !alreadyLogged {
+            if !hasLoggedPermissionWarning {
+                hasLoggedPermissionWarning = true
                 logger.geofenceAlwaysAuthorizationRequired(currentStatus: status)
             }
             return false
@@ -151,7 +141,7 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, CLL
         return true
     }
 
-    private func currentLocationData() -> LocationData? {
+    private nonisolated func locationDataFrom(_ manager: CLLocationManager) -> LocationData? {
         guard let location = manager.location,
               CLLocationCoordinate2DIsValid(location.coordinate)
         else {

--- a/Sources/Location/Geofence/Monitor/CoreLocationGeofenceMonitor.swift
+++ b/Sources/Location/Geofence/Monitor/CoreLocationGeofenceMonitor.swift
@@ -11,10 +11,11 @@ import Foundation
 /// Tracks which regions this monitor owns so it does not interfere with regions
 /// registered by the host app or other SDKs (CLLocationManager.monitoredRegions is shared app-wide).
 ///
-/// Must be created on the main thread so CLLocationManager and delegate setup run on main.
-/// CLLocationManager method calls are dispatched to the main actor via fire-and-forget
-/// `Task { @MainActor in ... }` so the ownership-set update and OS-call dispatch happen
-/// atomically on the actor executor with no reentrancy point between them.
+/// `init` is `@MainActor` so CLLocationManager creation and delegate wiring run on main
+/// (a CLLocationManager requirement). Subsequent CLLocationManager method calls are
+/// dispatched to the main actor via fire-and-forget `Task { @MainActor in ... }` so the
+/// ownership-set update and OS-call dispatch happen atomically on the actor executor with
+/// no reentrancy point between them.
 actor CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, CLLocationManagerDelegate {
     private let manager: CLLocationManager
     private let logger: Logger
@@ -23,6 +24,7 @@ actor CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, CLLocatio
     private var hasLoggedPermissionWarning = false
     private var ownedRegionIdentifiers: Set<String> = []
 
+    @MainActor
     init(logger: Logger) {
         let manager = CLLocationManager()
         self.manager = manager

--- a/Sources/Location/Geofence/Monitor/GeofenceRegionMonitoring.swift
+++ b/Sources/Location/Geofence/Monitor/GeofenceRegionMonitoring.swift
@@ -16,9 +16,11 @@ typealias GeofenceTransitionHandler = @Sendable (String, GeofenceTransition, Loc
 ///
 /// The monitor owns a CLLocationManager and handles the delegate callbacks for region events.
 /// Business logic decides which regions to monitor; this component only manages the OS registrations.
-protocol GeofenceRegionMonitoring: AnyObject {
-    /// Handler called when a geofence transition (enter/exit) occurs.
-    var onTransition: GeofenceTransitionHandler? { get set }
+///
+/// Implementations are actor-isolated; all methods are async to ensure thread safety without locks.
+protocol GeofenceRegionMonitoring: Sendable, AnyObject {
+    /// Sets the handler called when a geofence transition (enter/exit) occurs.
+    func setOnTransition(_ handler: GeofenceTransitionHandler?) async
 
     /// Starts monitoring a circular geofence region.
     /// - Parameters:
@@ -26,14 +28,14 @@ protocol GeofenceRegionMonitoring: AnyObject {
     ///   - center: Center coordinate.
     ///   - radius: Radius in meters. Clamped to `CLLocationManager.maximumRegionMonitoringDistance` if exceeded.
     ///   - transitionTypes: Which transitions to monitor (enter, exit, or both).
-    func startMonitoring(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>)
+    func startMonitoring(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) async
 
     /// Stops monitoring the region with the given identifier.
-    func stopMonitoring(identifier: String)
+    func stopMonitoring(identifier: String) async
 
-    /// Stops monitoring all currently monitored regions managed by this monitor.
-    func stopMonitoringAll()
+    /// Stops monitoring all regions managed by this monitor.
+    func stopMonitoringAll() async
 
-    /// Returns the set of region identifiers currently being monitored.
-    var monitoredRegionIdentifiers: Set<String> { get }
+    /// Returns the set of region identifiers currently being monitored by this monitor.
+    var monitoredRegionIdentifiers: Set<String> { get async }
 }

--- a/Sources/Location/Geofence/Monitor/GeofenceRegionMonitoring.swift
+++ b/Sources/Location/Geofence/Monitor/GeofenceRegionMonitoring.swift
@@ -10,6 +10,11 @@ enum GeofenceTransition: String, Codable, Sendable {
 
 /// Callback when a geofence transition occurs.
 /// Parameters: region identifier, transition type, user's current location (from CLLocationManager.location, may be nil).
+///
+/// Invoked synchronously on the main actor (CLLocationManager delegate callbacks arrive on main).
+/// The closure body is not statically isolated — callers are free to hop to whatever actor they
+/// need: `Task.detached { ... }` for off-main work, `MainActor.assumeIsolated { ... }` for direct
+/// main-actor reads, or an `await someActor.method()` to hand off to another isolation domain.
 typealias GeofenceTransitionHandler = @Sendable (String, GeofenceTransition, LocationData?) -> Void
 
 /// Abstracts CLLocationManager's region monitoring.
@@ -17,10 +22,14 @@ typealias GeofenceTransitionHandler = @Sendable (String, GeofenceTransition, Loc
 /// The monitor owns a CLLocationManager and handles the delegate callbacks for region events.
 /// Business logic decides which regions to monitor; this component only manages the OS registrations.
 ///
-/// Implementations are actor-isolated; all methods are async to ensure thread safety without locks.
-protocol GeofenceRegionMonitoring: Sendable, AnyObject {
+/// Main-actor isolated because CLLocationManager must be created and called on the main thread,
+/// and its delegate callbacks arrive on main. Keeping the monitor's bookkeeping state in the
+/// same isolation domain as the OS calls removes the need for locks, fire-and-forget Tasks,
+/// or reentrancy reasoning between state mutations and OS dispatches.
+@MainActor
+protocol GeofenceRegionMonitoring: AnyObject, Sendable {
     /// Sets the handler called when a geofence transition (enter/exit) occurs.
-    func setOnTransition(_ handler: GeofenceTransitionHandler?) async
+    func setOnTransition(_ handler: GeofenceTransitionHandler?)
 
     /// Starts monitoring a circular geofence region.
     /// - Parameters:
@@ -28,14 +37,14 @@ protocol GeofenceRegionMonitoring: Sendable, AnyObject {
     ///   - center: Center coordinate.
     ///   - radius: Radius in meters. Clamped to `CLLocationManager.maximumRegionMonitoringDistance` if exceeded.
     ///   - transitionTypes: Which transitions to monitor (enter, exit, or both).
-    func startMonitoring(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) async
+    func startMonitoring(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>)
 
     /// Stops monitoring the region with the given identifier.
-    func stopMonitoring(identifier: String) async
+    func stopMonitoring(identifier: String)
 
     /// Stops monitoring all regions managed by this monitor.
-    func stopMonitoringAll() async
+    func stopMonitoringAll()
 
     /// Returns the set of region identifiers currently being monitored by this monitor.
-    var monitoredRegionIdentifiers: Set<String> { get async }
+    var monitoredRegionIdentifiers: Set<String> { get }
 }

--- a/Tests/Location/Geofence/Stub/MockGeofenceRegionMonitor.swift
+++ b/Tests/Location/Geofence/Stub/MockGeofenceRegionMonitor.swift
@@ -9,7 +9,8 @@ struct MonitoredRegionRecord: Sendable {
     let transitionTypes: Set<GeofenceTransition>
 }
 
-actor MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
+@MainActor
+final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
     private var onTransition: GeofenceTransitionHandler?
     private(set) var startedRegions: [MonitoredRegionRecord] = []
     private(set) var stoppedIdentifiers: [String] = []

--- a/Tests/Location/Geofence/Stub/MockGeofenceRegionMonitor.swift
+++ b/Tests/Location/Geofence/Stub/MockGeofenceRegionMonitor.swift
@@ -2,16 +2,15 @@
 @testable import CioLocation
 import Foundation
 
-struct MonitoredRegionRecord {
+struct MonitoredRegionRecord: Sendable {
     let identifier: String
     let center: LocationData
     let radius: Double
     let transitionTypes: Set<GeofenceTransition>
 }
 
-final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
-    var onTransition: GeofenceTransitionHandler?
-
+actor MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
+    private var onTransition: GeofenceTransitionHandler?
     private(set) var startedRegions: [MonitoredRegionRecord] = []
     private(set) var stoppedIdentifiers: [String] = []
     private(set) var stopAllCallCount = 0
@@ -19,6 +18,10 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
 
     var monitoredRegionIdentifiers: Set<String> {
         activeIdentifiers
+    }
+
+    func setOnTransition(_ handler: GeofenceTransitionHandler?) {
+        onTransition = handler
     }
 
     func startMonitoring(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) {


### PR DESCRIPTION
Ticket: [MBL-1626](https://linear.app/customerio/issue/MBL-1626/ios-handle-os-geofence-monitoring)

Follow-up to #1036 addressing review feedback that landed during the original PR:
- @mahmoud-elmorabea: "Should this be actor instead?"
- @hollyschilling-cio: prefers actor / `@MainActor` over locks
- Cursor: "Mutable state accessed without thread-safety guarantees"
- Cursor (post-merge): "Lock scope too narrow causes state desynchronization race"

We committed in the review thread to do this in the next PR.

## Summary
- Replace `final class` + `NSLock` with `@MainActor final class`.
- Make `GeofenceRegionMonitoring` `@MainActor` — protocol describes a CLLocationManager-backed contract, which is main-bound by Apple's API.
- Replace the `onTransition` get/set property with `setOnTransition(_:)` (cleaner contract for a side-effecting handler).
- `MockGeofenceRegionMonitor` becomes `@MainActor final class` to match.

## Design rationale

CLLocationManager must be created and called on main, and its delegate callbacks arrive on main. The monitor's bookkeeping state (`ownedRegionIdentifiers`, handler, permission-warning flag) has no reason to live on a different executor than the OS calls that touch it.

Two approaches were prototyped during review:

1. **`actor`** (initial attempt — first commit on this branch, see history): state lives on the actor's executor; OS calls hop to main via `Task { @MainActor in ... }`; delegate methods are `nonisolated` and re-enter the actor via `Task { await self... }`. This works but introduces three executors for one logical object, requires FIFO-of-same-priority assumptions for correctness, and Cursor flagged a real reentrancy edge case in an earlier draft.
2. **`@MainActor final class`** (final design, this PR): state and OS calls share one executor. Reentrancy between them is structurally impossible. No fire-and-forget Tasks. No `nonisolated` delegate dance. Delegate callbacks land in the correct domain naturally.

The `@MainActor` approach is the more honest model — the monitor wraps a main-anchored OS object and lives where that object lives. State synchronization is free because there is no concurrency on this class.

The transition handler stays as plain `@Sendable` (not `@MainActor`) so consumers (the upcoming coordinator in MBL-1630) can write closure bodies in whatever isolation they need. The handler is invoked on main at runtime (delegate callback context) — documented in the typealias doc comment.

`@preconcurrency` on the `CLLocationManagerDelegate` conformance is required because Apple's protocol predates Swift concurrency; callbacks do arrive on main since we created the manager on main, so the annotation is accurate.

## Scope
Three files: protocol, implementation, mock stub. No other consumers on this branch — the coordinator that will use this monitor lands in MBL-1630.

## Preserved fixes from #1036
All threading/correctness fixes from the previous review remain intact:
- Ownership tracking via `ownedRegionIdentifiers` (scoped to SDK-owned regions; doesn't touch host app or other SDK regions).
- Insert into ownership set before `manager.startMonitoring` (race ordering fix — now also structurally safe because both happen synchronously on main).
- `stopMonitoring`: remove from set first, then OS — avoids leaking identifier when OS drops a region silently.
- `monitoringDidFailFor` removes from ownership set so a failed registration doesn't leave a phantom entry against the 19-region budget.
- `Set<GeofenceTransition>` for order-independent equality (diff-based re-registration).
- Invalid coordinates logged at `error` level.

## Net diff
- Source: 56 insertions, 82 deletions (−26 lines vs. the merged class+NSLock baseline; even smaller vs. the actor draft).
- Tests: mock stub updated mechanically.

## Test plan
- [x] Location scheme builds clean
- [x] Whole-package test build succeeds
- [x] Zero warnings under `-strict-concurrency=complete` on geofence files
- [x] `make generate && make format && make lint` — 0 violations
- [x] No new unit tests — `CoreLocationGeofenceMonitor` wraps `CLLocationManager` and isn't meaningfully unit-testable without a fake of the OS API; mock-only tests were deleted per @hollyschilling-cio's prior feedback that they "provide no value"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Concurrency model changes for `CLLocationManager` geofence monitoring and protocol API surface, which could impact call sites and main-thread assumptions, but does not alter geofence business rules or persistence.
> 
> **Overview**
> Refactors geofence region monitoring to be **main-actor isolated** by marking `GeofenceRegionMonitoring`, `CoreLocationGeofenceMonitor`, and the test `MockGeofenceRegionMonitor` as `@MainActor`, eliminating the prior `NSLock`-based synchronization.
> 
> Updates the monitoring interface by replacing the mutable `onTransition` property with `setOnTransition(_:)`, and adjusts the CoreLocation delegate handling accordingly (including `@preconcurrency` conformance) while keeping the same region ownership tracking and start/stop behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afe994b3f754af9cea170661f5e028b076afa127. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->