### PR TITLE
refactor: Added Synchronized primitive and tests for it

### DIFF
--- a/Sources/Common/Synchronized/Synchronized+Arithmetic.swift
+++ b/Sources/Common/Synchronized/Synchronized+Arithmetic.swift
@@ -1,0 +1,25 @@
+extension Synchronized where T: AdditiveArithmetic {
+    public static func + (lhs: Synchronized<T>, rhs: T) -> T {
+        lhs.using { lhsValue in
+            lhsValue + rhs
+        }
+    }
+
+    public static func - (lhs: Synchronized<T>, rhs: T) -> T {
+        lhs.using { lhsValue in
+            lhsValue - rhs
+        }
+    }
+
+    public static func += (lhs: Synchronized<T>, rhs: T) {
+        lhs.mutating { lhsValue in
+            lhsValue += rhs
+        }
+    }
+
+    public static func -= (lhs: Synchronized<T>, rhs: T) {
+        lhs.mutating { lhsValue in
+            lhsValue -= rhs
+        }
+    }
+}

--- a/Sources/Common/Synchronized/Synchronized+Arithmetic.swift
+++ b/Sources/Common/Synchronized/Synchronized+Arithmetic.swift
@@ -1,23 +1,23 @@
-extension Synchronized where T: AdditiveArithmetic {
-    public static func + (lhs: Synchronized<T>, rhs: T) -> T {
+public extension Synchronized where T: AdditiveArithmetic {
+    static func + (lhs: Synchronized<T>, rhs: T) -> T {
         lhs.using { lhsValue in
             lhsValue + rhs
         }
     }
 
-    public static func - (lhs: Synchronized<T>, rhs: T) -> T {
+    static func - (lhs: Synchronized<T>, rhs: T) -> T {
         lhs.using { lhsValue in
             lhsValue - rhs
         }
     }
 
-    public static func += (lhs: Synchronized<T>, rhs: T) {
+    static func += (lhs: Synchronized<T>, rhs: T) {
         lhs.mutating { lhsValue in
             lhsValue += rhs
         }
     }
 
-    public static func -= (lhs: Synchronized<T>, rhs: T) {
+    static func -= (lhs: Synchronized<T>, rhs: T) {
         lhs.mutating { lhsValue in
             lhsValue -= rhs
         }

--- a/Sources/Common/Synchronized/Synchronized+Bool.swift
+++ b/Sources/Common/Synchronized/Synchronized+Bool.swift
@@ -1,0 +1,7 @@
+extension Synchronized where T == Bool {
+    public func toggle() {
+        mutating { value in
+            value.toggle()
+        }
+    }
+}

--- a/Sources/Common/Synchronized/Synchronized+Bool.swift
+++ b/Sources/Common/Synchronized/Synchronized+Bool.swift
@@ -1,5 +1,5 @@
-extension Synchronized where T == Bool {
-    public func toggle() {
+public extension Synchronized where T == Bool {
+    func toggle() {
         mutating { value in
             value.toggle()
         }

--- a/Sources/Common/Synchronized/Synchronized+Collections.swift
+++ b/Sources/Common/Synchronized/Synchronized+Collections.swift
@@ -1,0 +1,78 @@
+extension Synchronized where T: Collection {
+    public var count: Int {
+        using { value in value.count }
+    }
+
+    public var isEmpty: Bool {
+        using { value in value.isEmpty }
+    }
+}
+
+extension Synchronized where T: MutableCollection {
+    /// Accesses the element at `position` in a thread-safe manner.
+    ///
+    /// - Warning: The getter and setter each acquire the lock independently.
+    ///   Chained compound mutations such as `sync[i].property = value` are
+    ///   **not** atomic — use `mutating { $0[i].property = value }` instead.
+    public subscript(position: T.Index) -> T.Element {
+        get {
+            using { value in
+                value[position]
+            }
+        }
+        set {
+            mutating { value in
+                value[position] = newValue
+            }
+        }
+    }
+}
+
+extension Synchronized where T: RangeReplaceableCollection {
+    public static func += <S>(lhs: Synchronized<T>, rhs: S)
+    where S: Sequence, T.Element == S.Element {
+        lhs.append(contentsOf: rhs)
+    }
+
+    public static func += (lhs: Synchronized<T>, rhs: T.Element) {
+        lhs.append(rhs)
+    }
+
+    public func append(_ newElement: T.Element) {
+        mutating { value in
+            value.append(newElement)
+        }
+    }
+
+    public func append<S>(contentsOf newElements: S) where S: Sequence, T.Element == S.Element {
+        mutating { value in
+            value.append(contentsOf: newElements)
+        }
+    }
+
+    public func insert(_ newElement: T.Element, at i: T.Index) {
+        mutating { value in
+            value.insert(newElement, at: i)
+        }
+    }
+
+    public func insert<S>(contentsOf newElements: S, at i: T.Index)
+    where S: Collection, T.Element == S.Element {
+        mutating { value in
+            value.insert(contentsOf: newElements, at: i)
+        }
+    }
+
+    public func removeAll(keepingCapacity keepCapacity: Bool = false) {
+        mutating { value in
+            value.removeAll(keepingCapacity: keepCapacity)
+        }
+    }
+
+    public func removeAll(where matching: (T.Element) throws -> Bool) rethrows {
+        try mutating { value in
+            try value.removeAll(where: matching)
+        }
+    }
+
+}

--- a/Sources/Common/Synchronized/Synchronized+Collections.swift
+++ b/Sources/Common/Synchronized/Synchronized+Collections.swift
@@ -1,20 +1,20 @@
-extension Synchronized where T: Collection {
-    public var count: Int {
+public extension Synchronized where T: Collection {
+    var count: Int {
         using { value in value.count }
     }
 
-    public var isEmpty: Bool {
+    var isEmpty: Bool {
         using { value in value.isEmpty }
     }
 }
 
-extension Synchronized where T: MutableCollection {
+public extension Synchronized where T: MutableCollection {
     /// Accesses the element at `position` in a thread-safe manner.
     ///
     /// - Warning: The getter and setter each acquire the lock independently.
     ///   Chained compound mutations such as `sync[i].property = value` are
     ///   **not** atomic — use `mutating { $0[i].property = value }` instead.
-    public subscript(position: T.Index) -> T.Element {
+    subscript(position: T.Index) -> T.Element {
         get {
             using { value in
                 value[position]
@@ -28,51 +28,50 @@ extension Synchronized where T: MutableCollection {
     }
 }
 
-extension Synchronized where T: RangeReplaceableCollection {
-    public static func += <S>(lhs: Synchronized<T>, rhs: S)
-    where S: Sequence, T.Element == S.Element {
+public extension Synchronized where T: RangeReplaceableCollection {
+    static func += <S>(lhs: Synchronized<T>, rhs: S)
+        where S: Sequence, T.Element == S.Element {
         lhs.append(contentsOf: rhs)
     }
 
-    public static func += (lhs: Synchronized<T>, rhs: T.Element) {
+    static func += (lhs: Synchronized<T>, rhs: T.Element) {
         lhs.append(rhs)
     }
 
-    public func append(_ newElement: T.Element) {
+    func append(_ newElement: T.Element) {
         mutating { value in
             value.append(newElement)
         }
     }
 
-    public func append<S>(contentsOf newElements: S) where S: Sequence, T.Element == S.Element {
+    func append<S>(contentsOf newElements: S) where S: Sequence, T.Element == S.Element {
         mutating { value in
             value.append(contentsOf: newElements)
         }
     }
 
-    public func insert(_ newElement: T.Element, at i: T.Index) {
+    func insert(_ newElement: T.Element, at i: T.Index) {
         mutating { value in
             value.insert(newElement, at: i)
         }
     }
 
-    public func insert<S>(contentsOf newElements: S, at i: T.Index)
-    where S: Collection, T.Element == S.Element {
+    func insert<S>(contentsOf newElements: S, at i: T.Index)
+        where S: Collection, T.Element == S.Element {
         mutating { value in
             value.insert(contentsOf: newElements, at: i)
         }
     }
 
-    public func removeAll(keepingCapacity keepCapacity: Bool = false) {
+    func removeAll(keepingCapacity keepCapacity: Bool = false) {
         mutating { value in
             value.removeAll(keepingCapacity: keepCapacity)
         }
     }
 
-    public func removeAll(where matching: (T.Element) throws -> Bool) rethrows {
+    func removeAll(where matching: (T.Element) throws -> Bool) rethrows {
         try mutating { value in
             try value.removeAll(where: matching)
         }
     }
-
 }

--- a/Sources/Common/Synchronized/Synchronized+Comparable.swift
+++ b/Sources/Common/Synchronized/Synchronized+Comparable.swift
@@ -1,0 +1,25 @@
+extension Synchronized where T: Comparable {
+    public static func < (lhs: Synchronized<T>, rhs: T) -> Bool {
+        lhs.using { lhsValue in
+            lhsValue < rhs
+        }
+    }
+
+    public static func <= (lhs: Synchronized<T>, rhs: T) -> Bool {
+        lhs.using { lhsValue in
+            lhsValue <= rhs
+        }
+    }
+
+    public static func > (lhs: Synchronized<T>, rhs: T) -> Bool {
+        lhs.using { lhsValue in
+            lhsValue > rhs
+        }
+    }
+
+    public static func >= (lhs: Synchronized<T>, rhs: T) -> Bool {
+        lhs.using { lhsValue in
+            lhsValue >= rhs
+        }
+    }
+}

--- a/Sources/Common/Synchronized/Synchronized+Comparable.swift
+++ b/Sources/Common/Synchronized/Synchronized+Comparable.swift
@@ -1,23 +1,23 @@
-extension Synchronized where T: Comparable {
-    public static func < (lhs: Synchronized<T>, rhs: T) -> Bool {
+public extension Synchronized where T: Comparable {
+    static func < (lhs: Synchronized<T>, rhs: T) -> Bool {
         lhs.using { lhsValue in
             lhsValue < rhs
         }
     }
 
-    public static func <= (lhs: Synchronized<T>, rhs: T) -> Bool {
+    static func <= (lhs: Synchronized<T>, rhs: T) -> Bool {
         lhs.using { lhsValue in
             lhsValue <= rhs
         }
     }
 
-    public static func > (lhs: Synchronized<T>, rhs: T) -> Bool {
+    static func > (lhs: Synchronized<T>, rhs: T) -> Bool {
         lhs.using { lhsValue in
             lhsValue > rhs
         }
     }
 
-    public static func >= (lhs: Synchronized<T>, rhs: T) -> Bool {
+    static func >= (lhs: Synchronized<T>, rhs: T) -> Bool {
         lhs.using { lhsValue in
             lhsValue >= rhs
         }

--- a/Sources/Common/Synchronized/Synchronized+Dictionaries.swift
+++ b/Sources/Common/Synchronized/Synchronized+Dictionaries.swift
@@ -1,0 +1,41 @@
+public protocol DictionaryProtocol {
+    associatedtype Key: Hashable
+    associatedtype Value
+
+    subscript(key: Key) -> Value? { get set }
+    mutating func removeValue(forKey key: Key) -> Value?
+}
+
+extension Dictionary: DictionaryProtocol {}
+
+extension Synchronized: DictionaryProtocol where T: DictionaryProtocol {
+    public typealias Key = T.Key
+    public typealias Value = T.Value
+
+    /// Accesses the value associated with `key` in a thread-safe manner.
+    ///
+    /// - Warning: The getter and setter each acquire the lock independently.
+    ///   Chained compound mutations such as `sync["key"]?.property = value` are
+    ///   **not** atomic — use `mutating { $0["key"]?.property = value }` instead.
+    public subscript(key: Key) -> Value? {
+        get {
+            using { value in
+                value[key]
+            }
+        }
+        set {
+            mutating { value in
+                value[key] = newValue
+            }
+        }
+    }
+
+    @discardableResult
+    public func removeValue(forKey key: Key) -> Value? {
+        var result: Value?
+        mutating { value in
+            result = value.removeValue(forKey: key)
+        }
+        return result
+    }
+}

--- a/Sources/Common/Synchronized/Synchronized+Dictionaries.swift
+++ b/Sources/Common/Synchronized/Synchronized+Dictionaries.swift
@@ -32,10 +32,8 @@ extension Synchronized: DictionaryProtocol where T: DictionaryProtocol {
 
     @discardableResult
     public func removeValue(forKey key: Key) -> Value? {
-        var result: Value?
         mutating { value in
-            result = value.removeValue(forKey: key)
+            value.removeValue(forKey: key)
         }
-        return result
     }
 }

--- a/Sources/Common/Synchronized/Synchronized+Equatable.swift
+++ b/Sources/Common/Synchronized/Synchronized+Equatable.swift
@@ -1,0 +1,25 @@
+extension Synchronized: Equatable where T: Equatable {
+    // Locks are always acquired in ObjectIdentifier order so that concurrent calls to
+    // `a == b` and `b == a` on different threads cannot produce an ABBA deadlock.
+    public static func == (lhs: Synchronized<T>, rhs: Synchronized<T>) -> Bool {
+        guard lhs !== rhs else { return true }
+
+        if ObjectIdentifier(lhs) < ObjectIdentifier(rhs) {
+            return lhs.using { lhsValue in rhs.using { lhsValue == $0 } }
+        } else {
+            return rhs.using { rhsValue in lhs.using { $0 == rhsValue } }
+        }
+    }
+
+    public static func == (lhs: Synchronized<T>, rhs: T) -> Bool {
+        lhs.using { lhsValue in
+            lhsValue == rhs
+        }
+    }
+
+    public static func != (lhs: Synchronized<T>, rhs: T) -> Bool {
+        lhs.using { lhsValue in
+            lhsValue != rhs
+        }
+    }
+}

--- a/Sources/Common/Synchronized/Synchronized+Hashable.swift
+++ b/Sources/Common/Synchronized/Synchronized+Hashable.swift
@@ -1,0 +1,7 @@
+extension Synchronized: Hashable where T: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        using { value in
+            value.hash(into: &hasher)
+        }
+    }
+}

--- a/Sources/Common/Synchronized/Synchronized.swift
+++ b/Sources/Common/Synchronized/Synchronized.swift
@@ -1,0 +1,52 @@
+import Dispatch
+import Foundation
+
+/// A wrapper for primitive types to make them thread safe and able to conform to `Sendable`.
+public final class Synchronized<T>: @unchecked Sendable {
+    private let lock = NSRecursiveLock()
+    private var _wrappedValue: T
+    public var wrappedValue: T {
+        get {
+            lock.withLock {
+                _wrappedValue
+            }
+        }
+        set {
+            lock.withLock {
+                _wrappedValue = newValue
+            }
+        }
+    }
+
+    public init(_ initial: T) {
+        self._wrappedValue = initial
+    }
+
+    /// Modify the wrapped value in a thread-safe manor.
+    /// - Parameters:
+    /// - body: The critical section of code that may modify the wrapped value.
+    /// - Returns: The value returned from the inner function.
+    public func mutating<Result>(_ body: (inout T) throws -> Result) rethrows -> Result {
+        try lock.withLock {
+            try body(&_wrappedValue)
+        }
+    }
+
+    /// Access the wrapped value in a thread-safe manor.
+    /// - Parameters:
+    ///  - body: The code to access the wrapped value. The return value is passed through and returned to the caller, leaving the original value unchanged.
+    public func using<Result>(_ body: (T) throws -> Result) rethrows -> Result {
+        try lock.withLock {
+            try body(_wrappedValue)
+        }
+    }
+
+    /// Sets a new value while returning the old one in one atomic operation..
+    public func atomicSetAndFetch(_ newValue: T) -> T {
+        mutating {
+            let oldValue = $0
+            $0 = newValue
+            return oldValue
+        }
+    }
+}

--- a/Tests/Common/Synchronized/SynchronizedTests.swift
+++ b/Tests/Common/Synchronized/SynchronizedTests.swift
@@ -1,0 +1,317 @@
+import Dispatch
+import Testing
+
+@testable import CioInternalCommon
+
+// MARK: - Core read/write
+
+@Suite struct SynchronizedCoreTests {
+
+    @Test func wrappedValueGetSet() {
+        let box = Synchronized(42)
+        #expect(box.wrappedValue == 42)
+        box.wrappedValue = 99
+        #expect(box.wrappedValue == 99)
+    }
+
+    @Test func mutatingReturnsResult() {
+        let box = Synchronized("hello")
+        let old = box.mutating { value -> String in
+            let previous = value
+            value = "world"
+            return previous
+        }
+        #expect(old == "hello")
+        #expect(box.wrappedValue == "world")
+    }
+
+    @Test func mutatingThrows() {
+        struct TestError: Error {}
+        let box = Synchronized(0)
+        #expect(throws: TestError.self) {
+            try box.mutating { _ in throw TestError() }
+        }
+    }
+
+    @Test func usingDoesNotMutate() {
+        let box = Synchronized([1, 2, 3])
+        let sum = box.using { $0.reduce(0, +) }
+        #expect(sum == 6)
+        #expect(box.wrappedValue == [1, 2, 3])
+    }
+
+    @Test func usingThrows() {
+        struct TestError: Error {}
+        let box = Synchronized(0)
+        #expect(throws: TestError.self) {
+            try box.using { _ in throw TestError() }
+        }
+    }
+
+    @Test func atomicSetAndFetch() {
+        let box = Synchronized(10)
+        let old = box.atomicSetAndFetch(20)
+        #expect(old == 10)
+        #expect(box.wrappedValue == 20)
+    }
+
+    @Test func concurrentWritesSafelyAccumulate() async {
+        let box = Synchronized(0)
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<100 {
+                group.addTask {
+                    box.mutating { $0 += 1 }
+                }
+            }
+        }
+        #expect(box.wrappedValue == 100)
+    }
+}
+
+// MARK: - Arithmetic
+
+@Suite struct SynchronizedArithmeticTests {
+
+    @Test func addRawValue() {
+        let a = Synchronized(10)
+        #expect(a + 5 == 15)
+    }
+
+    @Test func subtractRawValue() {
+        let a = Synchronized(10)
+        #expect(a - 4 == 6)
+    }
+
+    @Test func addAssignRawValue() {
+        let a = Synchronized(5)
+        a += 3
+        #expect(a.wrappedValue == 8)
+    }
+
+    @Test func subtractAssignRawValue() {
+        let a = Synchronized(10)
+        a -= 4
+        #expect(a.wrappedValue == 6)
+    }
+}
+
+// MARK: - Bool
+
+@Suite struct SynchronizedBoolTests {
+
+    @Test func toggle() {
+        let flag = Synchronized(false)
+        flag.toggle()
+        #expect(flag.wrappedValue == true)
+        flag.toggle()
+        #expect(flag.wrappedValue == false)
+    }
+}
+
+// MARK: - Collections
+
+@Suite struct SynchronizedCollectionTests {
+
+    @Test func countAndIsEmpty() {
+        let list: Synchronized<[Int]> = Synchronized([])
+        #expect(list.isEmpty)
+        #expect(list.count == 0)
+        list.append(1)
+        #expect(!list.isEmpty)
+        #expect(list.count == 1)
+    }
+
+    @Test func subscriptGetSet() {
+        let list = Synchronized([10, 20, 30])
+        #expect(list[1] == 20)
+        list[1] = 99
+        #expect(list[1] == 99)
+    }
+
+    @Test func append() {
+        let list: Synchronized<[String]> = Synchronized([])
+        list.append("a")
+        list.append("b")
+        #expect(list.wrappedValue == ["a", "b"])
+    }
+
+    @Test func appendContentsOf() {
+        let list: Synchronized<[Int]> = Synchronized([1, 2])
+        list.append(contentsOf: [3, 4])
+        #expect(list.wrappedValue == [1, 2, 3, 4])
+    }
+
+    @Test func insertAt() {
+        let list: Synchronized<[Int]> = Synchronized([1, 3])
+        list.insert(2, at: 1)
+        #expect(list.wrappedValue == [1, 2, 3])
+    }
+
+    @Test func insertContentsOf() {
+        let list: Synchronized<[Int]> = Synchronized([1, 4])
+        list.insert(contentsOf: [2, 3], at: 1)
+        #expect(list.wrappedValue == [1, 2, 3, 4])
+    }
+
+    @Test func removeAll() {
+        let list = Synchronized([1, 2, 3])
+        list.removeAll()
+        #expect(list.isEmpty)
+    }
+
+    @Test func removeAllKeepingCapacity() {
+        var list = Synchronized([1, 2, 3])
+        let capacityBefore = list.using { $0.capacity }
+        list.removeAll(keepingCapacity: true)
+        #expect(list.isEmpty)
+        #expect(list.using { $0.capacity } >= capacityBefore)
+    }
+
+    @Test func removeAllWhere() {
+        let list = Synchronized([1, 2, 3, 4, 5])
+        list.removeAll(where: { $0 % 2 == 0 })
+        #expect(list.wrappedValue == [1, 3, 5])
+    }
+
+    @Test func plusEqualsElement() {
+        let list: Synchronized<[Int]> = Synchronized([1])
+        list += 2
+        #expect(list.wrappedValue == [1, 2])
+    }
+
+    @Test func plusEqualsSequence() {
+        let list: Synchronized<[Int]> = Synchronized([1])
+        list += [2, 3]
+        #expect(list.wrappedValue == [1, 2, 3])
+    }
+}
+
+// MARK: - Comparable
+
+@Suite struct SynchronizedComparableTests {
+
+    @Test func lessThanRaw() {
+        let a = Synchronized(1)
+        #expect(a < 5)
+        #expect(!(a < 1))
+    }
+
+    @Test func lessThanOrEqualRaw() {
+        let a = Synchronized(1)
+        #expect(a <= 1)
+        #expect(!(a <= 0))
+    }
+
+    @Test func greaterThanRaw() {
+        let a = Synchronized(5)
+        #expect(a > 1)
+        #expect(!(a > 5))
+    }
+
+    @Test func greaterThanOrEqualRaw() {
+        let a = Synchronized(5)
+        #expect(a >= 5)
+        #expect(!(a >= 6))
+    }
+}
+
+// MARK: - Equatable
+
+@Suite struct SynchronizedEquatableTests {
+
+    @Test func equalBoxes() {
+        let a = Synchronized("foo")
+        let b = Synchronized("foo")
+        #expect(a == b)
+    }
+
+    @Test func notEqualBoxes() {
+        let a = Synchronized("foo")
+        let b = Synchronized("bar")
+        #expect(a != b)
+    }
+
+    @Test func equalRaw() {
+        let a = Synchronized(42)
+        #expect(a == 42)
+        #expect(a != 99)
+    }
+
+    @Test func sameInstanceEqual() {
+        let a = Synchronized(7)
+        #expect(a == a)
+        #expect(!(a != a))
+    }
+
+    // Calls a == b and b == a concurrently. Without the ObjectIdentifier lock-ordering in ==,
+    // this reliably deadlocks. The 30s timeout converts a hang into a test failure.
+    @Test func equalsConcurrentlyDoesNotDeadlock() {
+        let a = Synchronized(1)
+        let b = Synchronized(1)
+        let group = DispatchGroup()
+
+        for _ in 0..<1_000 {
+            group.enter()
+            DispatchQueue.global().async { _ = a == b; group.leave() }
+            group.enter()
+            DispatchQueue.global().async { _ = b == a; group.leave() }
+        }
+
+        #expect(group.wait(timeout: .now() + 30) == .success)
+    }
+}
+
+// MARK: - Hashable
+
+@Suite struct SynchronizedHashableTests {
+
+    @Test func usableInSet() {
+        let a = Synchronized(1)
+        let b = Synchronized(2)
+        let set: Set = [a, b]
+        #expect(set.count == 2)
+    }
+
+    @Test func usableAsDictionaryKey() {
+        let key = Synchronized("k")
+        var dict: [Synchronized<String>: Int] = [:]
+        dict[key] = 99
+        #expect(dict[key] == 99)
+    }
+
+    @Test func hashMatchesWrappedValue() {
+        let a = Synchronized(123)
+        let b = Synchronized(123)
+        var ha = Hasher()
+        var hb = Hasher()
+        a.hash(into: &ha)
+        b.hash(into: &hb)
+        #expect(ha.finalize() == hb.finalize())
+    }
+}
+
+// MARK: - Dictionaries
+
+@Suite struct SynchronizedDictionaryTests {
+
+    @Test func subscriptGetSet() {
+        let dict: Synchronized<[String: Int]> = Synchronized([:])
+        dict["a"] = 1
+        #expect(dict["a"] == 1)
+        dict["a"] = nil
+        #expect(dict["a"] == nil)
+    }
+
+    @Test func removeValue() {
+        let dict: Synchronized<[String: Int]> = Synchronized(["x": 10])
+        let removed = dict.removeValue(forKey: "x")
+        #expect(removed == 10)
+        #expect(dict["x"] == nil)
+    }
+
+    @Test func removeValueMissingKey() {
+        let dict: Synchronized<[String: Int]> = Synchronized([:])
+        let removed = dict.removeValue(forKey: "missing")
+        #expect(removed == nil)
+    }
+}

--- a/Tests/Common/Synchronized/SynchronizedTests.swift
+++ b/Tests/Common/Synchronized/SynchronizedTests.swift
@@ -6,7 +6,6 @@ import Testing
 // MARK: - Core read/write
 
 @Suite struct SynchronizedCoreTests {
-
     @Test func wrappedValueGetSet() {
         let box = Synchronized(42)
         #expect(box.wrappedValue == 42)
@@ -58,7 +57,7 @@ import Testing
     @Test func concurrentWritesSafelyAccumulate() async {
         let box = Synchronized(0)
         await withTaskGroup(of: Void.self) { group in
-            for _ in 0..<100 {
+            for _ in 0 ..< 100 {
                 group.addTask {
                     box.mutating { $0 += 1 }
                 }
@@ -71,7 +70,6 @@ import Testing
 // MARK: - Arithmetic
 
 @Suite struct SynchronizedArithmeticTests {
-
     @Test func addRawValue() {
         let a = Synchronized(10)
         #expect(a + 5 == 15)
@@ -98,7 +96,6 @@ import Testing
 // MARK: - Bool
 
 @Suite struct SynchronizedBoolTests {
-
     @Test func toggle() {
         let flag = Synchronized(false)
         flag.toggle()
@@ -111,11 +108,10 @@ import Testing
 // MARK: - Collections
 
 @Suite struct SynchronizedCollectionTests {
-
     @Test func countAndIsEmpty() {
         let list: Synchronized<[Int]> = Synchronized([])
         #expect(list.isEmpty)
-        #expect(list.count == 0)
+        #expect(list.isEmpty)
         list.append(1)
         #expect(!list.isEmpty)
         #expect(list.count == 1)
@@ -189,7 +185,6 @@ import Testing
 // MARK: - Comparable
 
 @Suite struct SynchronizedComparableTests {
-
     @Test func lessThanRaw() {
         let a = Synchronized(1)
         #expect(a < 5)
@@ -218,7 +213,6 @@ import Testing
 // MARK: - Equatable
 
 @Suite struct SynchronizedEquatableTests {
-
     @Test func equalBoxes() {
         let a = Synchronized("foo")
         let b = Synchronized("foo")
@@ -250,11 +244,15 @@ import Testing
         let b = Synchronized(1)
         let group = DispatchGroup()
 
-        for _ in 0..<1_000 {
+        for _ in 0 ..< 1000 {
             group.enter()
-            DispatchQueue.global().async { _ = a == b; group.leave() }
+            DispatchQueue.global().async { _ = a == b
+                group.leave()
+            }
             group.enter()
-            DispatchQueue.global().async { _ = b == a; group.leave() }
+            DispatchQueue.global().async { _ = b == a
+                group.leave()
+            }
         }
 
         #expect(group.wait(timeout: .now() + 30) == .success)
@@ -264,7 +262,6 @@ import Testing
 // MARK: - Hashable
 
 @Suite struct SynchronizedHashableTests {
-
     @Test func usableInSet() {
         let a = Synchronized(1)
         let b = Synchronized(2)
@@ -293,7 +290,6 @@ import Testing
 // MARK: - Dictionaries
 
 @Suite struct SynchronizedDictionaryTests {
-
     @Test func subscriptGetSet() {
         let dict: Synchronized<[String: Int]> = Synchronized([:])
         dict["a"] = 1

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -189,6 +189,10 @@ public interface CioInternalCommon.DeviceInfo {
 	public var deviceLocale: String;
 	public fun func isPushSubscribed(completion: @escaping (Boolean) -> Unit);
 }
+public interface CioInternalCommon.DictionaryProtocol {
+	public fun subscript(key: Key) -> Value?;
+	public fun mutating func removeValue(forKey key: Key) -> Value?;
+}
 public interface CioInternalCommon.DoNotTrackScreenViewEvent {
 }
 public enum CioInternalCommon.DownloadFileType {
@@ -506,6 +510,13 @@ public interface CioInternalCommon.SharedKeyValueStorage {
 public final class CioInternalCommon.StringAnyEncodable {
 	public fun init(logger: Logger, _ data: List<String: Any>);
 	public fun func encode(to encoder: Encoder) throws;
+}
+public final class CioInternalCommon.Synchronized {
+	public var wrappedValue: T;
+	public fun init(_ initial: T);
+	public fun func mutating<Result>(_ body: (inout T) throws -> Result) rethrows -> Result;
+	public fun func using<Result>(_ body: (T) throws -> Result) rethrows -> Result;
+	public fun func atomicSetAndFetch(_ newValue: T) -> T;
 }
 public interface CioInternalCommon.SystemLogger {
 	public fun func log(_ message: String, _ level: CioLogLevel);


### PR DESCRIPTION
Added the synchronized primitive type for use elsewhere in the SDK. It is unused except for in the tests. 

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After code reviews are approved and you determine this PR is ready to merge, select *Squash and Merge* button on this screen, leave the title and description to the default values, then merge the PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new locking-based concurrency primitive and related operator/subscript overloads, which can be subtly incorrect under contention or lead to unexpected non-atomic compound mutations. Currently appears isolated (mainly exercised by new tests), limiting blast radius.
> 
> **Overview**
> Adds a new `Synchronized<T>` reference wrapper that guards a stored value with an `NSRecursiveLock`, exposing `wrappedValue`, `mutating`, `using`, and `atomicSetAndFetch` for thread-safe access.
> 
> Extends `Synchronized` with convenience APIs and protocol conformances for common types: arithmetic operators for `AdditiveArithmetic`, comparisons for `Comparable`, `toggle()` for `Bool`, collection helpers (count/isEmpty, subscript, append/insert/removeAll), `Equatable` with lock-ordering to avoid ABBA deadlocks, `Hashable`, and dictionary-style access via a new `DictionaryProtocol`.
> 
> Adds a comprehensive `SynchronizedTests` suite covering core behavior, operators, collection/dictionary helpers, hashing, and a concurrency regression test for `==` deadlock avoidance, and updates the generated `CioInternalCommon.api` to include the new public symbols.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d545e5ab94d635db9e39a87ca3499f73ba4dad4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->