### PR TITLE
chore: add pending geofence metric file-backed queue

### DIFF
--- a/Sources/Common/Communication/Event.swift
+++ b/Sources/Common/Communication/Event.swift
@@ -48,6 +48,7 @@ public enum EventTypesRegistry {
             ResetEvent.self,
             TrackMetricEvent.self,
             TrackInAppMetricEvent.self,
+            TrackGeofenceMetricEvent.self,
             RegisterDeviceTokenEvent.self,
             DeleteDeviceTokenEvent.self,
             NewSubscriptionEvent.self
@@ -151,6 +152,22 @@ public struct TrackInAppMetricEvent: EventRepresentable {
         self.params = params
         self.deliveryID = deliveryID
         self.event = event
+        self.timestamp = timestamp
+    }
+}
+
+public struct TrackGeofenceMetricEvent: EventRepresentable {
+    public let storageId: String
+    public let params: [String: String]
+    public let geofenceId: String
+    public let transition: GeofenceTransition
+    public let timestamp: Date
+
+    public init(storageId: String = UUID().uuidString, geofenceId: String, transition: GeofenceTransition, timestamp: Date = Date(), params: [String: String] = [:]) {
+        self.storageId = storageId
+        self.params = params
+        self.geofenceId = geofenceId
+        self.transition = transition
         self.timestamp = timestamp
     }
 }

--- a/Sources/Common/Type/GeofenceTransition.swift
+++ b/Sources/Common/Type/GeofenceTransition.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Transition type for geofence boundary crossings.
+///
+/// Lives in Common (not Location) so cross-module consumers — `TrackGeofenceMetricEvent`
+/// in the EventBus path, `PendingGeofenceMetric` in the queue path — can carry the type
+/// directly instead of round-tripping through a `String`. Raw values are the wire format
+/// (`"enter"` / `"exit"`) and match the Android SDK.
+public enum GeofenceTransition: String, Codable, Sendable {
+    case enter
+    case exit
+}
+
+public extension GeofenceTransition {
+    /// Analytics event name for this transition. Matches the Android SDK's
+    /// `"GeoFence Entered"` / `"GeoFence Exited"` (capital F mid-word).
+    var trackEventName: String {
+        switch self {
+        case .enter: return "GeoFence Entered"
+        case .exit: return "GeoFence Exited"
+        }
+    }
+}

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -93,6 +93,10 @@ class DataPipelineImplementation: DataPipelineInstance, DataPipelineTracking {
             self.trackInAppMetric(deliveryID: metric.deliveryID, event: metric.event, metaData: metric.params)
         }
 
+        eventBusHandler.addObserver(TrackGeofenceMetricEvent.self) { metric in
+            self.track(name: metric.transition.trackEventName, properties: ["geofence_id": metric.geofenceId])
+        }
+
         eventBusHandler.addObserver(RegisterDeviceTokenEvent.self) { event in
             self.registerDeviceToken(event.token)
         }

--- a/Sources/Location/Geofence/Event/GeofenceEventTracker.swift
+++ b/Sources/Location/Geofence/Event/GeofenceEventTracker.swift
@@ -1,0 +1,52 @@
+import CioInternalCommon
+import Foundation
+
+/// Sends geofence transition events to the data pipeline with cooldown-based deduplication.
+///
+/// Events are keyed by "geofenceId:transitionType" and suppressed if the same event
+/// was emitted within the cooldown interval. Cooldowns are persisted to survive app restarts
+/// via the `GeofenceStorage` actor.
+///
+/// Communicates with DataPipeline via `EventBusHandler` (matching the in-app and push
+/// metric pattern) so the geofence module has no direct dependency on the DataPipeline module.
+final class GeofenceEventTracker {
+    private let storage: GeofenceStorage
+    private let eventBusHandler: EventBusHandler
+    private let dateUtil: DateUtil
+    private let logger: Logger
+    private let cooldownInterval: TimeInterval
+
+    init(
+        storage: GeofenceStorage,
+        eventBusHandler: EventBusHandler,
+        dateUtil: DateUtil,
+        logger: Logger,
+        cooldownInterval: TimeInterval = GeofenceConstants.eventCooldownInterval
+    ) {
+        self.storage = storage
+        self.eventBusHandler = eventBusHandler
+        self.dateUtil = dateUtil
+        self.logger = logger
+        self.cooldownInterval = cooldownInterval
+    }
+
+    /// Tracks a geofence transition event, suppressing duplicates within the cooldown window.
+    /// Also purges expired cooldown entries opportunistically.
+    func trackTransition(geofenceId: String, transition: GeofenceTransition) async {
+        let cooldownKey = "\(geofenceId):\(transition.rawValue)"
+        let now = dateUtil.now
+
+        guard await storage.tryAcquireCooldown(key: cooldownKey, now: now, interval: cooldownInterval) else {
+            logger.geofenceEventSuppressed(geofenceId: geofenceId, transition: transition)
+            return
+        }
+
+        eventBusHandler.postEvent(TrackGeofenceMetricEvent(
+            geofenceId: geofenceId,
+            transition: transition
+        ))
+        logger.geofenceEventTracked(geofenceId: geofenceId, transition: transition)
+
+        await storage.purgeExpiredCooldowns(now: now, interval: cooldownInterval)
+    }
+}

