### PR TITLE
chore: Add geofence state persistence layer

### DIFF
--- a/Sources/Location/Geofence/Model/GeofenceState.swift
+++ b/Sources/Location/Geofence/Model/GeofenceState.swift
@@ -1,0 +1,19 @@
+import CioInternalCommon
+import Foundation
+
+/// Persisted state for geofence monitoring.
+/// Fields are optional so partial state (e.g. only cooldowns) can be stored without requiring all fields.
+struct GeofenceState: Codable, Equatable, Sendable {
+    /// Geofences cached from the last server fetch.
+    var cachedGeofences: [Geofence]?
+    /// Location where the last server sync was performed.
+    var lastServerSyncLocation: LocationData?
+    /// Timestamp of the last server sync.
+    var lastServerSyncTimestamp: Date?
+    /// IDs of business geofences currently being monitored by the OS.
+    var monitoredGeofenceIds: Set<String>?
+    /// Center of the current Movement Trigger Geofence.
+    var movementTriggerCenter: LocationData?
+    /// Cooldown records for geofence transition events, keyed by "geofenceId:transitionType".
+    var eventCooldowns: [String: Date]?
+}

--- a/Sources/Location/Geofence/Storage/GeofenceStorage.swift
+++ b/Sources/Location/Geofence/Storage/GeofenceStorage.swift
@@ -1,0 +1,132 @@
+import CioInternalCommon
+import Foundation
+
+/// Thread-safe persistence for geofence state.
+///
+/// Implemented as an actor so all read-modify-write sequences are naturally atomic via
+/// actor isolation — no locks, no `@unchecked Sendable`. State is persisted to a JSON
+/// file with iOS Data Protection (`completeUntilFirstUserAuthentication`) so geofence
+/// callbacks that fire while the app is killed can still read cooldowns after the first
+/// user unlock. The file is excluded from backups (geofence cache is device-local context).
+///
+/// Each public method that mutates state performs the load → modify → save sequence
+/// synchronously within the actor, so no `await` interleaves and updates can never be
+/// lost to reentrancy.
+actor GeofenceStorage {
+    private static let defaultSubdirectory = "io.customer.sdk.geofence"
+    private static let filename = "geofenceState.json"
+    private static let protection = FileProtectionType.completeUntilFirstUserAuthentication
+
+    private let fileManager: FileManager
+    private let directoryURL: URL?
+
+    /// - Parameters:
+    ///   - fileManager: File manager used for I/O. Defaults to `.default`.
+    ///   - directoryURL: Directory for the state file. If `nil`, uses Application Support in the app container.
+    init(
+        fileManager: FileManager = .default,
+        directoryURL: URL? = nil
+    ) {
+        self.fileManager = fileManager
+        self.directoryURL = directoryURL
+    }
+
+    // MARK: - Event Cooldowns
+
+    func getEventCooldowns() -> [String: Date] {
+        loadFromDisk()?.eventCooldowns ?? [:]
+    }
+
+    func recordEventCooldown(key: String, timestamp: Date) {
+        var state = loadFromDisk() ?? GeofenceState()
+        var cooldowns = state.eventCooldowns ?? [:]
+        cooldowns[key] = timestamp
+        state.eventCooldowns = cooldowns
+        saveToDisk(state)
+    }
+
+    func purgeExpiredCooldowns(keys: Set<String>) {
+        guard !keys.isEmpty else { return }
+        var state = loadFromDisk() ?? GeofenceState()
+        var cooldowns = state.eventCooldowns ?? [:]
+        for key in keys {
+            cooldowns.removeValue(forKey: key)
+        }
+        state.eventCooldowns = cooldowns
+        saveToDisk(state)
+    }
+
+    func clearEventCooldowns() {
+        var state = loadFromDisk() ?? GeofenceState()
+        state.eventCooldowns = nil
+        saveToDisk(state)
+    }
+
+    // MARK: - Private (file persistence)
+
+    private func loadFromDisk() -> GeofenceState? {
+        guard let url = stateFileURL() else { return nil }
+        guard fileManager.fileExists(atPath: url.path),
+              let data = try? Data(contentsOf: url)
+        else {
+            return nil
+        }
+        return try? Self.makeDecoder().decode(GeofenceState.self, from: data)
+    }
+
+    private func saveToDisk(_ state: GeofenceState) {
+        guard let data = try? Self.makeEncoder().encode(state),
+              let url = stateFileURL()
+        else {
+            return
+        }
+        let directory = url.deletingLastPathComponent()
+        try? fileManager.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.protectionKey: Self.protection]
+        )
+        setExcludedFromBackup(on: directory)
+        do {
+            try data.write(to: url, options: .atomic)
+            try fileManager.setAttributes(
+                [.protectionKey: Self.protection],
+                ofItemAtPath: url.path
+            )
+            setExcludedFromBackup(on: url)
+        } catch {
+            // Persistence is best-effort.
+        }
+    }
+
+    private func setExcludedFromBackup(on url: URL) {
+        var url = url
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        try? url.setResourceValues(values)
+    }
+
+    private func stateFileURL() -> URL? {
+        if let directory = directoryURL {
+            return directory.appendingPathComponent(Self.filename)
+        }
+        guard let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            return nil
+        }
+        return appSupport
+            .appendingPathComponent(Self.defaultSubdirectory)
+            .appendingPathComponent(Self.filename)
+    }
+
+    private static func makeEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        return encoder
+    }
+
+    private static func makeDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        return decoder
+    }
+}

