### PR TITLE
chore: LocationModule.bootstrapForBackgroundDelivery for cold-wake

### DIFF
--- a/Sources/Location/Geofence/Event/GeofenceEventTracker.swift
+++ b/Sources/Location/Geofence/Event/GeofenceEventTracker.swift
@@ -1,6 +1,8 @@
 import CioInternalCommon
 import Foundation
 
+// sourcery: InjectRegisterShared = "GeofenceEventTracker"
+// sourcery: InjectCustomShared
 /// Sends geofence transition events through a three-layer delivery flow:
 /// 1. Cooldown-based deduplication (keyed by "geofenceId:transitionType")
 /// 2. Persist to `PendingGeofenceMetricStore` before any send attempt
@@ -135,5 +137,42 @@ final class GeofenceEventTracker: @unchecked Sendable {
             transition: metric.transition
         ))
         logger.geofenceEventTracked(geofenceId: metric.geofenceId, transition: metric.transition)
+    }
+}
+
+// MARK: - DI
+
+extension DIGraphShared {
+    var customGeofenceEventTracker: GeofenceEventTracker {
+        GeofenceEventTracker.shared(di: self)
+    }
+}
+
+extension GeofenceEventTracker {
+    private static let sharedHolder = Synchronized<GeofenceEventTracker?>(nil)
+
+    /// Lazily constructs and caches a process-wide singleton. Both `LocationModule.initialize`
+    /// (foreground) and `LocationModule.bootstrapForBackgroundDelivery` (cold-wake) resolve
+    /// through this DI accessor so they share the same tracker — same active-delivery dedup
+    /// set, same `PendingGeofenceMetricStore`, same cooldown actor.
+    static func shared(di: DIGraphShared) -> GeofenceEventTracker {
+        sharedHolder.mutating { current in
+            if let current { return current }
+            let deliveryTracker = GeofenceDeliveryTrackerImpl(
+                httpClient: di.backgroundDeliveryHttpClient,
+                logger: di.logger
+            )
+            let tracker = GeofenceEventTracker(
+                storage: di.geofenceStorage,
+                pendingStore: PendingGeofenceMetricStore(),
+                deliveryTracker: deliveryTracker,
+                contextStore: di.backgroundDeliveryContextStore,
+                eventBusHandler: di.eventBusHandler,
+                dateUtil: di.dateUtil,
+                logger: di.logger
+            )
+            current = tracker
+            return tracker
+        }
     }
 }

--- a/Sources/Location/Geofence/GeofenceBootstrap.swift
+++ b/Sources/Location/Geofence/GeofenceBootstrap.swift
@@ -1,0 +1,31 @@
+import CioInternalCommon
+import Foundation
+
+/// Wires the geofence monitor into the SDK and (optionally) emits a discoverability log
+/// about cold-wake real-time delivery. Shared by `LocationModule.initialize` (foreground)
+/// and `LocationModule.bootstrapForBackgroundDelivery` (cold-wake) so both paths run the
+/// same setup against the same DI-resolved singletons.
+@MainActor
+enum GeofenceBootstrap {
+    static func wireMonitor(di: DIGraphShared) async {
+        // Fetch cache BEFORE touching the monitor: once CLLocationManager exists, its delegate
+        // is live and the OS can deliver queued cold-wake region callbacks. Any `await`
+        // between delegate-set and `startMonitoring` would drop those events.
+        let geofences = await di.geofenceStorage.getCachedGeofences()
+        let monitor = di.geofenceMonitor
+        let tracker = di.geofenceEventTracker
+        GeofenceMonitorBinder.bind(monitor: monitor, geofences: geofences, tracker: tracker)
+    }
+
+    /// Logs a one-line note when cold-wake real-time delivery is unavailable for this
+    /// customer (no `cdpApiKey` persisted and no in-memory DataPipeline source). Surfaces
+    /// only at bootstrap-time, when the customer's choice has observable consequences.
+    static func emitDiscoverabilityLogIfNeeded(di: DIGraphShared) {
+        if di.backgroundDeliveryContextStore.currentCdpApiKey == nil {
+            di.logger.info(
+                "Geofence cold-wake transitions will queue until next foreground session. Enable real-time delivery with SDKConfigBuilder.allowBackgroundDelivery(true).",
+                "Location"
+            )
+        }
+    }
+}