--- a/Sources/Location/Geofence/Logger+Geofence.swift
+++ b/Sources/Location/Geofence/Logger+Geofence.swift
@@ -28,4 +28,20 @@ extension Logger {
             nil
         )
     }
+
+    // MARK: - Event Tracking
+
+    func geofenceEventTracked(geofenceId: String, transition: GeofenceTransition) {
+        debug(
+            "Tracked \(transition.rawValue) event for geofence \(geofenceId)",
+            geofenceTag
+        )
+    }
+
+    func geofenceEventSuppressed(geofenceId: String, transition: GeofenceTransition) {
+        debug(
+            "Suppressed duplicate \(transition.rawValue) event for geofence \(geofenceId), within cooldown",
+            geofenceTag
+        )
+    }
 }

--- a/Sources/Location/Geofence/Monitor/GeofenceRegionMonitoring.swift
+++ b/Sources/Location/Geofence/Monitor/GeofenceRegionMonitoring.swift
@@ -2,12 +2,6 @@ import CioInternalCommon
 import CoreLocation
 import Foundation
 
-/// Transition type for geofence boundary crossings.
-enum GeofenceTransition: String, Codable, Sendable {
-    case enter
-    case exit
-}
-
 /// Callback when a geofence transition occurs.
 /// Parameters: region identifier, transition type, user's current location (from CLLocationManager.location, may be nil).
 ///

--- a/Sources/Location/Geofence/Storage/GeofenceStorage.swift
+++ b/Sources/Location/Geofence/Storage/GeofenceStorage.swift
@@ -45,13 +45,32 @@ actor GeofenceStorage {
         saveToDisk(state)
     }
 
