### PR TITLE
feat: Added InstallationId to the SDK and attached it to `context.device`

### DIFF
--- a/Sources/Common/CustomerIOInstance.swift
+++ b/Sources/Common/CustomerIOInstance.swift
@@ -61,6 +61,12 @@ public protocol CustomerIOInstance: AutoMockable {
      */
     func clearIdentify()
 
+    // MARK: - Installation
+
+    /// A stable, unique identifier for this app installation.
+    /// Generated on first SDK use and persisted across launches. Not reset by `clearIdentify()`.
+    var installationId: String { get }
+
     // MARK: - Device
 
     /**
@@ -258,6 +264,10 @@ public class CustomerIO: CustomerIOInstance {
 
     public func clearIdentify() {
         implementation?.clearIdentify()
+    }
+
+    public var installationId: String {
+        implementation?.installationId ?? ""
     }
 
     public var deviceAttributes: [String: Any] {

--- a/Sources/Common/Store/GlobalDataStore.swift
+++ b/Sources/Common/Store/GlobalDataStore.swift
@@ -2,6 +2,9 @@ import Foundation
 
 /// SDK data that is common between all site ids.
 public protocol GlobalDataStore: AutoMockable {
+    // Stable per-installation UUID, generated on first use and never reset
+    var installationId: String? { get set }
+
     // APN or FCM device token
     var pushDeviceToken: String? { get set }
 
@@ -12,6 +15,11 @@ public protocol GlobalDataStore: AutoMockable {
 // sourcery: InjectRegisterShared = "GlobalDataStore"
 public class CioSharedDataStore: GlobalDataStore {
     private let keyValueStorage: SharedKeyValueStorage
+
+    public var installationId: String? {
+        get { keyValueStorage.string(.installationId) }
+        set { keyValueStorage.setString(newValue, forKey: .installationId) }
+    }
 
     public var pushDeviceToken: String? {
         get {

--- a/Sources/Common/Util/KeyValueStorageKey.swift
+++ b/Sources/Common/Util/KeyValueStorageKey.swift
@@ -5,6 +5,7 @@ import Foundation
  */
 public enum KeyValueStorageKey: String {
     case identifiedProfileId
+    case installationId
     case pushDeviceToken
     case inAppUserQueueFetchCachedResponse
     case broadcastMessages = "broadcast_messages"

--- a/Sources/Common/autogenerated/AutoMockable.generated.swift
+++ b/Sources/Common/autogenerated/AutoMockable.generated.swift
@@ -132,6 +132,42 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
      When setter of the property called, the value given to setter is set here.
      When the getter of the property called, the value set here will be returned. Your chance to mock the property.
      */
+    public var underlyingInstallationId: String!
+    /// `true` if the getter or setter of property is called at least once.
+    public var installationIdCalled: Bool {
+        installationIdGetCalled || installationIdSetCalled
+    }
+
+    /// `true` if the getter called on the property at least once.
+    public var installationIdGetCalled: Bool {
+        installationIdGetCallsCount > 0
+    }
+
+    public var installationIdGetCallsCount = 0
+    /// `true` if the setter called on the property at least once.
+    public var installationIdSetCalled: Bool {
+        installationIdSetCallsCount > 0
+    }
+
+    public var installationIdSetCallsCount = 0
+    /// The mocked property with a getter and setter.
+    public var installationId: String {
+        get {
+            mockCalled = true
+            installationIdGetCallsCount += 1
+            return underlyingInstallationId
+        }
+        set(value) {
+            mockCalled = true
+            installationIdSetCallsCount += 1
+            underlyingInstallationId = value
+        }
+    }
+
+    /**
+     When setter of the property called, the value given to setter is set here.
+     When the getter of the property called, the value set here will be returned. Your chance to mock the property.
+     */
     public var underlyingDeviceAttributes: [String: Any] = [:]
     /// `true` if the getter or setter of property is called at least once.
     public var deviceAttributesCalled: Bool {
@@ -203,6 +239,8 @@ public class CustomerIOInstanceMock: CustomerIOInstance, Mock {
     public func resetMock() {
         profileAttributesGetCallsCount = 0
         profileAttributesSetCallsCount = 0
+        installationIdGetCallsCount = 0
+        installationIdSetCallsCount = 0
         deviceAttributesGetCallsCount = 0
         deviceAttributesSetCallsCount = 0
         registeredDeviceToken = nil
@@ -1650,6 +1688,42 @@ public class GlobalDataStoreMock: GlobalDataStore, Mock {
      When setter of the property called, the value given to setter is set here.
      When the getter of the property called, the value set here will be returned. Your chance to mock the property.
      */
+    public var underlyingInstallationId: String? = nil
+    /// `true` if the getter or setter of property is called at least once.
+    public var installationIdCalled: Bool {
+        installationIdGetCalled || installationIdSetCalled
+    }
+
+    /// `true` if the getter called on the property at least once.
+    public var installationIdGetCalled: Bool {
+        installationIdGetCallsCount > 0
+    }
+
+    public var installationIdGetCallsCount = 0
+    /// `true` if the setter called on the property at least once.
+    public var installationIdSetCalled: Bool {
+        installationIdSetCallsCount > 0
+    }
+
+    public var installationIdSetCallsCount = 0
+    /// The mocked property with a getter and setter.
+    public var installationId: String? {
+        get {
+            mockCalled = true
+            installationIdGetCallsCount += 1
+            return underlyingInstallationId
+        }
+        set(value) {
+            mockCalled = true
+            installationIdSetCallsCount += 1
+            underlyingInstallationId = value
+        }
+    }
+
+    /**
+     When setter of the property called, the value given to setter is set here.
+     When the getter of the property called, the value set here will be returned. Your chance to mock the property.
+     */
     public var underlyingPushDeviceToken: String? = nil
     /// `true` if the getter or setter of property is called at least once.
     public var pushDeviceTokenCalled: Bool {
@@ -1683,6 +1757,9 @@ public class GlobalDataStoreMock: GlobalDataStore, Mock {
     }
 
     public func resetMock() {
+        installationId = nil
+        installationIdGetCallsCount = 0
+        installationIdSetCallsCount = 0
         pushDeviceToken = nil
         pushDeviceTokenGetCallsCount = 0
         pushDeviceTokenSetCallsCount = 0

--- a/Sources/DataPipeline/DataPipeline.swift
+++ b/Sources/DataPipeline/DataPipeline.swift
@@ -101,6 +101,10 @@ public class DataPipeline: ModuleTopLevelObject<DataPipelineInstance>, DataPipel
         implementation?.setDeviceAttributes(attributes.sanitizedForJSON())
     }
 
+    public var installationId: String {
+        implementation?.installationId ?? ""
+    }
+
     public var registeredDeviceToken: String? {
         implementation?.registeredDeviceToken
     }

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -57,6 +57,7 @@ class DataPipelineImplementation: DataPipelineInstance, DataPipelineTracking {
 
         // plugin to update context properties for each request
         analytics.add(plugin: contextPlugin)
+        contextPlugin.installationId = installationId
 
         // plugin that adds provider attributes (e.g. location) to identify context
         analytics.add(plugin: IdentifyContextPlugin(registry: diGraph.profileEnrichmentRegistry, logger: logger))

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -211,10 +211,6 @@ class DataPipelineImplementation: DataPipelineInstance, DataPipelineTracking {
         logger.debug("resetting user profile")
         analytics.reset()
 
-        // TODO: pending group design decision — installationId may be device-scoped and should survive clearIdentify.
-        // Remove these two lines if the group decides it should not reset.
-        globalDataStore.installationId = nil
-        contextPlugin.installationId = installationId
     }
 
     func deleteDeviceToken() {

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -64,8 +64,8 @@ class DataPipelineImplementation: DataPipelineInstance, DataPipelineTracking {
         }
 
         // plugin to update context properties for each request
-        analytics.add(plugin: contextPlugin)
         contextPlugin.installationId = installationId
+        analytics.add(plugin: contextPlugin)
 
         // plugin that adds provider attributes (e.g. location) to identify context
         analytics.add(plugin: IdentifyContextPlugin(registry: diGraph.profileEnrichmentRegistry, logger: logger))

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -117,6 +117,15 @@ class DataPipelineImplementation: DataPipelineInstance, DataPipelineTracking {
         analytics.identify(traits: traits)
     }
 
+    var installationId: String {
+        if let existing = globalDataStore.installationId {
+            return existing
+        }
+        let newId = UUID().uuidString
+        globalDataStore.installationId = newId
+        return newId
+    }
+
     var registeredDeviceToken: String? {
         globalDataStore.pushDeviceToken
     }

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -25,11 +25,11 @@ class DataPipelineImplementation: DataPipelineInstance, DataPipelineTracking {
 
         self.eventBusHandler = diGraph.eventBusHandler
         self.globalDataStore = diGraph.globalDataStore
-        if let existing = self.globalDataStore.installationId {
+        if let existing = globalDataStore.installationId {
             self.installationId = existing
         } else {
             let newId = UUID().uuidString
-            self.globalDataStore.installationId = newId
+            globalDataStore.installationId = newId
             self.installationId = newId
         }
         self.deviceAttributesProvider = diGraph.deviceAttributesProvider
@@ -209,7 +209,6 @@ class DataPipelineImplementation: DataPipelineInstance, DataPipelineTracking {
         // reset all to default state
         logger.debug("resetting user profile")
         analytics.reset()
-
     }
 
     func deleteDeviceToken() {

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -214,7 +214,7 @@ class DataPipelineImplementation: DataPipelineInstance, DataPipelineTracking {
         // TODO: pending group design decision — installationId may be device-scoped and should survive clearIdentify.
         // Remove these two lines if the group decides it should not reset.
         globalDataStore.installationId = nil
-        contextPlugin.installationId = nil
+        contextPlugin.installationId = installationId
     }
 
     func deleteDeviceToken() {

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -10,6 +10,7 @@ class DataPipelineImplementation: DataPipelineInstance, DataPipelineTracking {
     let eventBusHandler: EventBusHandler
 
     private var globalDataStore: GlobalDataStore
+    let installationId: String
     private let deviceAttributesProvider: DeviceAttributesProvider
     private let dateUtil: DateUtil
     private let deviceInfo: DeviceInfo
@@ -24,6 +25,13 @@ class DataPipelineImplementation: DataPipelineInstance, DataPipelineTracking {
 
         self.eventBusHandler = diGraph.eventBusHandler
         self.globalDataStore = diGraph.globalDataStore
+        if let existing = self.globalDataStore.installationId {
+            self.installationId = existing
+        } else {
+            let newId = UUID().uuidString
+            self.globalDataStore.installationId = newId
+            self.installationId = newId
+        }
         self.deviceAttributesProvider = diGraph.deviceAttributesProvider
         self.dateUtil = diGraph.dateUtil
         self.deviceInfo = diGraph.deviceInfo
@@ -117,15 +125,6 @@ class DataPipelineImplementation: DataPipelineInstance, DataPipelineTracking {
     ///   - traits: A dictionary of traits you know about the user. Things like: email, name, plan, etc.
     func identify(traits: Codable) {
         analytics.identify(traits: traits)
-    }
-
-    var installationId: String {
-        if let existing = globalDataStore.installationId {
-            return existing
-        }
-        let newId = UUID().uuidString
-        globalDataStore.installationId = newId
-        return newId
     }
 
     var registeredDeviceToken: String? {

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -1,5 +1,6 @@
 import CioAnalytics
 import CioInternalCommon
+import Foundation
 
 class DataPipelineImplementation: DataPipelineInstance, DataPipelineTracking {
     private let moduleConfig: DataPipelineConfigOptions

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -210,6 +210,11 @@ class DataPipelineImplementation: DataPipelineInstance, DataPipelineTracking {
         // reset all to default state
         logger.debug("resetting user profile")
         analytics.reset()
+
+        // TODO: pending group design decision — installationId may be device-scoped and should survive clearIdentify.
+        // Remove these two lines if the group decides it should not reset.
+        globalDataStore.installationId = nil
+        contextPlugin.installationId = nil
     }
 
     func deleteDeviceToken() {

--- a/Sources/DataPipeline/Plugins/Context.swift
+++ b/Sources/DataPipeline/Plugins/Context.swift
@@ -7,6 +7,7 @@ class Context: Plugin {
     public weak var analytics: Analytics?
 
     public var deviceToken: String?
+    public var installationId: String?
     public var attributes: [String: Any] = [:]
 
     let userAgentUtil: UserAgentUtil
@@ -32,6 +33,10 @@ class Context: Plugin {
             if let token = deviceToken, bgToken == nil {
                 context[keyPath: "device.token"] = token
                 workingEvent.context = try JSON(context)
+            }
+
+            if let id = installationId {
+                context[keyPath: "device.installationId"] = id
             }
 
             // Our push logic is currently hardcoded against ios

--- a/api-docs/CioDataPipelines.api
+++ b/api-docs/CioDataPipelines.api
@@ -14,6 +14,7 @@ public final class CioDataPipelines.DataPipeline {
 	public var moduleConfig: DataPipelineConfigOptions?;
 	public var profileAttributes: Map<String, Any>;
 	public var deviceAttributes: Map<String, Any>;
+	public var installationId: String;
 	public var registeredDeviceToken: String?;
 	public fun func setUpSharedInstanceForUnitTest(implementation: DataPipelineInstance, config: DataPipelineConfigOptions) -> DataPipelineInstance;
 	public fun func setUpSharedInstanceForIntegrationTest(diGraphShared: DIGraphShared, config: DataPipelineConfigOptions) -> DataPipelineInstance;

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -71,6 +71,7 @@ public final class CioInternalCommon.CioQueue {
 	public fun func deleteProcessedTask(_ task: QueueTaskMetadata, siteId: String);
 }
 public final class CioInternalCommon.CioSharedDataStore {
+	public var installationId: String?;
 	public var pushDeviceToken: String?;
 	public fun init(keyValueStorage: SharedKeyValueStorage);
 	public fun func deleteAll();
@@ -89,6 +90,7 @@ public final class CioInternalCommon.CustomerIO {
 	public var shared: CustomerIO;
 	public var implementation: (any CustomerIOInstance)?;
 	public var profileAttributes: Map<String, Any>;
+	public var installationId: String;
 	public var deviceAttributes: Map<String, Any>;
 	public var registeredDeviceToken: String?;
 	public fun func resetSharedTestEnvironment();
@@ -108,6 +110,7 @@ public final class CioInternalCommon.CustomerIO {
 }
 public interface CioInternalCommon.CustomerIOInstance {
 	public var profileAttributes: Map<String, Any>;
+	public var installationId: String;
 	public var deviceAttributes: Map<String, Any>;
 	public var registeredDeviceToken: String?;
 	public fun func setProfileAttributes(_ attributes: List<String: Any>);
@@ -255,6 +258,7 @@ public interface CioInternalCommon.FileStorage {
 public enum CioInternalCommon.FileType {
 }
 public interface CioInternalCommon.GlobalDataStore {
+	public var installationId: String?;
 	public var pushDeviceToken: String?;
 	public fun func deleteAll();
 }


### PR DESCRIPTION
This PR adds `installationId` to the SDK for use with Live Activities. It also adds that value as `context.device.installationId`. Per conversations with Colby, this is the intended place to send this field along. 

Currently, this PR includes clearing the installationId when `clearIdentify` is called. I'm not certain that is the right call at the moment and have added a comment to inspire discussion. I can see the value of each possibility.



Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After code reviews are approved and you determine this PR is ready to merge, select *Squash and Merge* button on this screen, leave the title and description to the default values, then merge the PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new persisted per-install identifier and injects it into analytics request context, which can affect downstream event schemas and data consistency across upgrades.
> 
> **Overview**
> Adds a new `installationId` surface area to the public SDK (`CustomerIOInstance`, `CustomerIO`, and `DataPipeline`) and internal storage (`GlobalDataStore`/`KeyValueStorageKey`) to provide a stable per-app-install identifier.
> 
> `DataPipelineImplementation` now generates and persists the UUID on first use and the `Context` plugin attaches it to outgoing payloads as `context.device.installationId`; autogenerated mocks and API docs are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2d1d944f423ea475a61bf81862b6ba68a58a02b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->