### PR TITLE
chore: Send geofence transition events

### DIFF
--- a/Sources/Common/Communication/Event.swift
+++ b/Sources/Common/Communication/Event.swift
@@ -48,6 +48,7 @@ public enum EventTypesRegistry {
             ResetEvent.self,
             TrackMetricEvent.self,
             TrackInAppMetricEvent.self,
+            TrackGeofenceMetricEvent.self,
             RegisterDeviceTokenEvent.self,
             DeleteDeviceTokenEvent.self,
             NewSubscriptionEvent.self
@@ -151,6 +152,22 @@ public struct TrackInAppMetricEvent: EventRepresentable {
         self.params = params
         self.deliveryID = deliveryID
         self.event = event
+        self.timestamp = timestamp
+    }
+}
+
+public struct TrackGeofenceMetricEvent: EventRepresentable {
+    public let storageId: String
+    public let params: [String: String]
+    public let geofenceId: String
+    public let transition: GeofenceTransition
+    public let timestamp: Date
+
+    public init(storageId: String = UUID().uuidString, geofenceId: String, transition: GeofenceTransition, timestamp: Date = Date(), params: [String: String] = [:]) {
+        self.storageId = storageId
+        self.params = params
+        self.geofenceId = geofenceId
+        self.transition = transition
         self.timestamp = timestamp
     }
 }

--- a/Sources/Common/Type/GeofenceTransition.swift
+++ b/Sources/Common/Type/GeofenceTransition.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Transition type for geofence boundary crossings.
+///
+/// Lives in Common (not Location) so cross-module consumers — `TrackGeofenceMetricEvent`
+/// in the EventBus path, `PendingGeofenceMetric` in the queue path — can carry the type
+/// directly instead of round-tripping through a `String`. Raw values are the wire format
+/// (`"enter"` / `"exit"`) and match the Android SDK.
+public enum GeofenceTransition: String, Codable, Sendable {
+    case enter
+    case exit
+}
+
+public extension GeofenceTransition {
+    /// Analytics event name for this transition. Matches the Android SDK's
+    /// `"GeoFence Entered"` / `"GeoFence Exited"` (capital F mid-word).
+    var trackEventName: String {
+        switch self {
+        case .enter: return "GeoFence Entered"
+        case .exit: return "GeoFence Exited"
+        }
+    }
+}

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -93,6 +93,10 @@ class DataPipelineImplementation: DataPipelineInstance, DataPipelineTracking {
             self.trackInAppMetric(deliveryID: metric.deliveryID, event: metric.event, metaData: metric.params)
         }
 
+        eventBusHandler.addObserver(TrackGeofenceMetricEvent.self) { metric in
+            self.track(name: metric.transition.trackEventName, properties: ["geofence_id": metric.geofenceId])
+        }
+
         eventBusHandler.addObserver(RegisterDeviceTokenEvent.self) { event in
             self.registerDeviceToken(event.token)
         }