-    func purgeExpiredCooldowns(keys: Set<String>) {
-        guard !keys.isEmpty else { return }
+    /// Atomically checks whether the cooldown window for `key` has expired and, if so,
+    /// records the new timestamp. Returns `true` when the caller may proceed (no active
+    /// cooldown), `false` when the event should be suppressed. The whole check-and-record
+    /// runs inside the actor with no `await` between steps, so concurrent callers cannot
+    /// both observe an expired window and both fire the event.
+    func tryAcquireCooldown(key: String, now: Date, interval: TimeInterval) -> Bool {
         var state = loadFromDisk() ?? GeofenceState()
         var cooldowns = state.eventCooldowns ?? [:]
-        for key in keys {
-            cooldowns.removeValue(forKey: key)
+        if let last = cooldowns[key], now.timeIntervalSince(last) < interval {
+            return false
         }
+        cooldowns[key] = now
+        state.eventCooldowns = cooldowns
+        saveToDisk(state)
+        return true
+    }
+
+    /// Atomically removes cooldown entries whose recorded timestamp is older than `interval`
+    /// before `now`. Filtering happens inside the actor so a concurrent `tryAcquireCooldown`
+    /// cannot have its fresh write deleted by a stale snapshot.
+    func purgeExpiredCooldowns(now: Date, interval: TimeInterval) {
+        var state = loadFromDisk() ?? GeofenceState()
+        guard var cooldowns = state.eventCooldowns, !cooldowns.isEmpty else { return }
+        let beforeCount = cooldowns.count
+        cooldowns = cooldowns.filter { now.timeIntervalSince($0.value) < interval }
+        if cooldowns.count == beforeCount { return }
         state.eventCooldowns = cooldowns
         saveToDisk(state)
     }

--- a/Sources/Location/Geofence/Storage/PendingGeofenceMetric.swift
+++ b/Sources/Location/Geofence/Storage/PendingGeofenceMetric.swift
@@ -1,0 +1,37 @@
+import CioInternalCommon
+import Foundation
+
+/// A geofence transition queued for direct-HTTP delivery.
+struct PendingGeofenceMetric: Codable, Equatable, Sendable {
+    let id: UUID
+    let geofenceId: String
+    let transition: GeofenceTransition
+    let latitude: Double?
+    let longitude: Double?
+    let timestamp: Date
+
+    init(
+        id: UUID = UUID(),
+        geofenceId: String,
+        transition: GeofenceTransition,
+        latitude: Double?,
+        longitude: Double?,
+        timestamp: Date
+    ) {
+        self.id = id
+        self.geofenceId = geofenceId
+        self.transition = transition
+        self.latitude = latitude
+        self.longitude = longitude
+        self.timestamp = timestamp
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case geofenceId = "geofence_id"
+        case transition
+        case latitude
+        case longitude
+        case timestamp
+    }
+}

--- a/Sources/Location/Geofence/Storage/PendingGeofenceMetricStore.swift
+++ b/Sources/Location/Geofence/Storage/PendingGeofenceMetricStore.swift
@@ -1,0 +1,150 @@
+import CioInternalCommon
+import Foundation
+
+/// File-backed queue of geofence transition events awaiting direct-HTTP delivery.
+///
+/// Same persistence shape as `PendingPushDeliveryStore` but in the app's container
+/// (geofence callbacks run in the main process — no app group needed). File uses
+/// `completeUntilFirstUserAuthentication` Data Protection and is excluded from backups.
+///
+/// Actor-isolated: every method's load → modify → save runs without `await`, so
+/// concurrent callers can't observe a half-applied state.
+///
+/// Leftover rows are flushed on next module init. RN/Flutter wrappers may defer that
+/// flush indefinitely if the SDK isn't re-initialized.
+actor PendingGeofenceMetricStore {
+    private static let defaultSubdirectory = "io.customer.sdk.geofence"
+    private static let filename = "pending_geofence_metrics.json"
+    private static let maxEntries = 100
+    private static let protection = FileProtectionType.completeUntilFirstUserAuthentication
+
+    private let fileManager: FileManager
+    private let directoryURL: URL?
+
+    /// - Parameters:
+    ///   - fileManager: File manager used for I/O. Defaults to `.default`.
+    ///   - directoryURL: Directory for the queue file. If `nil`, uses Application Support in the app container.
+    init(
+        fileManager: FileManager = .default,
+        directoryURL: URL? = nil
+    ) {
+        self.fileManager = fileManager
+        self.directoryURL = directoryURL
+    }
+
+    /// Appends a metric. When over capacity, drops the **oldest** entries first.
+    /// Returns `false` if the file could not be persisted.
+    func append(_ metric: PendingGeofenceMetric) -> Bool {
+        var items = loadFromDisk()
+        items.append(metric)
+        if items.count > Self.maxEntries {
+            items = Array(items.suffix(Self.maxEntries))
+        }
+        return saveToDisk(items)
+    }
+
+    /// All pending metrics, oldest first.
+    func loadAll() -> [PendingGeofenceMetric] {
+        loadFromDisk()
+    }
+
+    /// Removes one pending entry by id. Returns `true` when the entry was found and removed.
+    func remove(id: UUID) -> Bool {
+        var items = loadFromDisk()
+        let originalCount = items.count
+        items.removeAll { $0.id == id }
+        guard items.count != originalCount else { return false }
+        return saveToDisk(items)
+    }
+
+    /// Removes entries whose ids are in `ids` in one read-modify-write.
+    /// Returns `true` when the file was updated, `false` when none of the ids were present.
+    func removeAll(ids: Set<UUID>) -> Bool {
+        guard !ids.isEmpty else { return true }
+        var items = loadFromDisk()
+        let originalCount = items.count
+        items.removeAll { ids.contains($0.id) }
+        guard items.count != originalCount else { return false }
+        return saveToDisk(items)
+    }
+
+    /// Wipes the queue. Used on sign-out to avoid sending one user's queued events with the next user's identifier.
+    func clearAll() {
+        _ = saveToDisk([])
+    }
+
+    // MARK: - Private (file persistence)
+
+    private func loadFromDisk() -> [PendingGeofenceMetric] {
+        guard let url = fileURL(),
+              fileManager.fileExists(atPath: url.path),
+              let data = try? Data(contentsOf: url)
+        else {
+            return []
+        }
+        // Corrupted or unreadable JSON returns empty so the next write overwrites it.
+        return (try? Self.makeDecoder().decode([PendingGeofenceMetric].self, from: data)) ?? []
+    }
+
+    private func saveToDisk(_ items: [PendingGeofenceMetric]) -> Bool {
+        guard let url = fileURL(),
+              let data = try? Self.makeEncoder().encode(items)
+        else {
+            return false
+        }
+        let directory = url.deletingLastPathComponent()
+        try? fileManager.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.protectionKey: Self.protection]
+        )
+        setExcludedFromBackup(on: directory)
+        do {
+            try data.write(to: url, options: .atomic)
+        } catch {
+            return false
+        }
+        // Post-write hardening (file protection class + backup exclusion) is best-effort.
+        // The bytes are already durable on disk, so a failure here must not be reported as
+        // a save failure — the caller would otherwise treat the row as un-persisted and
+        // retry, which could lead to duplicate entries.
+        try? fileManager.setAttributes(
+            [.protectionKey: Self.protection],
+            ofItemAtPath: url.path
+        )
+        setExcludedFromBackup(on: url)
+        return true
+    }
+
+    private func setExcludedFromBackup(on url: URL) {
+        var url = url
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        try? url.setResourceValues(values)
+    }
+
+    private func fileURL() -> URL? {
+        if let directory = directoryURL {
+            return directory.appendingPathComponent(Self.filename)
+        }
+        guard let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            return nil
+        }
+        return appSupport
+            .appendingPathComponent(Self.defaultSubdirectory)
+            .appendingPathComponent(Self.filename)
+    }
+
+    private static func makeEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        encoder.dateEncodingStrategy = .secondsSince1970
+        return encoder
+    }
+
+    private static func makeDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        return decoder
+    }
+}

