### PR TITLE
docs: fix broken Code of Conduct link in README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![min swift version is 5.3](https://img.shields.io/badge/min%20Swift%20version-5.3-orange)
 ![min ios version is 13](https://img.shields.io/badge/min%20iOS%20version-13-blue)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](code_of_conduct.md) 
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](CODE_OF_CONDUCT.md)
 [![codecov](https://codecov.io/gh/customerio/customerio-ios/branch/develop/graph/badge.svg?token=IZ9RP9XD1O)](https://codecov.io/gh/customerio/customerio-ios)
 
 # Customer.io iOS SDK
@@ -53,7 +53,7 @@ See our complete SDK documentation at [https://customer.io/docs/sdk/ios/](https:
 
 Thanks for taking an interest in our project! We welcome your contributions. Check out [our development instructions](docs/dev-notes/DEVELOPMENT.md) to get your environment set up and start contributing.
 
-> **Note**: We value an open, welcoming, diverse, inclusive, and healthy community for this project. We expect all  contributors to follow our [code of conduct](CODE_OF_CONDUCT.md). 
+> **Note**: We value an open, welcoming, diverse, inclusive, and healthy community for this project. We expect all contributors to follow our [code of conduct](CODE_OF_CONDUCT.md). 
 
 # License
 


### PR DESCRIPTION
The Contributor Covenant badge in the README links to `code_of_conduct.md` (lowercase), but the actual file in the repo is `CODE_OF_CONDUCT.md` (uppercase). The lowercase link 404s on github.com and on case-sensitive filesystems.

The same README correctly references the file with uppercase further down (line 56), so this brings the badge in line with that. Also removed a stray double-space on that line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no runtime or security impact.
> 
> **Overview**
> Fixes the **Contributor Covenant** badge in `README.md` so it points to `CODE_OF_CONDUCT.md` instead of the broken lowercase `code_of_conduct.md` path, matching the link already used in the Contributing section.
> 
> Also trims an extra space in the community note (“all  contributors” → “all contributors”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e02424f54c3a6ec7e1c1e789b9849bce4d3e930. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->