### PR TITLE
chore: wire geofence sync triggers and add handleMovement Tier A/B

### DIFF
--- a/Sources/Location/Geofence/Coordinator/GeofenceSyncCoordinator.swift
+++ b/Sources/Location/Geofence/Coordinator/GeofenceSyncCoordinator.swift
@@ -1,4 +1,5 @@
 import CioInternalCommon
+import CoreLocation
 import Foundation
 
 /// Errors surfaced by `GeofenceSyncCoordinator` callers.
@@ -8,16 +9,28 @@ enum GeofenceSyncError: Error, Equatable {
     case fetchFailed(GeofenceApiError)
 }
 
-/// Sync pipeline for the on-device geofence cache. Two entry points:
+/// Which branch `handleMovement` took for the current EXIT.
+enum HandleMovementTier: String, Sendable {
+    /// Re-rank cached regions for the new location; no API call.
+    case localRerank
+    /// Anchor moved beyond `remoteFetchRefreshTriggerRadius` (or absent) — refetch from server.
+    case remoteRefresh
+}
+
+/// Sync pipeline for the on-device geofence cache. Entry points:
 ///
 /// - `refresh(latitude:longitude:)` — fetch from the server, distance-filter, register,
 ///   persist. Gated on identified user, in-flight dedup, and freshness.
+/// - `handleMovement(latitude:longitude:)` — movement-trigger EXIT entry. Two-tier:
+///   re-rank cache when within `remoteFetchRefreshTriggerRadius` of the API anchor,
+///   otherwise refetch from the server. Shares the same dedup gate as `refresh`.
 /// - `applyCachedRegistration(...)` — synchronously register from caller-fetched state,
 ///   used by cold-wake / boot / auth-change paths. Synchronous on the main actor so
 ///   `ownedRegionIdentifiers` is populated before the next yield — otherwise the OS may
 ///   deliver a queued cold-wake transition into an empty filter set.