--- a/Tests/DataPipeline/DataPipelineEventBustTests.swift
+++ b/Tests/DataPipeline/DataPipelineEventBustTests.swift
@@ -58,6 +58,45 @@ class DataPipelineEventBustTests: IntegrationTest {
         )
     }
 
+    func testSubscribeToJourneyEvents_DataPipelineHandlesTrackGeofenceMetricEvent_enter() async {
+        let givenGeofenceId = String.random
+
+        await eventBusHandler.postEventAndWait(
+            TrackGeofenceMetricEvent(geofenceId: givenGeofenceId, transition: .enter)
+        )
+
+        guard let trackEvent = outputReader.lastEvent as? TrackEvent else {
+            XCTFail("recorded event is not an instance of TrackEvent")
+            return
+        }
+
+        XCTAssertEqual(trackEvent.type, "track")
+        XCTAssertEqual(trackEvent.event, "GeoFence Entered")
+        XCTAssertMatches(
+            trackEvent.properties,
+            ["geofence_id": givenGeofenceId]
+        )
+    }
+
+    func testSubscribeToJourneyEvents_DataPipelineHandlesTrackGeofenceMetricEvent_exit() async {
+        let givenGeofenceId = String.random
+
+        await eventBusHandler.postEventAndWait(
+            TrackGeofenceMetricEvent(geofenceId: givenGeofenceId, transition: .exit)
+        )
+
+        guard let trackEvent = outputReader.lastEvent as? TrackEvent else {
+            XCTFail("recorded event is not an instance of TrackEvent")
+            return
+        }
+
+        XCTAssertEqual(trackEvent.event, "GeoFence Exited")
+        XCTAssertMatches(
+            trackEvent.properties,
+            ["geofence_id": givenGeofenceId]
+        )
+    }
+
     func testSubscribeToJourneyEvents_DataPipelineHandlesRegisterDeviceEvent() async {
         let givenToken = String.random
 

--- a/Tests/Location/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/Location/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -1,0 +1,176 @@
+@testable import CioInternalCommon
+@testable import CioLocation
+import Foundation
+import SharedTests
+import Testing
+
+@Suite("GeofenceEventTracker")
+struct GeofenceEventTrackerTests {
+    private let cooldownInterval: TimeInterval = 3600
+
+    private func makeTempDirectory() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    }
+
+    private func makeStorage(directory: URL) -> GeofenceStorage {
+        GeofenceStorage(fileManager: .default, directoryURL: directory)
+    }
+
+    private func makeTracker(
+        storage: GeofenceStorage,
+        eventBus: EventBusHandlerMock,
+        dateUtil: DateUtil = DateUtilStub()
+    ) -> GeofenceEventTracker {
+        GeofenceEventTracker(
+            storage: storage,
+            eventBusHandler: eventBus,
+            dateUtil: dateUtil,
+            logger: LoggerMock(),
+            cooldownInterval: cooldownInterval
+        )
+    }
+
+    private func postedGeofenceEvents(from bus: EventBusHandlerMock) -> [TrackGeofenceMetricEvent] {
+        bus.postEventReceivedInvocations.compactMap { $0 as? TrackGeofenceMetricEvent }
+    }
+
+    @Test
+    func trackTransition_givenEnter_expectMetricEventPosted() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let bus = EventBusHandlerMock()
+        let tracker = makeTracker(storage: storage, eventBus: bus)
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+
+        let events = postedGeofenceEvents(from: bus)
+        #expect(events.count == 1)
+        #expect(events.first?.geofenceId == "geo_1")
+        #expect(events.first?.transition == .enter)
+    }
+
+    @Test
+    func trackTransition_givenExit_expectMetricEventPosted() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let bus = EventBusHandlerMock()
+        let tracker = makeTracker(storage: storage, eventBus: bus)
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .exit)
+
+        let events = postedGeofenceEvents(from: bus)
+        #expect(events.count == 1)
+        #expect(events.first?.transition == .exit)
+    }
+
+    @Test
+    func trackTransition_givenSameEventWithinCooldown_expectSuppressed() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let dateUtil = DateUtilStub()
+        let baseTime = Date(timeIntervalSince1970: 1700000000)
+        dateUtil.givenNow = baseTime
+        let bus = EventBusHandlerMock()
+        let tracker = makeTracker(storage: storage, eventBus: bus, dateUtil: dateUtil)
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+        #expect(postedGeofenceEvents(from: bus).count == 1)
+
+        dateUtil.givenNow = baseTime.addingTimeInterval(1800)
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+        #expect(postedGeofenceEvents(from: bus).count == 1)
+    }
+
+    @Test
+    func trackTransition_givenSameEventAfterCooldown_expectTracked() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let dateUtil = DateUtilStub()
+        let baseTime = Date(timeIntervalSince1970: 1700000000)
+        dateUtil.givenNow = baseTime
+        let bus = EventBusHandlerMock()
+        let tracker = makeTracker(storage: storage, eventBus: bus, dateUtil: dateUtil)
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+        #expect(postedGeofenceEvents(from: bus).count == 1)
+
+        dateUtil.givenNow = baseTime.addingTimeInterval(cooldownInterval)
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+        #expect(postedGeofenceEvents(from: bus).count == 2)
+    }
+
+    @Test
+    func trackTransition_givenDifferentTransitionTypes_expectBothTracked() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let bus = EventBusHandlerMock()
+        let tracker = makeTracker(storage: storage, eventBus: bus)
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .exit)
+
+        #expect(postedGeofenceEvents(from: bus).count == 2)
+    }
+
+    @Test
+    func trackTransition_givenDifferentGeofences_expectBothTracked() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let bus = EventBusHandlerMock()
+        let tracker = makeTracker(storage: storage, eventBus: bus)
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+        await tracker.trackTransition(geofenceId: "geo_2", transition: .enter)
+
+        #expect(postedGeofenceEvents(from: bus).count == 2)
+    }
+
+    @Test
+    func trackTransition_givenExpiredCooldowns_expectPurged() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let dateUtil = DateUtilStub()
+        let baseTime = Date(timeIntervalSince1970: 1700000000)
+        dateUtil.givenNow = baseTime
+        let bus = EventBusHandlerMock()
+        let tracker = makeTracker(storage: storage, eventBus: bus, dateUtil: dateUtil)
+
+        await tracker.trackTransition(geofenceId: "geo_old", transition: .enter)
+        #expect(await storage.getEventCooldowns().count == 1)
+
+        dateUtil.givenNow = baseTime.addingTimeInterval(cooldownInterval + 1)
+        await tracker.trackTransition(geofenceId: "geo_new", transition: .enter)
+
+        let cooldowns = await storage.getEventCooldowns()
+        #expect(cooldowns["geo_old:enter"] == nil)
+        #expect(cooldowns["geo_new:enter"] != nil)
+    }
+
+    @Test
+    func trackTransition_givenCooldownPersisted_expectSurvivedNewTrackerInstance() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let sharedStorage = makeStorage(directory: dir)
+        let dateUtil = DateUtilStub()
+        let baseTime = Date(timeIntervalSince1970: 1700000000)
+        dateUtil.givenNow = baseTime
+
+        let bus1 = EventBusHandlerMock()
+        let tracker1 = makeTracker(storage: sharedStorage, eventBus: bus1, dateUtil: dateUtil)
+        await tracker1.trackTransition(geofenceId: "geo_1", transition: .enter)
+        #expect(postedGeofenceEvents(from: bus1).count == 1)
+
+        dateUtil.givenNow = baseTime.addingTimeInterval(1800)
+        let bus2 = EventBusHandlerMock()
+        let tracker2 = makeTracker(storage: sharedStorage, eventBus: bus2, dateUtil: dateUtil)
+        await tracker2.trackTransition(geofenceId: "geo_1", transition: .enter)
+        #expect(postedGeofenceEvents(from: bus2).isEmpty)
+    }
+}

