### PR TITLE
chore: GeofenceConfig model + LastSyncRecord storage

### DIFF
--- a/Sources/Location/Geofence/Event/GeofenceEventTracker.swift
+++ b/Sources/Location/Geofence/Event/GeofenceEventTracker.swift
@@ -58,8 +58,11 @@ final class GeofenceEventTracker: @unchecked Sendable {
     ) async {
         let cooldownKey = "\(geofenceId):\(transition.rawValue)"
         let now = dateUtil.now
+        // Cached config wins when present so a workspace can tune the dedup window without
+        // an SDK release; constructor default applies otherwise.
+        let interval = await storage.getCachedConfig()?.duplicateEventsExpiry ?? cooldownInterval
 
-        guard await storage.tryAcquireCooldown(key: cooldownKey, now: now, interval: cooldownInterval) else {
+        guard await storage.tryAcquireCooldown(key: cooldownKey, now: now, interval: interval) else {
             logger.geofenceEventSuppressed(geofenceId: geofenceId, transition: transition)
             return
         }
@@ -74,7 +77,7 @@ final class GeofenceEventTracker: @unchecked Sendable {
         _ = await pendingStore.append(metric)
 
         await deliver(metric: metric)
-        await storage.purgeExpiredCooldowns(now: now, interval: cooldownInterval)
+        await storage.purgeExpiredCooldowns(now: now, interval: interval)
     }
 
     /// Replays every queued metric through `deliver`.

--- a/Sources/Location/Geofence/Model/GeofenceConfig.swift
+++ b/Sources/Location/Geofence/Model/GeofenceConfig.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Server-driven geofence configuration. Each field overrides the corresponding fallback
+/// constant in `GeofenceConstants`; `GeofenceConfig.fallback` mirrors those constants for
+/// callers that need a fully-formed default.
+///
+/// Persisted alongside the cached business geofences in `GeofenceState`. Decoders are
+/// responsible for per-field sanitization (positive numerics, in-range counts) so any
+/// `GeofenceConfig` instance is already valid.
+///
+/// `maxBusinessGeofences` is 0…19 on iOS: 20 monitored regions total, one slot reserved
+/// for the SDK-built movement-trigger geofence. `0` is a valid server-side kill switch —
+/// disables business region registration for the account without uninstalling the SDK.
+struct GeofenceConfig: Codable, Equatable, Sendable {
+    /// Movement-trigger geofence radius in meters. Default 1000m.
+    let localRefreshTriggerRadius: Double
+    /// Distance in meters from the last server sync that triggers a fresh server fetch.
+    let remoteFetchRefreshTriggerRadius: Double
+    /// Freshness window for cached sync. A successful sync within this interval suppresses
+    /// redundant API calls from identify / app-launch triggers.
+    let remoteFetchRefreshExpiry: TimeInterval
+    /// Duplicate-transition suppression window keyed by "geofenceId:transitionType".
+    let duplicateEventsExpiry: TimeInterval
+    /// Maximum number of business geofences to monitor. Always 0…19 on iOS (movement
+    /// trigger consumes the 20th OS slot).
+    let maxBusinessGeofences: Int
+}
+
+extension GeofenceConfig {
+    /// Mirrors `GeofenceConstants` for callers that need a fully-formed config when no
+    /// cached value is available yet (first launch, pre-server-rollout, decode failure).
+    static let fallback = GeofenceConfig(
+        localRefreshTriggerRadius: GeofenceConstants.movementTriggerRadius,
+        remoteFetchRefreshTriggerRadius: GeofenceConstants.serverFetchDistance,
+        remoteFetchRefreshExpiry: GeofenceConstants.staleSyncInterval,
+        duplicateEventsExpiry: GeofenceConstants.eventCooldownInterval,
+        maxBusinessGeofences: GeofenceConstants.maxMonitoredGeofences
+    )
+}

--- a/Sources/Location/Geofence/Model/GeofenceState.swift
+++ b/Sources/Location/Geofence/Model/GeofenceState.swift
@@ -16,4 +16,8 @@ struct GeofenceState: Codable, Equatable, Sendable {
     var movementTriggerCenter: LocationData?
     /// Cooldown records for geofence transition events, keyed by "geofenceId:transitionType".
     var eventCooldowns: [String: Date]?
+    /// Server-driven configuration from the last successful sync. `nil` when no sync has
+    /// landed a `config` block yet — consumers fall back to `GeofenceConfig.fallback` or
+    /// their component defaults.
+    var cachedConfig: GeofenceConfig?
 }

--- a/Sources/Location/Geofence/Model/LastSyncRecord.swift
+++ b/Sources/Location/Geofence/Model/LastSyncRecord.swift
@@ -1,0 +1,10 @@
+import CioInternalCommon
+import Foundation
+
+/// Snapshot of a successful server sync. Returned as an atomic pair from
+/// `GeofenceStorage.getLastSync()` so callers never see a timestamp without its
+/// matching location (or vice versa).
+struct LastSyncRecord: Equatable, Sendable {
+    let timestamp: Date
+    let location: LocationData
+}

--- a/Sources/Location/Geofence/Storage/GeofenceStorage.swift
+++ b/Sources/Location/Geofence/Storage/GeofenceStorage.swift
@@ -95,6 +95,42 @@ actor GeofenceStorage {
         saveToDisk(state)
     }
 
+    // MARK: - Cached Config
+
+    func getCachedConfig() -> GeofenceConfig? {
+        loadFromDisk()?.cachedConfig
+    }
+
+    func setCachedConfig(_ config: GeofenceConfig) {
+        var state = loadFromDisk() ?? GeofenceState()
+        state.cachedConfig = config
+        saveToDisk(state)
+    }
+
+    // MARK: - Last Sync
+
+    /// Returns the last successful server sync as an atomic `(timestamp, location)` pair.
+    /// Returns `nil` if either half is missing — defensive against torn state that could
+    /// arise from older clients or future schema changes.
+    func getLastSync() -> LastSyncRecord? {
+        guard let state = loadFromDisk(),
+              let timestamp = state.lastServerSyncTimestamp,
+              let location = state.lastServerSyncLocation
+        else {
+            return nil
+        }
+        return LastSyncRecord(timestamp: timestamp, location: location)
+    }
+
+    /// Records a successful server sync. Writes both timestamp and location in the same
+    /// load-modify-save so a partial update cannot leave the two fields out of step.
+    func recordSync(timestamp: Date, location: LocationData) {
+        var state = loadFromDisk() ?? GeofenceState()
+        state.lastServerSyncTimestamp = timestamp
+        state.lastServerSyncLocation = location
+        saveToDisk(state)
+    }
+
     // MARK: - Private (file persistence)
 
     private func loadFromDisk() -> GeofenceState? {

--- a/Tests/Location/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/Location/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -226,6 +226,50 @@ struct GeofenceEventTrackerTests {
         #expect(delivery.deliverCallsCount == 2)
     }
 
+    @Test
+    func trackTransition_givenCachedConfigCooldown_expectServerValueWinsOverConstructorDefault() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        // Server-driven cooldown is 30 min; constructor's `cooldownInterval` is the
+        // test default (1h). The tracker should consult cached config first.
+        let serverCooldown: TimeInterval = 30 * 60
+        await storage.setCachedConfig(GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 3000,
+            remoteFetchRefreshExpiry: 24 * 60 * 60,
+            duplicateEventsExpiry: serverCooldown,
+            maxBusinessGeofences: 19
+        ))
+        let pending = makePendingStore(directory: dir)
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.deliverClosure = { _, _, onComplete in onComplete(.success(())) }
+        let dateUtil = DateUtilStub()
+        let baseTime = Date(timeIntervalSince1970: 1700000000)
+        dateUtil.givenNow = baseTime
+        let bus = EventBusHandlerMock()
+        let tracker = makeTracker(
+            storage: storage,
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_42"),
+            eventBus: bus,
+            dateUtil: dateUtil
+        )
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+        // Halfway through the server cooldown → suppressed (would have been allowed if
+        // the constructor's 1h default were in effect).
+        dateUtil.givenNow = baseTime.addingTimeInterval(serverCooldown / 2)
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+        #expect(delivery.deliverCallsCount == 1)
+
+        // Past the server cooldown but still within the constructor default → allowed.
+        dateUtil.givenNow = baseTime.addingTimeInterval(serverCooldown + 1)
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+        #expect(delivery.deliverCallsCount == 2)
+    }
+
     // MARK: - flushPending
 
     @Test

--- a/Tests/Location/Geofence/Storage/GeofenceStorageTests.swift
+++ b/Tests/Location/Geofence/Storage/GeofenceStorageTests.swift
@@ -239,6 +239,203 @@ struct GeofenceStorageTests {
         #expect(cached.map(\.id) == ["g1"])
     }
 
+    // MARK: - Cached config
+
+    @Test
+    func getCachedConfig_givenNoState_expectNil() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let config = await storage.getCachedConfig()
+        #expect(config == nil)
+    }
+
+    @Test
+    func setCachedConfig_thenGet_expectRoundTrip() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 750,
+            remoteFetchRefreshTriggerRadius: 4000,
+            remoteFetchRefreshExpiry: 12 * 60 * 60,
+            duplicateEventsExpiry: 30 * 60,
+            maxBusinessGeofences: 10
+        )
+        await storage.setCachedConfig(config)
+        let cached = await storage.getCachedConfig()
+        #expect(cached == config)
+    }
+
+    @Test
+    func setCachedConfig_givenNewStorageInstance_expectLoadsFromDisk() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let config = GeofenceConfig.fallback
+
+        let storage1 = makeStorage(directory: dir)
+        await storage1.setCachedConfig(config)
+
+        let storage2 = makeStorage(directory: dir)
+        let cached = await storage2.getCachedConfig()
+        #expect(cached == config)
+    }
+
+    @Test
+    func setCachedConfig_doesNotClearGeofencesOrCooldowns() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let timestamp = Date(timeIntervalSince1970: 1700000000)
+        await storage.recordEventCooldown(key: "geo_1:enter", timestamp: timestamp)
+        await storage.setCachedGeofences([makeGeofence(id: "g1")])
+
+        await storage.setCachedConfig(.fallback)
+
+        let cooldowns = await storage.getEventCooldowns()
+        #expect(cooldowns["geo_1:enter"] == timestamp)
+        let geofences = await storage.getCachedGeofences()
+        #expect(geofences.map(\.id) == ["g1"])
+    }
+
+    @Test
+    func setCachedConfig_givenSecondCall_expectOverwrites() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        await storage.setCachedConfig(.fallback)
+        let updated = GeofenceConfig(
+            localRefreshTriggerRadius: 500,
+            remoteFetchRefreshTriggerRadius: 2000,
+            remoteFetchRefreshExpiry: 60,
+            duplicateEventsExpiry: 30,
+            maxBusinessGeofences: 5
+        )
+        await storage.setCachedConfig(updated)
+        let cached = await storage.getCachedConfig()
+        #expect(cached == updated)
+    }
+
+    // MARK: - Last sync
+
+    @Test
+    func getLastSync_givenNoState_expectNil() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let record = await storage.getLastSync()
+        #expect(record == nil)
+    }
+
+    @Test
+    func recordSync_thenGet_expectRoundTrip() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let timestamp = Date(timeIntervalSince1970: 1700000000)
+        let location = LocationData(latitude: 37.7749, longitude: -122.4194)
+
+        await storage.recordSync(timestamp: timestamp, location: location)
+        let record = await storage.getLastSync()
+
+        #expect(record?.timestamp == timestamp)
+        #expect(record?.location == location)
+    }
+
+    @Test
+    func recordSync_givenSecondCall_expectOverwritesBothFields() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let firstTime = Date(timeIntervalSince1970: 1700000000)
+        let firstLocation = LocationData(latitude: 37.7749, longitude: -122.4194)
+        let secondTime = Date(timeIntervalSince1970: 1700003600)
+        let secondLocation = LocationData(latitude: 40.7128, longitude: -74.0060)
+
+        await storage.recordSync(timestamp: firstTime, location: firstLocation)
+        await storage.recordSync(timestamp: secondTime, location: secondLocation)
+        let record = await storage.getLastSync()
+
+        #expect(record?.timestamp == secondTime)
+        #expect(record?.location == secondLocation)
+    }
+
+    @Test
+    func recordSync_givenNewStorageInstance_expectLoadsFromDisk() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let timestamp = Date(timeIntervalSince1970: 1700000000)
+        let location = LocationData(latitude: 1.0, longitude: 2.0)
+
+        let storage1 = makeStorage(directory: dir)
+        await storage1.recordSync(timestamp: timestamp, location: location)
+
+        let storage2 = makeStorage(directory: dir)
+        let record = await storage2.getLastSync()
+
+        #expect(record?.timestamp == timestamp)
+        #expect(record?.location == location)
+    }
+
+    @Test
+    func getLastSync_givenOnlyTimestampOnDisk_expectNilFromDefensiveGuard() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        // Write a state file with timestamp but no location — simulates a torn state from
+        // an older client or a partial future-schema migration.
+        var partial = GeofenceState()
+        partial.lastServerSyncTimestamp = Date(timeIntervalSince1970: 1700000000)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        try? encoder.encode(partial).write(to: dir.appendingPathComponent("geofenceState.json"))
+
+        let storage = makeStorage(directory: dir)
+        let record = await storage.getLastSync()
+
+        #expect(record == nil)
+    }
+
+    @Test
+    func getLastSync_givenOnlyLocationOnDisk_expectNilFromDefensiveGuard() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        var partial = GeofenceState()
+        partial.lastServerSyncLocation = LocationData(latitude: 1.0, longitude: 2.0)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        try? encoder.encode(partial).write(to: dir.appendingPathComponent("geofenceState.json"))
+
+        let storage = makeStorage(directory: dir)
+        let record = await storage.getLastSync()
+
+        #expect(record == nil)
+    }
+
+    @Test
+    func recordSync_doesNotClearOtherState() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let cooldownTime = Date(timeIntervalSince1970: 1700000000)
+        await storage.recordEventCooldown(key: "geo_1:enter", timestamp: cooldownTime)
+        await storage.setCachedGeofences([makeGeofence(id: "g1")])
+        await storage.setCachedConfig(.fallback)
+
+        await storage.recordSync(
+            timestamp: Date(timeIntervalSince1970: 1700003600),
+            location: LocationData(latitude: 1.0, longitude: 2.0)
+        )
+
+        let cooldowns = await storage.getEventCooldowns()
+        #expect(cooldowns["geo_1:enter"] == cooldownTime)
+        let geofences = await storage.getCachedGeofences()
+        #expect(geofences.map(\.id) == ["g1"])
+        let config = await storage.getCachedConfig()
+        #expect(config == .fallback)
+    }
+
     @Test
     func setCachedGeofences_doesNotClearCooldowns() async {
         let dir = makeTempDirectory()


### PR DESCRIPTION
## Stack
Part of the geofence work. Stacked on top of the MBL-1626 + MBL-1628 chain. Merge in order:

- [#1060](https://github.com/customerio/customerio-ios/pull/1060) — geofence transition event delivery via EventBus
- [#1061](https://github.com/customerio/customerio-ios/pull/1061) — pending-metric file-backed queue
- [#1062](https://github.com/customerio/customerio-ios/pull/1062) — direct-HTTP `GeofenceDeliveryTracker`
- [#1064](https://github.com/customerio/customerio-ios/pull/1064) — `BackgroundDeliveryContextStore` in Common
- [#1065](https://github.com/customerio/customerio-ios/pull/1065) — three-layer geofence transition delivery wireup
- [#1066](https://github.com/customerio/customerio-ios/pull/1066) — opt-in `cdpApiKey` persistence
- [#1067](https://github.com/customerio/customerio-ios/pull/1067) — wire `CoreLocationGeofenceMonitor` to `GeofenceEventTracker`
- [#1068](https://github.com/customerio/customerio-ios/pull/1068) — drop MessagingPush `HttpClient` dependency
- [#1069](https://github.com/customerio/customerio-ios/pull/1069) — `LocationModule.bootstrapForBackgroundDelivery` cold-wake entry
- [#1070](https://github.com/customerio/customerio-ios/pull/1070) — relax permission gate + self-heal on auth change (base for this PR)
- **This PR** — `GeofenceConfig` model + `LastSyncRecord` storage + cooldown adoption

## Ticket
[MBL-1624 — Fetch and Sync Geofences](https://linear.app/customerio/issue/MBL-1624/ios-fetch-and-sync-geofences) (part 1 of 2 — data layer; the API service that populates this lands in part 2)

## Summary
Data-layer scaffolding for the server-driven config + sync metadata. The API service that populates this lands next; the coordinator that consumes the remaining tunables lands in MBL-1630.

**`GeofenceConfig`** mirrors the server response shape with Swift naming. All five tunables are present so consumers can be wired progressively without re-shaping the model.

| Field | Purpose | Fallback |
|---|---|---|
| `localRefreshTriggerRadius` | Movement-trigger geofence radius (m) | `GeofenceConstants.movementTriggerRadius` (1km) |
| `remoteFetchRefreshTriggerRadius` | Distance from last sync that forces remote fetch (m) | `GeofenceConstants.serverFetchDistance` (3km) |
| `remoteFetchRefreshExpiry` | Freshness window for cached sync (s) | `GeofenceConstants.staleSyncInterval` (24h) |
| `duplicateEventsExpiry` | Dedup cooldown window (s) | `GeofenceConstants.eventCooldownInterval` (1h) |
| `maxBusinessGeofences` | Max regions to register (0…19 on iOS) | `GeofenceConstants.maxMonitoredGeofences` (19) |

`maxBusinessGeofences` is bounded 0…19: iOS allows 20 monitored regions total, one OS slot reserved for the SDK-built movement-trigger geofence. `0` is a valid server-side kill switch — disables business region registration for the account without uninstalling the SDK. Per-field sanitization happens at the decoder boundary (part 2); any `GeofenceConfig` instance is already valid.

**`LastSyncRecord`** is an atomic `(timestamp, location)` pair. The paired storage API rules out torn state: `recordSync(timestamp:location:)` writes both fields in the same load-modify-save block inside the actor; `getLastSync()` returns `nil` if either half is missing — defensive against older clients or future schema changes.

**`GeofenceEventTracker`** now consults the cached config first for the dedup cooldown, falling back to the constructor's `cooldownInterval`. The read happens inside the actor-isolated `trackTransition`, so each transition picks up the latest cached value without extra plumbing — workspaces can tune the dedup window without an SDK release.

## Changes
- **`GeofenceConfig`** (new) — Codable / Equatable / Sendable struct with all 5 tunables. `GeofenceConfig.fallback` mirrors `GeofenceConstants` for callers that need a fully-formed default.
- **`GeofenceState.cachedConfig: GeofenceConfig?`** — optional so partial state remains valid across SDK updates.
- **`GeofenceStorage.getCachedConfig()` / `setCachedConfig(_:)`** — actor-isolated round-trip.
- **`LastSyncRecord`** (new) — `(timestamp: Date, location: LocationData)` value type.
- **`GeofenceStorage.getLastSync()` / `recordSync(timestamp:location:)`** — atomic paired API.
- **`GeofenceEventTracker.trackTransition`** — `await storage.getCachedConfig()?.duplicateEventsExpiry ?? cooldownInterval`, with the same `interval` used for both `tryAcquireCooldown` and `purgeExpiredCooldowns` so a mid-call config change doesn't tear within one transition.

## Design rationale
- **Why paired API for sync metadata?** Two separate getters/setters would let a caller update one without the other (different transactions). A `LastSyncRecord` reader returning `nil` on partial state is structurally race-free — a caller can never observe a timestamp without its matching location.
- **Why `LastSyncRecord` as a separate type, not just a tuple?** Equatable + Sendable + Codable are all explicit; a tuple wouldn't get the same affordances.
- **Why keep `GeofenceState` fields separate (not nested)?** Avoids a schema migration for existing on-disk state from PR #1048. The pair-shaped API is at the storage boundary only.
- **Why not also adopt the other config fields (`localRefreshTriggerRadius`, etc.) in this PR?** They have no current consumer — the coordinator that uses them lands in MBL-1630. Shipping adoption ahead of consumers is the failure mode the [log-with-consumer](../wiki/log-with-consumer) rule guards against.
- **Movement trigger out of scope.** It's built on-the-fly by the coordinator (MBL-1630), not persisted, and not part of the API response. Constants for its ID and radius already exist.

## Scope
- Source: 98 insertions (40 `GeofenceConfig` + 10 `LastSyncRecord` + 4 state field + 36 storage methods + 8 tracker)
- Tests: 237 insertions (193 storage + 44 tracker)
- No public API surface changes (no `api-docs` regen needed)

## Test plan
- [x] `make generate && make format && make lint` clean
- [x] `GeofenceStorageTests` — 5 cached-config tests (round-trip, persistence, overwrite, cross-field isolation, fallback) + 7 sync tests (round-trip, persistence, overwrite, both-fields atomic, cross-field isolation, **2 defensive-guard tests** for partial on-disk state)
- [x] `GeofenceEventTrackerTests` — new `trackTransition_givenCachedConfigCooldown_expectServerValueWinsOverConstructorDefault` verifies server cooldown is honored over constructor default
- [x] Full `LocationTests` suite (126 tests) passes locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal geofence persistence and dedup-window selection only; optional cached config with existing fallbacks and no public API changes.
> 
> **Overview**
> Adds **server-driven geofence settings** and **sync metadata** to persisted `GeofenceState`, plus storage APIs to read/write them atomically.
> 
> Introduces `GeofenceConfig` (five tunables with `GeofenceConfig.fallback` from `GeofenceConstants`) and persists it via `GeofenceStorage.getCachedConfig()` / `setCachedConfig(_:)`. Adds `LastSyncRecord` and paired `getLastSync()` / `recordSync(timestamp:location:)` so callers never see a timestamp without its location (returns `nil` if either field is missing).
> 
> **`GeofenceEventTracker`** now uses `cachedConfig.duplicateEventsExpiry` for dedup cooldown and purge when present, otherwise the constructor default—same interval for acquire and purge within one transition.
> 
> Heavy test coverage for config/sync round-trips, partial on-disk state, isolation from cooldowns/geofences, and server cooldown overriding the tracker default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93911e63cc560bb24646c6767c238fa4c942f769. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->