--- a/Sources/Location/Geofence/Event/GeofenceEventTracker.swift
+++ b/Sources/Location/Geofence/Event/GeofenceEventTracker.swift
@@ -1,0 +1,52 @@
+import CioInternalCommon
+import Foundation
+
+/// Sends geofence transition events to the data pipeline with cooldown-based deduplication.
+///
+/// Events are keyed by "geofenceId:transitionType" and suppressed if the same event
+/// was emitted within the cooldown interval. Cooldowns are persisted to survive app restarts
+/// via the `GeofenceStorage` actor.
+///
+/// Communicates with DataPipeline via `EventBusHandler` (matching the in-app and push
+/// metric pattern) so the geofence module has no direct dependency on the DataPipeline module.
+final class GeofenceEventTracker {
+    private let storage: GeofenceStorage
+    private let eventBusHandler: EventBusHandler
+    private let dateUtil: DateUtil
+    private let logger: Logger
+    private let cooldownInterval: TimeInterval
+
+    init(
+        storage: GeofenceStorage,
+        eventBusHandler: EventBusHandler,
+        dateUtil: DateUtil,
+        logger: Logger,
+        cooldownInterval: TimeInterval = GeofenceConstants.eventCooldownInterval
+    ) {
+        self.storage = storage
+        self.eventBusHandler = eventBusHandler
+        self.dateUtil = dateUtil
+        self.logger = logger
+        self.cooldownInterval = cooldownInterval
+    }
+
+    /// Tracks a geofence transition event, suppressing duplicates within the cooldown window.
+    /// Also purges expired cooldown entries opportunistically.
+    func trackTransition(geofenceId: String, transition: GeofenceTransition) async {
+        let cooldownKey = "\(geofenceId):\(transition.rawValue)"
+        let now = dateUtil.now
+
+        guard await storage.tryAcquireCooldown(key: cooldownKey, now: now, interval: cooldownInterval) else {
+            logger.geofenceEventSuppressed(geofenceId: geofenceId, transition: transition)
+            return
+        }
+
+        eventBusHandler.postEvent(TrackGeofenceMetricEvent(
+            geofenceId: geofenceId,
+            transition: transition
+        ))
+        logger.geofenceEventTracked(geofenceId: geofenceId, transition: transition)
+
+        await storage.purgeExpiredCooldowns(now: now, interval: cooldownInterval)
+    }
+}

--- a/Sources/Location/Geofence/Logger+Geofence.swift
+++ b/Sources/Location/Geofence/Logger+Geofence.swift
@@ -28,4 +28,20 @@ extension Logger {
             nil
         )
     }
+
+    // MARK: - Event Tracking
+
+    func geofenceEventTracked(geofenceId: String, transition: GeofenceTransition) {
+        debug(
+            "Tracked \(transition.rawValue) event for geofence \(geofenceId)",
+            geofenceTag
+        )
+    }
+
+    func geofenceEventSuppressed(geofenceId: String, transition: GeofenceTransition) {
+        debug(
+            "Suppressed duplicate \(transition.rawValue) event for geofence \(geofenceId), within cooldown",
+            geofenceTag
+        )
+    }
 }

--- a/Sources/Location/Geofence/Monitor/GeofenceRegionMonitoring.swift
+++ b/Sources/Location/Geofence/Monitor/GeofenceRegionMonitoring.swift
@@ -2,12 +2,6 @@ import CioInternalCommon
 import CoreLocation
 import Foundation
 
-/// Transition type for geofence boundary crossings.
-enum GeofenceTransition: String, Codable, Sendable {
-    case enter
-    case exit
-}
-
 /// Callback when a geofence transition occurs.
 /// Parameters: region identifier, transition type, user's current location (from CLLocationManager.location, may be nil).
 ///

--- a/Sources/Location/Geofence/Storage/GeofenceStorage.swift
+++ b/Sources/Location/Geofence/Storage/GeofenceStorage.swift
@@ -45,13 +45,32 @@ actor GeofenceStorage {
         saveToDisk(state)
     }
 