--- a/Tests/Location/Geofence/Storage/GeofenceStorageTests.swift
+++ b/Tests/Location/Geofence/Storage/GeofenceStorageTests.swift
@@ -52,30 +52,97 @@ struct GeofenceStorageTests {
     }
 
     @Test
-    func purgeExpiredCooldowns_givenExpiredKeys_expectRemoved() async {
+    func purgeExpiredCooldowns_givenSomeExpired_expectOnlyExpiredRemoved() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let storage = makeStorage(directory: dir)
-        let t1 = Date(timeIntervalSince1970: 1700000000)
-        let t2 = Date(timeIntervalSince1970: 1700001000)
-        await storage.recordEventCooldown(key: "geo_1:enter", timestamp: t1)
-        await storage.recordEventCooldown(key: "geo_2:enter", timestamp: t2)
-        await storage.purgeExpiredCooldowns(keys: ["geo_1:enter"])
+        let interval: TimeInterval = 3600
+        let now = Date(timeIntervalSince1970: 1700000000)
+        let staleTimestamp = now.addingTimeInterval(-interval - 1)
+        let freshTimestamp = now.addingTimeInterval(-1)
+        await storage.recordEventCooldown(key: "geo_stale:enter", timestamp: staleTimestamp)
+        await storage.recordEventCooldown(key: "geo_fresh:enter", timestamp: freshTimestamp)
+
+        await storage.purgeExpiredCooldowns(now: now, interval: interval)
+
         let cooldowns = await storage.getEventCooldowns()
-        #expect(cooldowns.count == 1)
-        #expect(cooldowns["geo_1:enter"] == nil)
-        #expect(cooldowns["geo_2:enter"] == t2)
+        #expect(cooldowns["geo_stale:enter"] == nil)
+        #expect(cooldowns["geo_fresh:enter"] == freshTimestamp)
     }
 
     @Test