--- a/Sources/Location/Geofence/Monitor/CoreLocationGeofenceMonitor.swift
+++ b/Sources/Location/Geofence/Monitor/CoreLocationGeofenceMonitor.swift
@@ -121,3 +121,22 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
         return LocationData(latitude: location.coordinate.latitude, longitude: location.coordinate.longitude)
     }
 }
+
+// MARK: - DI
+
+extension DIGraphShared {
+    /// Process-wide singleton. Hand-written rather than via Sourcery's `InjectRegisterShared`
+    /// because that template's eager-init resolution test references the property from a
+    /// non-isolated context, which clashes with `@MainActor` isolation propagated through
+    /// `GeofenceRegionMonitoring`. The override check below mirrors the generated DI accessors
+    /// so tests can still substitute via `di.override(value:forType:)`.
+    @MainActor
+    var geofenceMonitor: GeofenceRegionMonitoring {
+        getOverriddenInstance() ?? CoreLocationGeofenceMonitor.shared
+    }
+}
+
+extension CoreLocationGeofenceMonitor {
+    @MainActor
+    static let shared = CoreLocationGeofenceMonitor(logger: DIGraphShared.shared.logger)
+}

--- a/Sources/Location/Geofence/Storage/GeofenceStorage.swift
+++ b/Sources/Location/Geofence/Storage/GeofenceStorage.swift
@@ -1,6 +1,8 @@
 import CioInternalCommon
 import Foundation
 
+// sourcery: InjectRegisterShared = "GeofenceStorage"
+// sourcery: InjectCustomShared
 /// Thread-safe persistence for geofence state.
 ///
 /// Implemented as an actor so all read-modify-write sequences are naturally atomic via
@@ -160,4 +162,16 @@ actor GeofenceStorage {
         decoder.dateDecodingStrategy = .secondsSince1970
         return decoder
     }
+}
+
+// MARK: - DI
+
+extension DIGraphShared {
+    var customGeofenceStorage: GeofenceStorage {
+        GeofenceStorage.shared
+    }
+}
+
+extension GeofenceStorage {
+    static let shared = GeofenceStorage()
 }

--- a/Sources/Location/LocationModule.swift
+++ b/Sources/Location/LocationModule.swift
@@ -1,5 +1,6 @@
 import CioInternalCommon
 import Foundation
+import UIKit
 
 /// Location module that can be registered via `SDKConfigBuilder.addModule(_:)` so Location is initialized during `CustomerIO.initialize(withConfig:)`.
 ///
@@ -27,6 +28,29 @@ public final class LocationModule: CustomerIOModule {
                 "Location",
                 nil
             )
+        }
+    }
+
+    /// Bootstraps geofence cold-wake delivery from the host's `AppDelegate`.
+    ///
+    /// Wrapper SDKs (RN, Flutter) do not run `CustomerIO.initialize` in the cold-wake
+    /// process — there is no JS/Dart runtime. This entry reads all the state it needs
+    /// from persisted stores and wires up region monitoring + direct-HTTP delivery
+    /// without requiring any module's `initialize` to have run in this process.
+    ///
+    /// Safe to call on every launch. When the SDK has been initialized via
+    /// `CustomerIO.initialize(withConfig:)`, the same DI-resolved singletons are
+    /// reused — no double-init, no duplicate monitoring.
+    @MainActor
+    public static func bootstrapForBackgroundDelivery(launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
+        // Reserved for future cold-wake detection (e.g. `launchOptions[.location]`).
+        _ = launchOptions
+
+        let di = DIGraphShared.shared
+        GeofenceBootstrap.emitDiscoverabilityLogIfNeeded(di: di)
+        Task { await di.geofenceEventTracker.flushPending() }
+        Task { @MainActor in
+            await GeofenceBootstrap.wireMonitor(di: di)
         }
     }
 }