-    func purgeExpiredCooldowns(keys: Set<String>) {
-        guard !keys.isEmpty else { return }
+    /// Atomically checks whether the cooldown window for `key` has expired and, if so,
+    /// records the new timestamp. Returns `true` when the caller may proceed (no active
+    /// cooldown), `false` when the event should be suppressed. The whole check-and-record
+    /// runs inside the actor with no `await` between steps, so concurrent callers cannot
+    /// both observe an expired window and both fire the event.
+    func tryAcquireCooldown(key: String, now: Date, interval: TimeInterval) -> Bool {
         var state = loadFromDisk() ?? GeofenceState()
         var cooldowns = state.eventCooldowns ?? [:]
-        for key in keys {
-            cooldowns.removeValue(forKey: key)
+        if let last = cooldowns[key], now.timeIntervalSince(last) < interval {
+            return false
         }
+        cooldowns[key] = now
+        state.eventCooldowns = cooldowns
+        saveToDisk(state)
+        return true
+    }
+
+    /// Atomically removes cooldown entries whose recorded timestamp is older than `interval`
+    /// before `now`. Filtering happens inside the actor so a concurrent `tryAcquireCooldown`
+    /// cannot have its fresh write deleted by a stale snapshot.
+    func purgeExpiredCooldowns(now: Date, interval: TimeInterval) {
+        var state = loadFromDisk() ?? GeofenceState()
+        guard var cooldowns = state.eventCooldowns, !cooldowns.isEmpty else { return }
+        let beforeCount = cooldowns.count
+        cooldowns = cooldowns.filter { now.timeIntervalSince($0.value) < interval }
+        if cooldowns.count == beforeCount { return }
         state.eventCooldowns = cooldowns
         saveToDisk(state)
     }

--- a/Tests/DataPipeline/DataPipelineEventBustTests.swift
+++ b/Tests/DataPipeline/DataPipelineEventBustTests.swift
@@ -58,6 +58,45 @@ class DataPipelineEventBustTests: IntegrationTest {
         )
     }
 
+    func testSubscribeToJourneyEvents_DataPipelineHandlesTrackGeofenceMetricEvent_enter() async {
+        let givenGeofenceId = String.random
+
+        await eventBusHandler.postEventAndWait(
+            TrackGeofenceMetricEvent(geofenceId: givenGeofenceId, transition: .enter)
+        )
+
+        guard let trackEvent = outputReader.lastEvent as? TrackEvent else {
+            XCTFail("recorded event is not an instance of TrackEvent")
+            return
+        }
+
+        XCTAssertEqual(trackEvent.type, "track")
+        XCTAssertEqual(trackEvent.event, "GeoFence Entered")
+        XCTAssertMatches(
+            trackEvent.properties,
+            ["geofence_id": givenGeofenceId]
+        )
+    }
+
+    func testSubscribeToJourneyEvents_DataPipelineHandlesTrackGeofenceMetricEvent_exit() async {
+        let givenGeofenceId = String.random
+
+        await eventBusHandler.postEventAndWait(
+            TrackGeofenceMetricEvent(geofenceId: givenGeofenceId, transition: .exit)
+        )
+
+        guard let trackEvent = outputReader.lastEvent as? TrackEvent else {
+            XCTFail("recorded event is not an instance of TrackEvent")
+            return
+        }
+
+        XCTAssertEqual(trackEvent.event, "GeoFence Exited")
+        XCTAssertMatches(
+            trackEvent.properties,
+            ["geofence_id": givenGeofenceId]
+        )
+    }
+
     func testSubscribeToJourneyEvents_DataPipelineHandlesRegisterDeviceEvent() async {
         let givenToken = String.random
 

--- a/Tests/Location/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/Location/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -1,0 +1,176 @@
+@testable import CioInternalCommon
+@testable import CioLocation
+import Foundation
+import SharedTests
+import Testing
+
+@Suite("GeofenceEventTracker")
+struct GeofenceEventTrackerTests {
+    private let cooldownInterval: TimeInterval = 3600
+
+    private func makeTempDirectory() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    }
+
+    private func makeStorage(directory: URL) -> GeofenceStorage {
+        GeofenceStorage(fileManager: .default, directoryURL: directory)
+    }
+
+    private func makeTracker(
+        storage: GeofenceStorage,
+        eventBus: EventBusHandlerMock,
+        dateUtil: DateUtil = DateUtilStub()
+    ) -> GeofenceEventTracker {
+        GeofenceEventTracker(
+            storage: storage,
+            eventBusHandler: eventBus,
+            dateUtil: dateUtil,
+            logger: LoggerMock(),
+            cooldownInterval: cooldownInterval
+        )
+    }
+
+    private func postedGeofenceEvents(from bus: EventBusHandlerMock) -> [TrackGeofenceMetricEvent] {
+        bus.postEventReceivedInvocations.compactMap { $0 as? TrackGeofenceMetricEvent }
+    }
+
+    @Test
+    func trackTransition_givenEnter_expectMetricEventPosted() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let bus = EventBusHandlerMock()
+        let tracker = makeTracker(storage: storage, eventBus: bus)
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+
+        let events = postedGeofenceEvents(from: bus)
+        #expect(events.count == 1)
+        #expect(events.first?.geofenceId == "geo_1")
+        #expect(events.first?.transition == .enter)
+    }
+
+    @Test
+    func trackTransition_givenExit_expectMetricEventPosted() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let bus = EventBusHandlerMock()
+        let tracker = makeTracker(storage: storage, eventBus: bus)
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .exit)
+
+        let events = postedGeofenceEvents(from: bus)
+        #expect(events.count == 1)
+        #expect(events.first?.transition == .exit)
+    }
+
+    @Test
+    func trackTransition_givenSameEventWithinCooldown_expectSuppressed() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let dateUtil = DateUtilStub()
+        let baseTime = Date(timeIntervalSince1970: 1700000000)
+        dateUtil.givenNow = baseTime
+        let bus = EventBusHandlerMock()
+        let tracker = makeTracker(storage: storage, eventBus: bus, dateUtil: dateUtil)
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+        #expect(postedGeofenceEvents(from: bus).count == 1)
+
+        dateUtil.givenNow = baseTime.addingTimeInterval(1800)
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+        #expect(postedGeofenceEvents(from: bus).count == 1)
+    }
+
+    @Test
+    func trackTransition_givenSameEventAfterCooldown_expectTracked() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let dateUtil = DateUtilStub()
+        let baseTime = Date(timeIntervalSince1970: 1700000000)
+        dateUtil.givenNow = baseTime
+        let bus = EventBusHandlerMock()
+        let tracker = makeTracker(storage: storage, eventBus: bus, dateUtil: dateUtil)
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+        #expect(postedGeofenceEvents(from: bus).count == 1)
+
+        dateUtil.givenNow = baseTime.addingTimeInterval(cooldownInterval)
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+        #expect(postedGeofenceEvents(from: bus).count == 2)
+    }
+
+    @Test
+    func trackTransition_givenDifferentTransitionTypes_expectBothTracked() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let bus = EventBusHandlerMock()
+        let tracker = makeTracker(storage: storage, eventBus: bus)
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .exit)
+
+        #expect(postedGeofenceEvents(from: bus).count == 2)
+    }
+
+    @Test
+    func trackTransition_givenDifferentGeofences_expectBothTracked() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let bus = EventBusHandlerMock()
+        let tracker = makeTracker(storage: storage, eventBus: bus)
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+        await tracker.trackTransition(geofenceId: "geo_2", transition: .enter)
+
+        #expect(postedGeofenceEvents(from: bus).count == 2)
+    }
+
+    @Test
+    func trackTransition_givenExpiredCooldowns_expectPurged() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let dateUtil = DateUtilStub()
+        let baseTime = Date(timeIntervalSince1970: 1700000000)
+        dateUtil.givenNow = baseTime
+        let bus = EventBusHandlerMock()
+        let tracker = makeTracker(storage: storage, eventBus: bus, dateUtil: dateUtil)
+
+        await tracker.trackTransition(geofenceId: "geo_old", transition: .enter)
+        #expect(await storage.getEventCooldowns().count == 1)
+
+        dateUtil.givenNow = baseTime.addingTimeInterval(cooldownInterval + 1)
+        await tracker.trackTransition(geofenceId: "geo_new", transition: .enter)
+
+        let cooldowns = await storage.getEventCooldowns()
+        #expect(cooldowns["geo_old:enter"] == nil)
+        #expect(cooldowns["geo_new:enter"] != nil)
+    }
+
+    @Test
+    func trackTransition_givenCooldownPersisted_expectSurvivedNewTrackerInstance() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let sharedStorage = makeStorage(directory: dir)
+        let dateUtil = DateUtilStub()
+        let baseTime = Date(timeIntervalSince1970: 1700000000)
+        dateUtil.givenNow = baseTime
+
+        let bus1 = EventBusHandlerMock()
+        let tracker1 = makeTracker(storage: sharedStorage, eventBus: bus1, dateUtil: dateUtil)
+        await tracker1.trackTransition(geofenceId: "geo_1", transition: .enter)
+        #expect(postedGeofenceEvents(from: bus1).count == 1)
+
+        dateUtil.givenNow = baseTime.addingTimeInterval(1800)
+        let bus2 = EventBusHandlerMock()
+        let tracker2 = makeTracker(storage: sharedStorage, eventBus: bus2, dateUtil: dateUtil)
+        await tracker2.trackTransition(geofenceId: "geo_1", transition: .enter)
+        #expect(postedGeofenceEvents(from: bus2).isEmpty)
+    }
+}

