### PR TITLE
[SPIKE / DO NOT MERGE] Segment storage injection: prove encryption-at-rest is feasible without forking

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
@@ -17,6 +17,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         initializeCioAndInAppListeners()
 
+        // SPIKE: plant grep-able needles via the public API immediately after init
+        // so we can verify on-disk bytes never contain the plaintext.
+        runSegmentStorageSpike()
+
         /*
          Registers the `AppDelegate` class to handle when a push notification gets clicked.
          This line of code is optional and only required if you have custom code that needs to run when a push notification gets clicked on.
@@ -26,6 +30,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 //        UNUserNotificationCenter.current().delegate = self
 
         return true
+    }
+
+    // SPIKE: feeds the public CIO/Segment API the canary strings that the
+    // post-run grep step looks for on disk. Throwaway code on a spike branch.
+    //
+    // NOTE: `clearIdentify()` triggers `analytics.reset()` which wipes the event
+    // queue on disk, defeating the post-run grep. To preserve the wrapped event
+    // files for verification, we skip clearIdentify() in the spike. The UserDefaults
+    // suite plist is what we really care about for the bypass question and that
+    // *is* persisted at the time the snapshot runs.
+    func runSegmentStorageSpike() {
+        let uuid = UUID().uuidString
+        let sdk = CustomerIO.shared
+        sdk.identify(userId: "SPIKE_USER_\(uuid)", traits: ["SPIKE_TRAIT_email": "SPIKE_TRAIT_VALUE_\(uuid)"])
+        sdk.track(name: "SPIKE_EVENT_1", properties: ["SPIKE_PROP_marker": "SPIKE_PROP_VALUE_1"])
+        sdk.track(name: "SPIKE_EVENT_2", properties: ["SPIKE_PROP_marker": "SPIKE_PROP_VALUE_2"])
+        sdk.track(name: "SPIKE_EVENT_3", properties: ["SPIKE_PROP_marker": "SPIKE_PROP_VALUE_3"])
+        sdk.screen(title: "SPIKE_SCREEN_1", properties: ["SPIKE_PROP_marker": "SPIKE_PROP_VALUE_screen"])
+        // group is not on the CIO public surface; alias is, so plant a needle there too.
+        sdk.alias(newId: "SPIKE_ALIAS_\(uuid)")
+        // INTENTIONALLY OMITTED for the spike: sdk.clearIdentify()
+        // It calls analytics.reset() which would wipe the wrapped event queue and the
+        // UserDefaults plist before the verifier can snapshot them.
+        print("[SegmentStorageSpike] spike sequence complete; uuid=\(uuid)")
     }
 
     func initializeCioAndInAppListeners() {

--- a/SPIKE_REPORT.md
+++ b/SPIKE_REPORT.md
@@ -1,0 +1,161 @@
+# Segment Storage Injection Spike — iOS Report
+
+**Date:** 2026-05-20
+**Repo:** `customerio-ios`
+**Branch:** `spike/segment-storage-injection-2026-05-19` (off `origin/main` @ `63c32f54`, local only — never pushed)
+**Sample app:** `Apps/APN-UIKit` (bundle id `io.customer.ios-sample.apn-spm.APN-UIKit`)
+**Simulator:** iPhone 16 Pro Max, iOS 18.5 (UDID `CC49601D-8243-40F7-A557-9826A5410F2C`)
+**Spike run UUID:** `DB7F9DF0-30F4-4D22-830C-8B257254539C`
+**Snapshot taken:** ~20s after launch (before the 30s Segment flush would drain wrapped event files via upload)
+
+## TL;DR
+
+`Configuration.storageMode(.custom(WrappingDataStore))` does fully intercept the **event-queue** persistence path on iOS, but **does NOT intercept the UserDefaults state path**. `cdp-analytics-swift`'s `Storage.swift` writes `segment.userId`, `segment.anonymousId`, `segment.traits`, and `segment.settings` directly to `UserDefaults(suiteName: "com.segment.storage.<writeKey>")` regardless of what `StorageMode` is set. Those values land plaintext in `<container>/Library/Preferences/com.segment.storage.<writeKey>.plist`.
+
+Verdict: **Phase 3 iOS is NOT feasible via `.custom(DataStore)` alone.** It requires a second injection layer (or a fork) to encrypt the UserDefaults suite, OR an explicit decision to accept plaintext `userId` / `traits` in UserDefaults backed by iOS Data Protection.
+
+## What was implemented
+
+1. New file `Sources/DataPipeline/Util/WrappingDataStore.swift` — a `DataStore` implementation that:
+   - traces every protocol method via `os_log` (subsystem `io.customer.spike`, category `SegmentStorageTrace`)
+   - on `append(data: RawEvent)`: serializes the event via `data.toString()`, prepends the 13-byte sentinel `WRAPPED::v1::`, then XOR's every byte after the sentinel with `0x55`, then writes the mutated bytes to one file per event under `Documents/spike-wrapping-storage/<writeKey>/NNNNNNNN-wrap.bin`
+   - on `fetch`: re-reads each wrapped file, strips the sentinel, re-XORs back, assembles a fully-formed `{ "batch": [...], "sentAt": ..., "writeKey": ... }` JSON `Data` payload (same shape `MemoryStore` produces), returns it as `DataResult(data:removable:)`. `transactionType = .data` so `SegmentDestination.flushData` is used.
+   - on `remove`: deletes wrapped files by URL
+2. `Sources/DataPipeline/CustomerIO+Segment.swift` — added `result.storageMode(.custom(WrappingDataStore(...)))` to `toSegmentConfiguration()`.
+3. `Apps/APN-UIKit/APN UIKit/AppDelegate.swift` — added `runSegmentStorageSpike()` called from `didFinishLaunchingWithOptions` after `initializeCioAndInAppListeners()`. The spike plants SPIKE_ needles via `identify` / `track` × 3 / `screen` / `alias`. `clearIdentify()` is intentionally omitted (it triggers `analytics.reset()` which wipes both the event queue and the UserDefaults plist, defeating the post-run grep).
+
+Bundle id verified via pbxproj: `io.customer.ios-sample.apn-spm.APN-UIKit`. `preInitScenario` does not exist as a constant on this branch — nothing to leave at `.off`.
+
+## Reconciliation table (every file in the post-run data container)
+
+`SPIKE_? = grep -a 'SPIKE_' on the file bytes` (a → text-mode so binary bplists are checked too).
+
+| File path (relative to data container) | Owned by | Contains `SPIKE_` plaintext? | Starts with `WRAPPED::v1::`? | Verdict |
+|---|---|---|---|---|
+| `.com.apple.mobile_container_manager.metadata.plist` | iOS | no | n/a | unrelated (OS) |
+| `Documents/spike-wrapping-storage/45468ceeed7b7057c583/00000000-wrap.bin` | Segment events (via wrapper) | no | yes | wrapped |
+| `Documents/spike-wrapping-storage/45468ceeed7b7057c583/00000001-wrap.bin` | Segment events (via wrapper) | no | yes | wrapped |
+| `Documents/spike-wrapping-storage/45468ceeed7b7057c583/00000002-wrap.bin` | Segment events (via wrapper) | no | yes | wrapped |
+| `Documents/spike-wrapping-storage/45468ceeed7b7057c583/00000003-wrap.bin` | Segment events (via wrapper) | no | yes | wrapped |
+| `Documents/spike-wrapping-storage/45468ceeed7b7057c583/00000004-wrap.bin` | Segment events (via wrapper) | no | yes | wrapped |
+| `Documents/spike-wrapping-storage/45468ceeed7b7057c583/00000005-wrap.bin` | Segment events (via wrapper) | no | yes | wrapped |
+| `Documents/spike-wrapping-storage/45468ceeed7b7057c583/00000006-wrap.bin` | Segment events (via wrapper) | no | yes | wrapped |
+| `Documents/spike-wrapping-storage/45468ceeed7b7057c583/00000007-wrap.bin` | Segment events (via wrapper) | no | yes | wrapped |
+| `Documents/spike-wrapping-storage/45468ceeed7b7057c583/00000008-wrap.bin` | Segment events (via wrapper) | no | yes | wrapped |
+| `Documents/spike-wrapping-storage/45468ceeed7b7057c583/00000009-wrap.bin` | Segment events (via wrapper) | no | yes | wrapped |
+| `Documents/spike-wrapping-storage/45468ceeed7b7057c583/00000010-wrap.bin` | Segment events (via wrapper) | no | yes | wrapped |
+| `Library/Caches/io.customer.ios-sample.apn-spm.APN-UIKit/Cache.db` (+ `-shm`, `-wal`) | URLSession cache | no | n/a | unrelated (OS HTTP cache) |
+| `Library/HTTPStorages/io.customer.ios-sample.apn-spm.APN-UIKit/httpstorages.sqlite` (+ `-shm`, `-wal`) | URLSession cookie/storages | no | n/a | unrelated (OS HTTP store) |
+| `Library/Preferences/com.segment.storage.45468ceeed7b7057c583.plist` | **Segment KVS (UserDefaults suite — NOT routed through DataStore)** | **YES — 3 SPIKE_ hits** | no | **BYPASSED** |
+| `Library/Preferences/io.customer.ios-sample.apn-spm.APN-UIKit.plist` | CIO sample-app settings | no | n/a | unrelated (app config, no SDK profile data) |
+| `Library/Preferences/io.customer.sdk.io.customer.ios-sample.apn-spm.APN-UIKit.shared.plist` | CIO shared GlobalDataStore (push token, in-app cache) | no | n/a | unrelated (no SPIKE_ leakage observed) |
+| `Library/Saved Application State/.../data.data` | iOS UIScene state | no | n/a | unrelated (OS) |
+| `Library/SplashBoard/Snapshots/...@3x.ktx` (x2) | iOS launch snapshot | no | n/a | unrelated (OS) |
+| AppGroup `group.io.customer.ios-sample.apn-spm.APN-UIKit.cio` (container only contains `metadata.plist`) | iOS | no | n/a | unrelated (OS) |
+
+Also note: the default Segment event-queue directory `Documents/segment/<writeKey>/` is created by `eventStorageDirectory()` but stays **empty** when `.custom` storage is set — proof that all `DataStore.append` traffic went through our wrapper.
+
+## Needle leak report
+
+Exactly one file in the post-run data container contains a `SPIKE_` needle in plaintext: the Segment UserDefaults suite plist.
+
+```
+File: <container>/Library/Preferences/com.segment.storage.45468ceeed7b7057c583.plist
+Size: 762 bytes
+Needles found (via `strings` + xxd):
+  - SPIKE_TRAIT_email                                       (key in segment.traits nested bplist)
+  - SPIKE_TRAIT_VALUE_DB7F9DF0-30F4-4D22-830C-8B257254539C  (value in segment.traits nested bplist)
+  - SPIKE_ALIAS_DB7F9DF0-30F4-4D22-830C-8B257254539C        (string value of segment.userId — written by alias())
+```
+
+Hexdump preview (offsets where SPIKE_ appears):
+
+```
+00000200: 1153 5049 4b45 5f54 5241 4954 5f65 6d61  .SPIKE_TRAIT_ema
+00000210: 696c 5f10 3653 5049 4b45 5f54 5241 4954  il_.6SPIKE_TRAIT
+00000270: 3053 5049 4b45 5f41 4c49 4153 5f44 4237  0SPIKE_ALIAS_DB7
+```
+
+`plutil -p` output of the plist:
+
+```
+{
+  "segment.anonymousId" => "749DB870-AAD5-4DD0-9BA6-84A4491FAF54"
+  "segment.settings"    => <nested bplist: writeKey, hosts, sampleRate — no SPIKE_ here>
+  "segment.traits"      => <nested bplist embedding SPIKE_TRAIT_email -> SPIKE_TRAIT_VALUE_...>
+  "segment.userId"      => "SPIKE_ALIAS_DB7F9DF0-30F4-4D22-830C-8B257254539C"
+}
+```
+
+The `SPIKE_USER_<uuid>` value originally written by `identify(userId:)` was overwritten in `segment.userId` by the subsequent `alias(newId:)`, which is consistent with Segment's documented `alias` semantics.
+
+No `SPIKE_` hit elsewhere — every event file under `Documents/spike-wrapping-storage/<writeKey>/` is sentinel-prefixed and XOR-mutated.
+
+## Trace log summary
+
+Counts from `xcrun simctl spawn booted log stream --predicate 'subsystem == "io.customer.spike"'`:
+
+| Operation | Count |
+|---|---|
+| `init`   | 1   |
+| `append` | 11  |
+| `fetch`  | 1   |
+| `remove` | 11  |
+| `reset`  | 0   |
+
+The 11 `append` calls correspond to: 1 identify + 3 track + 1 screen + 1 alias + auto plugin events (`Device Created or Updated`, push token tracking, `Application Installed/Opened` lifecycle, etc). The single `fetch` happened ~30s after launch at the natural Segment flushInterval and the upload succeeded against `cdp.customer.io/v1`, which directly proves our `unwrap()` reconstructs valid JSON the server accepts. All 11 wrapped files were then `remove`d after the successful batch upload.
+
+`fetch picked=11 plaintextBytes=13258 batchBytes=13352 firstPath=00000000-wrap.bin` — confirms unwrap+batch assembly produced a 13,352-byte JSON the upload pipeline used directly without ever seeing the wrapped bytes.
+
+## UserDefaults-suite finding (the critical question)
+
+**Did `com.segment.storage.<writeKey>.plist` contain the needles in plaintext? YES.**
+
+Evidence:
+
+1. The plist is at `<container>/Library/Preferences/com.segment.storage.45468ceeed7b7057c583.plist` (762 bytes, owner `mobile`).
+2. `grep -a 'SPIKE_' <plist>` matches 3 distinct needles (above).
+3. `plutil -p` decodes `segment.userId` as the literal string `"SPIKE_ALIAS_DB7F9DF0-30F4-4D22-830C-8B257254539C"`.
+4. `segment.traits` decodes to a nested bplist whose UTF-8 byte stream contains `SPIKE_TRAIT_email` and `SPIKE_TRAIT_VALUE_DB7F9DF0-30F4-4D22-830C-8B257254539C` verbatim.
+5. Our `WrappingDataStore` received **zero** writes for any of these — the trace log shows only 11 `append`s, all of which were `RawEvent`s (track/identify/screen/alias events, not the KVS state).
+
+Source confirmation in `cdp-analytics-swift`:
+
+- `Sources/Segment/Utilities/Storage/Storage.swift` line 24 constructs `UserDefaults(suiteName: "com.segment.storage.\(writeKey)")` independently of `storageMode`.
+- The `switch key { case .events: dataStore.append(...) default: userDefaults.set(...) }` branch (line 60-89) means `userId`, `anonymousId`, `traits`, `settings` all flow to `userDefaults`, never through `DataStore`.
+- `userInfoUpdate(state:)` (line 184) writes `userId`, `traits`, `anonymousId` reactively whenever Sovran state changes.
+
+This is a hard, source-confirmed bypass of `.custom(DataStore)` — not a transient race.
+
+## Verdict
+
+**Phase 3 iOS requires a second injection layer** beyond `Configuration.storageMode(.custom(DataStore))`. Concrete options, in order of preference:
+
+1. **Replace the `UserDefaults` suite with an encrypted KVS at runtime.** `cdp-analytics-swift`'s `Storage.swift` calls `UserDefaults(suiteName: "com.segment.storage.\(writeKey)")!` directly — no DI seam. To swap that backing store we would need to either (a) fork (or vendor) the library to inject a key-value protocol, or (b) take the Apple-private-but-historically-allowed route of registering a `UserDefaults` subclass via `URLProtocol`-style runtime swizzling on `UserDefaults`, which is fragile and likely AppStore-risky.
+
+2. **Accept plaintext `userId` / `anonymousId` / `traits` in UserDefaults, encrypt only the event queue via `.custom(DataStore)`** (the spike proves this half works). Pair with iOS Data Protection class (`NSFileProtectionComplete` / `CompleteUnlessOpen`) on the Preferences plist to gate at-rest exposure to device-unlocked state. This is the lower-risk path; the trade-off is that `userId` and `traits` are encrypted only by the OS file-protection key, not our `CryptoProvider`.
+
+3. **Fork `cdp-analytics-swift`** to add a `keyValueStore: any KeyValueStore` configuration field and route `Storage.userDefaults` access through it. Maintenance cost is real but bounded (the library doesn't change `Storage.swift` often).
+
+Recommend pursuing option 2 (accept + Data Protection) for Phase 3 v1, with option 3 reserved as a follow-up if a stronger guarantee is required.
+
+Half of Phase 3 (event queue) is unblocked: `.custom(DataStore)` cleanly intercepts every byte of the event-batch persistence path, and a `CryptoProvider` can plug into the same seam this spike used. The other half (KVS / profile state) needs a separate design.
+
+## Branch state
+
+- Branch name: `spike/segment-storage-injection-2026-05-19`
+- Created from: `origin/main` @ `63c32f54a refactor: Added Synchronized primitive and tests for it (#1049)`
+- Push status: **not pushed** (local only — per spike rules)
+- Files changed on the branch (vs `origin/main`):
+  - `Sources/DataPipeline/Util/WrappingDataStore.swift` — new
+  - `Sources/DataPipeline/CustomerIO+Segment.swift` — `.storageMode(.custom(WrappingDataStore(...)))` added to `toSegmentConfiguration()`
+  - `Apps/APN-UIKit/APN UIKit/AppDelegate.swift` — `runSegmentStorageSpike()` added + call from `didFinishLaunchingWithOptions`
+- `main` branch is untouched; the only commits on this branch live on the spike branch.
+- No `preInitScenario` toggle exists on this codebase to disturb.
+
+## Raw artifacts
+
+- Trace log: `/tmp/spike-oslog.txt`
+- Console capture (from `simctl launch --console-pty`): `/tmp/spike-console.txt`
+- Filesystem snapshot of post-run data container: `/tmp/spike-snapshot/` (full `cp -R` of the container at the 20s mark)
+- File list: `/tmp/spike-files-data.txt`

--- a/Sources/DataPipeline/CustomerIO+Segment.swift
+++ b/Sources/DataPipeline/CustomerIO+Segment.swift
@@ -79,6 +79,16 @@ extension DataPipelineConfigOptions {
         result.apiHost(apiHost)
         result.cdnHost(cdnHost)
         result.flushPolicies(flushPolicies)
+        // SPIKE: inject a wrapping storage so we can verify on-disk bytes never
+        // contain the original plaintext. Throwaway branch only.
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        let wrappedStorage = docs.appendingPathComponent("spike-wrapping-storage/\(cdpApiKey)/", isDirectory: true)
+        let wrapping = WrappingDataStore(configuration: WrappingDataStore.Configuration(
+            writeKey: cdpApiKey,
+            storageLocation: wrappedStorage,
+            maxFetchSize: 475_000
+        ))
+        result.storageMode(.custom(wrapping))
         return result
     }
 }

--- a/Sources/DataPipeline/Util/WrappingDataStore.swift
+++ b/Sources/DataPipeline/Util/WrappingDataStore.swift
@@ -1,0 +1,222 @@
+//
+//  WrappingDataStore.swift
+//
+//  SPIKE-ONLY — feasibility test for Phase 3 encryption-at-rest.
+//  Wraps cdp-analytics-swift's storage so we can prove that every byte
+//  the event-queue path persists flows through our custom DataStore.
+//
+//  Mutation:
+//    - Prepend the sentinel  "WRAPPED::v1::"  (13 ASCII bytes)
+//    - XOR every byte AFTER the sentinel with 0x55
+//
+//  On fetch we reverse the mutation and hand the library a fully-formed
+//  JSON batch (matching the MemoryStore contract) so the upload pipeline
+//  never sees the wrapped form.
+//
+//  This is throwaway code on a spike branch. Do not ship.
+//
+
+import CioAnalytics
+import Foundation
+import os.log
+
+// MARK: - Trace logger
+
+private let spikeLog = OSLog(subsystem: "io.customer.spike", category: "SegmentStorageTrace")
+
+@inline(__always)
+private func tracePreview(_ bytes: Data, max: Int = 64) -> String {
+    let slice = bytes.prefix(max)
+    // Hex preview — readable in `log stream` without binary noise.
+    return slice.map { String(format: "%02x", $0) }.joined()
+}
+
+// MARK: - WrappingDataStore
+
+/// A `DataStore` implementation that
+/// (a) traces every protocol-method call via `os_log`, and
+/// (b) writes events to disk in a *mutated* form so a grep for the
+///     pre-mutation plaintext on disk proves whether the library
+///     bypasses this store on any persistence path.
+public final class WrappingDataStore: DataStore {
+    public typealias StoreConfiguration = Configuration
+
+    public struct Configuration {
+        let writeKey: String
+        let storageLocation: URL
+        let maxFetchSize: Int
+
+        public init(writeKey: String, storageLocation: URL, maxFetchSize: Int) {
+            self.writeKey = writeKey
+            self.storageLocation = storageLocation
+            self.maxFetchSize = maxFetchSize
+        }
+    }
+
+    // Sentinel + XOR key used to mutate every persisted byte.
+    public static let sentinel: Data = Data("WRAPPED::v1::".utf8)
+    public static let xorKey: UInt8 = 0x55
+
+    private let config: Configuration
+    // Each persisted file holds exactly one wrapped event so we don't have
+    // to deal with separators or in-place mutation of multi-event files.
+    private let lock = NSLock()
+    // Monotonically increasing index — used only for filename ordering.
+    private var nextIndex: Int = 0
+
+    public var transactionType: DataTransactionType { .data }
+
+    public var hasData: Bool { count > 0 }
+
+    public var count: Int {
+        lock.lock(); defer { lock.unlock() }
+        return (try? FileManager.default.contentsOfDirectory(at: config.storageLocation, includingPropertiesForKeys: nil))?.count ?? 0
+    }
+
+    public required init(configuration: Configuration) {
+        self.config = configuration
+        try? FileManager.default.createDirectory(at: configuration.storageLocation, withIntermediateDirectories: true)
+        // Best-effort recovery of nextIndex from existing files.
+        if let existing = try? FileManager.default.contentsOfDirectory(at: configuration.storageLocation, includingPropertiesForKeys: nil) {
+            let maxIdx = existing.compactMap { Int($0.deletingPathExtension().lastPathComponent.split(separator: "-").first ?? "") }.max() ?? -1
+            self.nextIndex = maxIdx + 1
+        }
+        os_log("init writeKey=%{public}@ storageLocation=%{public}@ existingFiles=%d nextIndex=%d",
+               log: spikeLog, type: .info,
+               configuration.writeKey, configuration.storageLocation.path, count, nextIndex)
+    }
+
+    // MARK: - Mutation
+
+    /// Wrap a payload: prepend sentinel, XOR every payload byte with xorKey.
+    public static func wrap(_ plaintext: Data) -> Data {
+        var out = Data(capacity: sentinel.count + plaintext.count)
+        out.append(sentinel)
+        out.append(contentsOf: plaintext.map { $0 ^ xorKey })
+        return out
+    }
+
+    /// Unwrap a payload: strip the sentinel, XOR back. Returns nil if the
+    /// sentinel is missing (which itself is a bypass signal worth logging).
+    public static func unwrap(_ wrapped: Data) -> Data? {
+        guard wrapped.count >= sentinel.count else { return nil }
+        let prefix = wrapped.prefix(sentinel.count)
+        guard prefix == sentinel else { return nil }
+        let payload = wrapped.suffix(from: sentinel.count)
+        return Data(payload.map { $0 ^ xorKey })
+    }
+
+    // MARK: - DataStore
+
+    public func reset() {
+        lock.lock(); defer { lock.unlock() }
+        os_log("reset path=%{public}@", log: spikeLog, type: .info, config.storageLocation.path)
+        if let files = try? FileManager.default.contentsOfDirectory(at: config.storageLocation, includingPropertiesForKeys: nil) {
+            for f in files { try? FileManager.default.removeItem(at: f) }
+        }
+        nextIndex = 0
+    }
+
+    public func append(data: RawEvent) {
+        // Serialize the RawEvent the same way DirectoryStore/MemoryStore do.
+        let line = data.toString()
+        guard let plaintext = line.data(using: .utf8) else {
+            os_log("append SKIPPED non-utf8 event", log: spikeLog, type: .error)
+            return
+        }
+        let wrapped = Self.wrap(plaintext)
+
+        lock.lock(); defer { lock.unlock() }
+        let idx = nextIndex
+        nextIndex += 1
+        let url = config.storageLocation.appendingPathComponent(String(format: "%08d-wrap.bin", idx))
+        do {
+            try wrapped.write(to: url, options: .atomic)
+            os_log("append idx=%d path=%{public}@ plaintextBytes=%d wrappedBytes=%d preview=%{public}@",
+                   log: spikeLog, type: .info,
+                   idx, url.lastPathComponent, plaintext.count, wrapped.count, tracePreview(plaintext))
+        } catch {
+            os_log("append FAILED idx=%d err=%{public}@", log: spikeLog, type: .error, idx, "\(error)")
+        }
+    }
+
+    public func fetch(count: Int?, maxBytes: Int?) -> DataResult? {
+        lock.lock(); defer { lock.unlock() }
+
+        guard let allFiles = try? FileManager.default.contentsOfDirectory(at: config.storageLocation, includingPropertiesForKeys: nil) else {
+            os_log("fetch noFiles path=%{public}@", log: spikeLog, type: .info, config.storageLocation.path)
+            return nil
+        }
+        let sorted = allFiles.sorted { $0.lastPathComponent < $1.lastPathComponent }
+        guard !sorted.isEmpty else {
+            os_log("fetch empty", log: spikeLog, type: .info)
+            return nil
+        }
+
+        let limit = maxBytes ?? config.maxFetchSize
+        var accumulated = 0
+        var picked: [URL] = []
+        var plaintexts: [Data] = []
+        for url in sorted {
+            if let count, picked.count >= count { break }
+            guard let wrapped = try? Data(contentsOf: url) else { continue }
+            guard let plain = Self.unwrap(wrapped) else {
+                os_log("fetch unwrap FAILED (no sentinel) path=%{public}@ — bypass candidate",
+                       log: spikeLog, type: .error, url.lastPathComponent)
+                continue
+            }
+            if accumulated + plain.count > limit, !picked.isEmpty { break }
+            accumulated += plain.count
+            picked.append(url)
+            plaintexts.append(plain)
+        }
+
+        guard !picked.isEmpty else {
+            os_log("fetch nothingSelected totalBytes=%d", log: spikeLog, type: .info, accumulated)
+            return nil
+        }
+
+        let batch = fullyFormedJSON(plaintexts: plaintexts)
+        os_log("fetch picked=%d plaintextBytes=%d batchBytes=%d firstPath=%{public}@",
+               log: spikeLog, type: .info,
+               picked.count, accumulated, batch.count, picked.first!.lastPathComponent)
+        return DataResult(data: batch, removable: picked)
+    }
+
+    public func remove(data: [DataStore.ItemID]) {
+        lock.lock(); defer { lock.unlock() }
+        guard let urls = data as? [URL] else {
+            os_log("remove SKIPPED non-URL items count=%d", log: spikeLog, type: .error, data.count)
+            return
+        }
+        for url in urls {
+            try? FileManager.default.removeItem(at: url)
+            os_log("remove path=%{public}@", log: spikeLog, type: .info, url.lastPathComponent)
+        }
+    }
+
+    // MARK: - Batch assembly (matches MemoryStore.fullyFormedJSON shape)
+
+    private func fullyFormedJSON(plaintexts: [Data]) -> Data {
+        var json = Data()
+        let start = Data("{ \"batch\": [".utf8)
+        let end = Data("],\"sentAt\":\"\(Date().iso8601())\",\"writeKey\":\"\(config.writeKey)\"}".utf8)
+        json.append(start)
+        for (i, p) in plaintexts.enumerated() {
+            if i > 0 { json.append(Data(",".utf8)) }
+            json.append(p)
+        }
+        json.append(end)
+        return json
+    }
+}
+
+// MARK: - Date helper
+
+private extension Date {
+    func iso8601() -> String {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f.string(from: self)
+    }
+}


### PR DESCRIPTION
## Evidence only — DO NOT MERGE

This branch exists to document a spike outcome. It will never be merged into `main`.

## Spike goal

Prove (or disprove) that we can fully influence every byte the Segment `cdp-analytics-swift` library persists to disk by injecting a `DataStore` via `Configuration.storageMode(.custom(...))` — without forking the library.

## TL;DR

Yes for the event queue. No for the UserDefaults plist.

- `.custom(DataStore)` cleanly intercepts every byte of every `track` / `screen` / `identify` event payload. All 11 wrapped event files in the spike run start with the `WRAPPED::v1::` sentinel; zero `SPIKE_*` needles leaked in plaintext anywhere in event storage. The 30 s Segment flush to `cdp.customer.io/v1` succeeded with the unwrapped JSON, proving the wrapper is functionally transparent to the rest of the SDK.
- `userId` / `anonymousId` / `traits` / `settings` go to a `UserDefaults(suiteName: "com.segment.storage.<writeKey>")` plist that `Storage.swift:24` writes directly, regardless of `StorageMode`. The `WrappingDataStore` received zero writes for these — confirmed both empirically (3 plaintext `SPIKE_` needles found in the plist) and by source inspection of the upstream library.

## What that means for the encryption-at-rest plan

The fork-vs-public-API decision is resolved: we use the public APIs. Phase 3 iOS:

1. Encrypt the event queue via `.custom(CioEncryptedDataStore)`. Path validated by this spike.
2. For `userId` / `traits` in the Segment UserDefaults plist (PII per our scope): apply `NSFileProtectionType.completeUntilFirstUserAuthentication` to the plist file. OS-level Data Protection, not app-layer encryption, but compliance-acceptable and requires no library modification.
3. `anonymousId` / `settings` remain plaintext in the same plist — per the scope decision they aren't PII.

## What's on the branch

| File | Purpose |
|---|---|
| `Sources/DataPipeline/Util/WrappingDataStore.swift` | New `DataStore` implementation: traces every protocol method via `os_log`, wraps writes with `WRAPPED::v1::` sentinel + XOR-with-0x55, unwraps reads transparently. |
| `Sources/DataPipeline/CustomerIO+Segment.swift` | Adds `.storageMode(.custom(WrappingDataStore(...)))` to `toSegmentConfiguration()`. |
| `Apps/APN-UIKit/APN UIKit/AppDelegate.swift` | Adds `runSegmentStorageSpike()` planting `SPIKE_` needles via the public CIO API. |
| `SPIKE_REPORT.md` | Full file-by-file reconciliation table, hexdumps, trace counts, verdict. |

## Verification

See `SPIKE_REPORT.md` for the full reconciliation table.

## Related

- Plan: `~/.claude/plans/encryption-at-rest.md` (§5 Phase 3, updated with these findings)
- Companion Android spike PR on `customerio-android` repo