-    func purgeExpiredCooldowns_givenEmptyKeys_expectNoChange() async {
+    func purgeExpiredCooldowns_givenNoneExpired_expectAllRetained() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let storage = makeStorage(directory: dir)
-        await storage.recordEventCooldown(key: "geo_1:enter", timestamp: Date())
-        await storage.purgeExpiredCooldowns(keys: [])
+        let now = Date(timeIntervalSince1970: 1700000000)
+        await storage.recordEventCooldown(key: "geo_1:enter", timestamp: now)
+
+        await storage.purgeExpiredCooldowns(now: now, interval: 3600)
+
         let cooldowns = await storage.getEventCooldowns()
-        #expect(cooldowns.count == 1)
+        #expect(cooldowns["geo_1:enter"] == now)
+    }
+
+    // MARK: - Atomic cooldown acquisition
+
+    @Test
+    func tryAcquireCooldown_givenNoExistingEntry_expectAcquiredAndRecorded() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let now = Date(timeIntervalSince1970: 1700000000)
+
+        let acquired = await storage.tryAcquireCooldown(key: "geo_1:enter", now: now, interval: 3600)
+
+        #expect(acquired == true)
+        let cooldowns = await storage.getEventCooldowns()
+        #expect(cooldowns["geo_1:enter"] == now)
+    }
+
+    @Test
+    func tryAcquireCooldown_givenEntryWithinInterval_expectNotAcquiredAndTimestampUnchanged() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let firstAttempt = Date(timeIntervalSince1970: 1700000000)
+        let secondAttempt = firstAttempt.addingTimeInterval(1800)
+
+        _ = await storage.tryAcquireCooldown(key: "geo_1:enter", now: firstAttempt, interval: 3600)
+        let acquired = await storage.tryAcquireCooldown(key: "geo_1:enter", now: secondAttempt, interval: 3600)
+
+        #expect(acquired == false)
+        let cooldowns = await storage.getEventCooldowns()
+        #expect(cooldowns["geo_1:enter"] == firstAttempt)
+    }
+
+    @Test
+    func tryAcquireCooldown_givenEntryAtIntervalBoundary_expectAcquiredAndTimestampReplaced() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let firstAttempt = Date(timeIntervalSince1970: 1700000000)
+        let secondAttempt = firstAttempt.addingTimeInterval(3600)
+
+        _ = await storage.tryAcquireCooldown(key: "geo_1:enter", now: firstAttempt, interval: 3600)
+        let acquired = await storage.tryAcquireCooldown(key: "geo_1:enter", now: secondAttempt, interval: 3600)
+
+        #expect(acquired == true)
+        let cooldowns = await storage.getEventCooldowns()
+        #expect(cooldowns["geo_1:enter"] == secondAttempt)
+    }
+
+    @Test
+    func tryAcquireCooldown_givenDifferentKey_expectIndependentAcquisition() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let now = Date(timeIntervalSince1970: 1700000000)
+
+        _ = await storage.tryAcquireCooldown(key: "geo_1:enter", now: now, interval: 3600)
+        let acquired = await storage.tryAcquireCooldown(key: "geo_2:enter", now: now, interval: 3600)
+
+        #expect(acquired == true)
     }
 
     @Test
@@ -137,7 +204,7 @@ struct GeofenceStorageTests {
                         case 1:
                             _ = await storage.getEventCooldowns()
                         case 2:
-                            await storage.purgeExpiredCooldowns(keys: ["geo_\(i):enter"])
+                            await storage.purgeExpiredCooldowns(now: Date(), interval: 3600)
                         default:
                             break
                         }