--- a/Tests/Location/Geofence/Storage/GeofenceStorageTests.swift
+++ b/Tests/Location/Geofence/Storage/GeofenceStorageTests.swift
@@ -52,30 +52,97 @@ struct GeofenceStorageTests {
     }
 
     @Test
-    func purgeExpiredCooldowns_givenExpiredKeys_expectRemoved() async {
+    func purgeExpiredCooldowns_givenSomeExpired_expectOnlyExpiredRemoved() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let storage = makeStorage(directory: dir)
-        let t1 = Date(timeIntervalSince1970: 1700000000)
-        let t2 = Date(timeIntervalSince1970: 1700001000)
-        await storage.recordEventCooldown(key: "geo_1:enter", timestamp: t1)
-        await storage.recordEventCooldown(key: "geo_2:enter", timestamp: t2)
-        await storage.purgeExpiredCooldowns(keys: ["geo_1:enter"])
+        let interval: TimeInterval = 3600
+        let now = Date(timeIntervalSince1970: 1700000000)
+        let staleTimestamp = now.addingTimeInterval(-interval - 1)
+        let freshTimestamp = now.addingTimeInterval(-1)
+        await storage.recordEventCooldown(key: "geo_stale:enter", timestamp: staleTimestamp)
+        await storage.recordEventCooldown(key: "geo_fresh:enter", timestamp: freshTimestamp)
+
+        await storage.purgeExpiredCooldowns(now: now, interval: interval)
+
         let cooldowns = await storage.getEventCooldowns()
-        #expect(cooldowns.count == 1)
-        #expect(cooldowns["geo_1:enter"] == nil)
-        #expect(cooldowns["geo_2:enter"] == t2)
+        #expect(cooldowns["geo_stale:enter"] == nil)
+        #expect(cooldowns["geo_fresh:enter"] == freshTimestamp)
     }
 
     @Test
