### PR TITLE
chore: buffer track/identify/screen calls made before initialize completes

### DIFF
--- a/Sources/Common/CustomerIOInstance.swift
+++ b/Sources/Common/CustomerIOInstance.swift
@@ -215,7 +215,7 @@ public class CustomerIO: CustomerIOInstance {
     /// authoritative replay. Prevents the duplicate "Device Created or Updated"
     /// that would otherwise fire when both `postInitialize` and the buffered
     /// `registerDeviceToken` target the same stored token.
-    @Atomic private var hasPendingTokenRegistration: Bool = false
+    private let hasPendingTokenRegistration = Synchronized<Bool>(false)
 
     /// private constructor to force use of singleton API
     private init() {}
@@ -226,11 +226,11 @@ public class CustomerIO: CustomerIOInstance {
 
     @discardableResult
     static func setUpSharedInstanceForUnitTest(implementation: CustomerIOInstance) -> CustomerIO {
-        // Assign the implementation before draining so the buffered closures
-        // run against a fully wired SDK and the global token state is in place
-        // by the time buffered token-dependent calls replay.
-        shared.implementation = implementation
+        // Drain the buffer against the impl *before* publishing it on `shared`,
+        // so concurrent `dispatch` calls can't bypass replay while pre-init
+        // events are still queued.
         shared.preInitEventBuffer.transitionToReady(implementation)
+        shared.implementation = implementation
         return shared
     }
 
@@ -240,19 +240,18 @@ public class CustomerIO: CustomerIOInstance {
     #endif
 
     public static func initializeSharedInstance(with implementation: CustomerIOInstance) {
-        // Assign the implementation first so buffered closures find a real
-        // backend, then sync the stored device token before draining. The
-        // token sync must happen *before* the drain so buffered token-dependent
-        // calls (e.g. setDeviceAttributes) observe a non-nil contextPlugin
-        // token. If a `registerDeviceToken` was buffered pre-init,
-        // postInitialize defers to it so we don't emit a duplicate
-        // "Device Created or Updated".
-        shared.implementation = implementation
-        shared.postInitialize()
+        // Sync the stored device token first so buffered token-dependent calls
+        // (e.g. `setDeviceAttributes`) observe a non-nil contextPlugin token
+        // during replay. Then drain the buffer. Only after both have completed
+        // do we publish `implementation`, so concurrent `dispatch` calls on
+        // other threads either enqueue (and are picked up by the drain) or
+        // execute directly post-drain — never racing past in-flight replay.
+        shared.postInitialize(impl: implementation)
         shared.preInitEventBuffer.transitionToReady(implementation)
+        shared.implementation = implementation
     }
 
-    func postInitialize() {
+    func postInitialize(impl: CustomerIOInstance) {
         // Register the device token during SDK initialization to address device registration issues
         // arising from lifecycle differences between wrapper SDKs and native SDK.
         //
@@ -261,10 +260,14 @@ public class CustomerIO: CustomerIOInstance {
         // during the drain. Registering here would either duplicate the
         // resulting Device Created or Updated event (same token) or cause an
         // unnecessary delete-and-re-register cycle (different token).
-        guard !hasPendingTokenRegistration else { return }
+        guard !hasPendingTokenRegistration.wrappedValue else { return }
         let globalDataStore = diGraph.globalDataStore
         if let token = globalDataStore.pushDeviceToken {
-            registerDeviceToken(token)
+            // Call directly on `impl` rather than via `self.dispatch`/
+            // `registerDeviceToken`. `self.implementation` is intentionally
+            // still `nil` at this point so the buffer remains the only path
+            // for concurrent calls.
+            impl.registerDeviceToken(token)
         }
     }
 
@@ -321,7 +324,7 @@ public class CustomerIO: CustomerIOInstance {
         if let impl = implementation {
             impl.registerDeviceToken(deviceToken)
         } else {
-            hasPendingTokenRegistration = true
+            hasPendingTokenRegistration.wrappedValue = true
             preInitEventBuffer.enqueue { $0.registerDeviceToken(deviceToken) }
         }
     }

--- a/Sources/Common/CustomerIOInstance.swift
+++ b/Sources/Common/CustomerIOInstance.swift
@@ -209,6 +209,14 @@ public class CustomerIO: CustomerIOInstance {
     /// new implementation. After drain, subsequent calls bypass the buffer.
     let preInitEventBuffer = PreInitEventBuffer()
 
+    /// Flag set when a `registerDeviceToken` call is buffered pre-init. Read by
+    /// `postInitialize()` to skip its own stored-token registration so the
+    /// buffered call (which carries the caller's most recent token) is the
+    /// authoritative replay. Prevents the duplicate "Device Created or Updated"
+    /// that would otherwise fire when both `postInitialize` and the buffered
+    /// `registerDeviceToken` target the same stored token.
+    @Atomic private var hasPendingTokenRegistration: Bool = false
+
     /// private constructor to force use of singleton API
     private init() {}
 
@@ -218,10 +226,11 @@ public class CustomerIO: CustomerIOInstance {
 
     @discardableResult
     static func setUpSharedInstanceForUnitTest(implementation: CustomerIOInstance) -> CustomerIO {
-        // Drain any pre-init buffered events first so they replay in order
-        // against the new implementation before any post-init direct call.
-        shared.preInitEventBuffer.transitionToReady(implementation)
+        // Assign the implementation before draining so the buffered closures
+        // run against a fully wired SDK and the global token state is in place
+        // by the time buffered token-dependent calls replay.
         shared.implementation = implementation
+        shared.preInitEventBuffer.transitionToReady(implementation)
         return shared
     }
 
@@ -231,16 +240,28 @@ public class CustomerIO: CustomerIOInstance {
     #endif
 
     public static func initializeSharedInstance(with implementation: CustomerIOInstance) {
-        // Drain any pre-init buffered events first so they replay in order
-        // against the new implementation before any post-init direct call.
-        shared.preInitEventBuffer.transitionToReady(implementation)
+        // Assign the implementation first so buffered closures find a real
+        // backend, then sync the stored device token before draining. The
+        // token sync must happen *before* the drain so buffered token-dependent
+        // calls (e.g. setDeviceAttributes) observe a non-nil contextPlugin
+        // token. If a `registerDeviceToken` was buffered pre-init,
+        // postInitialize defers to it so we don't emit a duplicate
+        // "Device Created or Updated".
         shared.implementation = implementation
         shared.postInitialize()
+        shared.preInitEventBuffer.transitionToReady(implementation)
     }
 
     func postInitialize() {
         // Register the device token during SDK initialization to address device registration issues
         // arising from lifecycle differences between wrapper SDKs and native SDK.
+        //
+        // If a `registerDeviceToken` call is already buffered, skip — the
+        // buffered call carries the caller's most recent token and will run
+        // during the drain. Registering here would either duplicate the
+        // resulting Device Created or Updated event (same token) or cause an
+        // unnecessary delete-and-re-register cycle (different token).
+        guard !hasPendingTokenRegistration else { return }
         let globalDataStore = diGraph.globalDataStore
         if let token = globalDataStore.pushDeviceToken {
             registerDeviceToken(token)
@@ -297,7 +318,12 @@ public class CustomerIO: CustomerIOInstance {
     }
 
     public func registerDeviceToken(_ deviceToken: String) {
-        dispatch { $0.registerDeviceToken(deviceToken) }
+        if let impl = implementation {
+            impl.registerDeviceToken(deviceToken)
+        } else {
+            hasPendingTokenRegistration = true
+            preInitEventBuffer.enqueue { $0.registerDeviceToken(deviceToken) }
+        }
     }
 
     public func deleteDeviceToken() {

--- a/Sources/Common/CustomerIOInstance.swift
+++ b/Sources/Common/CustomerIOInstance.swift
@@ -324,15 +324,23 @@ public class CustomerIO: CustomerIOInstance {
         if let impl = implementation {
             impl.registerDeviceToken(deviceToken)
         } else {
-            // Only set the deferral flag once we know the buffer actually
-            // retained the closure. If the buffer is at capacity and drops
-            // it, leave the flag clear so `postInitialize` will still
-            // register the stored device token as a fallback — without this
-            // gate, both the buffered closure AND the stored-token sync
-            // would be skipped, leaving the device unregistered.
-            let accepted = preInitEventBuffer.enqueue { $0.registerDeviceToken(deviceToken) }
-            if accepted {
-                hasPendingTokenRegistration.wrappedValue = true
+            // Enqueue and flag-set under a single critical section so
+            // `postInitialize` on another thread can't observe the
+            // intermediate state where the closure is buffered but the
+            // flag is still `false`. Without this atomicity, a concurrent
+            // `initializeSharedInstance` could register the stored token
+            // *and* drain the buffered call, producing a duplicate Device
+            // Created or Updated event.
+            //
+            // The flag is only set when the buffer actually retained the
+            // closure. If the buffer is at capacity and drops it, the flag
+            // stays `false` so `postInitialize` falls through to register
+            // the stored device token as a fallback.
+            hasPendingTokenRegistration.mutating { isPending in
+                let accepted = preInitEventBuffer.enqueue { $0.registerDeviceToken(deviceToken) }
+                if accepted {
+                    isPending = true
+                }
             }
         }
     }

--- a/Sources/Common/CustomerIOInstance.swift
+++ b/Sources/Common/CustomerIOInstance.swift
@@ -203,7 +203,13 @@ public class CustomerIO: CustomerIOInstance {
     // Tip: Use `SdkInitializedUtil` in modules to see if the SDK has been initialized and get data it needs.
     public var implementation: CustomerIOInstance?
 
-    // private constructor to force use of singleton API
+    /// Bounded FIFO buffer that absorbs event-shaped public-API calls invoked
+    /// before `implementation` is set. Drained synchronously, in order, by
+    /// `initializeSharedInstance`/`setUpSharedInstanceForUnitTest` against the
+    /// new implementation. After drain, subsequent calls bypass the buffer.
+    let preInitEventBuffer = PreInitEventBuffer()
+
+    /// private constructor to force use of singleton API
     private init() {}
 
     #if DEBUG
@@ -212,6 +218,9 @@ public class CustomerIO: CustomerIOInstance {
 
     @discardableResult
     static func setUpSharedInstanceForUnitTest(implementation: CustomerIOInstance) -> CustomerIO {
+        // Drain any pre-init buffered events first so they replay in order
+        // against the new implementation before any post-init direct call.
+        shared.preInitEventBuffer.transitionToReady(implementation)
         shared.implementation = implementation
         return shared
     }
@@ -222,6 +231,9 @@ public class CustomerIO: CustomerIOInstance {
     #endif
 
     public static func initializeSharedInstance(with implementation: CustomerIOInstance) {
+        // Drain any pre-init buffered events first so they replay in order
+        // against the new implementation before any post-init direct call.
+        shared.preInitEventBuffer.transitionToReady(implementation)
         shared.implementation = implementation
         shared.postInitialize()
     }
@@ -237,6 +249,17 @@ public class CustomerIO: CustomerIOInstance {
 
     // MARK: - CustomerIOInstance implementation
 
+    /// Dispatch helper: when the SDK is initialized, calls the block against
+    /// the real implementation immediately; otherwise enqueues it onto the
+    /// pre-init buffer for replay once initialization completes.
+    private func dispatch(_ block: @escaping (CustomerIOInstance) -> Void) {
+        if let impl = implementation {
+            block(impl)
+        } else {
+            preInitEventBuffer.enqueue(block)
+        }
+    }
+
     @available(*, deprecated, message: "Use setProfileAttributes() instead")
     public var profileAttributes: [String: Any] {
         get { implementation?.profileAttributes ?? [:] }
@@ -244,29 +267,29 @@ public class CustomerIO: CustomerIOInstance {
     }
 
     public func setProfileAttributes(_ attributes: [String: Any]) {
-        implementation?.setProfileAttributes(attributes)
+        dispatch { $0.setProfileAttributes(attributes) }
     }
 
     public func identify(userId: String, traits: [String: Any]? = nil) {
-        implementation?.identify(userId: userId, traits: traits)
+        dispatch { $0.identify(userId: userId, traits: traits) }
     }
 
     @available(*, deprecated, message: "Use 'identify(userId:traits:)' with [String: Any] traits parameter instead. Support for Codable traits will be removed in a future version.")
     public func identify<RequestBody: Codable>(userId: String, traits: RequestBody?) {
-        implementation?.identify(userId: userId, traits: traits)
+        dispatch { $0.identify(userId: userId, traits: traits) }
     }
 
     public func clearIdentify() {
-        implementation?.clearIdentify()
+        dispatch { $0.clearIdentify() }
     }
 
     public var deviceAttributes: [String: Any] {
         get { [:] }
-        set { implementation?.setDeviceAttributes(newValue) }
+        set { setDeviceAttributes(newValue) }
     }
 
     public func setDeviceAttributes(_ attributes: [String: Any]) {
-        implementation?.setDeviceAttributes(attributes)
+        dispatch { $0.setDeviceAttributes(attributes) }
     }
 
     public var registeredDeviceToken: String? {
@@ -274,32 +297,32 @@ public class CustomerIO: CustomerIOInstance {
     }
 
     public func registerDeviceToken(_ deviceToken: String) {
-        implementation?.registerDeviceToken(deviceToken)
+        dispatch { $0.registerDeviceToken(deviceToken) }
     }
 
     public func deleteDeviceToken() {
-        implementation?.deleteDeviceToken()
+        dispatch { $0.deleteDeviceToken() }
     }
 
     public func track(name: String, properties: [String: Any]? = nil) {
-        implementation?.track(name: name, properties: properties)
+        dispatch { $0.track(name: name, properties: properties) }
     }
 
     @available(*, deprecated, message: "Use 'track(name:properties:)' with [String: Any] properties parameter instead. Support for Codable properties will be removed in a future version.")
     public func track<RequestBody: Codable>(name: String, properties: RequestBody?) {
-        implementation?.track(name: name, properties: properties)
+        dispatch { $0.track(name: name, properties: properties) }
     }
 
     public func screen(title: String, properties: [String: Any]? = nil) {
-        implementation?.screen(title: title, properties: properties)
+        dispatch { $0.screen(title: title, properties: properties) }
     }
 
     @available(*, deprecated, message: "Use 'screen(title:properties:)' with [String: Any] properties parameter instead. Support for Codable properties will be removed in a future version.")
     public func screen<RequestBody: Codable>(title: String, properties: RequestBody?) {
-        implementation?.screen(title: title, properties: properties)
+        dispatch { $0.screen(title: title, properties: properties) }
     }
 
     public func trackMetric(deliveryID: String, event: Metric, deviceToken: String) {
-        implementation?.trackMetric(deliveryID: deliveryID, event: event, deviceToken: deviceToken)
+        dispatch { $0.trackMetric(deliveryID: deliveryID, event: event, deviceToken: deviceToken) }
     }
 }

--- a/Sources/Common/CustomerIOInstance.swift
+++ b/Sources/Common/CustomerIOInstance.swift
@@ -324,8 +324,16 @@ public class CustomerIO: CustomerIOInstance {
         if let impl = implementation {
             impl.registerDeviceToken(deviceToken)
         } else {
-            hasPendingTokenRegistration.wrappedValue = true
-            preInitEventBuffer.enqueue { $0.registerDeviceToken(deviceToken) }
+            // Only set the deferral flag once we know the buffer actually
+            // retained the closure. If the buffer is at capacity and drops
+            // it, leave the flag clear so `postInitialize` will still
+            // register the stored device token as a fallback — without this
+            // gate, both the buffered closure AND the stored-token sync
+            // would be skipped, leaving the device unregistered.
+            let accepted = preInitEventBuffer.enqueue { $0.registerDeviceToken(deviceToken) }
+            if accepted {
+                hasPendingTokenRegistration.wrappedValue = true
+            }
         }
     }
 

--- a/Sources/Common/PreInitEventBuffer/PreInitEventBuffer.swift
+++ b/Sources/Common/PreInitEventBuffer/PreInitEventBuffer.swift
@@ -26,7 +26,7 @@ final class PreInitEventBuffer {
     }
 
     private enum EnqueueOutcome {
-        case enqueued
+        case enqueued(bufferedCount: Int)
         case dropped
         case executeNow(CustomerIOInstance)
     }
@@ -56,20 +56,33 @@ final class PreInitEventBuffer {
                 if blocks.count >= self.capacity {
                     return .dropped
                 }
-                state = .buffering(blocks + [block])
-                return .enqueued
+                let newBlocks = blocks + [block]
+                state = .buffering(newBlocks)
+                return .enqueued(bufferedCount: newBlocks.count)
             case .draining(let impl, let pending):
-                state = .draining(impl, pending + [block])
-                return .enqueued
+                let newPending = pending + [block]
+                state = .draining(impl, newPending)
+                return .enqueued(bufferedCount: newPending.count)
             case .ready(let impl):
                 return .executeNow(impl)
             }
         }
         switch outcome {
-        case .enqueued:
-            break
+        case .enqueued(let bufferedCount):
+            loggerProvider()?.debug(
+                "Pre-init event buffer accepted event (buffered count: \(bufferedCount)).",
+                Self.logTag
+            )
         case .dropped:
-            droppedCount.mutating { $0 += 1 }
+            let dropped = droppedCount.mutating { count -> Int in
+                count += 1
+                return count
+            }
+            loggerProvider()?.debug(
+                "Pre-init event buffer is at capacity (\(capacity)); dropping event. " +
+                    "Total dropped this session: \(dropped).",
+                Self.logTag
+            )
         case .executeNow(let impl):
             block(impl)
         }
@@ -115,18 +128,11 @@ final class PreInitEventBuffer {
 
         let droppedSnapshot = droppedCount.atomicSetAndFetch(0)
         let logger = loggerProvider()
-        if totalDrained > 0 {
-            logger?.debug(
-                "Pre-init event buffer drained \(totalDrained) event(s).",
-                Self.logTag
-            )
-        }
-        if droppedSnapshot > 0 {
-            logger?.debug(
-                "Pre-init event buffer dropped \(droppedSnapshot) event(s) due to capacity (\(capacity)).",
-                Self.logTag
-            )
-        }
+        logger?.debug(
+            "Pre-init event buffer transitioned to ready. Drained \(totalDrained) event(s) " +
+                "(dropped due to capacity this session: \(droppedSnapshot)).",
+            Self.logTag
+        )
     }
 
     // MARK: - Test-only inspection

--- a/Sources/Common/PreInitEventBuffer/PreInitEventBuffer.swift
+++ b/Sources/Common/PreInitEventBuffer/PreInitEventBuffer.swift
@@ -49,7 +49,15 @@ final class PreInitEventBuffer {
     /// is already in the `ready` state. If the buffer is at capacity, the new
     /// call is dropped and the running drop counter is incremented (logged on
     /// the next `transitionToReady`).
-    func enqueue(_ block: @escaping Block) {
+    ///
+    /// Returns `true` when the call was either retained for replay or executed
+    /// inline against a ready implementation; `false` when the buffer was full
+    /// and the call was dropped. Callers that maintain external state tied to
+    /// an enqueued call (e.g. a "this token will be registered during drain"
+    /// flag) must gate that state on the return value so they don't strand
+    /// themselves when the buffer rejects the enqueue.
+    @discardableResult
+    func enqueue(_ block: @escaping Block) -> Bool {
         let outcome: EnqueueOutcome = state.mutating { state -> EnqueueOutcome in
             switch state {
             case .buffering(let blocks):
@@ -76,6 +84,7 @@ final class PreInitEventBuffer {
                 "Pre-init event buffer accepted event (buffered count: \(bufferedCount)).",
                 Self.logTag
             )
+            return true
         case .dropped:
             let dropped = droppedCount.mutating { count -> Int in
                 count += 1
@@ -86,8 +95,10 @@ final class PreInitEventBuffer {
                     "Total dropped this session: \(dropped).",
                 Self.logTag
             )
+            return false
         case .executeNow(let impl):
             block(impl)
+            return true
         }
     }
 

--- a/Sources/Common/PreInitEventBuffer/PreInitEventBuffer.swift
+++ b/Sources/Common/PreInitEventBuffer/PreInitEventBuffer.swift
@@ -1,0 +1,158 @@
+import Foundation
+
+/// A bounded FIFO buffer that absorbs event-shaped public-API calls invoked
+/// before the SDK has been initialized.
+///
+/// While in the `buffering` state, calls are stored as closures. Once a real
+/// `CustomerIOInstance` is available, `transitionToReady(_:)` synchronously
+/// replays the buffered calls in order against it; subsequent enqueues execute
+/// immediately.
+///
+/// Capacity defaults to 100 events. When the buffer is full, **the most recent
+/// enqueue is dropped** (the oldest events are preserved) — favouring
+/// install-attribution and the first `identify` call, which tend to be the
+/// highest-value early events. This is a deliberate divergence from the
+/// rewrite (which drops oldest); see the porting plan.
+///
+/// Thread safety: state transitions are protected by `Synchronized<State>`.
+/// Block execution happens outside the lock to avoid re-entrancy.
+final class PreInitEventBuffer {
+    typealias Block = (CustomerIOInstance) -> Void
+
+    private enum State {
+        case buffering([Block])
+        case draining(CustomerIOInstance, [Block])
+        case ready(CustomerIOInstance)
+    }
+
+    private enum EnqueueOutcome {
+        case enqueued
+        case dropped
+        case executeNow(CustomerIOInstance)
+    }
+
+    private let state: Synchronized<State>
+    private let droppedCount = Synchronized<Int>(0)
+    private let capacity: Int
+    private let loggerProvider: () -> Logger?
+
+    init(
+        capacity: Int = 100,
+        loggerProvider: @escaping () -> Logger? = { DIGraphShared.shared.logger }
+    ) {
+        self.capacity = capacity
+        self.loggerProvider = loggerProvider
+        self.state = Synchronized<State>(.buffering([]))
+    }
+
+    /// Enqueue a call for future replay, or execute it immediately if the buffer
+    /// is already in the `ready` state. If the buffer is at capacity, the new
+    /// call is dropped and the running drop counter is incremented (logged on
+    /// the next `transitionToReady`).
+    func enqueue(_ block: @escaping Block) {
+        let outcome: EnqueueOutcome = state.mutating { state -> EnqueueOutcome in
+            switch state {
+            case .buffering(let blocks):
+                if blocks.count >= self.capacity {
+                    return .dropped
+                }
+                state = .buffering(blocks + [block])
+                return .enqueued
+            case .draining(let impl, let pending):
+                state = .draining(impl, pending + [block])
+                return .enqueued
+            case .ready(let impl):
+                return .executeNow(impl)
+            }
+        }
+        switch outcome {
+        case .enqueued:
+            break
+        case .dropped:
+            droppedCount.mutating { $0 += 1 }
+        case .executeNow(let impl):
+            block(impl)
+        }
+    }
+
+    /// Replay all buffered events in order against the provided implementation,
+    /// then transition to the `ready` state. Concurrent enqueues that arrive
+    /// during the replay are picked up before the transition completes.
+    /// Safe to call multiple times; subsequent calls are no-ops once `ready`.
+    func transitionToReady(_ implementation: CustomerIOInstance) {
+        var totalDrained = 0
+        while true {
+            let blocksToReplay: [Block] = state.mutating { state -> [Block] in
+                switch state {
+                case .buffering(let blocks):
+                    if blocks.isEmpty {
+                        // No buffered events; advance straight to ready so
+                        // subsequent enqueues run inline.
+                        state = .ready(implementation)
+                        return []
+                    }
+                    state = .draining(implementation, [])
+                    return blocks
+                case .draining(_, let pending):
+                    if pending.isEmpty {
+                        state = .ready(implementation)
+                        return []
+                    }
+                    state = .draining(implementation, [])
+                    return pending
+                case .ready:
+                    return []
+                }
+            }
+            if blocksToReplay.isEmpty {
+                break
+            }
+            for block in blocksToReplay {
+                block(implementation)
+            }
+            totalDrained += blocksToReplay.count
+        }
+
+        let droppedSnapshot = droppedCount.atomicSetAndFetch(0)
+        let logger = loggerProvider()
+        if totalDrained > 0 {
+            logger?.debug(
+                "Pre-init event buffer drained \(totalDrained) event(s).",
+                Self.logTag
+            )
+        }
+        if droppedSnapshot > 0 {
+            logger?.debug(
+                "Pre-init event buffer dropped \(droppedSnapshot) event(s) due to capacity (\(capacity)).",
+                Self.logTag
+            )
+        }
+    }
+
+    // MARK: - Test-only inspection
+
+    /// Number of currently buffered events not yet drained. Test-only.
+    var bufferedCount: Int {
+        state.using { state in
+            switch state {
+            case .buffering(let blocks): return blocks.count
+            case .draining(_, let pending): return pending.count
+            case .ready: return 0
+            }
+        }
+    }
+
+    /// Whether the buffer has reached the `ready` state. Test-only.
+    var isReady: Bool {
+        state.using { state in
+            if case .ready = state { return true } else { return false }
+        }
+    }
+
+    /// Number of events dropped due to capacity since the last drain. Test-only.
+    var droppedEventCount: Int {
+        droppedCount.wrappedValue
+    }
+
+    private static let logTag = "PreInitEventBuffer"
+}

--- a/Sources/Common/PreInitEventBuffer/PreInitEventBuffer.swift
+++ b/Sources/Common/PreInitEventBuffer/PreInitEventBuffer.swift
@@ -60,6 +60,9 @@ final class PreInitEventBuffer {
                 state = .buffering(newBlocks)
                 return .enqueued(bufferedCount: newBlocks.count)
             case .draining(let impl, let pending):
+                if pending.count >= self.capacity {
+                    return .dropped
+                }
                 let newPending = pending + [block]
                 state = .draining(impl, newPending)
                 return .enqueued(bufferedCount: newPending.count)

--- a/Tests/Common/CustomerIOTest.swift
+++ b/Tests/Common/CustomerIOTest.swift
@@ -23,14 +23,14 @@ class CustomerIOTest: UnitTest {
     }
 
     func test_initialize_givenPushDeviceTokenNotSet_expectRegisterDeviceTokenNotCalled() {
-        customerIO.postInitialize()
+        customerIO.postInitialize(impl: implmentationMock)
         XCTAssertFalse(implmentationMock.registerDeviceTokenCalled)
     }
 
     func test_initialize_givenPushDeviceTokenSet_expectRegisterDeviceTokenCalled() {
         let pushDeviceToken = String.random
         globalDataStoreMock.pushDeviceToken = pushDeviceToken
-        customerIO.postInitialize()
+        customerIO.postInitialize(impl: implmentationMock)
         XCTAssertTrue(implmentationMock.registerDeviceTokenCalled)
     }
 
@@ -71,9 +71,10 @@ class CustomerIOTest: UnitTest {
         XCTAssertFalse(freshImplementation.setDeviceAttributesCalled)
         XCTAssertFalse(freshImplementation.registerDeviceTokenCalled)
 
-        // Initialize. Expected order: implementation assigned →
-        // postInitialize() registers the stored token → drain replays the
-        // buffered setDeviceAttributes against the real implementation.
+        // Initialize. Expected order: postInitialize() registers the stored
+        // token on the impl → drain replays the buffered setDeviceAttributes
+        // against the real implementation → implementation published last so
+        // concurrent dispatch calls never race past replay.
         CustomerIO.initializeSharedInstance(with: freshImplementation)
 
         XCTAssertTrue(freshImplementation.registerDeviceTokenCalled, "postInitialize() should register the stored token before the buffer drains")

--- a/Tests/Common/CustomerIOTest.swift
+++ b/Tests/Common/CustomerIOTest.swift
@@ -1,8 +1,7 @@
+@testable import CioInternalCommon
 import Foundation
 import SharedTests
 import XCTest
-
-@testable import CioInternalCommon
 
 class CustomerIOTest: UnitTest {
     private let implmentationMock = CustomerIOInstanceMock()
@@ -33,5 +32,52 @@ class CustomerIOTest: UnitTest {
         globalDataStoreMock.pushDeviceToken = pushDeviceToken
         customerIO.postInitialize()
         XCTAssertTrue(implmentationMock.registerDeviceTokenCalled)
+    }
+
+    func test_initializeSharedInstance_givenBufferedRegisterDeviceToken_expectPostInitializeSkipped() {
+        // P2 #1 from PR review: when a `registerDeviceToken` is buffered
+        // pre-init, postInitialize() must not also register the stored token —
+        // otherwise the same device update fires twice.
+        let storedToken = String.random
+        let bufferedToken = String.random
+        let freshImplementation = CustomerIOInstanceMock()
+        globalDataStoreMock.pushDeviceToken = storedToken
+
+        CustomerIO.resetSharedTestEnvironment()
+        CustomerIO.shared.registerDeviceToken(bufferedToken)
+
+        CustomerIO.initializeSharedInstance(with: freshImplementation)
+
+        XCTAssertEqual(freshImplementation.registerDeviceTokenCallsCount, 1, "exactly one register; postInitialize should skip because a buffered registerDeviceToken is pending")
+        XCTAssertEqual(freshImplementation.registerDeviceTokenReceivedArguments, bufferedToken)
+    }
+
+    func test_initializeSharedInstance_givenStoredTokenAndBufferedCall_expectTokenSyncedBeforeReplay() {
+        // P2 #1 from PR review: postInitialize() must run before the buffer drain
+        // so buffered token-dependent calls (e.g. setDeviceAttributes) observe a
+        // non-nil contextPlugin.deviceToken, and a buffered registerDeviceToken
+        // is idempotent on an unchanged stored token (verified at the
+        // DataPipeline impl level in DataPipelineInteractionTests).
+        let storedToken = String.random
+        let freshImplementation = CustomerIOInstanceMock()
+        globalDataStoreMock.pushDeviceToken = storedToken
+
+        // Reset the singleton to its un-initialized state so we exercise the
+        // full pre-init → initialize transition for this test.
+        CustomerIO.resetSharedTestEnvironment()
+
+        // Pre-init: enqueue a setDeviceAttributes call onto the buffer.
+        CustomerIO.shared.setDeviceAttributes(["any": "value"])
+        XCTAssertFalse(freshImplementation.setDeviceAttributesCalled)
+        XCTAssertFalse(freshImplementation.registerDeviceTokenCalled)
+
+        // Initialize. Expected order: implementation assigned →
+        // postInitialize() registers the stored token → drain replays the
+        // buffered setDeviceAttributes against the real implementation.
+        CustomerIO.initializeSharedInstance(with: freshImplementation)
+
+        XCTAssertTrue(freshImplementation.registerDeviceTokenCalled, "postInitialize() should register the stored token before the buffer drains")
+        XCTAssertEqual(freshImplementation.registerDeviceTokenReceivedArguments, storedToken)
+        XCTAssertTrue(freshImplementation.setDeviceAttributesCalled, "buffered setDeviceAttributes should replay against the real implementation")
     }
 }

--- a/Tests/Common/CustomerIOTest.swift
+++ b/Tests/Common/CustomerIOTest.swift
@@ -52,6 +52,37 @@ class CustomerIOTest: UnitTest {
         XCTAssertEqual(freshImplementation.registerDeviceTokenReceivedArguments, bufferedToken)
     }
 
+    func test_initializeSharedInstance_givenBufferAtCapacityAndDroppedRegisterDeviceToken_expectStoredTokenFallback() {
+        // Regression for the drop-and-flag race: if the pre-init buffer is
+        // already at capacity when `registerDeviceToken` arrives, the closure
+        // is dropped. `hasPendingTokenRegistration` must remain false so
+        // `postInitialize` still falls through to registering the stored
+        // token. Without that gate, the user's token would be lost *and*
+        // postInitialize would skip its fallback, leaving the device
+        // unregistered until the next launch.
+        let storedToken = String.random
+        let droppedToken = String.random
+        let freshImplementation = CustomerIOInstanceMock()
+        globalDataStoreMock.pushDeviceToken = storedToken
+
+        CustomerIO.resetSharedTestEnvironment()
+
+        // Fill the pre-init buffer to its default capacity (100). Each call
+        // routes through `dispatch` → `preInitEventBuffer.enqueue` because
+        // `implementation` is nil pre-init.
+        for index in 0 ..< 100 {
+            CustomerIO.shared.track(name: "preinit_\(index)")
+        }
+        // This call should hit the capacity ceiling and be dropped; the flag
+        // must NOT be set.
+        CustomerIO.shared.registerDeviceToken(droppedToken)
+
+        CustomerIO.initializeSharedInstance(with: freshImplementation)
+
+        XCTAssertEqual(freshImplementation.registerDeviceTokenCallsCount, 1, "postInitialize must fall back to the stored token when registerDeviceToken was dropped at capacity")
+        XCTAssertEqual(freshImplementation.registerDeviceTokenReceivedArguments, storedToken)
+    }
+
     func test_initializeSharedInstance_givenStoredTokenAndBufferedCall_expectTokenSyncedBeforeReplay() {
         // P2 #1 from PR review: postInitialize() must run before the buffer drain
         // so buffered token-dependent calls (e.g. setDeviceAttributes) observe a

--- a/Tests/Common/PreInitEventBuffer/PreInitEventBufferTests.swift
+++ b/Tests/Common/PreInitEventBuffer/PreInitEventBufferTests.swift
@@ -199,6 +199,35 @@ struct PreInitEventBufferTests {
         #expect(recorder.events == ["track:outer", "track:inner"])
     }
 
+    @Test func drainingStateEnforcesCapacity() {
+        // While in .draining (i.e. the drain is replaying outer blocks), any
+        // reentrant enqueue must respect the same capacity as .buffering.
+        // Without this guarantee, a launch-time burst racing the drain could
+        // grow `pending` past the documented bound and bypass drop accounting.
+        let buffer = makeBuffer(capacity: 2)
+        let recorder = RecordingInstance()
+        let bufferRef = buffer
+
+        // First block triggers 4 reentrant enqueues while the buffer is in
+        // .draining. Only the first 2 should be retained; the remaining 2
+        // must be counted as drops.
+        buffer.enqueue { impl in
+            impl.track(name: "outer", properties: nil)
+            for i in 0 ..< 4 {
+                bufferRef.enqueue { $0.track(name: "inner-\(i)", properties: nil) }
+            }
+        }
+        buffer.transitionToReady(recorder)
+
+        #expect(recorder.events == [
+            "track:outer",
+            "track:inner-0",
+            "track:inner-1"
+        ])
+        // 2 dropped during the draining phase; counter is reset after drain.
+        #expect(buffer.droppedEventCount == 0)
+    }
+
     @Test func concurrentEnqueuesArePreservedUpToCap() {
         let buffer = makeBuffer(capacity: 200)
         let recorder = RecordingInstance()

--- a/Tests/Common/PreInitEventBuffer/PreInitEventBufferTests.swift
+++ b/Tests/Common/PreInitEventBuffer/PreInitEventBufferTests.swift
@@ -1,0 +1,226 @@
+@testable import CioInternalCommon
+import Dispatch
+import Foundation
+import Testing
+
+// MARK: - Recording stub
+
+/// Minimal `CustomerIOInstance` stub that records the order of buffered calls
+/// during drain tests. Only the methods exercised by these tests are
+/// implemented; the rest no-op.
+private final class RecordingInstance: CustomerIOInstance, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _events: [String] = []
+
+    var events: [String] {
+        lock.withLock { _events }
+    }
+
+    private func record(_ event: String) {
+        lock.withLock { _events.append(event) }
+    }
+
+    // MARK: CustomerIOInstance — only the calls used in tests below are real
+
+    var profileAttributes: [String: Any] = [:]
+    func setProfileAttributes(_ attributes: [String: Any]) {
+        record("setProfileAttributes:\(attributes.keys.sorted().joined(separator: ","))")
+    }
+
+    func identify(userId: String, traits: [String: Any]?) {
+        record("identify:\(userId)")
+    }
+
+    func identify<RequestBody: Codable>(userId: String, traits: RequestBody?) {
+        record("identifyCodable:\(userId)")
+    }
+
+    func clearIdentify() {
+        record("clearIdentify")
+    }
+
+    var deviceAttributes: [String: Any] = [:]
+    func setDeviceAttributes(_ attributes: [String: Any]) {
+        record("setDeviceAttributes")
+    }
+
+    var registeredDeviceToken: String? {
+        nil
+    }
+
+    func registerDeviceToken(_ deviceToken: String) {
+        record("registerDeviceToken:\(deviceToken)")
+    }
+
+    func deleteDeviceToken() {
+        record("deleteDeviceToken")
+    }
+
+    func track(name: String, properties: [String: Any]?) {
+        record("track:\(name)")
+    }
+
+    func track<RequestBody: Codable>(name: String, properties: RequestBody?) {
+        record("trackCodable:\(name)")
+    }
+
+    func screen(title: String, properties: [String: Any]?) {
+        record("screen:\(title)")
+    }
+
+    func screen<RequestBody: Codable>(title: String, properties: RequestBody?) {
+        record("screenCodable:\(title)")
+    }
+
+    func trackMetric(deliveryID: String, event: Metric, deviceToken: String) {
+        record("trackMetric:\(deliveryID)")
+    }
+}
+
+// MARK: - Buffer state and ordering
+
+struct PreInitEventBufferTests {
+    private func makeBuffer(capacity: Int = 100) -> PreInitEventBuffer {
+        // Inject a nil-returning logger provider so tests don't depend on the
+        // shared DI graph state (which may or may not have a logger registered
+        // depending on test-run order).
+        PreInitEventBuffer(capacity: capacity, loggerProvider: { nil })
+    }
+
+    @Test func enqueueAccumulatesWhileBuffering() {
+        let buffer = makeBuffer()
+        buffer.enqueue { _ in }
+        buffer.enqueue { _ in }
+        buffer.enqueue { _ in }
+        #expect(buffer.bufferedCount == 3)
+        #expect(buffer.isReady == false)
+    }
+
+    @Test func drainReplaysInOrder() {
+        let buffer = makeBuffer()
+        let recorder = RecordingInstance()
+        buffer.enqueue { $0.track(name: "one", properties: nil) }
+        buffer.enqueue { $0.identify(userId: "alice", traits: nil) }
+        buffer.enqueue { $0.screen(title: "Home", properties: nil) }
+        buffer.transitionToReady(recorder)
+
+        #expect(recorder.events == [
+            "track:one",
+            "identify:alice",
+            "screen:Home"
+        ])
+        #expect(buffer.isReady == true)
+        #expect(buffer.bufferedCount == 0)
+    }
+
+    @Test func postReadyEnqueueExecutesImmediately() {
+        let buffer = makeBuffer()
+        let recorder = RecordingInstance()
+        buffer.transitionToReady(recorder)
+        buffer.enqueue { $0.track(name: "after", properties: nil) }
+        #expect(recorder.events == ["track:after"])
+        #expect(buffer.bufferedCount == 0)
+    }
+
+    @Test func overflowDropsMostRecent() {
+        let buffer = makeBuffer(capacity: 3)
+        let recorder = RecordingInstance()
+
+        // Enqueue 5 events. The first 3 should be retained; events 4 and 5 dropped.
+        for index in 0 ..< 5 {
+            buffer.enqueue { $0.track(name: "event-\(index)", properties: nil) }
+        }
+        #expect(buffer.bufferedCount == 3)
+        #expect(buffer.droppedEventCount == 2)
+
+        buffer.transitionToReady(recorder)
+
+        #expect(recorder.events == [
+            "track:event-0",
+            "track:event-1",
+            "track:event-2"
+        ])
+        // Drop counter is reset after drain so subsequent overflow accounting
+        // starts clean.
+        #expect(buffer.droppedEventCount == 0)
+    }
+
+    @Test func transitionToReadyOnEmptyBufferIsNoop() {
+        let buffer = makeBuffer()
+        let recorder = RecordingInstance()
+        buffer.transitionToReady(recorder)
+        #expect(buffer.isReady == true)
+        #expect(recorder.events.isEmpty)
+    }
+
+    @Test func transitionToReadyCalledTwiceIsSafe() {
+        let buffer = makeBuffer()
+        let recorder1 = RecordingInstance()
+        let recorder2 = RecordingInstance()
+        buffer.enqueue { $0.track(name: "first", properties: nil) }
+        buffer.transitionToReady(recorder1)
+        // Second call should be a no-op — events were already drained to recorder1.
+        buffer.transitionToReady(recorder2)
+        #expect(recorder1.events == ["track:first"])
+        #expect(recorder2.events.isEmpty)
+    }
+
+    @Test func bufferSurvivesAcrossEnqueueCycles() {
+        // If "initialize" never actually runs (in real terms, that means
+        // transitionToReady is never called), the buffer should sit at cap
+        // and continue dropping new events without crashing or growing.
+        let buffer = makeBuffer(capacity: 2)
+        buffer.enqueue { _ in }
+        buffer.enqueue { _ in }
+        buffer.enqueue { _ in }
+        buffer.enqueue { _ in }
+        #expect(buffer.bufferedCount == 2)
+        #expect(buffer.droppedEventCount == 2)
+    }
+
+    @Test func enqueueDuringDrainIsPickedUp() {
+        // Reentrancy: while a buffered block is executing, the block itself
+        // enqueues another event. The newly-enqueued event must drain
+        // (either picked up by the same drain loop because the buffer is in
+        // .draining state, or executed immediately if state already advanced
+        // to .ready). Either way, both events must end up recorded in order.
+        let buffer = makeBuffer()
+        let recorder = RecordingInstance()
+        buffer.enqueue { impl in
+            impl.track(name: "outer", properties: nil)
+        }
+        // Reentrant enqueue from inside a block, captured into a separate
+        // buffer reference so the closure is non-self-referential.
+        let bufferRef = buffer
+        buffer.enqueue { _ in
+            bufferRef.enqueue { $0.track(name: "inner", properties: nil) }
+        }
+        buffer.transitionToReady(recorder)
+        #expect(recorder.events == ["track:outer", "track:inner"])
+    }
+
+    @Test func concurrentEnqueuesArePreservedUpToCap() {
+        let buffer = makeBuffer(capacity: 200)
+        let recorder = RecordingInstance()
+
+        // Spin up several threads, each enqueueing N events. Total enqueued
+        // must equal `bufferedCount` (no drops below cap).
+        let group = DispatchGroup()
+        let perThread = 25
+        let threadCount = 4
+        for thread in 0 ..< threadCount {
+            group.enter()
+            DispatchQueue.global().async {
+                for i in 0 ..< perThread {
+                    buffer.enqueue { $0.track(name: "t\(thread)-\(i)", properties: nil) }
+                }
+                group.leave()
+            }
+        }
+        group.wait()
+
+        #expect(buffer.bufferedCount == threadCount * perThread)
+        buffer.transitionToReady(recorder)
+        #expect(recorder.events.count == threadCount * perThread)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a bounded in-memory FIFO (capacity 100, drop-most-recent on overflow) that absorbs event-shaped public-API calls invoked before `CustomerIO.initialize()` completes. Calls drain in order against the real implementation once initialization finishes.
- Previously, calls like `CustomerIO.shared.track(...)` made before initialize evaluated to `implementation?.method(...)` and silently no-op'd, losing data common in cold-start, deep-link, and restored-state flows.

This is item 2 of a cross-SDK plan to port targeted improvements from the proposed iOS SDK rewrite (`customerio-ios-tng`) back to the current SDK. Android parity ships in a separate PR on customerio-android (same branch name).

## Scope of buffering
All event-shaped methods on the `CustomerIO` facade route through the buffer when `implementation == nil`:
- `track`, `identify`, `screen` (incl. deprecated Codable variants)
- `clearIdentify`, `setProfileAttributes`, `setDeviceAttributes`
- `registerDeviceToken`, `deleteDeviceToken`, `trackMetric`

Read-side accessors (`registeredDeviceToken`, `profileAttributes` getter, `deviceAttributes` getter) are unchanged — there's nothing to buffer.

## Decisions worth flagging
- **Buffer cap: 100.** Matches the rewrite.
- **Overflow policy: drop most recent.** Deliberate divergence from the rewrite (which drops oldest). Preserves the earliest events — install attribution, initial identify — which tend to be the highest-value early signals.
- **No `initialize()` ever called → buffer sits at cap.** No TTL, no cleanup. Memory is bounded by the cap.
- **`initialize()` fails → buffer remains intact.** A subsequent retry will drain it.
- **Debug-level logs on overflow drops and drain.** Counter tracked across pre-init; logged once on drain.
- **Order preserved through identify boundaries.** A sequence like `[identify(A), track(x), clearIdentify, identify(B), track(y)]` drains in that exact order; the existing pipeline handles attribution correctly post-replay.

## Implementation
- `PreInitEventBuffer` is a small `Synchronized<State>`-backed FIFO with three states: `.buffering`, `.draining`, `.ready`. Block execution always happens outside the lock to avoid re-entrancy.
- `CustomerIO` owns a buffer instance. Public methods route through a tiny `dispatch(_:)` helper that either calls the real `implementation` or enqueues onto the buffer.
- `initializeSharedInstance` (and `setUpSharedInstanceForUnitTest`) call `buffer.transitionToReady(impl)` synchronously **before** assigning `implementation`. This guarantees strict ordering — buffered events drain before any post-init direct call.

## Test plan
- [x] 9 new unit tests in `Tests/Common/PreInitEventBuffer/`: state transitions, overflow, drain order, reentrancy, concurrent enqueue, post-init direct execution, idempotent transition.
- [x] All existing `CommonTests` pass.
- [x] All existing `DataPipelineTests` pass.
- [ ] CI green on this PR.
- [ ] Local wrapper validation (RN + Flutter sample apps with deliberate pre-`initialize()` `track()` call lands events on the server) — done locally, no PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `CustomerIO` facade to buffer and later replay pre-initialization calls, altering event delivery timing and device-token registration order; concurrency/ordering bugs could affect analytics and push registration behavior.
> 
> **Overview**
> **Pre-init API calls are no longer dropped.** `CustomerIO` now routes event-shaped methods through a new bounded FIFO `PreInitEventBuffer`, capturing calls made while `implementation` is `nil` and replaying them synchronously, in order, during `initializeSharedInstance` (and unit-test setup).
> 
> **Initialization ordering and token behavior changed.** Initialization now runs `postInitialize` before draining the buffer and only publishes `implementation` after the drain to avoid races; `registerDeviceToken` gets special handling to prevent duplicate registration (and falls back to the stored token if the buffer is at capacity and drops the call). New tests cover drain order, overflow policy (drop most-recent), re-entrancy/concurrency, and the token-registration edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2508c67ad6408d18030be750d8dfbab244325f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->