--- a/Tests/Location/Geofence/Storage/PendingGeofenceMetricStoreTests.swift
+++ b/Tests/Location/Geofence/Storage/PendingGeofenceMetricStoreTests.swift
@@ -1,0 +1,262 @@
+@testable import CioInternalCommon
+@testable import CioLocation
+import Foundation
+import SharedTests
+import Testing
+
+@Suite("PendingGeofenceMetricStore")
+struct PendingGeofenceMetricStoreTests {
+    private func makeTempDirectory() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    }
+
+    private func makeStore(directory: URL) -> PendingGeofenceMetricStore {
+        PendingGeofenceMetricStore(fileManager: .default, directoryURL: directory)
+    }
+
+    private func makeMetric(geofenceId: String = "geo_1", transition: GeofenceTransition = .enter) -> PendingGeofenceMetric {
+        PendingGeofenceMetric(
+            geofenceId: geofenceId,
+            transition: transition,
+            latitude: 12.34,
+            longitude: 56.78,
+            timestamp: Date(timeIntervalSince1970: 1700000000)
+        )
+    }
+
+    // MARK: - Basic append + loadAll
+
+    @Test
+    func loadAll_givenEmpty_expectEmptyArray() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = makeStore(directory: dir)
+
+        let items = await store.loadAll()
+
+        #expect(items.isEmpty)
+    }
+
+    @Test
+    func append_givenMetric_expectPersisted() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = makeStore(directory: dir)
+        let metric = makeMetric()
+
+        let appended = await store.append(metric)
+        let items = await store.loadAll()
+
+        #expect(appended == true)
+        #expect(items.count == 1)
+        #expect(items.first == metric)
+    }
+
+    @Test
+    func append_givenMultiple_expectAllPersistedInOrder() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = makeStore(directory: dir)
+        let first = makeMetric(geofenceId: "geo_1")
+        let second = makeMetric(geofenceId: "geo_2")
+
+        _ = await store.append(first)
+        _ = await store.append(second)
+        let items = await store.loadAll()
+
+        #expect(items.count == 2)
+        #expect(items[0] == first)
+        #expect(items[1] == second)
+    }
+
+    // MARK: - Capacity bound
+
+    @Test
+    func append_givenOverCapacity_expectOldestDropped() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = makeStore(directory: dir)
+
+        // Append 105 metrics; cap is 100. First 5 should be dropped.
+        for i in 0 ..< 105 {
+            _ = await store.append(makeMetric(geofenceId: "geo_\(i)"))
+        }
+        let items = await store.loadAll()
+
+        #expect(items.count == 100)
+        #expect(items.first?.geofenceId == "geo_5")
+        #expect(items.last?.geofenceId == "geo_104")
+    }
+
+    @Test
+    func append_givenExactlyAtCapacity_expectAllPreserved() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = makeStore(directory: dir)
+
+        // Append exactly 100 (the cap); guards against an off-by-one in the `>` check.
+        for i in 0 ..< 100 {
+            _ = await store.append(makeMetric(geofenceId: "geo_\(i)"))
+        }
+        let items = await store.loadAll()
+
+        #expect(items.count == 100)
+        #expect(items.first?.geofenceId == "geo_0")
+        #expect(items.last?.geofenceId == "geo_99")
+    }
+
+    // MARK: - Remove
+
+    @Test
+    func remove_givenExistingId_expectRemovedAndReturnTrue() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = makeStore(directory: dir)
+        let toKeep = makeMetric(geofenceId: "keep")
+        let toRemove = makeMetric(geofenceId: "remove")
+        _ = await store.append(toKeep)
+        _ = await store.append(toRemove)
+
+        let removed = await store.remove(id: toRemove.id)
+        let items = await store.loadAll()
+
+        #expect(removed == true)
+        #expect(items.count == 1)
+        #expect(items.first == toKeep)
+    }
+
+    @Test
+    func remove_givenMissingId_expectReturnFalseAndNoChange() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = makeStore(directory: dir)
+        let metric = makeMetric()
+        _ = await store.append(metric)
+
+        let removed = await store.remove(id: UUID())
+        let items = await store.loadAll()
+
+        #expect(removed == false)
+        #expect(items.count == 1)
+    }
+
+    // MARK: - RemoveAll
+
+    @Test
+    func removeAll_givenAllPresent_expectAllRemoved() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = makeStore(directory: dir)
+        let first = makeMetric(geofenceId: "geo_1")
+        let second = makeMetric(geofenceId: "geo_2")
+        _ = await store.append(first)
+        _ = await store.append(second)
+
+        let success = await store.removeAll(ids: [first.id, second.id])
+        let items = await store.loadAll()
+
+        #expect(success == true)
+        #expect(items.isEmpty)
+    }
+
+    @Test
+    func removeAll_givenPartialMatch_expectOnlyMatchingRemoved() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = makeStore(directory: dir)
+        let toKeep = makeMetric(geofenceId: "keep")
+        let toRemove = makeMetric(geofenceId: "remove")
+        _ = await store.append(toKeep)
+        _ = await store.append(toRemove)
+
+        let success = await store.removeAll(ids: [toRemove.id, UUID()])
+        let items = await store.loadAll()
+
+        #expect(success == true)
+        #expect(items == [toKeep])
+    }
+
+    @Test
+    func removeAll_givenEmptySet_expectNoOp() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = makeStore(directory: dir)
+        _ = await store.append(makeMetric())
+
+        let success = await store.removeAll(ids: [])
+        let items = await store.loadAll()
+
+        #expect(success == true)
+        #expect(items.count == 1)
+    }
+
+    // MARK: - Clear
+
+    @Test
+    func clearAll_givenItems_expectEmpty() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = makeStore(directory: dir)
+        _ = await store.append(makeMetric(geofenceId: "geo_1"))
+        _ = await store.append(makeMetric(geofenceId: "geo_2"))
+
+        await store.clearAll()
+        let items = await store.loadAll()
+
+        #expect(items.isEmpty)
+    }
+
+    // MARK: - Persistence across instances
+
+    @Test
+    func loadAll_givenNewStoreInstance_expectLoadsFromDisk() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let metric = makeMetric()
+
+        let firstStore = makeStore(directory: dir)
+        _ = await firstStore.append(metric)
+
+        let secondStore = makeStore(directory: dir)
+        let items = await secondStore.loadAll()
+
+        #expect(items == [metric])
+    }
+
+    // MARK: - Concurrent safety
+
+    @Test
+    func concurrentOperations_expectCapacityInvariantHolds() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = makeStore(directory: dir)
+
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0 ..< 20 {
+                group.addTask {
+                    for j in 0 ..< 10 {
+                        switch (i + j) % 3 {
+                        case 0:
+                            _ = await store.append(PendingGeofenceMetric(
+                                geofenceId: "geo_\(i)_\(j)",
+                                transition: .enter,
+                                latitude: nil,
+                                longitude: nil,
+                                timestamp: Date()
+                            ))
+                        case 1:
+                            _ = await store.loadAll()
+                        case 2:
+                            await store.clearAll()
+                        default:
+                            break
+                        }
+                    }
+                }
+            }
+        }
+
+        let items = await store.loadAll()
+        #expect(items.count <= 100)
+    }
+}

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -258,6 +258,8 @@ public interface CioInternalCommon.FileStorage {
 }
 public enum CioInternalCommon.FileType {
 }
