### PR TITLE
chore: wire CoreLocationGeofenceMonitor to GeofenceEventTracker

### DIFF
--- a/Sources/Location/Geofence/Event/GeofenceEventTracker.swift
+++ b/Sources/Location/Geofence/Event/GeofenceEventTracker.swift
@@ -12,7 +12,10 @@ import Foundation
 /// `flushPending()` replays queued rows on module init and on every `ProfileIdentifiedEvent`.
 /// Concurrent deliveries for the same row are deduplicated in-process via the active-delivery
 /// ID set; on app kill the row stays on disk and is retried in the next process.
-final class GeofenceEventTracker {
+///
+/// `@unchecked Sendable`: all stored properties are `let`; mutable state is wrapped in
+/// `Synchronized`. Required for the weak capture in the `@Sendable` transition handler.
+final class GeofenceEventTracker: @unchecked Sendable {
     private let storage: GeofenceStorage
     private let pendingStore: PendingGeofenceMetricStore
     private let deliveryTracker: GeofenceDeliveryTracker?

--- a/Sources/Location/Geofence/GeofenceMonitorBinder.swift
+++ b/Sources/Location/Geofence/GeofenceMonitorBinder.swift
@@ -1,0 +1,33 @@
+import CioInternalCommon
+import Foundation
+
+/// Wires `GeofenceRegionMonitoring` into the SDK: routes OS region transitions to
+/// `GeofenceEventTracker.trackTransition` and seeds the monitor with the given regions
+/// so a fresh process resumes monitoring without waiting on a server-sync round trip.
+///
+/// Synchronous by design. Callers MUST fetch the cached geofences before constructing the
+/// monitor — any `await` between the `CLLocationManager` delegate being set and
+/// `startMonitoring` being called creates a window where pending cold-wake delegate
+/// callbacks pass the filter on `ownedRegionIdentifiers` (still empty) and are dropped.
+@MainActor
+enum GeofenceMonitorBinder {
+    static func bind(
+        monitor: GeofenceRegionMonitoring,
+        geofences: [Geofence],
+        tracker: GeofenceEventTracker
+    ) {
+        monitor.setOnTransition { [weak tracker] identifier, transition, location in
+            // CLLocationManager delivers on main; trackTransition is async with its own
+            // serialization (active-delivery dedup), so a fire-and-forget Task is safe.
+            Task { await tracker?.trackTransition(geofenceId: identifier, transition: transition, location: location) }
+        }
+        for geofence in geofences {
+            monitor.startMonitoring(
+                identifier: geofence.id,
+                center: LocationData(latitude: geofence.latitude, longitude: geofence.longitude),
+                radius: geofence.radius,
+                transitionTypes: geofence.transitionTypes
+            )
+        }
+    }
+}

--- a/Sources/Location/Geofence/Storage/GeofenceStorage.swift
+++ b/Sources/Location/Geofence/Storage/GeofenceStorage.swift
@@ -81,6 +81,18 @@ actor GeofenceStorage {
         saveToDisk(state)
     }
 
+    // MARK: - Cached Geofences
+
+    func getCachedGeofences() -> [Geofence] {
+        loadFromDisk()?.cachedGeofences ?? []
+    }
+
+    func setCachedGeofences(_ geofences: [Geofence]) {
+        var state = loadFromDisk() ?? GeofenceState()
+        state.cachedGeofences = geofences
+        saveToDisk(state)
+    }
+
     // MARK: - Private (file persistence)
 
     private func loadFromDisk() -> GeofenceState? {

--- a/Sources/Location/LocationModuleState.swift
+++ b/Sources/Location/LocationModuleState.swift
@@ -10,6 +10,9 @@ final class LocationModuleState {
 
     private var services: LocationServices = UninitializedLocationServices(logger: DIGraphShared.shared.logger)
     private let lock = NSLock()
+    /// Retains the geofence monitor across the process lifetime so CLLocationManager delegate
+    /// callbacks land on a live instance. Accessed only from the main actor.
+    @MainActor private var geofenceMonitor: GeofenceRegionMonitoring?
 
     private init() {}
 
@@ -35,13 +38,27 @@ final class LocationModuleState {
         )
         let locationEnrichmentProvider = LocationProfileEnrichmentProvider(storage: storage, config: config)
         di.profileEnrichmentRegistry.register(locationEnrichmentProvider)
-        let geofenceEventTracker = makeGeofenceEventTracker(di: di)
+        let geofenceStorage = GeofenceStorage()
+        let geofenceEventTracker = makeGeofenceEventTracker(di: di, geofenceStorage: geofenceStorage)
         registerEventSubscriptions(
             coordinator: coordinator,
             geofenceEventTracker: geofenceEventTracker,
             eventBusHandler: di.eventBusHandler
         )
         Task { await geofenceEventTracker.flushPending() }
+        Task { @MainActor [weak self] in
+            // Fetch cache BEFORE constructing the monitor: once CLLocationManager is created,
+            // its delegate is live and the OS can deliver queued cold-wake region callbacks.
+            // Any `await` between delegate-set and `startMonitoring` would drop those events.
+            let geofences = await geofenceStorage.getCachedGeofences()
+            let monitor = CoreLocationGeofenceMonitor(logger: di.logger)
+            self?.geofenceMonitor = monitor
+            GeofenceMonitorBinder.bind(
+                monitor: monitor,
+                geofences: geofences,
+                tracker: geofenceEventTracker
+            )
+        }
         let locationProvider = CoreLocationProvider(logger: di.logger)
         let implementation = LocationServicesImplementation(
             config: config,
@@ -66,13 +83,13 @@ final class LocationModuleState {
         }
     }
 
-    private func makeGeofenceEventTracker(di: DIGraphShared) -> GeofenceEventTracker {
+    private func makeGeofenceEventTracker(di: DIGraphShared, geofenceStorage: GeofenceStorage) -> GeofenceEventTracker {
         let contextStore = di.backgroundDeliveryContextStore
         let deliveryTracker: GeofenceDeliveryTracker? = di.getOptional(HttpClient.self).map {
             GeofenceDeliveryTrackerImpl(httpClient: $0, contextStore: contextStore, logger: di.logger)
         }
         return GeofenceEventTracker(
-            storage: GeofenceStorage(),
+            storage: geofenceStorage,
             pendingStore: PendingGeofenceMetricStore(),
             deliveryTracker: deliveryTracker,
             contextStore: contextStore,

--- a/Tests/Location/Geofence/GeofenceMonitorBinderTests.swift
+++ b/Tests/Location/Geofence/GeofenceMonitorBinderTests.swift
@@ -1,0 +1,103 @@
+@testable import CioInternalCommon
+@testable import CioLocation
+import Foundation
+import SharedTests
+import Testing
+
+@Suite("GeofenceMonitorBinder")
+@MainActor
+struct GeofenceMonitorBinderTests {
+    private func makeTracker() -> GeofenceEventTracker {
+        let contextStore = BackgroundDeliveryContextStore(
+            fileManager: .default,
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        let storage = GeofenceStorage(
+            fileManager: .default,
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        return GeofenceEventTracker(
+            storage: storage,
+            pendingStore: PendingGeofenceMetricStore(),
+            deliveryTracker: nil,
+            contextStore: contextStore,
+            eventBusHandler: EventBusHandlerMock(),
+            dateUtil: DateUtilStub(),
+            logger: LoggerMock()
+        )
+    }
+
+    private func makeGeofence(id: String, radius: Double, transitions: Set<GeofenceTransition>) -> Geofence {
+        Geofence(id: id, latitude: 1.0, longitude: 2.0, radius: radius, name: id, transitionTypes: transitions, lastUpdated: Date())
+    }
+
+    @Test
+    func bind_givenGeofences_expectStartMonitoringForEach() {
+        let geofences = [
+            makeGeofence(id: "g1", radius: 100, transitions: [.enter]),
+            makeGeofence(id: "g2", radius: 200, transitions: [.enter, .exit])
+        ]
+        let monitor = GeofenceRegionMonitoringMock()
+        let tracker = makeTracker()
+
+        GeofenceMonitorBinder.bind(monitor: monitor, geofences: geofences, tracker: tracker)
+
+        #expect(monitor.setOnTransitionCallsCount == 1)
+        #expect(monitor.startMonitoringCalls.count == 2)
+        let identifiers = Set(monitor.startMonitoringCalls.map(\.identifier))
+        #expect(identifiers == Set(["g1", "g2"]))
+        let g1 = monitor.startMonitoringCalls.first { $0.identifier == "g1" }
+        #expect(g1?.radius == 100)
+        #expect(g1?.transitionTypes == [.enter])
+        let g2 = monitor.startMonitoringCalls.first { $0.identifier == "g2" }
+        #expect(g2?.transitionTypes == [.enter, .exit])
+    }
+
+    @Test
+    func bind_givenEmpty_expectHandlerRegisteredAndNoMonitoring() {
+        let monitor = GeofenceRegionMonitoringMock()
+        let tracker = makeTracker()
+
+        GeofenceMonitorBinder.bind(monitor: monitor, geofences: [], tracker: tracker)
+
+        #expect(monitor.setOnTransitionCallsCount == 1)
+        #expect(monitor.startMonitoringCalls.isEmpty)
+    }
+}
+
+// MARK: - Mock
+
+struct StartMonitoringCall: Equatable {
+    let identifier: String
+    let center: LocationData
+    let radius: Double
+    let transitionTypes: Set<GeofenceTransition>
+}
+
+@MainActor
+final class GeofenceRegionMonitoringMock: GeofenceRegionMonitoring {
+    var setOnTransitionCallsCount = 0
+    var startMonitoringCalls: [StartMonitoringCall] = []
+    var stopMonitoringCalls: [String] = []
+    var stopMonitoringAllCallsCount = 0
+    var monitoredRegionIdentifiers: Set<String> = []
+
+    func setOnTransition(_ handler: GeofenceTransitionHandler?) {
+        setOnTransitionCallsCount += 1
+    }
+
+    func startMonitoring(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) {
+        startMonitoringCalls.append(StartMonitoringCall(identifier: identifier, center: center, radius: radius, transitionTypes: transitionTypes))
+        monitoredRegionIdentifiers.insert(identifier)
+    }
+
+    func stopMonitoring(identifier: String) {
+        stopMonitoringCalls.append(identifier)
+        monitoredRegionIdentifiers.remove(identifier)
+    }
+
+    func stopMonitoringAll() {
+        stopMonitoringAllCallsCount += 1
+        monitoredRegionIdentifiers.removeAll()
+    }
+}

--- a/Tests/Location/Geofence/Storage/GeofenceStorageTests.swift
+++ b/Tests/Location/Geofence/Storage/GeofenceStorageTests.swift
@@ -186,6 +186,73 @@ struct GeofenceStorageTests {
         #expect(cooldowns["geo_1:enter"] == second)
     }
 
+    // MARK: - Cached geofences
+
+    private func makeGeofence(id: String, radius: Double = 100, transitions: Set<GeofenceTransition> = [.enter]) -> Geofence {
+        Geofence(id: id, latitude: 1.0, longitude: 2.0, radius: radius, name: id, transitionTypes: transitions, lastUpdated: Date(timeIntervalSince1970: 1700000000))
+    }
+
+    @Test
+    func getCachedGeofences_givenNoState_expectEmpty() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let cached = await storage.getCachedGeofences()
+        #expect(cached.isEmpty)
+    }
+
+    @Test
+    func setCachedGeofences_thenGet_expectRoundTrip() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let geofences = [
+            makeGeofence(id: "g1", radius: 100, transitions: [.enter]),
+            makeGeofence(id: "g2", radius: 200, transitions: [.enter, .exit])
+        ]
+        await storage.setCachedGeofences(geofences)
+        let cached = await storage.getCachedGeofences()
+        #expect(cached == geofences)
+    }
+
+    @Test
+    func setCachedGeofences_givenSecondCall_expectOverwrites() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        await storage.setCachedGeofences([makeGeofence(id: "g1")])
+        await storage.setCachedGeofences([makeGeofence(id: "g2"), makeGeofence(id: "g3")])
+        let cached = await storage.getCachedGeofences()
+        #expect(cached.map(\.id) == ["g2", "g3"])
+    }
+
+    @Test
+    func setCachedGeofences_givenNewStorageInstance_expectLoadsFromDisk() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let storage1 = makeStorage(directory: dir)
+        await storage1.setCachedGeofences([makeGeofence(id: "g1")])
+
+        let storage2 = makeStorage(directory: dir)
+        let cached = await storage2.getCachedGeofences()
+        #expect(cached.map(\.id) == ["g1"])
+    }
+
+    @Test
+    func setCachedGeofences_doesNotClearCooldowns() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let timestamp = Date(timeIntervalSince1970: 1700000000)
+        await storage.recordEventCooldown(key: "geo_1:enter", timestamp: timestamp)
+
+        await storage.setCachedGeofences([makeGeofence(id: "g1")])
+
+        let cooldowns = await storage.getEventCooldowns()
+        #expect(cooldowns["geo_1:enter"] == timestamp)
+    }
+
     // MARK: - Concurrent safety
 
     @Test


### PR DESCRIPTION
## Stack
Part of the MBL-1628 stack. Merge in order:

- [#1060](https://github.com/customerio/customerio-ios/pull/1060) — geofence transition event delivery via EventBus (in review)
- [#1061](https://github.com/customerio/customerio-ios/pull/1061) — pending-metric file-backed queue (in review)
- [#1062](https://github.com/customerio/customerio-ios/pull/1062) — direct-HTTP `GeofenceDeliveryTracker` (in review)
- [#1064](https://github.com/customerio/customerio-ios/pull/1064) — `BackgroundDeliveryContextStore` in Common (in review)
- [#1065](https://github.com/customerio/customerio-ios/pull/1065) — three-layer geofence transition delivery wireup (in review)
- [#1066](https://github.com/customerio/customerio-ios/pull/1066) — opt-in `cdpApiKey` persistence (in review, base for this PR)
- **This PR** — wire `CoreLocationGeofenceMonitor` to `GeofenceEventTracker` + seed monitoring from cache
- _(next)_ — cold-wake bootstrap entry point

## Ticket
[MBL-1628 — Send Geofence Transition Events](https://linear.app/customerio/issue/MBL-1628/ios-send-geofence-transition-events)

## Summary
Wires CoreLocation region transitions into the three-layer delivery flow landed in #1065. On Location module init, `GeofenceMonitorBinder` (a new `@MainActor` helper) routes `CLLocationManager` region callbacks to `GeofenceEventTracker.trackTransition` and seeds the monitor with any geofences persisted in `GeofenceState.cachedGeofences`, so a fresh process resumes monitoring without waiting on a server-sync round trip.

## Changes
- **`GeofenceMonitorBinder`** — small `@MainActor` enum that owns the wiring. Testable in isolation from `LocationModuleState`.
- **`GeofenceStorage`** — adds `getCachedGeofences()` / `setCachedGeofences(_:)`. Cache reads happen here; future server-sync writes will use the setter.
- **`LocationModuleState`** — constructs `GeofenceStorage` once, shares it with the tracker, retains the monitor in a `@MainActor` property for process lifetime, and invokes `bind(...)` on the main actor.
- **`GeofenceEventTracker: @unchecked Sendable`** — required because the `@Sendable` transition handler installed by `bind` weakly captures the tracker. The class already meets the contract: all stored properties are `let`, the one mutable field (`activeDeliveryIds`) is wrapped in `Synchronized`. Matches the codebase pattern (`BackgroundDeliveryContextStore`, `DIGraphShared`, `Synchronized<T>`). Without it, plain `Sendable` cascades through `EventBusHandler` / `DateUtil` / `Logger` / `GeofenceDeliveryTracker`, a project-wide change.

## Design notes
- **Why a separate binder enum?** Keeps the main-actor wiring testable without standing up a full `LocationModuleState`.
- **Weak capture of tracker** — `[weak tracker]` avoids a retain cycle if the tracker is ever released. Practically the tracker lives for process lifetime via the eventBus observer; the weak capture is defensive.
- **`Task { await tracker?.trackTransition(...) }` from the handler** — CLLocationManager delivers on main; `trackTransition` is `async` and serialised internally (active-delivery dedup), so fire-and-forget is safe.

## Concurrency review
- `bind` runs exactly once per process (gated by `LocationModuleState`'s NSLock + `services is LocationServicesImplementation` early-return).
- Handler invocations are serialised on the main actor by CLLocationManager. Each invocation creates a new `Task` calling `trackTransition`, so multiple Tasks can be in-flight concurrently — funneled through `tryAcquireCooldown` (actor-isolated) and `activeDeliveryIds` (Synchronized) for dedup. Same-row, same-transition duplicates within the cooldown window are suppressed.
- `await storage.getCachedGeofences()` inside `bind` is actor-isolated; no race with the subsequent `startMonitoring` calls (sequential on main actor).
- Lifetimes: `geofenceMonitor` retained for process lifetime via a `@MainActor` var on `LocationModuleState`; `tracker` retained via the EventBus observer closure.

## Scope
- Source: ~66 lines (binder + storage methods + module wiring + Sendable conformance)
- Tests: ~177 lines (excluded from the 250-line cap)
- No new public API — all changes are internal

## Test plan
- [x] `make format && make lint` clean (0 violations)
- [x] Targeted: `LocationTests/GeofenceMonitorBinderTests` — 2/2 pass
- [x] Targeted: `LocationTests/GeofenceStorageTests` — 18/18 pass (includes 5 new cached-geofences tests)
- [x] Coverage: bind with cached geofences, bind with empty cache, round-trip persistence, overwrite, cross-instance load, cooldown preservation, empty default

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes geofence init ordering and OS callback handling; mis-timing could drop cold-wake transitions, but scope is internal Location wiring with targeted tests.
> 
> **Overview**
> Connects **CoreLocation** region transitions to the existing **geofence event delivery** path on Location module init.
> 
> A new **`GeofenceMonitorBinder`** (`@MainActor`) registers a transition handler that forwards OS callbacks to **`GeofenceEventTracker.trackTransition`** and immediately **`startMonitoring`** for each persisted geofence. **`GeofenceStorage`** gains **`getCachedGeofences` / `setCachedGeofences`** so a new process can re-seed regions without waiting on server sync (writes from sync land in a follow-up PR).
> 
> **`LocationModuleState`** now shares one **`GeofenceStorage`** with the tracker, retains **`CoreLocationGeofenceMonitor`** for the process lifetime, and on the main actor loads the cache **before** creating the monitor so cold-wake callbacks are not dropped between delegate setup and monitoring. **`GeofenceEventTracker`** adopts **`@unchecked Sendable`** so the **`@Sendable`** transition closure can weakly capture the tracker.
> 
> Tests cover binder wiring and cached-geofence persistence (including overwrite and cooldown isolation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1af7b7d8bd1198d547151e40ebdaca27be5c7fe3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->