--- a/Sources/Location/LocationModuleState.swift
+++ b/Sources/Location/LocationModuleState.swift
@@ -10,9 +10,6 @@ final class LocationModuleState {
 
     private var services: LocationServices = UninitializedLocationServices(logger: DIGraphShared.shared.logger)
     private let lock = NSLock()
-    /// Retains the geofence monitor across the process lifetime so CLLocationManager delegate
-    /// callbacks land on a live instance. Accessed only from the main actor.
-    @MainActor private var geofenceMonitor: GeofenceRegionMonitoring?
 
     private init() {}
 
@@ -38,26 +35,10 @@ final class LocationModuleState {
         )
         let locationEnrichmentProvider = LocationProfileEnrichmentProvider(storage: storage, config: config)
         di.profileEnrichmentRegistry.register(locationEnrichmentProvider)
-        let geofenceStorage = GeofenceStorage()
-        let geofenceEventTracker = makeGeofenceEventTracker(di: di, geofenceStorage: geofenceStorage)
-        registerEventSubscriptions(
-            coordinator: coordinator,
-            geofenceEventTracker: geofenceEventTracker,
-            eventBusHandler: di.eventBusHandler
-        )
-        Task { await geofenceEventTracker.flushPending() }
-        Task { @MainActor [weak self] in
-            // Fetch cache BEFORE constructing the monitor: once CLLocationManager is created,
-            // its delegate is live and the OS can deliver queued cold-wake region callbacks.
-            // Any `await` between delegate-set and `startMonitoring` would drop those events.
-            let geofences = await geofenceStorage.getCachedGeofences()
-            let monitor = CoreLocationGeofenceMonitor(logger: di.logger)
-            self?.geofenceMonitor = monitor
-            GeofenceMonitorBinder.bind(
-                monitor: monitor,
-                geofences: geofences,
-                tracker: geofenceEventTracker
-            )
+        registerEventSubscriptions(coordinator: coordinator, di: di)
+        Task { await di.geofenceEventTracker.flushPending() }
+        Task { @MainActor in
+            await GeofenceBootstrap.wireMonitor(di: di)
         }
         let locationProvider = CoreLocationProvider(logger: di.logger)
         let implementation = LocationServicesImplementation(
@@ -72,31 +53,11 @@ final class LocationModuleState {
         Task { await implementation.setUpLifecycleObserver() }
     }
 
-    private func registerEventSubscriptions(
-        coordinator: LocationSyncCoordinator,
-        geofenceEventTracker: GeofenceEventTracker,
-        eventBusHandler: EventBusHandler
-    ) {
-        eventBusHandler.addObserver(ProfileIdentifiedEvent.self) { _ in
+    private func registerEventSubscriptions(coordinator: LocationSyncCoordinator, di: DIGraphShared) {
+        di.eventBusHandler.addObserver(ProfileIdentifiedEvent.self) { _ in
             Task { await coordinator.syncCachedLocationIfNeeded() }
-            Task { await geofenceEventTracker.flushPending() }
+            Task { await di.geofenceEventTracker.flushPending() }
         }
-    }
-
-    private func makeGeofenceEventTracker(di: DIGraphShared, geofenceStorage: GeofenceStorage) -> GeofenceEventTracker {
-        let deliveryTracker = GeofenceDeliveryTrackerImpl(
-            httpClient: di.backgroundDeliveryHttpClient,
-            logger: di.logger
-        )
-        return GeofenceEventTracker(
-            storage: geofenceStorage,
-            pendingStore: PendingGeofenceMetricStore(),
-            deliveryTracker: deliveryTracker,
-            contextStore: di.backgroundDeliveryContextStore,
-            eventBusHandler: di.eventBusHandler,
-            dateUtil: di.dateUtil,
-            logger: di.logger
-        )
     }
 
     /// The current Location services instance. Before initialization, returns an implementation that logs an error when used.

--- a/Sources/Location/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/Location/autogenerated/AutoDependencyInjection.generated.swift
@@ -54,10 +54,27 @@ extension DIGraphShared {
     func testDependenciesAbleToResolve() -> Int {
         var countDependenciesResolved = 0
 
+        _ = geofenceEventTracker
+        countDependenciesResolved += 1
+
+        _ = geofenceStorage
+        countDependenciesResolved += 1
+
         return countDependenciesResolved
     }
 
     // Handle classes annotated with InjectRegisterShared
+    // GeofenceEventTracker (custom. property getter provided via extension)
+    var geofenceEventTracker: GeofenceEventTracker {
+        getOverriddenInstance() ??
+            customGeofenceEventTracker
+    }
+
+    // GeofenceStorage (custom. property getter provided via extension)
+    var geofenceStorage: GeofenceStorage {
+        getOverriddenInstance() ??
+            customGeofenceStorage
+    }
 }
 
 // swiftlint:enable all

--- a/Tests/Location/Geofence/GeofenceBootstrapTests.swift
+++ b/Tests/Location/Geofence/GeofenceBootstrapTests.swift
@@ -1,0 +1,98 @@
+@testable import CioInternalCommon
+@testable import CioLocation
+import Foundation
+import SharedTests
+import Testing
+
+@Suite("GeofenceBootstrap")
+@MainActor
+struct GeofenceBootstrapTests {
+    // MARK: - Discoverability log
+
+    @Test
+    func emitDiscoverabilityLog_givenNoCdpApiKey_expectInfoLogged() {
+        let di = DIGraphShared.shared
+        let store = BackgroundDeliveryContextStore(
+            fileManager: .default,
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        di.override(value: store, forType: BackgroundDeliveryContextStore.self)
+        let logger = LoggerMock()
+        di.override(value: logger, forType: Logger.self)
+        defer {
+            di.reset()
+        }
+
+        GeofenceBootstrap.emitDiscoverabilityLogIfNeeded(di: di)
+
+        #expect(logger.infoCallsCount == 1)
+        let message = logger.infoReceivedArguments?.message ?? ""
+        #expect(message.contains("allowBackgroundDelivery"))
+    }
+
+    @Test
+    func emitDiscoverabilityLog_givenCdpApiKeyPersisted_expectNoLog() {
+        let di = DIGraphShared.shared
+        let store = BackgroundDeliveryContextStore(
+            fileManager: .default,
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        store.setCdpApiKey("sk_test_abc")
+        di.override(value: store, forType: BackgroundDeliveryContextStore.self)
+        let logger = LoggerMock()
+        di.override(value: logger, forType: Logger.self)
+        defer {
+            di.reset()
+        }
+
+        GeofenceBootstrap.emitDiscoverabilityLogIfNeeded(di: di)
+
+        #expect(logger.infoCallsCount == 0)
+    }
+
+    // MARK: - DI singletons
+
+    @Test
+    func geofenceEventTracker_givenRepeatedResolution_expectSameInstance() {
+        let di = DIGraphShared.shared
+        let first = di.geofenceEventTracker
+        let second = di.geofenceEventTracker
+        #expect(first === second)
+    }
+
+    @Test
+    func geofenceStorage_givenRepeatedResolution_expectSameInstance() {
+        let di = DIGraphShared.shared
+        let first = di.geofenceStorage
+        let second = di.geofenceStorage
+        #expect(first === second)
+    }
+
+    @Test
+    func emitDiscoverabilityLog_givenProviderReturnsKey_expectNoLog() {
+        let di = DIGraphShared.shared
+        let store = BackgroundDeliveryContextStore(
+            fileManager: .default,
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        let provider = StubProvider(value: "live_key")
+        store.setCdpApiKeyProvider(provider)
+        di.override(value: store, forType: BackgroundDeliveryContextStore.self)
+        let logger = LoggerMock()
+        di.override(value: logger, forType: Logger.self)
+        defer {
+            di.reset()
+            _ = provider // keep alive until reset
+        }
+
+        GeofenceBootstrap.emitDiscoverabilityLogIfNeeded(di: di)
+
+        #expect(logger.infoCallsCount == 0)
+    }
+}
+
+private final class StubProvider: BackgroundDeliveryCdpApiKeyProvider {
+    let value: String?
+    init(value: String?) { self.value = value }
+    var cdpApiKey: String? { value }
+}

--- a/Tests/Location/Geofence/GeofenceMonitorBinderTests.swift
+++ b/Tests/Location/Geofence/GeofenceMonitorBinderTests.swift
@@ -63,6 +63,23 @@ struct GeofenceMonitorBinderTests {
         #expect(monitor.setOnTransitionCallsCount == 1)
         #expect(monitor.startMonitoringCalls.isEmpty)
     }
+
+    /// Double-bind can happen when both `LocationModule.initialize` and
+    /// `LocationModule.bootstrapForBackgroundDelivery` run in the same process. Each call
+    /// re-installs the handler and re-registers the regions — `CLLocationManager.startMonitoring`
+    /// is idempotent for the same identifier, and the handler is replaced with an equivalent one.
+    @Test
+    func bind_givenCalledTwice_expectHandlerReinstalledAndRegionsReregistered() {
+        let geofences = [makeGeofence(id: "g1", radius: 100, transitions: [.enter])]
+        let monitor = GeofenceRegionMonitoringMock()
+        let tracker = makeTracker()
+
+        GeofenceMonitorBinder.bind(monitor: monitor, geofences: geofences, tracker: tracker)
+        GeofenceMonitorBinder.bind(monitor: monitor, geofences: geofences, tracker: tracker)
+
+        #expect(monitor.setOnTransitionCallsCount == 2)
+        #expect(monitor.startMonitoringCalls.count == 2)
+    }
 }
 
 // MARK: - Mock

--- a/api-docs/CioLocation.api
+++ b/api-docs/CioLocation.api
@@ -6,6 +6,7 @@ public final class CioLocation.LocationModule {
 	public final val moduleName: String;
 	public fun init(config: LocationConfig);
 	public fun func initialize();
+	public fun func bootstrapForBackgroundDelivery(launchOptions: List<UIApplication.LaunchOptionsKey: Any>?);
 }
 public interface CioLocation.LocationServices {
 	public fun func setLastKnownLocation(_ location: CLLocation);


### PR DESCRIPTION
## Stack
Part of the MBL-1628 stack. Merge in order:

- [#1060](https://github.com/customerio/customerio-ios/pull/1060) — geofence transition event delivery via EventBus (in review)
- [#1061](https://github.com/customerio/customerio-ios/pull/1061) — pending-metric file-backed queue (in review)
- [#1062](https://github.com/customerio/customerio-ios/pull/1062) — direct-HTTP `GeofenceDeliveryTracker` (in review)
- [#1064](https://github.com/customerio/customerio-ios/pull/1064) — `BackgroundDeliveryContextStore` in Common (in review)
- [#1065](https://github.com/customerio/customerio-ios/pull/1065) — three-layer geofence transition delivery wireup (in review)
- [#1066](https://github.com/customerio/customerio-ios/pull/1066) — opt-in `cdpApiKey` persistence (in review)
- [#1067](https://github.com/customerio/customerio-ios/pull/1067) — wire `CoreLocationGeofenceMonitor` to `GeofenceEventTracker` (in review)
- [#1068](https://github.com/customerio/customerio-ios/pull/1068) — drop MessagingPush `HttpClient` dependency (in review, base for this PR)
- **This PR** — `LocationModule.bootstrapForBackgroundDelivery` cold-wake entry point

## Ticket
[MBL-1628 — Send Geofence Transition Events](https://linear.app/customerio/issue/MBL-1628/ios-send-geofence-transition-events)

## Summary
Wrapper SDKs (React Native, Flutter) initialize Customer.io from JS/Dart. On a cold-wake from a geofence transition, the JS/Dart runtime never starts, so `CustomerIO.initialize` never runs and the queued transition is dropped.

This PR adds `LocationModule.bootstrapForBackgroundDelivery(launchOptions:)`: a single-line AppDelegate entry that wires region monitoring and direct-HTTP delivery from native code only. It reads all the state it needs from persisted stores (`GeofenceStorage`, `BackgroundDeliveryContextStore`) — no module's `initialize` is required to run first.

The bootstrap shares the same DI-resolved singletons as `LocationModule.initialize`, so both paths converge on one `CoreLocationGeofenceMonitor`, one `GeofenceEventTracker`, and one in-process active-delivery dedup set. Native + wrapper apps both use the same line. No keys, no flags — `launchOptions` is accepted for forward compatibility (reserved for future cold-wake detection).

## Changes
- **`LocationModule.bootstrapForBackgroundDelivery(launchOptions:)`** (new public, `@MainActor`) — emits the discoverability log (deferred from #1066), starts `flushPending`, wires the monitor.
- **`GeofenceBootstrap`** (new, `@MainActor` enum) — factors the shared wiring (cache fetch → monitor → binder) and the discoverability log. Used by both `LocationModule.initialize` and `bootstrapForBackgroundDelivery`.
- **DI singletons** — `GeofenceStorage`, `GeofenceEventTracker`, `CoreLocationGeofenceMonitor` are now resolvable from `DIGraphShared` and constructed once per process:
  - `GeofenceStorage` and `GeofenceEventTracker` use Sourcery `InjectCustomShared`.
  - `CoreLocationGeofenceMonitor` uses a hand-written extension instead — the Sourcery-generated eager-init test references the property from a non-isolated context, which clashes with `@MainActor`. Documented in code.
- **`LocationModuleState.performInitialization`** refactored to consume the same DI singletons — no inline construction, no risk of foreground vs. cold-wake paths constructing separate monitors.

## Design rationale
- **Why one entry point, not two (cold-wake vs. foreground)?** The check `launchOptions[.location] != nil` is a hint, not a contract — the OS doesn't promise the key is set for every geofence-driven launch. Calling `bootstrap` unconditionally is safe (idempotent through DI singletons) and removes a branching footgun for hosts.
- **Why DI singletons instead of `LocationModuleState.shared`?** Reusing `LocationModuleState` would couple cold-wake (which only needs the geofence pieces) to the full Location service stack. DI lets the cold-wake path resolve exactly what it needs and naturally dedups against `initialize`.
- **Why drop Sourcery for the monitor?** The eager-init resolution test the template generates can't traverse a `@MainActor` boundary from its non-isolated test method. Two options: invent a `nonisolated` accessor that crashes at runtime if called off main (ugly + unsafe), or write the extension by hand (one-time tax, clearer semantics). Picked the hand-written extension.

## Scope
- Source: 143 insertions, 46 deletions (well under the 250-line cap)
- Tests: 115 LOC (new `GeofenceBootstrapTests`, additions to `GeofenceMonitorBinderTests`)
- New public API in `CioLocation`: `LocationModule.bootstrapForBackgroundDelivery(launchOptions:)`

## Test plan
- [x] `make generate && make format && make lint` clean
- [x] `GeofenceBootstrapTests` (new) — discoverability log fires on nil cdpApiKey, suppressed when persisted, suppressed when provider returns key; DI singletons resolve to the same instance across calls
- [x] `GeofenceMonitorBinderTests` — added double-bind test (idempotent re-bind from foreground + cold-wake in the same process)
- [x] Full `LocationTests` suite (106 tests) passes locally
- [x] api-docs baseline regenerated for new `bootstrapForBackgroundDelivery` public API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches geofence event delivery and process-wide singleton wiring; mis-sharing instances could drop or duplicate transitions, but changes are scoped and covered by tests.
> 
> **Overview**
> Adds **`LocationModule.bootstrapForBackgroundDelivery(launchOptions:)`** so hosts (especially RN/Flutter) can start geofence region monitoring and pending-metric replay from **AppDelegate** when `CustomerIO.initialize` never runs on a cold-wake.
> 
> **`GeofenceBootstrap`** centralizes the shared path: optional info log when background delivery isn’t configured, `flushPending`, then cache → monitor → binder (same ordering as before to avoid dropping queued region callbacks).
> 
> Foreground init in **`LocationModuleState`** no longer builds its own `GeofenceStorage` / tracker / monitor; it uses **`DIGraphShared`** singletons for **`GeofenceStorage`**, **`GeofenceEventTracker`**, and **`CoreLocationGeofenceMonitor`** so initialize and bootstrap share one monitor, one pending queue, and one in-process delivery dedup set. API docs and tests cover discoverability logging, DI identity, and double-bind idempotency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afeead9d7645403c8cecc70a3fe002144ed8c85f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->