+public enum CioInternalCommon.GeofenceTransition {
+}
 public interface CioInternalCommon.GlobalDataStore {
 	public var pushDeviceToken: String?;
 	public fun func deleteAll();
@@ -542,6 +544,14 @@ public final class CioInternalCommon.TrackEventQueueTaskData {
 	public final val identifier: String;
 	public final val attributesJsonString: String;
 	public fun init(identifier: String, attributesJsonString: String);
+}
+public final class CioInternalCommon.TrackGeofenceMetricEvent {
+	public final val storageId: String;
+	public final val params: List<String : String>;
+	public final val geofenceId: String;
+	public final val transition: GeofenceTransition;
+	public final val timestamp: Date;
+	public fun init(storageId: String = UUID().uuidString, geofenceId: String, transition: GeofenceTransition, timestamp: Date = Date(), params: List<String: String> = List<:>);
 }
 public final class CioInternalCommon.TrackInAppMetricEvent {
 	public final val storageId: String;


### PR DESCRIPTION
## Stack
Part of the MBL-1628 four-PR stack. Each PR layers one concern; merge in order:

- [#1060](https://github.com/customerio/customerio-ios/pull/1060) — geofence transition event delivery via EventBus (base for this PR, in review)
- **This PR** — file-backed pending-metric queue (persistence primitive)
- _(next)_ — direct-HTTP `GeofenceDeliveryTracker` (uses the queue's model)
- _(next)_ — wire `GeofenceEventTracker` to the three-layer flow + flush hook on init

## Ticket
[MBL-1628 — Send Geofence Transition Events](https://linear.app/customerio/issue/MBL-1628/ios-send-geofence-transition-events)

## Summary
Adds the file-backed queue layer of the three-layer geofence transition delivery design: a `PendingGeofenceMetric` model and a `PendingGeofenceMetricStore` actor that persists transitions before any HTTP attempt and retains them until the direct-HTTP layer (next PR) confirms success.

This PR adds only the persistence primitive — no wiring yet, no existing code path references it.

## Design rationale
- **File over `UserDefaults`** — written with `completeUntilFirstUserAuthentication` Data Protection so geofence callbacks that fire before the first unlock can still read after, and excluded from iCloud/iTunes backups (transient device-local context, not user data).
- **Single actor, no internal `await`** — every public method does load → modify → save in one actor-isolated step, so concurrent callers can't observe a half-applied state or lose a write. Same pattern as `GeofenceStorage`.
- **100-entry FIFO cap, drops oldest on overflow** — bounds disk usage if the device stays offline for a long time.
- **`.secondsSince1970` date strategy** — matches `GeofenceStorage` for cross-store consistency.

## Scope
Two new source files; nothing else touched. Not yet referenced by any module init or other code path — the wire-up PR adds the only call site.

## Diff size
- Source: ~180 lines (1 model + 1 actor)
- Tests: ~260 lines, excluded from the 250-line cap

## Test plan
- [x] `make generate && make format && make lint` clean
- [x] Targeted: `LocationTests/PendingGeofenceMetricStoreTests` — 13/13 pass (~1s)
- [x] Coverage: append/load/remove/clearAll happy paths, capacity boundary at exactly N (off-by-one guard), capacity overflow drops oldest, persistence across actor instances, concurrent ops stress test asserts capacity invariant holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only adds new, currently-unwired persistence code and tests; the main risk is potential file I/O/serialization edge cases when it gets integrated later.
> 
> **Overview**
> Adds a new persistence primitive for geofence transition delivery: a `PendingGeofenceMetric` model plus an actor-backed `PendingGeofenceMetricStore` that queues metrics in a JSON file under Application Support with a 100-item FIFO cap.
> 
> The store supports append/load/remove/clear operations, uses `.secondsSince1970` date encoding, applies `completeUntilFirstUserAuthentication` file protection, and excludes the directory/file from backups; comprehensive unit tests cover capacity, persistence across instances, and concurrent access invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08fecb6656b17b88181aee2fb4d8ae6875a28718. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->