### PR TITLE
chore: opt-in cdpApiKey persistence for background delivery

### DIFF
--- a/Sources/DataPipeline/Config/DataPipelineConfigOptions.swift
+++ b/Sources/DataPipeline/Config/DataPipelineConfigOptions.swift
@@ -31,6 +31,10 @@ public struct DataPipelineConfigOptions {
     /// Determines how SDK should handle screen view events
     public let screenViewUse: ScreenView
 
+    /// Whether the SDK is allowed to persist `cdpApiKey` for background-delivery features.
+    /// See `SDKConfigBuilder.allowBackgroundDelivery(_:)` for the customer-facing semantics.
+    public let allowBackgroundDelivery: Bool
+
     /// Plugins identified based on configuration provided by the user
     let autoConfiguredPlugins: [Plugin]
 }

--- a/Sources/DataPipeline/Config/SDKConfigBuilder.swift
+++ b/Sources/DataPipeline/Config/SDKConfigBuilder.swift
@@ -44,6 +44,7 @@ public class SDKConfigBuilder {
     private var autoTrackDeviceAttributes: Bool = true
     private var migrationSiteId: String?
     private var screenViewUse: ScreenView = .all
+    private var allowBackgroundDelivery: Bool = false
     private var deepLinkCallback: DeepLinkCallback?
 
     // Optional modules (e.g. Location) to initialize with the SDK.
@@ -160,6 +161,17 @@ public class SDKConfigBuilder {
         return self
     }
 
+    /// When `true`, the SDK persists `cdpApiKey` on disk so background-delivery features
+    /// (e.g. cold-wake geofence transitions) can authenticate without the full SDK being
+    /// initialized in the process. Defaults to `false`: cold-wake transitions queue and
+    /// deliver on the next foreground session. Customers fetching keys from a backend
+    /// should leave this off.
+    @discardableResult
+    public func allowBackgroundDelivery(_ enabled: Bool) -> SDKConfigBuilder {
+        allowBackgroundDelivery = enabled
+        return self
+    }
+
     @discardableResult
     @available(iOSApplicationExtension, unavailable)
     public func deepLinkCallback(_ callback: @escaping DeepLinkCallback) -> SDKConfigBuilder {
@@ -207,6 +219,7 @@ public class SDKConfigBuilder {
             autoTrackDeviceAttributes: autoTrackDeviceAttributes,
             migrationSiteId: migrationSiteId,
             screenViewUse: screenViewUse,
+            allowBackgroundDelivery: allowBackgroundDelivery,
             autoConfiguredPlugins: configuredPlugins
         )
 

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -75,6 +75,14 @@ class DataPipelineImplementation: DataPipelineInstance, DataPipelineTracking {
         // requiring DataPipeline to be initialized in their process.
         backgroundDeliveryContextStore.setApiHost(moduleConfig.apiHost)
 
+        // cdpApiKey is only persisted when the customer explicitly opts in. Clearing on
+        // opt-out wipes any key left by a prior launch that had it enabled.
+        if moduleConfig.allowBackgroundDelivery {
+            backgroundDeliveryContextStore.setCdpApiKey(moduleConfig.cdpApiKey)
+        } else {
+            backgroundDeliveryContextStore.setCdpApiKey(nil)
+        }
+
         // subscribe to journey events emmitted from push/in-app module to send them via datapipelines
         subscribeToJourneyEvents()
         postProfileAlreadyIdentified()

--- a/Tests/DataPipeline/DataPipelineImplementation+BackgroundDeliveryContextTests.swift
+++ b/Tests/DataPipeline/DataPipelineImplementation+BackgroundDeliveryContextTests.swift
@@ -15,16 +15,21 @@ class BackgroundDeliveryContextWriteTests: IntegrationTest {
     override open func setUpDependencies() {
         // Override the DI-resolved store with a temp-directory instance BEFORE
         // initializeSDKComponents runs (which constructs DataPipelineImplementation
-        // and captures the store reference).
-        tempDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        testStore = BackgroundDeliveryContextStore(fileManager: .default, directoryURL: tempDirectory)
+        // and captures the store reference). Pin the directory + store across re-setUp
+        // calls within a single test so disk state survives re-initialization.
+        if testStore == nil {
+            tempDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            testStore = BackgroundDeliveryContextStore(fileManager: .default, directoryURL: tempDirectory)
+        }
         diGraphShared.override(value: testStore, forType: BackgroundDeliveryContextStore.self)
 
         super.setUpDependencies()
     }
 
     override open func tearDown() {
-        try? FileManager.default.removeItem(at: tempDirectory)
+        if let dir = tempDirectory { try? FileManager.default.removeItem(at: dir) }
+        tempDirectory = nil
+        testStore = nil
         super.tearDown()
     }
 
@@ -62,5 +67,32 @@ class BackgroundDeliveryContextWriteTests: IntegrationTest {
 
         XCTAssertNil(testStore.currentUserId)
         XCTAssertNil(analytics.userId)
+    }
+
+    // MARK: - cdpApiKey persistence
+
+    func test_init_givenAllowBackgroundDeliveryDefaultOff_expectCdpApiKeyNotPersisted() {
+        // Default config has allowBackgroundDelivery = false, so DataPipeline init must
+        // not leave the key on disk.
+        XCTAssertNil(testStore.currentCdpApiKey)
+    }
+
+    func test_init_givenAllowBackgroundDeliveryOn_expectCdpApiKeyPersisted() {
+        setUp(modifySdkConfig: { config in
+            config.allowBackgroundDelivery(true)
+        })
+
+        XCTAssertEqual(testStore.currentCdpApiKey, dataPipelineConfigOptions.cdpApiKey)
+    }
+
+    func test_init_givenStalePersistedKey_andAllowBackgroundDeliveryOff_expectKeyCleared() {
+        // Simulate a key persisted by a prior launch that had the flag on. Re-init with
+        // the flag off must wipe it — otherwise opting out wouldn't actually revoke disk access.
+        testStore.setCdpApiKey("stale_key_from_prior_launch")
+        XCTAssertEqual(testStore.currentCdpApiKey, "stale_key_from_prior_launch")
+
+        setUp(modifySdkConfig: nil)
+
+        XCTAssertNil(testStore.currentCdpApiKey)
     }
 }

--- a/api-docs/CioDataPipelines.api
+++ b/api-docs/CioDataPipelines.api
@@ -43,6 +43,7 @@ public final class CioDataPipelines.DataPipelineConfigOptions {
 	public final val autoTrackDeviceAttributes: Boolean;
 	public final val migrationSiteId: String?;
 	public final val screenViewUse: ScreenView;
+	public final val allowBackgroundDelivery: Boolean;
 }
 public interface CioDataPipelines.DataPipelineInstance {
 	public var analytics: Analytics;
@@ -61,6 +62,7 @@ public final class CioDataPipelines.SDKConfigBuilder {
 	public fun func autoTrackDeviceAttributes(_ autoTrack: Boolean) -> SDKConfigBuilder;
 	public fun func migrationSiteId(_ siteId: String) -> SDKConfigBuilder;
 	public fun func screenViewUse(screenView: ScreenView) -> SDKConfigBuilder;
+	public fun func allowBackgroundDelivery(_ enabled: Boolean) -> SDKConfigBuilder;
 	public fun func deepLinkCallback(_ callback: @escaping DeepLinkCallback) -> SDKConfigBuilder;
 	public fun func addModule(_ module: CustomerIOModule) -> SDKConfigBuilder;
 	public fun func build() -> SDKConfigBuilderResult;


### PR DESCRIPTION
## Stack
Part of the MBL-1628 stack. Merge in order:

- [#1060](https://github.com/customerio/customerio-ios/pull/1060) — geofence transition event delivery via EventBus (in review)
- [#1061](https://github.com/customerio/customerio-ios/pull/1061) — pending-metric file-backed queue (in review)
- [#1062](https://github.com/customerio/customerio-ios/pull/1062) — direct-HTTP `GeofenceDeliveryTracker` (in review)
- [#1064](https://github.com/customerio/customerio-ios/pull/1064) — `BackgroundDeliveryContextStore` in Common (in review)
- [#1065](https://github.com/customerio/customerio-ios/pull/1065) — three-layer geofence transition delivery wireup (in review, base for this PR)
- **This PR** — opt-in `cdpApiKey` persistence for background delivery
- _(next)_ — wire `CoreLocationGeofenceMonitor` to `GeofenceEventTracker` + cold-wake bootstrap

## Ticket
[MBL-1628 — Send Geofence Transition Events](https://linear.app/customerio/issue/MBL-1628/ios-send-geofence-transition-events)

## Summary
Adds `SDKConfigBuilder.allowBackgroundDelivery(_:)` (defaults to `false` — secure by default). When enabled, `DataPipelineImplementation.init` persists `cdpApiKey` to `BackgroundDeliveryContextStore`; when disabled, the init explicitly clears any key left by a prior launch so toggling off across launches actually revokes disk access.

Cold-wake background-delivery features (landing in a follow-up PR) will read the persisted key to authenticate without the full SDK being initialized in the process. Customers fetching their key from a backend can leave the flag off and accept that cold-wake transitions queue until the next foreground session.

## Design rationale
- **DataPipeline owns the decision** — `cdpApiKey` belongs to `DataPipeline`, so the persistence opt-in lives on `DataPipelineConfigBuilder`, not on `LocationConfig`. LocationModule is purely a consumer; it reads whatever's in the store. No backwards dependencies, no init-order coordination.
- **Default OFF (secure by default)** — customers must consciously opt in to persist a credential on disk. Matches the "secure by default" posture.
- **Explicit clear on opt-out** — `setCdpApiKey(nil)` runs unconditionally in the `else` branch so opting out across launches actually wipes a previously-persisted key. Without that, a customer who flips `true → false` would silently leave the stale key behind.

## Scope
- 1 new field on `DataPipelineConfigOptions`
- 1 new builder method on `SDKConfigBuilder`
- 4 lines added in `DataPipelineImplementation.init`

## Diff size
- Source: ~21 lines
- Tests: ~40 lines, excluded from the 250-line cap

## Test plan
- [x] `make generate && make format && make lint` clean
- [x] Targeted: `DataPipelineTests/BackgroundDeliveryContextWriteTests` — 7/7 pass
- [x] Coverage: default off → key not persisted, opt-in → key persisted, stale-key on disk → cleared on opt-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces optional on-disk storage of the CDP API key; default-off and explicit clear on opt-out limit exposure, but enabling the flag is a credential-persistence decision customers must understand.
> 
> **Overview**
> Adds **`SDKConfigBuilder.allowBackgroundDelivery(_:)`** (default **`false`**) and threads **`allowBackgroundDelivery`** through **`DataPipelineConfigOptions`**.
> 
> On Data Pipeline init, when the flag is **on**, the SDK writes **`cdpApiKey`** to **`BackgroundDeliveryContextStore`** so cold-wake background delivery (e.g. geofence HTTP) can authenticate without a full SDK init; when **off**, it calls **`setCdpApiKey(nil)`** so a key from a prior opt-in launch is removed.
> 
> Integration tests cover default-off (no key on disk), opt-in persistence, and clearing a stale key on re-init with the flag off; test setup keeps the temp store across re-**`setUp`** for the stale-key case. Public API surface is reflected in **`api-docs/CioDataPipelines.api`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a902c82addbbb4b776cd312de1e783cb0c35724e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->