--- a/Tests/Location/Geofence/Storage/GeofenceStorageTests.swift
+++ b/Tests/Location/Geofence/Storage/GeofenceStorageTests.swift
@@ -1,0 +1,150 @@
+@testable import CioInternalCommon
+@testable import CioLocation
+import Foundation
+import SharedTests
+import Testing
+
+@Suite("GeofenceStorage")
+struct GeofenceStorageTests {
+    private func makeTempDirectory() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    }
+
+    private func makeStorage(directory: URL) -> GeofenceStorage {
+        GeofenceStorage(fileManager: .default, directoryURL: directory)
+    }
+
+    // MARK: - Cooldown operations
+
+    @Test
+    func getEventCooldowns_givenEmpty_expectEmptyDictionary() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let cooldowns = await storage.getEventCooldowns()
+        #expect(cooldowns.isEmpty)
+    }
+
+    @Test
+    func recordEventCooldown_givenKey_expectPersisted() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let timestamp = Date(timeIntervalSince1970: 1700000000)
+        await storage.recordEventCooldown(key: "geo_1:enter", timestamp: timestamp)
+        let cooldowns = await storage.getEventCooldowns()
+        #expect(cooldowns["geo_1:enter"] == timestamp)
+    }
+
+    @Test
+    func recordEventCooldown_givenMultipleKeys_expectAllPersisted() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let t1 = Date(timeIntervalSince1970: 1700000000)
+        let t2 = Date(timeIntervalSince1970: 1700001000)
+        await storage.recordEventCooldown(key: "geo_1:enter", timestamp: t1)
+        await storage.recordEventCooldown(key: "geo_1:exit", timestamp: t2)
+        let cooldowns = await storage.getEventCooldowns()
+        #expect(cooldowns.count == 2)
+        #expect(cooldowns["geo_1:enter"] == t1)
+        #expect(cooldowns["geo_1:exit"] == t2)
+    }
+
+    @Test
+    func purgeExpiredCooldowns_givenExpiredKeys_expectRemoved() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let t1 = Date(timeIntervalSince1970: 1700000000)
+        let t2 = Date(timeIntervalSince1970: 1700001000)
+        await storage.recordEventCooldown(key: "geo_1:enter", timestamp: t1)
+        await storage.recordEventCooldown(key: "geo_2:enter", timestamp: t2)
+        await storage.purgeExpiredCooldowns(keys: ["geo_1:enter"])
+        let cooldowns = await storage.getEventCooldowns()
+        #expect(cooldowns.count == 1)
+        #expect(cooldowns["geo_1:enter"] == nil)
+        #expect(cooldowns["geo_2:enter"] == t2)
+    }
+
+    @Test
+    func purgeExpiredCooldowns_givenEmptyKeys_expectNoChange() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        await storage.recordEventCooldown(key: "geo_1:enter", timestamp: Date())
+        await storage.purgeExpiredCooldowns(keys: [])
+        let cooldowns = await storage.getEventCooldowns()
+        #expect(cooldowns.count == 1)
+    }
+
+    @Test
+    func clearEventCooldowns_givenCooldowns_expectAllRemoved() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        await storage.recordEventCooldown(key: "geo_1:enter", timestamp: Date())
+        await storage.recordEventCooldown(key: "geo_2:exit", timestamp: Date())
+        await storage.clearEventCooldowns()
+        let cooldowns = await storage.getEventCooldowns()
+        #expect(cooldowns.isEmpty)
+    }
+
+    // MARK: - Persistence across instances
+
+    @Test
+    func recordEventCooldown_givenNewStorageInstance_expectLoadsFromDisk() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let storage1 = makeStorage(directory: dir)
+        let timestamp = Date(timeIntervalSince1970: 1700000000)
+        await storage1.recordEventCooldown(key: "geo_1:enter", timestamp: timestamp)
+
+        let storage2 = makeStorage(directory: dir)
+        let cooldowns = await storage2.getEventCooldowns()
+        #expect(cooldowns["geo_1:enter"] == timestamp)
+    }
+
+    @Test
+    func recordEventCooldown_givenSecondCall_expectOverwritesOnDisk() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let first = Date(timeIntervalSince1970: 1)
+        let second = Date(timeIntervalSince1970: 2)
+        await storage.recordEventCooldown(key: "geo_1:enter", timestamp: first)
+        await storage.recordEventCooldown(key: "geo_1:enter", timestamp: second)
+        let cooldowns = await storage.getEventCooldowns()
+        #expect(cooldowns["geo_1:enter"] == second)
+    }
+
+    // MARK: - Concurrent safety
+
+    @Test
+    func concurrentOperations_expectNoCrash() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0 ..< 20 {
+                group.addTask {
+                    for j in 0 ..< 10 {
+                        switch (i + j) % 3 {
+                        case 0:
+                            await storage.recordEventCooldown(key: "geo_\(i):enter", timestamp: Date())
+                        case 1:
+                            _ = await storage.getEventCooldowns()
+                        case 2:
+                            await storage.purgeExpiredCooldowns(keys: ["geo_\(i):enter"])
+                        default:
+                            break
+                        }
+                    }
+                }
+            }
+        }
+        _ = await storage.getEventCooldowns()
+    }
+}


