### PR TITLE
chore: relax geofence permission gate + self-heal on auth change

### DIFF
--- a/Sources/Location/Geofence/GeofenceBootstrap.swift
+++ b/Sources/Location/Geofence/GeofenceBootstrap.swift
@@ -15,6 +15,15 @@ enum GeofenceBootstrap {
         let monitor = di.geofenceMonitor
         let tracker = di.geofenceEventTracker
         GeofenceMonitorBinder.bind(monitor: monitor, geofences: geofences, tracker: tracker)
+
+        // Self-heal mid-process permission changes (Settings toggle, late prompt response).
+        // Bind is idempotent, and the handler replaces any prior one — no stacking when both
+        // foreground init and cold-wake bootstrap run in the same process.
+        monitor.setOnAuthorizationChanged {
+            Task { @MainActor in
+                await GeofenceBootstrap.wireMonitor(di: di)
+            }
+        }
     }
 
     /// Logs a one-line note when cold-wake real-time delivery is unavailable for this

--- a/Sources/Location/Geofence/Logger+Geofence.swift
+++ b/Sources/Location/Geofence/Logger+Geofence.swift
@@ -21,11 +21,17 @@ extension Logger {
         )
     }
 
-    func geofenceAlwaysAuthorizationRequired(currentStatus: CLAuthorizationStatus) {
-        error(
-            "Geofence monitoring requires 'Always' location authorization. Current status: \(currentStatus.rawValue). The host app must call CLLocationManager.requestAlwaysAuthorization().",
-            geofenceTag,
-            nil
+    func geofencePermissionUnavailable(currentStatus: CLAuthorizationStatus) {
+        info(
+            "Geofence registration skipped: location permission not granted (current status: \(currentStatus.rawValue)). The host app controls when and which permission to request.",
+            geofenceTag
+        )
+    }
+
+    func geofenceBackgroundDeliveryUnavailable(currentStatus: CLAuthorizationStatus) {
+        info(
+            "Geofence registered for foreground delivery only: WhenInUse authorization granted (current status: \(currentStatus.rawValue)). Background transitions require Always authorization.",
+            geofenceTag
         )
     }
 

--- a/Sources/Location/Geofence/Monitor/CoreLocationGeofenceMonitor.swift
+++ b/Sources/Location/Geofence/Monitor/CoreLocationGeofenceMonitor.swift
@@ -13,10 +13,23 @@ import Foundation
 /// registered by the host app or other SDKs (CLLocationManager.monitoredRegions is shared app-wide).
 @MainActor
 final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preconcurrency CLLocationManagerDelegate {
+    /// Tier of capability available given the current `CLAuthorizationStatus`. The SDK never
+    /// requests permission — the host app owns that — so the monitor adapts to whatever was
+    /// granted: `.authorizedAlways` enables background delivery, `.authorizedWhenInUse` falls
+    /// back to foreground-only (regions still register and fire while foregrounded),
+    /// everything else skips registration.
+    enum PermissionTier: Equatable {
+        case backgroundDelivery
+        case foregroundOnly
+        case blocked
+    }
+
     private let manager: CLLocationManager
     private let logger: Logger
     private var onTransition: GeofenceTransitionHandler?
-    private var hasLoggedPermissionWarning = false
+    private var onAuthorizationChanged: GeofenceAuthorizationChangedHandler?
+    private var hasLoggedBlocked = false
+    private var hasLoggedForegroundOnly = false
     private var ownedRegionIdentifiers: Set<String> = []
 
     init(logger: Logger) {
@@ -34,8 +47,27 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
         onTransition = handler
     }
 
+    func setOnAuthorizationChanged(_ handler: GeofenceAuthorizationChangedHandler?) {
+        onAuthorizationChanged = handler
+    }
+
     func startMonitoring(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) {
-        guard checkAlwaysAuthorization() else { return }
+        let status = currentAuthorizationStatus()
+        switch Self.permissionTier(for: status) {
+        case .blocked:
+            if !hasLoggedBlocked {
+                hasLoggedBlocked = true
+                logger.geofencePermissionUnavailable(currentStatus: status)
+            }
+            return
+        case .foregroundOnly:
+            if !hasLoggedForegroundOnly {
+                hasLoggedForegroundOnly = true
+                logger.geofenceBackgroundDeliveryUnavailable(currentStatus: status)
+            }
+        case .backgroundDelivery:
+            break
+        }
 
         let coordinate = CLLocationCoordinate2D(latitude: center.latitude, longitude: center.longitude)
         guard CLLocationCoordinate2DIsValid(coordinate) else {
@@ -92,24 +124,35 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
         logger.geofenceMonitoringFailed(region: identifier, error: error)
     }
 
+    // iOS 14+ fires this on delegate set with the current status, and again on every change.
+    // We surface it to callers so the bootstrap can re-attempt registration when permission
+    // improves mid-process (the initial fire after delegate-set is harmless — the bootstrap
+    // already read the current status synchronously before installing the handler).
+    func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        onAuthorizationChanged?()
+    }
+
     // MARK: - Private
 
-    private func checkAlwaysAuthorization() -> Bool {
-        let status: CLAuthorizationStatus
-        if #available(iOS 14.0, *) {
-            status = manager.authorizationStatus
-        } else {
-            status = CLLocationManager.authorizationStatus()
+    nonisolated static func permissionTier(for status: CLAuthorizationStatus) -> PermissionTier {
+        switch status {
+        case .authorizedAlways:
+            return .backgroundDelivery
+        case .authorizedWhenInUse:
+            return .foregroundOnly
+        case .notDetermined, .restricted, .denied:
+            return .blocked
+        @unknown default:
+            return .blocked
         }
+    }
 
-        guard status == .authorizedAlways else {
-            if !hasLoggedPermissionWarning {
-                hasLoggedPermissionWarning = true
-                logger.geofenceAlwaysAuthorizationRequired(currentStatus: status)
-            }
-            return false
+    private func currentAuthorizationStatus() -> CLAuthorizationStatus {
+        if #available(iOS 14.0, *) {
+            return manager.authorizationStatus
+        } else {
+            return CLLocationManager.authorizationStatus()
         }
-        return true
     }
 
     private func currentLocationData() -> LocationData? {
@@ -132,7 +175,11 @@ extension DIGraphShared {
     /// so tests can still substitute via `di.override(value:forType:)`.
     @MainActor
     var geofenceMonitor: GeofenceRegionMonitoring {
-        getOverriddenInstance() ?? CoreLocationGeofenceMonitor.shared
+        // Explicit type on the optional pins the generic `T` in `getOverriddenInstance()` to
+        // the protocol — without it, Swift infers `T` as the concrete `CoreLocationGeofenceMonitor`
+        // from the `??` right-hand side and the override lookup misses by key.
+        let overridden: GeofenceRegionMonitoring? = getOverriddenInstance()
+        return overridden ?? CoreLocationGeofenceMonitor.shared
     }
 }
 

--- a/Sources/Location/Geofence/Monitor/GeofenceRegionMonitoring.swift
+++ b/Sources/Location/Geofence/Monitor/GeofenceRegionMonitoring.swift
@@ -11,6 +11,10 @@ import Foundation
 /// main-actor reads, or an `await someActor.method()` to hand off to another isolation domain.
 typealias GeofenceTransitionHandler = @Sendable (String, GeofenceTransition, LocationData?) -> Void
 
+/// Callback when iOS reports a change to the location authorization status.
+/// Invoked on the main actor — same isolation domain as `CLLocationManagerDelegate`.
+typealias GeofenceAuthorizationChangedHandler = @MainActor () -> Void
+
 /// Abstracts CLLocationManager's region monitoring.
 ///
 /// The monitor owns a CLLocationManager and handles the delegate callbacks for region events.
@@ -24,6 +28,11 @@ typealias GeofenceTransitionHandler = @Sendable (String, GeofenceTransition, Loc
 protocol GeofenceRegionMonitoring: AnyObject, Sendable {
     /// Sets the handler called when a geofence transition (enter/exit) occurs.
     func setOnTransition(_ handler: GeofenceTransitionHandler?)
+
+    /// Sets the handler invoked when iOS reports an authorization status change. Lets callers
+    /// re-attempt registration when permission improves mid-process (e.g. host's permission
+    /// prompt resolved, or the user toggled the setting in Settings).
+    func setOnAuthorizationChanged(_ handler: GeofenceAuthorizationChangedHandler?)
 
     /// Starts monitoring a circular geofence region.
     /// - Parameters:

--- a/Tests/Location/Geofence/GeofenceBootstrapTests.swift
+++ b/Tests/Location/Geofence/GeofenceBootstrapTests.swift
@@ -4,7 +4,7 @@ import Foundation
 import SharedTests
 import Testing
 
-@Suite("GeofenceBootstrap")
+@Suite("GeofenceBootstrap", .serialized)
 @MainActor
 struct GeofenceBootstrapTests {
     // MARK: - Discoverability log
@@ -66,6 +66,54 @@ struct GeofenceBootstrapTests {
         let first = di.geofenceStorage
         let second = di.geofenceStorage
         #expect(first === second)
+    }
+
+    // MARK: - Self-heal on authorization change
+
+    @Test
+    func wireMonitor_givenInitialBind_expectAuthorizationHandlerInstalled() async {
+        let di = DIGraphShared.shared
+        let storage = GeofenceStorage(
+            fileManager: .default,
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        di.override(value: storage, forType: GeofenceStorage.self)
+        let monitor = GeofenceRegionMonitoringMock()
+        di.override(value: monitor as GeofenceRegionMonitoring, forType: GeofenceRegionMonitoring.self)
+        defer { di.reset() }
+
+        await GeofenceBootstrap.wireMonitor(di: di)
+
+        #expect(monitor.setOnAuthorizationChangedCallsCount == 1)
+        #expect(monitor.lastAuthorizationChangedHandler != nil)
+    }
+
+    @Test
+    func wireMonitor_givenAuthorizationFires_expectReRegistration() async {
+        let di = DIGraphShared.shared
+        let storage = GeofenceStorage(
+            fileManager: .default,
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        let geofence = Geofence(
+            id: "g1", latitude: 1.0, longitude: 2.0, radius: 100,
+            name: "g1", transitionTypes: [.enter], lastUpdated: Date()
+        )
+        await storage.setCachedGeofences([geofence])
+        di.override(value: storage, forType: GeofenceStorage.self)
+        let monitor = GeofenceRegionMonitoringMock()
+        di.override(value: monitor as GeofenceRegionMonitoring, forType: GeofenceRegionMonitoring.self)
+        defer { di.reset() }
+
+        await GeofenceBootstrap.wireMonitor(di: di)
+        #expect(monitor.startMonitoringCalls.count == 1)
+
+        // Simulate iOS reporting a permission change. The handler spawns a Task to re-run
+        // wireMonitor; the sleep gives that Task time to schedule and complete.
+        monitor.lastAuthorizationChangedHandler?()
+        try? await Task.sleep(nanoseconds: 100000000)
+
+        #expect(monitor.startMonitoringCalls.count == 2)
     }
 
     @Test

--- a/Tests/Location/Geofence/GeofenceMonitorBinderTests.swift
+++ b/Tests/Location/Geofence/GeofenceMonitorBinderTests.swift
@@ -94,6 +94,8 @@ struct StartMonitoringCall: Equatable {
 @MainActor
 final class GeofenceRegionMonitoringMock: GeofenceRegionMonitoring {
     var setOnTransitionCallsCount = 0
+    var setOnAuthorizationChangedCallsCount = 0
+    var lastAuthorizationChangedHandler: GeofenceAuthorizationChangedHandler?
     var startMonitoringCalls: [StartMonitoringCall] = []
     var stopMonitoringCalls: [String] = []
     var stopMonitoringAllCallsCount = 0
@@ -101,6 +103,11 @@ final class GeofenceRegionMonitoringMock: GeofenceRegionMonitoring {
 
     func setOnTransition(_ handler: GeofenceTransitionHandler?) {
         setOnTransitionCallsCount += 1
+    }
+
+    func setOnAuthorizationChanged(_ handler: GeofenceAuthorizationChangedHandler?) {
+        setOnAuthorizationChangedCallsCount += 1
+        lastAuthorizationChangedHandler = handler
     }
 
     func startMonitoring(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) {

--- a/Tests/Location/Geofence/Monitor/GeofenceMonitorPermissionTierTests.swift
+++ b/Tests/Location/Geofence/Monitor/GeofenceMonitorPermissionTierTests.swift
@@ -1,0 +1,32 @@
+@testable import CioLocation
+import CoreLocation
+import Foundation
+import Testing
+
+@Suite("CoreLocationGeofenceMonitor.permissionTier")
+struct GeofenceMonitorPermissionTierTests {
+    @Test
+    func permissionTier_givenAuthorizedAlways_expectBackgroundDelivery() {
+        #expect(CoreLocationGeofenceMonitor.permissionTier(for: .authorizedAlways) == .backgroundDelivery)
+    }
+
+    @Test
+    func permissionTier_givenAuthorizedWhenInUse_expectForegroundOnly() {
+        #expect(CoreLocationGeofenceMonitor.permissionTier(for: .authorizedWhenInUse) == .foregroundOnly)
+    }
+
+    @Test
+    func permissionTier_givenNotDetermined_expectBlocked() {
+        #expect(CoreLocationGeofenceMonitor.permissionTier(for: .notDetermined) == .blocked)
+    }
+
+    @Test
+    func permissionTier_givenDenied_expectBlocked() {
+        #expect(CoreLocationGeofenceMonitor.permissionTier(for: .denied) == .blocked)
+    }
+
+    @Test
+    func permissionTier_givenRestricted_expectBlocked() {
+        #expect(CoreLocationGeofenceMonitor.permissionTier(for: .restricted) == .blocked)
+    }
+}

--- a/Tests/Location/Geofence/Stub/MockGeofenceRegionMonitor.swift
+++ b/Tests/Location/Geofence/Stub/MockGeofenceRegionMonitor.swift
@@ -12,6 +12,7 @@ struct MonitoredRegionRecord: Sendable {
 @MainActor
 final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
     private var onTransition: GeofenceTransitionHandler?
+    private var onAuthorizationChanged: GeofenceAuthorizationChangedHandler?
     private(set) var startedRegions: [MonitoredRegionRecord] = []
     private(set) var stoppedIdentifiers: [String] = []
     private(set) var stopAllCallCount = 0
@@ -23,6 +24,10 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
 
     func setOnTransition(_ handler: GeofenceTransitionHandler?) {
         onTransition = handler
+    }
+
+    func setOnAuthorizationChanged(_ handler: GeofenceAuthorizationChangedHandler?) {
+        onAuthorizationChanged = handler
     }
 
     func startMonitoring(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) {


### PR DESCRIPTION
## Stack
Part of the geofence work. Stacked on top of the MBL-1628 chain. Merge in order:

- [#1060](https://github.com/customerio/customerio-ios/pull/1060) — geofence transition event delivery via EventBus
- [#1061](https://github.com/customerio/customerio-ios/pull/1061) — pending-metric file-backed queue
- [#1062](https://github.com/customerio/customerio-ios/pull/1062) — direct-HTTP `GeofenceDeliveryTracker`
- [#1064](https://github.com/customerio/customerio-ios/pull/1064) — `BackgroundDeliveryContextStore` in Common
- [#1065](https://github.com/customerio/customerio-ios/pull/1065) — three-layer geofence transition delivery wireup
- [#1066](https://github.com/customerio/customerio-ios/pull/1066) — opt-in `cdpApiKey` persistence
- [#1067](https://github.com/customerio/customerio-ios/pull/1067) — wire `CoreLocationGeofenceMonitor` to `GeofenceEventTracker`
- [#1068](https://github.com/customerio/customerio-ios/pull/1068) — drop MessagingPush `HttpClient` dependency
- [#1069](https://github.com/customerio/customerio-ios/pull/1069) — `LocationModule.bootstrapForBackgroundDelivery` cold-wake entry (base for this PR)
- **This PR** — relax permission gate + self-heal on authorization change

## Ticket
[MBL-1626 — Handle OS Geofence Monitoring](https://linear.app/customerio/issue/MBL-1626/ios-handle-os-geofence-monitoring) (follow-up to PR #1036; same bug the Android team caught and fixed in their port)

## Summary
Two related fixes that align iOS with the SDK's passive permission stance: the SDK never requests permission — the host app owns that — and the SDK adapts to whatever it's given.

**Gate relaxation.** `CoreLocationGeofenceMonitor.checkAlwaysAuthorization()` rejected any status other than `.authorizedAlways`, silently dropping registration on `.authorizedWhenInUse` hosts that are otherwise fully functional in the foreground. Now the monitor handles all three tiers explicitly:

| Status | Behavior | Log |
|---|---|---|
| `.authorizedAlways` | register | none |
| `.authorizedWhenInUse` | register | info, once: "foreground delivery only" |
| `.denied`/`.restricted`/`.notDetermined`/`@unknown` | skip | info, once: "permission not granted; host controls request" |

Logs are descriptive (not prescriptive) and fire from `startMonitoring`, so they only emit when there's actually a geofence to register — silent when the SDK has nothing to do.

**Mid-process self-heal.** `CoreLocationGeofenceMonitor` now observes `locationManagerDidChangeAuthorization(_:)` and notifies `GeofenceBootstrap`, which re-runs `wireMonitor`. This covers the realistic case where the host prompts late (so initial registration ran with `.notDetermined`) or the user toggles permission in Settings while the app is alive. Customer integration is unchanged — they call `LocationModule.initialize` or `bootstrapForBackgroundDelivery` once; iOS auto-fires the delegate on every subsequent status change.

## Changes
- **`CoreLocationGeofenceMonitor`** — new `PermissionTier` enum, `permissionTier(for:)` (`nonisolated static`, fully testable), tier-based `startMonitoring` gate.
- **`locationManagerDidChangeAuthorization(_:)`** — new delegate method, invokes the auth-changed handler.
- **`GeofenceRegionMonitoring`** protocol — new `setOnAuthorizationChanged(_:)` method + `GeofenceAuthorizationChangedHandler` typealias.
- **`GeofenceBootstrap.wireMonitor`** — installs the auth-changed handler after binding; handler re-runs `wireMonitor` (idempotent, no stacking across repeat calls).
- **`Logger+Geofence`** — `geofenceAlwaysAuthorizationRequired` (error, prescriptive) replaced by `geofencePermissionUnavailable` + `geofenceBackgroundDeliveryUnavailable` (both info, descriptive).
- **`DIGraphShared.geofenceMonitor`** — fixed a generic-`T` inference bug where the override lookup keyed by the concrete class instead of the protocol. Now explicitly types the optional so `getOverriddenInstance()` resolves correctly.

## Design rationale
- **Why split into a tier enum instead of two booleans?** The three states have distinct logging behavior. An enum makes the three branches in `startMonitoring` exhaustive and surfaces `@unknown` correctly.
- **Why `nonisolated` on `permissionTier(for:)`?** It's pure — no class state. `@MainActor` would force tests to spin up the monitor just to call it.
- **Why a delegate hook instead of polling?** `CLLocationManagerDelegate.locationManagerDidChangeAuthorization(_:)` is iOS-native. The OS fires it on every status change for free.
- **Why re-run `wireMonitor` (not a narrower retry)?** Bind is idempotent, the cache fetch is cheap, and reusing the existing entry path keeps the foreground/cold-wake/self-heal paths converged on a single code path.
- **Re-entrancy:** rapid status changes during `wireMonitor`'s `await` could spawn multiple concurrent re-runs. End state is correct (everything is idempotent); the redundancy is harmless because iOS doesn't fire permission changes in tight succession.

## Scope
- Source: 91 insertions, 21 deletions
- Tests: 94 insertions, 1 deletion
- No public API surface changes (no `api-docs` regen needed)

## Test plan
- [x] `make generate && make format && make lint` clean
- [x] `GeofenceMonitorPermissionTierTests` (new) — 5 cases covering each `CLAuthorizationStatus` value
- [x] `GeofenceBootstrapTests` (additions) — handler installed after `wireMonitor`; firing the handler re-runs registration
- [x] `.serialized` trait added to the suite — parallel test execution was racing on the singleton DI graph (exposed by the new test, also benefits existing override-based tests)
- [x] Mocks (`GeofenceRegionMonitoringMock` + `MockGeofenceRegionMonitor`) updated for the new protocol method
- [x] Audit: zero `requestAlwaysAuthorization` / `requestWhenInUseAuthorization` / `requestAuthorization` calls in `Sources/` (only doc/log mentions remain)
- [x] Full `LocationTests` suite (113 tests) passes locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when regions register and how background vs foreground transitions behave, which affects location-sensitive delivery paths but does not add permission prompts or public API surface.
> 
> **Overview**
> Geofence region registration no longer requires **Always** location permission. **`CoreLocationGeofenceMonitor`** maps authorization to three **permission tiers**: full registration for Always, registration with a one-time info log for **When In Use** (foreground-only transitions), and skip with a one-time info log when permission is missing or denied. Prescriptive error logging is replaced with descriptive info messages that defer permission prompts to the host app.
> 
> **Mid-process recovery** wires **`locationManagerDidChangeAuthorization`** through **`setOnAuthorizationChanged`** on **`GeofenceRegionMonitoring`**, so **`GeofenceBootstrap.wireMonitor`** re-runs after Settings toggles or late permission prompts (idempotent bind, handler replacement avoids stacking).
> 
> **`DIGraphShared.geofenceMonitor`** fixes test/production overrides by typing the optional as **`GeofenceRegionMonitoring`** so DI lookup keys the protocol, not the concrete monitor type. Tests add tier coverage, bootstrap self-heal behavior, and **`.serialized`** on **`GeofenceBootstrapTests`** to avoid DI singleton races.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f024fee741704112d5102a87ed401d5be54282c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

