### PR TITLE
chore(messaginginapp): dedupe messageShown opened metric by deliveryID

### DIFF
--- a/Sources/MessagingInApp/Gist/GistDelegate.swift
+++ b/Sources/MessagingInApp/Gist/GistDelegate.swift
@@ -23,6 +23,16 @@ class GistDelegateImpl: GistDelegate {
     private let eventBusHandler: EventBusHandler
     private var eventListener: InAppEventListener?
     private let threadUtil: ThreadUtil
+
+    // In-memory set of `campaignDeliveryId` values for which we've already posted
+    // a `messageShown` (`opened`) metric this session. Used to suppress duplicate
+    // metric emissions when Gist invokes `messageShown` more than once for the
+    // same delivery. Lifetime is GistDelegateImpl-scoped (per-process); the
+    // backend already dedupes `(deliveryID, opened)` pairs, so this is pure
+    // noise reduction. Guarded by `seenMessageShownLock`.
+    private var seenMessageShownDeliveryIds: Set<String> = []
+    private let seenMessageShownLock = NSLock()
+
     init(logger: Logger, eventBusHandler: EventBusHandler) {
         self.logger = logger
         self.eventBusHandler = eventBusHandler
@@ -39,7 +49,11 @@ class GistDelegateImpl: GistDelegate {
         logger.logWithModuleTag("Message shown: \(message.describeForLogs)", level: .debug)
 
         if let deliveryId = message.campaignDeliveryId {
-            eventBusHandler.postEvent(TrackInAppMetricEvent(deliveryID: deliveryId, event: InAppMetric.opened.rawValue))
+            if shouldPostMessageShownMetric(forDeliveryId: deliveryId) {
+                eventBusHandler.postEvent(TrackInAppMetricEvent(deliveryID: deliveryId, event: InAppMetric.opened.rawValue))
+            } else {
+                logger.logWithModuleTag("Skipping duplicate messageShown metric for deliveryId: \(deliveryId)", level: .debug)
+            }
         }
         // To ensure the keyboard is dismissed on displaying an in-app message,
         // Update UI on main thread only.
@@ -78,6 +92,15 @@ class GistDelegateImpl: GistDelegate {
             actionValue: action,
             actionName: name
         )
+    }
+
+    /// Returns true the first time a given `deliveryId` is observed (and records it),
+    /// false on subsequent calls. Thread-safe via `seenMessageShownLock`.
+    private func shouldPostMessageShownMetric(forDeliveryId deliveryId: String) -> Bool {
+        seenMessageShownLock.lock()
+        defer { seenMessageShownLock.unlock() }
+
+        return seenMessageShownDeliveryIds.insert(deliveryId).inserted
     }
 }
 

--- a/Tests/MessagingInApp/Gist/GistDelegateImplTests.swift
+++ b/Tests/MessagingInApp/Gist/GistDelegateImplTests.swift
@@ -75,6 +75,37 @@ class GistDelegateImplTests: UnitTest {
         XCTAssertEqual(mockEventListener.messageShownReceivedArguments?.messageId, "test-message-id", "Message ID should match")
     }
 
+    func test_messageShown_givenSameDeliveryIdCalledTwice_expectOnePostEvent() {
+        let message = Message(messageId: "test-message-id", campaignId: "duplicate-delivery-id")
+
+        gistDelegate.messageShown(message: message)
+        gistDelegate.messageShown(message: message)
+
+        XCTAssertEqual(mockEventBusHandler.postEventCallsCount, 1, "EventBusHandler should post the metric exactly once for repeat deliveryId")
+        XCTAssertEqual(mockEventListener.messageShownCallsCount, 2, "EventListener.messageShown must still fire on every call (host UI side-effect)")
+    }
+
+    func test_messageShown_givenDifferentDeliveryIds_expectTwoPostEvents() {
+        let firstMessage = Message(messageId: "first-message-id", campaignId: "delivery-id-1")
+        let secondMessage = Message(messageId: "second-message-id", campaignId: "delivery-id-2")
+
+        gistDelegate.messageShown(message: firstMessage)
+        gistDelegate.messageShown(message: secondMessage)
+
+        XCTAssertEqual(mockEventBusHandler.postEventCallsCount, 2, "EventBusHandler should post one metric per unique deliveryId")
+        XCTAssertEqual(mockEventListener.messageShownCallsCount, 2, "EventListener.messageShown should fire for each call")
+    }
+
+    func test_messageShown_givenNilDeliveryId_doesNotCrashAndDoesNotPost() {
+        // Construct a Message with no `gist.campaignId` so `campaignDeliveryId` resolves to nil.
+        let message = Message(messageId: "test-message-id", queueId: nil, priority: nil, properties: nil)
+
+        gistDelegate.messageShown(message: message)
+
+        XCTAssertFalse(mockEventBusHandler.postEventCalled, "EventBusHandler should not post a metric when deliveryId is nil")
+        XCTAssertTrue(mockEventListener.messageShownCalled, "EventListener.messageShown must still fire when deliveryId is nil")
+    }
+
     func testMessageDismissed() {
         let message = Message(messageId: "test-message-id")
 


### PR DESCRIPTION
Dedupes the in-app `messageShown` `opened` metric post by `campaignDeliveryId` within the SDK process lifetime. First show of a given delivery posts the metric; subsequent shows of the same delivery skip the post.

The host `eventListener.messageShown` callback still fires on every call, so app-level UI side-effects are unaffected — only the analytics metric emission is deduped.

Backend already dedupes `(deliveryID, opened)` pairs server-side, so this is bandwidth and analytics-queue noise reduction, not a metric-correctness change.