### PR DESCRIPTION
Foundation used by:
- [MBL-1628](https://linear.app/customerio/issue/MBL-1628/ios-send-geofence-transition-events) — cooldown records for event dedup
- [MBL-1630](https://linear.app/customerio/issue/MBL-1630/ios-smart-geofence-updates) — cached geofences, last server sync location/timestamp, monitored region IDs, movement trigger center

## Summary
- `GeofenceState` pure value-type model with optional fields so partial state can be stored without requiring all fields. Conforms to `Sendable`.
- `GeofenceStorage` actor that owns both file persistence and high-level operations. Read-modify-write sequences are atomic by construction (no internal `await`s), eliminating reentrancy concerns.
- Persists to a JSON file with iOS Data Protection (`completeUntilFirstUserAuthentication`) so state is readable when geofence callbacks fire while the app is killed (after first user unlock this boot).
- File is excluded from iCloud/iTunes backups (geofence cache is device-local context, not user data).

## Design rationale

**Single actor instead of layered protocol design**

The original split was `GeofenceStateStore` protocol → `FileGeofenceStateStore` class → `GeofenceStorage` protocol → `GeofenceStorageImpl` class with two `NSLock`s. Collapsing into one actor:
- Eliminates all locks and `@unchecked Sendable` annotations
- Makes read-modify-write atomic by construction (no `await` between load and save inside actor methods means no other task can interleave and cause lost updates)
- Reduces code (~3× fewer lines than the layered design)
- Tests use temp directories instead of an injected in-memory stub — still hermetic, no behavior change

**Why file-based instead of UserDefaults (Android parity question)**

Android uses SharedPreferences; iOS file-based is the more iOS-correct mirror because:
- Geofence cache is transient device-local context — should NOT be in iCloud/iTunes backups. File-based gives us `isExcludedFromBackup=true`; UserDefaults is backed up by default.
- Data Protection class is set explicitly (`completeUntilFirstUserAuthentication`); UserDefaults inherits the app's default.
- `GeofenceState` is structured Codable — UserDefaults would force encode-to-Data-blob anyway, just under a key.
- Matches the existing `FileLastLocationStateStore` pattern in the same module.

## Scope
This PR exposes only cooldown operations (used immediately by the upcoming event delivery PR). The full state model is in place so the sync coordinator PR (MBL-1630) can add cached-geofence, last-sync, monitored-ID, and movement-trigger operations without re-touching the underlying storage.

## Diff size
- Source: 151 lines (2 files: `GeofenceState.swift` + `GeofenceStorage.swift`)
- Tests: 150 lines (1 file: `GeofenceStorageTests.swift`)

## Test plan
- [x] `getEventCooldowns_givenEmpty_expectEmptyDictionary`
- [x] `recordEventCooldown_givenKey_expectPersisted`
- [x] `recordEventCooldown_givenMultipleKeys_expectAllPersisted`
- [x] `purgeExpiredCooldowns_givenExpiredKeys_expectRemoved`
- [x] `purgeExpiredCooldowns_givenEmptyKeys_expectNoChange` (early-return)
- [x] `clearEventCooldowns_givenCooldowns_expectAllRemoved`
- [x] `recordEventCooldown_givenNewStorageInstance_expectLoadsFromDisk` (cross-instance persistence)
- [x] `recordEventCooldown_givenSecondCall_expectOverwritesOnDisk` (overwrite semantics)
- [x] `concurrentOperations_expectNoCrash` (concurrent safety smoke test)
- [x] 9 tests, all passing
- [x] Full SDK build clean
- [x] `make generate && make format && make lint` — zero new errors
- [x] Zero warnings under `-strict-concurrency=complete`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new on-disk persistence for geofence state/cooldowns; file I/O and data-protection attributes can fail silently and could affect geofence event dedup behavior if serialization/pathing is wrong.
> 
> **Overview**
> Adds a new persisted `GeofenceState` model (Codable/Sendable) and an actor-based `GeofenceStorage` that reads/writes this state to an Application Support JSON file using iOS Data Protection and excluding it from backups.
> 
> Exposes initial public operations for geofence transition *event cooldown* management (`get`, `record`, `purge`, `clear`), and adds unit tests covering persistence semantics and basic concurrency safety.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adf66971013482e91b718aa7acc247b91a139bb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->