-    func purgeExpiredCooldowns_givenEmptyKeys_expectNoChange() async {
+    func purgeExpiredCooldowns_givenNoneExpired_expectAllRetained() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let storage = makeStorage(directory: dir)
-        await storage.recordEventCooldown(key: "geo_1:enter", timestamp: Date())
-        await storage.purgeExpiredCooldowns(keys: [])
+        let now = Date(timeIntervalSince1970: 1700000000)
+        await storage.recordEventCooldown(key: "geo_1:enter", timestamp: now)
+
+        await storage.purgeExpiredCooldowns(now: now, interval: 3600)
+
         let cooldowns = await storage.getEventCooldowns()
-        #expect(cooldowns.count == 1)
+        #expect(cooldowns["geo_1:enter"] == now)
+    }
+
+    // MARK: - Atomic cooldown acquisition
+
+    @Test
+    func tryAcquireCooldown_givenNoExistingEntry_expectAcquiredAndRecorded() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let now = Date(timeIntervalSince1970: 1700000000)
+
+        let acquired = await storage.tryAcquireCooldown(key: "geo_1:enter", now: now, interval: 3600)
+
+        #expect(acquired == true)
+        let cooldowns = await storage.getEventCooldowns()
+        #expect(cooldowns["geo_1:enter"] == now)
+    }
+
+    @Test
+    func tryAcquireCooldown_givenEntryWithinInterval_expectNotAcquiredAndTimestampUnchanged() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let firstAttempt = Date(timeIntervalSince1970: 1700000000)
+        let secondAttempt = firstAttempt.addingTimeInterval(1800)
+
+        _ = await storage.tryAcquireCooldown(key: "geo_1:enter", now: firstAttempt, interval: 3600)
+        let acquired = await storage.tryAcquireCooldown(key: "geo_1:enter", now: secondAttempt, interval: 3600)
+
+        #expect(acquired == false)
+        let cooldowns = await storage.getEventCooldowns()
+        #expect(cooldowns["geo_1:enter"] == firstAttempt)
+    }
+
+    @Test
+    func tryAcquireCooldown_givenEntryAtIntervalBoundary_expectAcquiredAndTimestampReplaced() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let firstAttempt = Date(timeIntervalSince1970: 1700000000)
+        let secondAttempt = firstAttempt.addingTimeInterval(3600)
+
+        _ = await storage.tryAcquireCooldown(key: "geo_1:enter", now: firstAttempt, interval: 3600)
+        let acquired = await storage.tryAcquireCooldown(key: "geo_1:enter", now: secondAttempt, interval: 3600)
+
+        #expect(acquired == true)
+        let cooldowns = await storage.getEventCooldowns()
+        #expect(cooldowns["geo_1:enter"] == secondAttempt)
+    }
+
+    @Test
+    func tryAcquireCooldown_givenDifferentKey_expectIndependentAcquisition() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let now = Date(timeIntervalSince1970: 1700000000)
+
+        _ = await storage.tryAcquireCooldown(key: "geo_1:enter", now: now, interval: 3600)
+        let acquired = await storage.tryAcquireCooldown(key: "geo_2:enter", now: now, interval: 3600)
+
+        #expect(acquired == true)
     }
 
     @Test