-protocol GeofenceSyncCoordinator: AutoMockable, Sendable {
+protocol GeofenceSyncCoordinator: AutoMockable, AnyObject, Sendable {
     func refresh(latitude: Double, longitude: Double) async -> Result<Void, GeofenceSyncError>
+    func handleMovement(latitude: Double, longitude: Double) async -> Result<Void, GeofenceSyncError>
     @MainActor
     func applyCachedRegistration(
         cachedRegions: [Geofence],
@@ -59,18 +72,11 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
     }
 
     func refresh(latitude: Double, longitude: Double) async -> Result<Void, GeofenceSyncError> {
-        // Concurrent calls return `.alreadyInProgress` (not `.success`) so callers can
-        // distinguish a skip-due-to-dedup from a real completion.
-        let acquired: Bool = refreshInProgress.mutating { inProgress in
-            if inProgress { return false }
-            inProgress = true
-            return true
-        }
-        guard acquired else {
+        guard acquireGate() else {
             logger.geofenceSyncSkipped(reason: "refresh already in progress")
             return .failure(.alreadyInProgress)
         }
-        defer { refreshInProgress.wrappedValue = false }
+        defer { releaseGate() }
 
         guard let userId = contextStore.currentUserId, !userId.isEmpty else {
             logger.geofenceSyncSkipped(reason: "no identified user")
@@ -86,6 +92,111 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
             }
         }
 
+        return await performRemoteRefresh(
+            latitude: latitude,
+            longitude: longitude,
+            cachedConfig: cachedConfig
+        )
+    }
+
+    func handleMovement(latitude: Double, longitude: Double) async -> Result<Void, GeofenceSyncError> {
+        guard acquireGate() else {
+            logger.geofenceSyncSkipped(reason: "refresh already in progress")
+            return .failure(.alreadyInProgress)
+        }
+        defer { releaseGate() }
+
+        guard let userId = contextStore.currentUserId, !userId.isEmpty else {
+            logger.geofenceSyncSkipped(reason: "no identified user")
+            return .failure(.noIdentifiedUser)
+        }
+
+        let cachedConfig = await storage.getCachedConfig()
+        let anchor = await storage.getLastSync()?.location
+        let effectiveConfig = cachedConfig ?? .fallback
+        // No anchor → no Tier A reference; fall through to remote.
+        let needsRemoteFetch: Bool = {
+            guard let anchor else { return true }
+            let distance = CLLocation(latitude: anchor.latitude, longitude: anchor.longitude)
+                .distance(from: CLLocation(latitude: latitude, longitude: longitude))
+            return distance >= effectiveConfig.remoteFetchRefreshTriggerRadius
+        }()
+
+        if needsRemoteFetch {
+            logger.geofenceMovementTrigger(tier: .remoteRefresh)
+            return await performRemoteRefresh(
+                latitude: latitude,
+                longitude: longitude,
+                cachedConfig: cachedConfig
+            )
+        } else {
+            logger.geofenceMovementTrigger(tier: .localRerank)
+            let cachedRegions = await storage.getCachedGeofences()
+            return await performLocalRefresh(
+                latitude: latitude,
+                longitude: longitude,
+                config: effectiveConfig,
+                cachedRegions: cachedRegions
+            )
+        }
+    }
+
+    @MainActor
+    func applyCachedRegistration(
+        cachedRegions: [Geofence],
+        anchor: LocationData?,
+        config: GeofenceConfig?,
+        userId: String?
+    ) {
+        guard let userId, !userId.isEmpty else {
+            logger.geofenceSyncSkipped(reason: "no identified user")
+            return
+        }
+        guard !cachedRegions.isEmpty else {
+            logger.geofenceSyncSkipped(reason: "no cached regions to restore")
+            return
+        }
+        // Need an anchor to distance-filter and to center the movement trigger. Skipping
+        // when absent is safer than re-using an arbitrary location.
+        guard let anchor else {
+            logger.geofenceSyncSkipped(reason: "no last-sync anchor to restore from")
+            return
+        }
+        guard acquireGate() else {
+            logger.geofenceSyncSkipped(reason: "restore already in progress")
+            return
+        }
+        defer { releaseGate() }
+
+        let effectiveConfig = config ?? .fallback
+        let nearest = distanceFilter.nearest(cachedRegions, to: anchor, limit: effectiveConfig.maxBusinessGeofences)
+        registerWithOsSync(
+            businessRegions: nearest,
+            movementTriggerLocation: anchor,
+            movementTriggerRadius: effectiveConfig.localRefreshTriggerRadius
+        )
+        logger.geofenceSyncCompleted(registeredCount: nearest.count)
+    }
+
+    /// Returns false when another call already holds the gate; the caller short-circuits.
+    private func acquireGate() -> Bool {
+        refreshInProgress.mutating { inProgress in
+            if inProgress { return false }
+            inProgress = true
+            return true
+        }
+    }
+
+    private func releaseGate() {
+        refreshInProgress.wrappedValue = false
+    }
+
+    /// Fetch + filter + register + persist. Caller owns the dedup gate and user-id check.
+    private func performRemoteRefresh(
+        latitude: Double,
+        longitude: Double,
+        cachedConfig: GeofenceConfig?
+    ) async -> Result<Void, GeofenceSyncError> {
         let fetchResult = await awaitApiFetch(latitude: latitude, longitude: longitude)
         let response: GeofenceApiResponse
         switch fetchResult {
@@ -120,46 +231,26 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         return .success(())
     }
 
-    @MainActor
-    func applyCachedRegistration(
-        cachedRegions: [Geofence],
-        anchor: LocationData?,
-        config: GeofenceConfig?,
-        userId: String?
-    ) {
-        guard let userId, !userId.isEmpty else {
-            logger.geofenceSyncSkipped(reason: "no identified user")
-            return
+    /// Re-rank cached regions for the new location and re-register with the OS. No API call,
+    /// no cache or `lastSync` writes — the API anchor is what `handleMovement` compared
+    /// against, so leaving it intact preserves the next Tier B threshold.
+    private func performLocalRefresh(
+        latitude: Double,
+        longitude: Double,
+        config: GeofenceConfig,
+        cachedRegions: [Geofence]
+    ) async -> Result<Void, GeofenceSyncError> {
+        let anchor = LocationData(latitude: latitude, longitude: longitude)
+        let nearest = distanceFilter.nearest(cachedRegions, to: anchor, limit: config.maxBusinessGeofences)
+        await MainActor.run {
+            registerWithOsSync(
+                businessRegions: nearest,
+                movementTriggerLocation: anchor,
+                movementTriggerRadius: config.localRefreshTriggerRadius
+            )
         }
-        guard !cachedRegions.isEmpty else {
-            logger.geofenceSyncSkipped(reason: "no cached regions to restore")
-            return
-        }
-        // Need an anchor to distance-filter and to center the movement trigger. Skipping
-        // when absent is safer than re-using an arbitrary location.
-        guard let anchor else {
-            logger.geofenceSyncSkipped(reason: "no last-sync anchor to restore from")
-            return
-        }
-        let acquired: Bool = refreshInProgress.mutating { inProgress in
-            if inProgress { return false }
-            inProgress = true
-            return true
-        }
-        guard acquired else {
-            logger.geofenceSyncSkipped(reason: "restore already in progress")
-            return
-        }
-        defer { refreshInProgress.wrappedValue = false }
-
-        let effectiveConfig = config ?? .fallback
-        let nearest = distanceFilter.nearest(cachedRegions, to: anchor, limit: effectiveConfig.maxBusinessGeofences)
-        registerWithOsSync(
-            businessRegions: nearest,
-            movementTriggerLocation: anchor,
-            movementTriggerRadius: effectiveConfig.localRefreshTriggerRadius
-        )
         logger.geofenceSyncCompleted(registeredCount: nearest.count)
+        return .success(())
     }
 
     private func awaitApiFetch(

--- a/Sources/Location/Geofence/GeofenceBootstrap.swift
+++ b/Sources/Location/Geofence/GeofenceBootstrap.swift
@@ -22,8 +22,9 @@ enum GeofenceBootstrap {
         // delegate call can land.
         let monitor = di.geofenceMonitor
         let tracker = di.geofenceEventTracker
-        GeofenceMonitorBinder.bind(monitor: monitor, tracker: tracker)
-        di.geofenceSyncCoordinator.applyCachedRegistration(
+        let coordinator = di.geofenceSyncCoordinator
+        GeofenceMonitorBinder.bind(monitor: monitor, tracker: tracker, coordinator: coordinator)
+        coordinator.applyCachedRegistration(
             cachedRegions: cachedRegions,
             anchor: lastSync?.location,
             config: cachedConfig,

--- a/Sources/Location/Geofence/GeofenceMonitorBinder.swift
+++ b/Sources/Location/Geofence/GeofenceMonitorBinder.swift
@@ -1,16 +1,32 @@
 import CioInternalCommon
 import Foundation
 
-/// Wires the monitor's transition handler to forward OS region transitions into
-/// `GeofenceEventTracker.trackTransition`. Synchronous by design — must run before any
+/// Wires the monitor's transition handler. Synchronous — must run before any
 /// `startMonitoring` call so cold-wake delegate callbacks arriving immediately after
 /// `CLLocationManager` becomes active have a handler to dispatch to.
+///
+/// Two dispatch paths:
+/// - `GeofenceConstants.movementTriggerIdentifier` (EXIT) → `coordinator.handleMovement`
+///   (internal; never tracked as a customer event).
+/// - Any other identifier → `tracker.trackTransition` (the business geofences).
 @MainActor
 enum GeofenceMonitorBinder {
-    static func bind(monitor: GeofenceRegionMonitoring, tracker: GeofenceEventTracker) {
-        monitor.setOnTransition { [weak tracker] identifier, transition, location in
-            // CLLocationManager delivers on main; trackTransition is async with its own
-            // serialization (active-delivery dedup), so a fire-and-forget Task is safe.
+    static func bind(
+        monitor: GeofenceRegionMonitoring,
+        tracker: GeofenceEventTracker,
+        coordinator: GeofenceSyncCoordinator
+    ) {
+        monitor.setOnTransition { [weak tracker, weak coordinator] identifier, transition, location in
+            // CLLocationManager delivers on main; both handlers below are async with their
+            // own serialization (tracker active-delivery dedup, coordinator refresh gate),
+            // so fire-and-forget Tasks are safe.
+            if identifier == GeofenceConstants.movementTriggerIdentifier {
+                // EXIT is the only registered transition for the movement trigger; the
+                // guard defends against an unexpected ENTER reaching this dispatch.
+                guard transition == .exit, let location else { return }
+                Task { _ = await coordinator?.handleMovement(latitude: location.latitude, longitude: location.longitude) }
+                return
+            }
             Task { await tracker?.trackTransition(geofenceId: identifier, transition: transition, location: location) }
         }
     }

--- a/Sources/Location/Geofence/Logger+Geofence.swift
+++ b/Sources/Location/Geofence/Logger+Geofence.swift
@@ -68,4 +68,8 @@ extension Logger {
     func geofenceSyncCompleted(registeredCount: Int) {
         info("Sync completed: registered \(registeredCount) business geofences + 1 movement trigger", geofenceTag)
     }
+
+    func geofenceMovementTrigger(tier: HandleMovementTier) {
+        debug("Movement trigger EXIT: \(tier.rawValue)", geofenceTag)
+    }
 }

--- a/Sources/Location/LocationModuleState.swift
+++ b/Sources/Location/LocationModuleState.swift
@@ -10,6 +10,8 @@ final class LocationModuleState {
 
     private var services: LocationServices = UninitializedLocationServices(logger: DIGraphShared.shared.logger)
     private let lock = NSLock()
+    /// Retains the foreground observer registered for geofence refresh.
+    private var geofenceForegroundToken: AppLifecycleObserverToken?
 
     private init() {}
 
@@ -35,8 +37,16 @@ final class LocationModuleState {
         )
         let locationEnrichmentProvider = LocationProfileEnrichmentProvider(storage: storage, config: config)
         di.profileEnrichmentRegistry.register(locationEnrichmentProvider)
-        registerEventSubscriptions(coordinator: coordinator, di: di)
+        registerEventSubscriptions(coordinator: coordinator, lastLocationStorage: storage, di: di)
         Task { await di.geofenceEventTracker.flushPending() }
+        let lifecycleNotifying = RealAppLifecycleNotifying()
+        // Foreground geofence refresh is intentionally mode-independent — geofence
+        // monitoring runs even when `LocationConfig.mode` disables periodic location
+        // updates. Skips silently with no cached anchor; movement EXIT drives the first
+        // registration in that case.
+        geofenceForegroundToken = lifecycleNotifying.addDidBecomeActiveObserver { [weak self] in
+            self?.refreshGeofencesIfPossible(lastLocationStorage: storage)
+        }
         Task { @MainActor in
             await GeofenceBootstrap.wireMonitor(di: di)
         }
@@ -46,17 +56,35 @@ final class LocationModuleState {
             logger: di.logger,
             locationProvider: locationProvider,
             locationSyncCoordinator: coordinator,
-            lifecycleNotifying: RealAppLifecycleNotifying(),
+            lifecycleNotifying: lifecycleNotifying,
             applicationStateProvider: RealApplicationStateProvider()
         )
         services = implementation
         Task { await implementation.setUpLifecycleObserver() }
     }
 
-    private func registerEventSubscriptions(coordinator: LocationSyncCoordinator, di: DIGraphShared) {
-        di.eventBusHandler.addObserver(ProfileIdentifiedEvent.self) { _ in
+    private func registerEventSubscriptions(
+        coordinator: LocationSyncCoordinator,
+        lastLocationStorage: LastLocationStorage,
+        di: DIGraphShared
+    ) {
+        di.eventBusHandler.addObserver(ProfileIdentifiedEvent.self) { [weak self] _ in
             Task { await coordinator.syncCachedLocationIfNeeded() }
             Task { await di.geofenceEventTracker.flushPending() }
+            self?.refreshGeofencesIfPossible(lastLocationStorage: lastLocationStorage)
+        }
+    }
+
+    /// Shared by the identify and foreground triggers. Mode-independent — geofence
+    /// registration is orthogonal to the location-tracking pipeline that populates
+    /// `LastLocationStorage` for enrichment.
+    private func refreshGeofencesIfPossible(lastLocationStorage: LastLocationStorage) {
+        guard let location = lastLocationStorage.getCachedLocation() else { return }
+        Task { @MainActor in
+            _ = await DIGraphShared.shared.geofenceSyncCoordinator.refresh(
+                latitude: location.latitude,
+                longitude: location.longitude
+            )
         }
     }
 

--- a/Sources/Location/autogenerated/AutoMockable.generated.swift
+++ b/Sources/Location/autogenerated/AutoMockable.generated.swift
@@ -197,6 +197,11 @@ class GeofenceSyncCoordinatorMock: GeofenceSyncCoordinator, Mock {
         refreshReceivedInvocations = []
 
         mockCalled = false // do last as resetting properties above can make this true
+        handleMovementCallsCount = 0
+        handleMovementReceivedArguments = nil
+        handleMovementReceivedInvocations = []
+
+        mockCalled = false // do last as resetting properties above can make this true
         applyCachedRegistrationCallsCount = 0
         applyCachedRegistrationReceivedArguments = nil
         applyCachedRegistrationReceivedInvocations = []
@@ -233,6 +238,37 @@ class GeofenceSyncCoordinatorMock: GeofenceSyncCoordinator, Mock {
         refreshReceivedArguments = (latitude: latitude, longitude: longitude)
         refreshReceivedInvocations.append((latitude: latitude, longitude: longitude))
         return refreshClosure.map { $0(latitude, longitude) } ?? refreshReturnValue
+    }
+
+    // MARK: - handleMovement
+
+    /// Number of times the function was called.
+    @Atomic private(set) var handleMovementCallsCount = 0
+    /// `true` if the function was ever called.
+    var handleMovementCalled: Bool {
+        handleMovementCallsCount > 0
+    }
+
+    /// The arguments from the *last* time the function was called.
+    @Atomic private(set) var handleMovementReceivedArguments: (latitude: Double, longitude: Double)?
+    /// Arguments from *all* of the times that the function was called.
+    @Atomic private(set) var handleMovementReceivedInvocations: [(latitude: Double, longitude: Double)] = []
+    /// Value to return from the mocked function.
+    var handleMovementReturnValue: Result<Void, GeofenceSyncError>!
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     The closure has first priority to return a value for the mocked function. If the closure returns `nil`,
+     then the mock will attempt to return the value for `handleMovementReturnValue`
+     */
+    var handleMovementClosure: ((Double, Double) -> Result<Void, GeofenceSyncError>)?
+
+    /// Mocked function for `handleMovement(latitude: Double, longitude: Double)`. Your opportunity to return a mocked value and check result of mock in test code.
+    func handleMovement(latitude: Double, longitude: Double) -> Result<Void, GeofenceSyncError> {
+        mockCalled = true
+        handleMovementCallsCount += 1
+        handleMovementReceivedArguments = (latitude: latitude, longitude: longitude)
+        handleMovementReceivedInvocations.append((latitude: latitude, longitude: longitude))
+        return handleMovementClosure.map { $0(latitude, longitude) } ?? handleMovementReturnValue
     }
 
     // MARK: - applyCachedRegistration

--- a/Tests/Location/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/Location/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -610,6 +610,197 @@ struct GeofenceSyncCoordinatorTests {
         #expect(second.isSuccess)
         #expect(api.fetchGeofencesCallsCount == 1)
     }
+
+    // MARK: - handleMovement
+
+    @Test
+    func handleMovement_givenNoUserId_expectFailureAndNoApiCall() async {
+        let storage = makeStorage()
+        let setup = makeCoordinator(storage: storage, contextStore: makeContextStore(userId: nil))
+
+        let result = await setup.coordinator.handleMovement(latitude: 1.0, longitude: 2.0)
+
+        #expect(result.errorOrNil == .noIdentifiedUser)
+        #expect(setup.api.fetchGeofencesCallsCount == 0)
+        #expect(setup.monitor.startedRegions.isEmpty)
+    }
+
+    @Test
+    func handleMovement_givenNoAnchor_expectTierBRemoteFetch() async {
+        // No prior sync → no anchor → can't distance-compare, so default to remote fetch.
+        // Matches Android's `anchor == null` branch.
+        let storage = makeStorage()
+        let api = GeofenceApiServiceMock()
+        api.fetchGeofencesClosure = { _, _, completion in
+            completion(.success(makeApiResponse(regions: [makeRegion(id: "g1", latitude: 0, longitude: 0)])))
+        }
+        let setup = makeCoordinator(api: api, storage: storage)
+
+        let result = await setup.coordinator.handleMovement(latitude: 1.0, longitude: 2.0)
+
+        #expect(result.isSuccess)
+        #expect(setup.api.fetchGeofencesCallsCount == 1)
+    }
+
+    @Test
+    func handleMovement_givenMovementWithinThreshold_expectTierALocalRerankAndNoApiCall() async {
+        let storage = makeStorage()
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 5000,
+            remoteFetchRefreshExpiry: 3600,
+            duplicateEventsExpiry: 3600,
+            maxBusinessGeofences: 10
+        )
+        await storage.setCachedConfig(config)
+        // Anchor at (0, 0); cached regions arrayed nearby for re-rank verification.
+        await storage.recordSync(timestamp: Date(timeIntervalSince1970: 100), location: LocationData(latitude: 0, longitude: 0))
+        await storage.setCachedGeofences([
+            makeRegion(id: "near", latitude: 0, longitude: 0.0005),
+            makeRegion(id: "far", latitude: 1, longitude: 1)
+        ])
+        let api = GeofenceApiServiceMock()
+        let setup = makeCoordinator(api: api, storage: storage)
+
+        // New position ~111 m from anchor — within 5 km Tier B threshold.
+        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
+
+        #expect(result.isSuccess)
+        #expect(setup.api.fetchGeofencesCallsCount == 0)
+        let businessRegistered = setup.monitor.startedRegions.filter { $0.identifier != GeofenceConstants.movementTriggerIdentifier }
+        #expect(businessRegistered.map(\.identifier) == ["near", "far"])
+    }
+
+    @Test
+    func handleMovement_givenMovementBeyondThreshold_expectTierBRemoteFetch() async {
+        let storage = makeStorage()
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 5000,
+            remoteFetchRefreshExpiry: 3600,
+            duplicateEventsExpiry: 3600,
+            maxBusinessGeofences: 10
+        )
+        await storage.setCachedConfig(config)
+        await storage.recordSync(timestamp: Date(timeIntervalSince1970: 100), location: LocationData(latitude: 0, longitude: 0))
+        let api = GeofenceApiServiceMock()
+        api.fetchGeofencesClosure = { _, _, completion in
+            completion(.success(makeApiResponse(regions: [makeRegion(id: "fresh", latitude: 1, longitude: 1)])))
+        }
+        let setup = makeCoordinator(api: api, storage: storage)
+
+        // ~157 km from anchor — well beyond 5 km Tier B threshold.
+        let result = await setup.coordinator.handleMovement(latitude: 1.0, longitude: 1.0)
+
+        #expect(result.isSuccess)
+        #expect(setup.api.fetchGeofencesCallsCount == 1)
+    }
+
+    @Test
+    func handleMovement_givenTierA_expectLastSyncAndCacheNotMutated() async {
+        // Tier A re-uses the existing API anchor — must not overwrite it, otherwise the next
+        // Tier B threshold check would always pass relative to wherever the user just stood.
+        let storage = makeStorage()
+        let originalAnchor = LocationData(latitude: 0, longitude: 0)
+        let originalTimestamp = Date(timeIntervalSince1970: 100)
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 5000,
+            remoteFetchRefreshExpiry: 3600,
+            duplicateEventsExpiry: 3600,
+            maxBusinessGeofences: 10
+        )
+        await storage.setCachedConfig(config)
+        await storage.recordSync(timestamp: originalTimestamp, location: originalAnchor)
+        await storage.setCachedGeofences([makeRegion(id: "g1", latitude: 0, longitude: 0)])
+        let setup = makeCoordinator(storage: storage)
+
+        _ = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
+
+        let lastSync = await storage.getLastSync()
+        #expect(lastSync?.location == originalAnchor)
+        #expect(lastSync?.timestamp == originalTimestamp)
+    }
+
+    @Test
+    func handleMovement_givenTierA_expectMovementTriggerRecenteredAtNewLocation() async {
+        // The movement trigger's job is to fire when the user leaves the *current* zone.
+        // After Tier A, it must center on where the user just stood, not the API anchor.
+        let storage = makeStorage()
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 5000,
+            remoteFetchRefreshExpiry: 3600,
+            duplicateEventsExpiry: 3600,
+            maxBusinessGeofences: 10
+        )
+        await storage.setCachedConfig(config)
+        await storage.recordSync(timestamp: Date(timeIntervalSince1970: 100), location: LocationData(latitude: 0, longitude: 0))
+        await storage.setCachedGeofences([makeRegion(id: "near", latitude: 0, longitude: 0.0005)])
+        let setup = makeCoordinator(storage: storage)
+
+        let newLocation = LocationData(latitude: 0, longitude: 0.001)
+        _ = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude)
+
+        let movementTrigger = setup.monitor.startedRegions.first { $0.identifier == GeofenceConstants.movementTriggerIdentifier }
+        #expect(movementTrigger?.center == newLocation)
+        #expect(movementTrigger?.radius == config.localRefreshTriggerRadius)
+    }
+
+    @Test
+    func handleMovement_givenInFlightRefresh_expectAlreadyInProgress() async {
+        // Shared `refreshInProgress` gate — a refresh holding it must short-circuit
+        // a concurrent movement EXIT. Verified by suspending the API mid-fetch on the
+        // first call, then issuing handleMovement while it's pending.
+        let storage = makeStorage()
+        let api = GeofenceApiServiceMock()
+        let suspendUntil = AsyncSignal()
+        let arrived = AsyncSignal()
+        api.fetchGeofencesClosure = { _, _, completion in
+            Task {
+                await arrived.fire()
+                await suspendUntil.wait()
+                completion(.success(makeApiResponse(regions: [])))
+            }
+        }
+        let setup = makeCoordinator(api: api, storage: storage)
+
+        async let firstRefresh = setup.coordinator.refresh(latitude: 0, longitude: 0)
+        await arrived.wait()
+        let movement = await setup.coordinator.handleMovement(latitude: 0, longitude: 0)
+        await suspendUntil.fire()
+        _ = await firstRefresh
+
+        #expect(movement.errorOrNil == .alreadyInProgress)
+    }
+
+    @Test
+    func refresh_givenInFlightHandleMovement_expectAlreadyInProgress() async {
+        // Reverse direction of the cross-entry gate — handleMovement holding it must
+        // short-circuit a concurrent refresh. Pinned independently because a regression
+        // that gave handleMovement its own gate would still pass the forward test.
+        let storage = makeStorage()
+        // No cached config → handleMovement falls back to `.fallback`, no anchor → Tier B.
+        let api = GeofenceApiServiceMock()
+        let suspendUntil = AsyncSignal()
+        let arrived = AsyncSignal()
+        api.fetchGeofencesClosure = { _, _, completion in
+            Task {
+                await arrived.fire()
+                await suspendUntil.wait()
+                completion(.success(makeApiResponse(regions: [])))
+            }
+        }
+        let setup = makeCoordinator(api: api, storage: storage)
+
+        async let firstMovement = setup.coordinator.handleMovement(latitude: 0, longitude: 0)
+        await arrived.wait()
+        let refreshResult = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+        await suspendUntil.fire()
+        _ = await firstMovement
+
+        #expect(refreshResult.errorOrNil == .alreadyInProgress)
+    }
 }
 
 // MARK: - Result matchers

--- a/Tests/Location/Geofence/GeofenceBootstrapTests.swift
+++ b/Tests/Location/Geofence/GeofenceBootstrapTests.swift
@@ -73,7 +73,7 @@ struct GeofenceBootstrapTests {
     @Test
     func wireMonitor_givenInitialBind_expectTransitionHandlerAndCoordinatorApplyAndAuthHandler() async {
         let di = DIGraphShared.shared
-        let monitor = GeofenceRegionMonitoringMock()
+        let monitor = MockGeofenceRegionMonitor()
         di.override(value: monitor as GeofenceRegionMonitoring, forType: GeofenceRegionMonitoring.self)
         let coordinator = GeofenceSyncCoordinatorMock()
         di.override(value: coordinator as GeofenceSyncCoordinator, forType: GeofenceSyncCoordinator.self)
@@ -84,7 +84,7 @@ struct GeofenceBootstrapTests {
         #expect(monitor.setOnTransitionCallsCount == 1)
         #expect(coordinator.applyCachedRegistrationCallsCount == 1)
         #expect(monitor.setOnAuthorizationChangedCallsCount == 1)
-        #expect(monitor.lastAuthorizationChangedHandler != nil)
+        #expect(monitor.onAuthorizationChanged != nil)
     }
 
     @Test
@@ -106,7 +106,7 @@ struct GeofenceBootstrapTests {
             )
         ])
         di.override(value: storage, forType: GeofenceStorage.self)
-        let monitor = GeofenceRegionMonitoringMock()
+        let monitor = MockGeofenceRegionMonitor()
         di.override(value: monitor as GeofenceRegionMonitoring, forType: GeofenceRegionMonitoring.self)
         let coordinator = GeofenceSyncCoordinatorMock()
         di.override(value: coordinator as GeofenceSyncCoordinator, forType: GeofenceSyncCoordinator.self)
@@ -130,7 +130,7 @@ struct GeofenceBootstrapTests {
     @Test
     func wireMonitor_givenAuthorizationFires_expectApplyCachedRegistrationRerun() async {
         let di = DIGraphShared.shared
-        let monitor = GeofenceRegionMonitoringMock()
+        let monitor = MockGeofenceRegionMonitor()
         di.override(value: monitor as GeofenceRegionMonitoring, forType: GeofenceRegionMonitoring.self)
         let coordinator = GeofenceSyncCoordinatorMock()
         di.override(value: coordinator as GeofenceSyncCoordinator, forType: GeofenceSyncCoordinator.self)
@@ -141,7 +141,7 @@ struct GeofenceBootstrapTests {
 
         // Simulate iOS reporting a permission change. The handler spawns a Task to re-run
         // wireMonitor; the sleep gives that Task time to schedule and complete.
-        monitor.lastAuthorizationChangedHandler?()
+        monitor.onAuthorizationChanged?()
         try? await Task.sleep(nanoseconds: 100000000)
 
         #expect(coordinator.applyCachedRegistrationCallsCount == 2)

--- a/Tests/Location/Geofence/GeofenceMonitorBinderTests.swift
+++ b/Tests/Location/Geofence/GeofenceMonitorBinderTests.swift
@@ -7,11 +7,12 @@ import Testing
 @Suite("GeofenceMonitorBinder")
 @MainActor
 struct GeofenceMonitorBinderTests {
-    private func makeTracker() -> GeofenceEventTracker {
+    private func makeTracker(eventBusHandler: EventBusHandler) -> GeofenceEventTracker {
         let contextStore = BackgroundDeliveryContextStore(
             fileManager: .default,
             directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         )
+        contextStore.setUserId("user-1")
         let storage = GeofenceStorage(
             fileManager: .default,
             directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
@@ -21,78 +22,107 @@ struct GeofenceMonitorBinderTests {
             pendingStore: PendingGeofenceMetricStore(),
             deliveryTracker: nil,
             contextStore: contextStore,
-            eventBusHandler: EventBusHandlerMock(),
+            eventBusHandler: eventBusHandler,
             dateUtil: DateUtilStub(),
             logger: LoggerMock()
         )
     }
 
+    private func makeCoordinatorMock() -> GeofenceSyncCoordinatorMock {
+        let mock = GeofenceSyncCoordinatorMock()
+        mock.refreshReturnValue = .success(())
+        mock.handleMovementReturnValue = .success(())
+        return mock
+    }
+
+    /// Polls the fire-and-forget Task created inside the transition handler. Bounded by a
+    /// finite iteration count so a regression doesn't hang the suite.
+    private func awaitDispatch(_ condition: @autoclosure () -> Bool) async {
+        for _ in 0 ..< 50 {
+            if condition() { return }
+            await Task.yield()
+        }
+    }
+
     @Test
-    func bind_expectTransitionHandlerInstalled() {
-        let monitor = GeofenceRegionMonitoringMock()
-        let tracker = makeTracker()
+    func bind_givenMovementTriggerExit_expectCoordinatorHandleMovementCalledWithLocation() async {
+        let monitor = MockGeofenceRegionMonitor()
+        let coordinator = makeCoordinatorMock()
+        let eventBus = EventBusHandlerMock()
+        let tracker = makeTracker(eventBusHandler: eventBus)
 
-        GeofenceMonitorBinder.bind(monitor: monitor, tracker: tracker)
+        GeofenceMonitorBinder.bind(monitor: monitor, tracker: tracker, coordinator: coordinator)
+        monitor.simulateTransition(
+            identifier: GeofenceConstants.movementTriggerIdentifier,
+            transition: .exit,
+            location: LocationData(latitude: 37.0, longitude: -122.0)
+        )
+        await awaitDispatch(coordinator.handleMovementCallsCount > 0)
 
-        #expect(monitor.setOnTransitionCallsCount == 1)
-        // Binder no longer registers regions — that's the coordinator's job now.
-        #expect(monitor.startMonitoringCalls.isEmpty)
+        #expect(coordinator.handleMovementCallsCount == 1)
+        #expect(coordinator.handleMovementReceivedArguments?.latitude == 37.0)
+        #expect(coordinator.handleMovementReceivedArguments?.longitude == -122.0)
     }
 
-    /// Double-bind can happen when both `LocationModule.initialize` and
-    /// `LocationModule.bootstrapForBackgroundDelivery` run in the same process.
+    /// We only register the movement trigger for `.exit`; an unexpected `.enter` on the
+    /// reserved identifier must NOT fall through to either the tracker or the coordinator.
     @Test
-    func bind_givenCalledTwice_expectHandlerReinstalled() {
-        let monitor = GeofenceRegionMonitoringMock()
-        let tracker = makeTracker()
+    func bind_givenMovementTriggerEnter_expectNeitherDispatchPathFires() async {
+        let monitor = MockGeofenceRegionMonitor()
+        let coordinator = makeCoordinatorMock()
+        let eventBus = EventBusHandlerMock()
+        let tracker = makeTracker(eventBusHandler: eventBus)
 
-        GeofenceMonitorBinder.bind(monitor: monitor, tracker: tracker)
-        GeofenceMonitorBinder.bind(monitor: monitor, tracker: tracker)
+        GeofenceMonitorBinder.bind(monitor: monitor, tracker: tracker, coordinator: coordinator)
+        monitor.simulateTransition(
+            identifier: GeofenceConstants.movementTriggerIdentifier,
+            transition: .enter,
+            location: LocationData(latitude: 37.0, longitude: -122.0)
+        )
+        for _ in 0 ..< 10 { await Task.yield() }
 
-        #expect(monitor.setOnTransitionCallsCount == 2)
-    }
-}
-
-// MARK: - Mock
-
-struct StartMonitoringCall: Equatable {
-    let identifier: String
-    let center: LocationData
-    let radius: Double
-    let transitionTypes: Set<GeofenceTransition>
-}
-
-@MainActor
-final class GeofenceRegionMonitoringMock: GeofenceRegionMonitoring {
-    var setOnTransitionCallsCount = 0
-    var setOnAuthorizationChangedCallsCount = 0
-    var lastAuthorizationChangedHandler: GeofenceAuthorizationChangedHandler?
-    var startMonitoringCalls: [StartMonitoringCall] = []
-    var stopMonitoringCalls: [String] = []
-    var stopMonitoringAllCallsCount = 0
-    var monitoredRegionIdentifiers: Set<String> = []
-
-    func setOnTransition(_ handler: GeofenceTransitionHandler?) {
-        setOnTransitionCallsCount += 1
+        #expect(coordinator.handleMovementCallsCount == 0)
+        #expect(eventBus.postEventCallsCount == 0)
     }
 
-    func setOnAuthorizationChanged(_ handler: GeofenceAuthorizationChangedHandler?) {
-        setOnAuthorizationChangedCallsCount += 1
-        lastAuthorizationChangedHandler = handler
+    /// Skip rather than guess at a location — `handleMovement` needs a real position to
+    /// distance-compare against the API anchor.
+    @Test
+    func bind_givenMovementTriggerExitWithNilLocation_expectCoordinatorNotCalled() async {
+        let monitor = MockGeofenceRegionMonitor()
+        let coordinator = makeCoordinatorMock()
+        let eventBus = EventBusHandlerMock()
+        let tracker = makeTracker(eventBusHandler: eventBus)
+
+        GeofenceMonitorBinder.bind(monitor: monitor, tracker: tracker, coordinator: coordinator)
+        monitor.simulateTransition(
+            identifier: GeofenceConstants.movementTriggerIdentifier,
+            transition: .exit,
+            location: nil
+        )
+        for _ in 0 ..< 10 { await Task.yield() }
+
+        #expect(coordinator.handleMovementCallsCount == 0)
     }
 
-    func startMonitoring(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) {
-        startMonitoringCalls.append(StartMonitoringCall(identifier: identifier, center: center, radius: radius, transitionTypes: transitionTypes))
-        monitoredRegionIdentifiers.insert(identifier)
-    }
+    @Test
+    func bind_givenBusinessGeofenceTransition_expectTrackerDispatchedAndCoordinatorIdle() async {
+        let monitor = MockGeofenceRegionMonitor()
+        let coordinator = makeCoordinatorMock()
+        let eventBus = EventBusHandlerMock()
+        let tracker = makeTracker(eventBusHandler: eventBus)
 
-    func stopMonitoring(identifier: String) {
-        stopMonitoringCalls.append(identifier)
-        monitoredRegionIdentifiers.remove(identifier)
-    }
+        GeofenceMonitorBinder.bind(monitor: monitor, tracker: tracker, coordinator: coordinator)
+        monitor.simulateTransition(
+            identifier: "business-region-1",
+            transition: .enter,
+            location: LocationData(latitude: 37.0, longitude: -122.0)
+        )
+        // With no deliveryTracker and a set userId, trackTransition posts a fallback event
+        // on the EventBus — observable signal that the binder routed to the tracker.
+        await awaitDispatch(eventBus.postEventCallsCount > 0)
 
-    func stopMonitoringAll() {
-        stopMonitoringAllCallsCount += 1
-        monitoredRegionIdentifiers.removeAll()
+        #expect(eventBus.postEventCallsCount == 1)
+        #expect(coordinator.handleMovementCallsCount == 0)
     }
 }

--- a/Tests/Location/Geofence/Stub/MockGeofenceRegionMonitor.swift
+++ b/Tests/Location/Geofence/Stub/MockGeofenceRegionMonitor.swift
@@ -20,7 +20,9 @@ enum MockMonitorOperation: Sendable, Equatable {
 @MainActor
 final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
     private var onTransition: GeofenceTransitionHandler?
-    private var onAuthorizationChanged: GeofenceAuthorizationChangedHandler?
+    private(set) var onAuthorizationChanged: GeofenceAuthorizationChangedHandler?
+    private(set) var setOnTransitionCallsCount = 0
+    private(set) var setOnAuthorizationChangedCallsCount = 0
     private(set) var startedRegions: [MonitoredRegionRecord] = []
     private(set) var stoppedIdentifiers: [String] = []
     private(set) var stopAllCallCount = 0
@@ -33,10 +35,12 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
 
     func setOnTransition(_ handler: GeofenceTransitionHandler?) {
         onTransition = handler
+        setOnTransitionCallsCount += 1
     }
 
     func setOnAuthorizationChanged(_ handler: GeofenceAuthorizationChangedHandler?) {
         onAuthorizationChanged = handler
+        setOnAuthorizationChangedCallsCount += 1
     }
 
     func startMonitoring(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) {


### PR DESCRIPTION
## Stack

Part of the geofence work. Stacks on top of MBL-1630 part 1. Merge in order:

- [#1060](https://github.com/customerio/customerio-ios/pull/1060) — geofence transition event delivery via EventBus
- [#1061](https://github.com/customerio/customerio-ios/pull/1061) — pending-metric file-backed queue
- [#1062](https://github.com/customerio/customerio-ios/pull/1062) — direct-HTTP `GeofenceDeliveryTracker`
- [#1064](https://github.com/customerio/customerio-ios/pull/1064) — `BackgroundDeliveryContextStore` in Common
- [#1065](https://github.com/customerio/customerio-ios/pull/1065) — three-layer geofence transition delivery wireup
- [#1066](https://github.com/customerio/customerio-ios/pull/1066) — opt-in `cdpApiKey` persistence
- [#1067](https://github.com/customerio/customerio-ios/pull/1067) — wire `CoreLocationGeofenceMonitor` to `GeofenceEventTracker`
- [#1068](https://github.com/customerio/customerio-ios/pull/1068) — drop MessagingPush `HttpClient` dependency
- [#1069](https://github.com/customerio/customerio-ios/pull/1069) — `LocationModule.bootstrapForBackgroundDelivery` cold-wake entry
- [#1070](https://github.com/customerio/customerio-ios/pull/1070) — relax permission gate + self-heal on auth change
- [#1071](https://github.com/customerio/customerio-ios/pull/1071) — `GeofenceConfig` model + `LastSyncRecord` storage
- [#1072](https://github.com/customerio/customerio-ios/pull/1072) — `GeofenceApiService` + wire response decoder
- [#1074](https://github.com/customerio/customerio-ios/pull/1074) — `GeofenceSyncCoordinator` with `refresh` + `applyCachedRegistration`
- **This PR** — sync triggers (identify / foreground / movement EXIT) + `handleMovement` Tier A/B

## Ticket

[MBL-1630 — iOS Smart Geofence Updates](https://linear.app/customerio/issue/MBL-1630/ios-smart-geofence-updates) (part 2 of 3 — trigger wiring + Tier A/B movement dispatch. First-run race fix + sign-out reset land in part 3.)

## Review surface

200 production LOC added across 5 files; 138 test LOC across 1 file (plus minor test-stub updates). `GeofenceSyncCoordinator.swift` is the substantive change (138/45); the rest is trigger plumbing.

## Summary

Closes the gap between `GeofenceSyncCoordinator` (#1074) and the events that should drive a sync. Three triggers + one new coordinator entry:

- **Identify** — existing `ProfileIdentifiedEvent` subscriber in `LocationModuleState` now also fires a geofence refresh.
- **Foreground** — new `addDidBecomeActiveObserver` block fires a geofence refresh on every `didBecomeActive`. Mode-independent.
- **Movement EXIT** — `GeofenceMonitorBinder` dispatches by identifier: the synthetic `cio_movement_trigger` region routes to `coordinator.handleMovement`; business geofences continue to `tracker.trackTransition`.
- **`handleMovement(latitude:longitude:)`** — new coordinator entry with two-tier dispatch matching the Android port.

`refresh()` and `handleMovement()` share extracted private helpers (`performRemoteRefresh` / `performLocalRefresh`) so the same distance-filter + OS-register step runs through both paths.

## Tier A / Tier B branching

`handleMovement` reads the API anchor (`storage.getLastSync()?.location`) and the cached config, then chooses:

- **Tier B (remote fetch)** — when `anchor == nil` (first EXIT after install / clearAll) OR straight-line distance to the new location is ≥ `remoteFetchRefreshTriggerRadius`. Calls `performRemoteRefresh` — same code path as `refresh`. Persists new cache + anchor + timestamp.
- **Tier A (local re-rank)** — otherwise. Calls `performLocalRefresh` — re-rank cached regions for the new location, re-register with the OS, **no API call and no storage writes**. The API anchor stays put so the next Tier B threshold check still compares against the last *server* fetch, not where the user just stood.

## Concurrency model

All three coordinator entries — `refresh`, `handleMovement`, `applyCachedRegistration` — share the existing `Synchronized<Bool> refreshInProgress` gate. Losers see `false` from `acquireGate()` and return `.alreadyInProgress` (or skip with log for `applyCachedRegistration`). Every exit path runs `defer { releaseGate() }`.

`performRemoteRefresh` and `performLocalRefresh` are private helpers and **do not touch the gate** — the public entry owns acquire+release. Avoids double-acquire / leaked-gate failure modes.

## Dispatch in the binder

```
movement-trigger EXIT + non-nil location → coordinator.handleMovement
movement-trigger ENTER (defensive)       → dropped
movement-trigger EXIT + nil location     → dropped (no anchor to decide on)
anything else                            → tracker.trackTransition
```

Movement-trigger transitions are never tracked as customer events.

## Foreground observer lifecycle

`RealAppLifecycleNotifying()` is hoisted to one shared instance used by both `LocationServicesImplementation` and the new geofence observer — avoids two NotificationCenter subscriptions firing. The observer token is retained in a new `LocationModuleState.geofenceForegroundToken` field.

## Mode independence

The foreground observer is unconditional — `LocationConfig.mode == .off` does **not** disable it. Geofence OS-side monitoring runs independently of the SDK's GPS-update subscription. Refresh from identify/foreground skips silently when no cached anchor exists (`LastLocationStorage.getCachedLocation()` returns nil); the first movement EXIT still drives the initial registration via the OS-supplied location.

For fresh installs with `mode == .off`, the seeding window is the first user EXIT from the movement trigger. The first-run race fix lands in MBL-1630c.

## Out of scope (deferred)

- First-run race (Android Bug 3) — `lastSkippedForNoLocation` + `onLocationAcquired` rising-edge re-arm. MBL-1630c.
- `reset(signedOutUserId:)` and the userId-recheck-after-API pattern. MBL-1630c.
- `lastMovementTriggerLocation` persistence (Android's `restoreFromCache` prefers it over the anchor). Functional with the anchor today; can revisit later.
- `registerWithBusinessDiff` (Android stale-cleanup optimization). Continuing with `stopMonitoringAll → start all`.

## Test plan

- [x] `make generate && make format && make lint` — 0 violations, 601 files
- [x] `GeofenceSyncCoordinatorTests` — 30 cases (7 new for `handleMovement`: no-userId / no-anchor → Tier B / within threshold → Tier A / beyond threshold → Tier B / Tier-A preserves lastSync+cache / Tier-A re-centers movement trigger at new location / dedup vs in-flight refresh — and the reverse: `refresh_givenInFlightHandleMovement_expectAlreadyInProgress` to pin the cross-entry gate in both directions)
- [x] `GeofenceMonitorBinderTests` — rewritten with `MockGeofenceRegionMonitor.simulateTransition`. 4 cases: movement EXIT routed to coordinator with correct args / movement ENTER dropped / movement EXIT + nil location dropped / business geofence routed to tracker (verified via EventBus fallback signal)
- [x] `GeofenceBootstrapTests` — retargeted at the shared `MockGeofenceRegionMonitor`; existing assertions on transition handler + `applyCachedRegistration` + auth-change handler all pass
- [x] Full `LocationTests` suite — 185 tests / 21 suites pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes background geofence registration, API fetch timing, and shared concurrency gating; behavior is well-covered by tests but mistakes could mis-register regions or skip refreshes.
> 
> **Overview**
> Wires **geofence sync** to real app events and adds **two-tier movement handling** when the synthetic movement region fires on EXIT.
> 
> **Triggers:** `ProfileIdentifiedEvent` and **app foreground** (`didBecomeActive`) now call `geofenceSyncCoordinator.refresh` using the last cached location (no-op if none). Foreground uses a retained lifecycle token and shares one `RealAppLifecycleNotifying` instance with location services—**independent of** `LocationConfig.mode`.
> 
> **Movement EXIT:** `GeofenceMonitorBinder` takes the sync coordinator; `cio_movement_trigger` **EXIT** with a location → `handleMovement` (not customer events). Business regions still go to `GeofenceEventTracker`.
> 
> **`handleMovement`:** Compares the new position to the **last API sync anchor**. Inside `remoteFetchRefreshTriggerRadius` → **Tier A**: re-rank cached geofences, re-register OS regions, **recenter** the movement trigger, **no** API or `lastSync`/cache writes. Otherwise (or no anchor) → **Tier B**: same path as `refresh` (`performRemoteRefresh`). `refresh`, `handleMovement`, and `applyCachedRegistration` share one **in-flight gate** (`acquireGate` / `releaseGate`); remote/local work lives in private helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 699412c4f66eee558febd03f208ddc7155022186. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->