@@ -137,7 +204,7 @@ struct GeofenceStorageTests {
                         case 1:
                             _ = await storage.getEventCooldowns()
                         case 2:
-                            await storage.purgeExpiredCooldowns(keys: ["geo_\(i):enter"])
+                            await storage.purgeExpiredCooldowns(now: Date(), interval: 3600)
                         default:
                             break
                         }

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -258,6 +258,8 @@ public interface CioInternalCommon.FileStorage {
 }
 public enum CioInternalCommon.FileType {
 }
+public enum CioInternalCommon.GeofenceTransition {
+}
 public interface CioInternalCommon.GlobalDataStore {
 	public var pushDeviceToken: String?;
 	public fun func deleteAll();
@@ -542,6 +544,14 @@ public final class CioInternalCommon.TrackEventQueueTaskData {
 	public final val identifier: String;
 	public final val attributesJsonString: String;
 	public fun init(identifier: String, attributesJsonString: String);
+}
+public final class CioInternalCommon.TrackGeofenceMetricEvent {
+	public final val storageId: String;
+	public final val params: List<String : String>;
+	public final val geofenceId: String;
+	public final val transition: GeofenceTransition;
+	public final val timestamp: Date;
+	public fun init(storageId: String = UUID().uuidString, geofenceId: String, transition: GeofenceTransition, timestamp: Date = Date(), params: List<String: String> = List<:>);
 }
 public final class CioInternalCommon.TrackInAppMetricEvent {
 	public final val storageId: String;


### PR DESCRIPTION
Ticket: [MBL-1628](https://linear.app/customerio/issue/MBL-1628/ios-send-geofence-transition-events)

## Summary
Send geofence enter/exit events to the data pipeline with persisted, race-free deduplication. Cooldowns survive app restarts so a transition that fired moments before a relaunch is not re-emitted. Event names match Android: `"GeoFence Entered"` / `"GeoFence Exited"`.

## Design rationale

**Communication via EventBus, not direct `DataPipelineTracking`.** Matches how `MessagingPush` and `MessagingInApp` track their metrics (`TrackMetricEvent`, `TrackInAppMetricEvent`). The geofence module has zero dependency on the DataPipeline module — DataPipeline subscribes to `TrackGeofenceMetricEvent` and translates it to a `track(...)` call. This avoids the `DIGraphShared.getOptional(DataPipelineTracking.self)` pattern that bakes a fragile optional dependency into the call site, and aligns with the inter-module communication architecture documented in CLAUDE.md. (`LocationSyncCoordinator` is still on the direct pattern; out of scope for this PR — separate follow-up.)

**Atomic cooldown acquisition.** Added `GeofenceStorage.tryAcquireCooldown(key:now:interval:)` that does check + record inside the actor with no `await` between steps. Closes a read-modify-write race where two concurrent `trackTransition` calls for the same key could both observe an expired window and both fire the event. Mirrors Android's `@Synchronized` invariant on `GeofenceCooldownFilter`.

**Pipeline-unavailable branch removed.** With EventBus, `eventBusHandler.postEvent(...)` is always callable — no nil case to guard, no `geofenceDataPipelineUnavailable` log path, no "would consuming the cooldown be wrong if pipeline is unavailable" reasoning. Simpler.

**Server-config-readiness.** `cooldownInterval` is constructor-injectable (default `GeofenceConstants.eventCooldownInterval`). When MBL-1624 lands and we have `GeofenceConfig.duplicateEventsExpiry` from the server, the coordinator will plumb that value through. Lesson applied from the Android port — the cooldown filter there was using a hardcoded constant and silently ignored the server-configured value.

## Scope
- `Sources/Common/Communication/Event.swift` — new `TrackGeofenceMetricEvent` + registration
- `Sources/DataPipeline/DataPipelineImplementation.swift` — subscriber that maps the event to `track(name:properties:)`
- `Sources/Location/Geofence/Event/GeofenceEventTracker.swift` — new tracker
- `Sources/Location/Geofence/Storage/GeofenceStorage.swift` — new `tryAcquireCooldown`
- `Sources/Location/Geofence/Logger+Geofence.swift` — two new log methods
- Tests for tracker (EventBus-verified) and the new storage op

## Not wired yet
The monitor → tracker subscription belongs to the coordinator in **MBL-1630a**, where the storage + tracker + monitor + coordinator are constructed together in `LocationModuleState`. This PR introduces the tracker as a tested unit so the coordinator PR is just wiring.

## Diff size
- Source: 113 lines across 5 files (well under the 250-line cap)
- Tests: 237 lines

## Test plan
- [x] Builds clean (whole package + Location scheme)
- [x] All 72 Location tests pass (8 new tracker tests + 4 new storage tests for `tryAcquireCooldown`)
- [x] All 50 Common tests pass (with the new event type registered)
- [x] DataPipeline tests pass (with the new subscriber added)
- [x] Zero warnings under `-strict-concurrency=complete` on geofence files
- [x] `make format && make lint` — 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new analytics event emission and modifies geofence cooldown persistence/cleanup logic, which could affect metric volume and local state behavior.
> 
> **Overview**
> **Adds geofence transition analytics.** Introduces `TrackGeofenceMetricEvent` and shared `GeofenceTransition` (`enter`/`exit`) in Common, and wires DataPipeline to translate these events into `track(...)` calls using Android-matching names (`"GeoFence Entered"` / `"GeoFence Exited"`).
> 
> **Adds cooldown-based, persisted deduplication for geofence events.** Implements `GeofenceEventTracker` to post transition metrics through the `EventBusHandler` while suppressing duplicates using `GeofenceStorage.tryAcquireCooldown(...)` and a new time-based `purgeExpiredCooldowns(now:interval:)`.
> 
> **Tests updated/added.** Expands DataPipeline event-bus tests for geofence events and adds new unit coverage for the tracker and atomic cooldown acquisition/purging behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 666337a1541b274453077ba2f9cfa263e0bc70a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->