### PR TITLE
chore: add geofence sign-out reset and first-run rearm

### DIFF
--- a/Sources/Location/Coordinator/LocationSyncCoordinator.swift
+++ b/Sources/Location/Coordinator/LocationSyncCoordinator.swift
@@ -8,6 +8,7 @@ actor LocationSyncCoordinator {
     private let dataPipeline: DataPipelineTracking?
     private let dateUtil: DateUtil
     private let logger: Logger
+    private var onLocationProcessed: (@Sendable (LocationData) -> Void)?
 
     init(
         storage: LastLocationStorage,
@@ -26,6 +27,8 @@ actor LocationSyncCoordinator {
     /// Called for every new location (from setLastKnownLocation or requestLocationUpdate). Always updates cache; sends track via pipeline when filter allows and user is identified.
     func processLocationUpdate(_ location: LocationData) {
         storage.setCachedLocation(location)
+        // Used by the geofence first-run race rearm in `LocationModuleState`.
+        onLocationProcessed?(location)
 
         guard filter.shouldSyncToServer(newLocation: location) else {
             logger.locationSyncFiltered()
@@ -33,6 +36,12 @@ actor LocationSyncCoordinator {
         }
 
         trySendLocationTrack(location)
+    }
+
+    /// Registers an observer for every processed location. Used by the geofence module to
+    /// re-arm a refresh that previously skipped due to no cached location.
+    func setOnLocationProcessed(_ handler: (@Sendable (LocationData) -> Void)?) {
+        onLocationProcessed = handler
     }
 
     /// Called when ProfileIdentifiedEvent is received. Syncs cached location if present and the 24h + 1 km filter allows.

--- a/Sources/Location/Geofence/Coordinator/GeofenceSyncCoordinator.swift
+++ b/Sources/Location/Geofence/Coordinator/GeofenceSyncCoordinator.swift
@@ -28,9 +28,12 @@ enum HandleMovementTier: String, Sendable {
 ///   used by cold-wake / boot / auth-change paths. Synchronous on the main actor so
 ///   `ownedRegionIdentifiers` is populated before the next yield — otherwise the OS may
 ///   deliver a queued cold-wake transition into an empty filter set.
+/// - `reset()` — sign-out cleanup. Stops OS-side monitoring and clears user-scoped store
+///   state (cooldowns, last-sync). Preserves the workspace cache.
 protocol GeofenceSyncCoordinator: AutoMockable, AnyObject, Sendable {
     func refresh(latitude: Double, longitude: Double) async -> Result<Void, GeofenceSyncError>
     func handleMovement(latitude: Double, longitude: Double) async -> Result<Void, GeofenceSyncError>
+    func reset() async -> Result<Void, GeofenceSyncError>
     @MainActor
     func applyCachedRegistration(
         cachedRegions: [Geofence],
@@ -93,6 +96,7 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         }
 
         return await performRemoteRefresh(
+            expectedUserId: userId,
             latitude: latitude,
             longitude: longitude,
             cachedConfig: cachedConfig
@@ -125,6 +129,7 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         if needsRemoteFetch {
             logger.geofenceMovementTrigger(tier: .remoteRefresh)
             return await performRemoteRefresh(
+                expectedUserId: userId,
                 latitude: latitude,
                 longitude: longitude,
                 cachedConfig: cachedConfig
@@ -139,6 +144,27 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
                 cachedRegions: cachedRegions
             )
         }
+    }
+
+    func reset() async -> Result<Void, GeofenceSyncError> {
+        guard acquireGate() else {
+            logger.geofenceSyncSkipped(reason: "refresh already in progress")
+            return .failure(.alreadyInProgress)
+        }
+        defer { releaseGate() }
+
+        // If a new user signed in between sign-out and this handler firing, skip — their
+        // own refresh path will register the right state for them, and clearing here
+        // would undo it.
+        if let currentUserId = contextStore.currentUserId, !currentUserId.isEmpty {
+            logger.geofenceResetSuperseded()
+            return .success(())
+        }
+
+        await MainActor.run { monitor.stopMonitoringAll() }
+        await storage.clearUserScopedState()
+        logger.geofenceResetCompleted()
+        return .success(())
     }
 
     @MainActor
@@ -191,8 +217,11 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         refreshInProgress.wrappedValue = false
     }
 
-    /// Fetch + filter + register + persist. Caller owns the dedup gate and user-id check.
+    /// Fetch + filter + register + persist. Caller owns the dedup gate and user-id check;
+    /// `expectedUserId` is the value captured before the API call so this helper can
+    /// re-check that the identified user hasn't changed during the (potentially long) fetch.
     private func performRemoteRefresh(
+        expectedUserId: String,
         latitude: Double,
         longitude: Double,
         cachedConfig: GeofenceConfig?
@@ -205,6 +234,14 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         case .failure(let error):
             logger.geofenceSyncFetchFailed(error: error)
             return .failure(.fetchFailed(error))
+        }
+
+        // If the user signed out / changed during the API call, drop the result —
+        // registering and persisting for a stale user would attribute geofences and
+        // events to whoever signs in next.
+        if contextStore.currentUserId != expectedUserId {
+            logger.geofenceSyncSupersededByUserChange()
+            return .success(())
         }
 
         let parsedConfig = response.toDomainConfig()

--- a/Sources/Location/Geofence/Logger+Geofence.swift
+++ b/Sources/Location/Geofence/Logger+Geofence.swift
@@ -72,4 +72,20 @@ extension Logger {
     func geofenceMovementTrigger(tier: HandleMovementTier) {
         debug("Movement trigger EXIT: \(tier.rawValue)", geofenceTag)
     }
+
+    func geofenceSyncSupersededByUserChange() {
+        info("Sync result discarded: identified user changed during fetch", geofenceTag)
+    }
+
+    func geofenceResetCompleted() {
+        info("Reset completed: monitoring stopped and user-scoped state cleared", geofenceTag)
+    }
+
+    func geofenceResetSuperseded() {
+        debug("Reset skipped: another user is signed in", geofenceTag)
+    }
+
+    func geofenceFirstRunRearm() {
+        debug("First-run refresh re-armed by new location fix", geofenceTag)
+    }
 }

--- a/Sources/Location/Geofence/Storage/GeofenceStorage.swift
+++ b/Sources/Location/Geofence/Storage/GeofenceStorage.swift
@@ -83,6 +83,19 @@ actor GeofenceStorage {
         saveToDisk(state)
     }
 
+    /// Clears the cooldown map and the last-sync record (timestamp + location) but
+    /// preserves the cached geofences and config. Called on sign-out: the workspace cache
+    /// is shared across users, while cooldowns belong to the signed-out user and the
+    /// last-sync anchor would otherwise let the freshness gate skip the first sync for
+    /// the next signed-in user against stale state.
+    func clearUserScopedState() {
+        var state = loadFromDisk() ?? GeofenceState()
+        state.eventCooldowns = nil
+        state.lastServerSyncTimestamp = nil
+        state.lastServerSyncLocation = nil
+        saveToDisk(state)
+    }
+
     // MARK: - Cached Geofences
 
     func getCachedGeofences() -> [Geofence] {

--- a/Sources/Location/Geofence/Storage/GeofenceSyncStorage.swift
+++ b/Sources/Location/Geofence/Storage/GeofenceSyncStorage.swift
@@ -11,6 +11,7 @@ protocol GeofenceSyncStorage: Sendable {
     func setCachedGeofences(_ regions: [Geofence]) async
     func setCachedConfig(_ config: GeofenceConfig) async
     func recordSync(timestamp: Date, location: LocationData) async
+    func clearUserScopedState() async
 }
 
 extension GeofenceStorage: GeofenceSyncStorage {}

--- a/Sources/Location/LocationModuleState.swift
+++ b/Sources/Location/LocationModuleState.swift
@@ -12,6 +12,10 @@ final class LocationModuleState {
     private let lock = NSLock()
     /// Retains the foreground observer registered for geofence refresh.
     private var geofenceForegroundToken: AppLifecycleObserverToken?
+    /// True when an identify or foreground trigger skipped because no cached location was
+    /// available. Re-armed (CAS true→false) on the next processed location fix so a fresh
+    /// install's first GPS update still drives the initial geofence registration.
+    private let lastSkippedForNoLocation = Synchronized<Bool>(false)
 
     private init() {}
 
@@ -47,6 +51,12 @@ final class LocationModuleState {
         geofenceForegroundToken = lifecycleNotifying.addDidBecomeActiveObserver { [weak self] in
             self?.refreshGeofencesIfPossible(lastLocationStorage: storage)
         }
+        // Rearm first-run refresh on the first fresh fix after an identify/foreground skip.
+        Task { [weak self] in
+            await coordinator.setOnLocationProcessed { location in
+                self?.rearmFirstRunRefreshIfArmed(location: location, di: di)
+            }
+        }
         Task { @MainActor in
             await GeofenceBootstrap.wireMonitor(di: di)
         }
@@ -73,15 +83,42 @@ final class LocationModuleState {
             Task { await di.geofenceEventTracker.flushPending() }
             self?.refreshGeofencesIfPossible(lastLocationStorage: lastLocationStorage)
         }
+        di.eventBusHandler.addObserver(ResetEvent.self) { _ in
+            Task { @MainActor in
+                _ = await DIGraphShared.shared.geofenceSyncCoordinator.reset()
+            }
+        }
     }
 
     /// Shared by the identify and foreground triggers. Mode-independent — geofence
     /// registration is orthogonal to the location-tracking pipeline that populates
-    /// `LastLocationStorage` for enrichment.
+    /// `LastLocationStorage` for enrichment. Arms the first-run rearm when no cached
+    /// location is available; the next processed fix will fire `refresh` once.
     private func refreshGeofencesIfPossible(lastLocationStorage: LastLocationStorage) {
-        guard let location = lastLocationStorage.getCachedLocation() else { return }
+        guard let location = lastLocationStorage.getCachedLocation() else {
+            lastSkippedForNoLocation.wrappedValue = true
+            return
+        }
         Task { @MainActor in
             _ = await DIGraphShared.shared.geofenceSyncCoordinator.refresh(
+                latitude: location.latitude,
+                longitude: location.longitude
+            )
+        }
+    }
+
+    /// Rising-edge CAS — fires `refresh` only on the first fix after an arming skip.
+    /// Subsequent fixes from a streaming-location host won't trigger refresh storms.
+    private func rearmFirstRunRefreshIfArmed(location: LocationData, di: DIGraphShared) {
+        let wasArmed = lastSkippedForNoLocation.mutating { armed in
+            let was = armed
+            armed = false
+            return was
+        }
+        guard wasArmed else { return }
+        di.logger.geofenceFirstRunRearm()
+        Task { @MainActor in
+            _ = await di.geofenceSyncCoordinator.refresh(
                 latitude: location.latitude,
                 longitude: location.longitude
             )

--- a/Sources/Location/autogenerated/AutoMockable.generated.swift
+++ b/Sources/Location/autogenerated/AutoMockable.generated.swift
@@ -202,6 +202,9 @@ class GeofenceSyncCoordinatorMock: GeofenceSyncCoordinator, Mock {
         handleMovementReceivedInvocations = []
 
         mockCalled = false // do last as resetting properties above can make this true
+        resetCallsCount = 0
+
+        mockCalled = false // do last as resetting properties above can make this true
         applyCachedRegistrationCallsCount = 0
         applyCachedRegistrationReceivedArguments = nil
         applyCachedRegistrationReceivedInvocations = []
@@ -269,6 +272,31 @@ class GeofenceSyncCoordinatorMock: GeofenceSyncCoordinator, Mock {
         handleMovementReceivedArguments = (latitude: latitude, longitude: longitude)
         handleMovementReceivedInvocations.append((latitude: latitude, longitude: longitude))
         return handleMovementClosure.map { $0(latitude, longitude) } ?? handleMovementReturnValue
+    }
+
+    // MARK: - reset
+
+    /// Number of times the function was called.
+    @Atomic private(set) var resetCallsCount = 0
+    /// `true` if the function was ever called.
+    var resetCalled: Bool {
+        resetCallsCount > 0
+    }
+
+    /// Value to return from the mocked function.
+    var resetReturnValue: Result<Void, GeofenceSyncError>!
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     The closure has first priority to return a value for the mocked function. If the closure returns `nil`,
+     then the mock will attempt to return the value for `resetReturnValue`
+     */
+    var resetClosure: (() -> Result<Void, GeofenceSyncError>)?
+
+    /// Mocked function for `reset()`. Your opportunity to return a mocked value and check result of mock in test code.
+    func reset() -> Result<Void, GeofenceSyncError> {
+        mockCalled = true
+        resetCallsCount += 1
+        return resetClosure.map { $0() } ?? resetReturnValue
     }
 
     // MARK: - applyCachedRegistration

--- a/Tests/Location/Coordinator/LocationSyncCoordinatorTests.swift
+++ b/Tests/Location/Coordinator/LocationSyncCoordinatorTests.swift
@@ -128,6 +128,18 @@ struct LocationSyncCoordinatorTests {
     }
 
     @Test
+    func processLocationUpdate_givenObserverRegistered_expectObserverCalledWithLocation() async {
+        let (coordinator, _) = makeCoordinator()
+        let received = Synchronized<[LocationData]>([])
+        await coordinator.setOnLocationProcessed { location in
+            received.mutating { $0.append(location) }
+        }
+        let location = LocationData(latitude: 37, longitude: -122)
+        await coordinator.processLocationUpdate(location)
+        #expect(received.wrappedValue == [location])
+    }
+
+    @Test
     func clearCache_clearsStorage() async {
         let (coordinator, storage) = makeCoordinator()
         let location = LocationData(latitude: 1, longitude: 2)

--- a/Tests/Location/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/Location/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -774,6 +774,137 @@ struct GeofenceSyncCoordinatorTests {
         #expect(movement.errorOrNil == .alreadyInProgress)
     }
 
+    // MARK: - reset
+
+    @Test
+    func reset_givenNoSignedInUser_expectStopMonitoringAndClearUserScopedState() async {
+        let storage = makeStorage()
+        await storage.setCachedGeofences([makeRegion(id: "keep", latitude: 0, longitude: 0)])
+        await storage.setCachedConfig(.fallback)
+        await storage.recordSync(timestamp: Date(timeIntervalSince1970: 100), location: LocationData(latitude: 0, longitude: 0))
+        _ = await storage.tryAcquireCooldown(key: "user-scoped", now: Date(timeIntervalSince1970: 100), interval: 3600)
+        let setup = makeCoordinator(storage: storage, contextStore: makeContextStore(userId: nil))
+
+        let result = await setup.coordinator.reset()
+
+        #expect(result.isSuccess)
+        #expect(setup.monitor.stopAllCallCount == 1)
+        // Workspace cache survives; user-scoped state is wiped.
+        let remainingRegions = await storage.getCachedGeofences()
+        let remainingConfig = await storage.getCachedConfig()
+        let remainingLastSync = await storage.getLastSync()
+        let remainingCooldowns = await storage.getEventCooldowns()
+        #expect(remainingRegions.map(\.id) == ["keep"])
+        #expect(remainingConfig != nil)
+        #expect(remainingLastSync == nil)
+        #expect(remainingCooldowns.isEmpty)
+    }
+
+    @Test
+    func reset_givenAnotherUserSignedIn_expectSkippedWithoutChanges() async {
+        // A re-login during the reset window must NOT wipe the new user's freshly-set state.
+        let storage = makeStorage()
+        await storage.setCachedGeofences([makeRegion(id: "keep", latitude: 0, longitude: 0)])
+        await storage.recordSync(timestamp: Date(timeIntervalSince1970: 100), location: LocationData(latitude: 0, longitude: 0))
+        _ = await storage.tryAcquireCooldown(key: "g1:enter", now: Date(timeIntervalSince1970: 100), interval: 3600)
+        let setup = makeCoordinator(storage: storage, contextStore: makeContextStore(userId: "new-user"))
+
+        let result = await setup.coordinator.reset()
+
+        #expect(result.isSuccess)
+        #expect(setup.monitor.stopAllCallCount == 0)
+        let lastSync = await storage.getLastSync()
+        let cooldowns = await storage.getEventCooldowns()
+        #expect(lastSync != nil)
+        #expect(cooldowns.count == 1)
+    }
+
+    @Test
+    func reset_givenInFlightRefresh_expectAlreadyInProgress() async {
+        let storage = makeStorage()
+        let api = GeofenceApiServiceMock()
+        let suspendUntil = AsyncSignal()
+        let arrived = AsyncSignal()
+        api.fetchGeofencesClosure = { _, _, completion in
+            Task {
+                await arrived.fire()
+                await suspendUntil.wait()
+                completion(.success(makeApiResponse(regions: [])))
+            }
+        }
+        let setup = makeCoordinator(api: api, storage: storage)
+
+        async let firstRefresh = setup.coordinator.refresh(latitude: 0, longitude: 0)
+        await arrived.wait()
+        let resetResult = await setup.coordinator.reset()
+        await suspendUntil.fire()
+        _ = await firstRefresh
+
+        #expect(resetResult.errorOrNil == .alreadyInProgress)
+    }
+
+    // MARK: - userId recheck after API
+
+    @Test
+    func refresh_givenUserSignedOutMidFetch_expectNoStorageWritesAndNoRegister() async {
+        let storage = makeStorage()
+        let contextStore = makeContextStore(userId: "user-1")
+        let api = GeofenceApiServiceMock()
+        let suspendUntil = AsyncSignal()
+        let arrived = AsyncSignal()
+        api.fetchGeofencesClosure = { _, _, completion in
+            Task {
+                await arrived.fire()
+                await suspendUntil.wait()
+                completion(.success(makeApiResponse(regions: [makeRegion(id: "g1", latitude: 0, longitude: 0)])))
+            }
+        }
+        let setup = makeCoordinator(api: api, storage: storage, contextStore: contextStore)
+
+        async let refreshResult = setup.coordinator.refresh(latitude: 0, longitude: 0)
+        await arrived.wait()
+        // User signs out while the API call is pending.
+        contextStore.setUserId(nil)
+        await suspendUntil.fire()
+        let result = await refreshResult
+
+        #expect(result.isSuccess)
+        // No register, no persistence — the result was attributed to a stale user.
+        #expect(setup.monitor.startedRegions.isEmpty)
+        let cached = await storage.getCachedGeofences()
+        #expect(cached.isEmpty)
+        let lastSync = await storage.getLastSync()
+        #expect(lastSync == nil)
+    }
+
+    @Test
+    func refresh_givenDifferentUserSignsInMidFetch_expectNoStorageWritesAndNoRegister() async {
+        let storage = makeStorage()
+        let contextStore = makeContextStore(userId: "user-1")
+        let api = GeofenceApiServiceMock()
+        let suspendUntil = AsyncSignal()
+        let arrived = AsyncSignal()
+        api.fetchGeofencesClosure = { _, _, completion in
+            Task {
+                await arrived.fire()
+                await suspendUntil.wait()
+                completion(.success(makeApiResponse(regions: [makeRegion(id: "g1", latitude: 0, longitude: 0)])))
+            }
+        }
+        let setup = makeCoordinator(api: api, storage: storage, contextStore: contextStore)
+
+        async let refreshResult = setup.coordinator.refresh(latitude: 0, longitude: 0)
+        await arrived.wait()
+        contextStore.setUserId("user-2")
+        await suspendUntil.fire()
+        let result = await refreshResult
+
+        #expect(result.isSuccess)
+        #expect(setup.monitor.startedRegions.isEmpty)
+        let cached = await storage.getCachedGeofences()
+        #expect(cached.isEmpty)
+    }
+
     @Test
     func refresh_givenInFlightHandleMovement_expectAlreadyInProgress() async {
         // Reverse direction of the cross-entry gate — handleMovement holding it must
@@ -827,6 +958,7 @@ private actor SpyGeofenceSyncStorage: GeofenceSyncStorage {
         case setCachedGeofences
         case setCachedConfig
         case recordSync
+        case clearUserScopedState
     }
 
     private let underlying: GeofenceStorage
@@ -864,6 +996,11 @@ private actor SpyGeofenceSyncStorage: GeofenceSyncStorage {
     func recordSync(timestamp: Date, location: LocationData) async {
         operations.append(.recordSync)
         await underlying.recordSync(timestamp: timestamp, location: location)
+    }
+
+    func clearUserScopedState() async {
+        operations.append(.clearUserScopedState)
+        await underlying.clearUserScopedState()
     }
 }
 

--- a/Tests/Location/Geofence/Storage/GeofenceStorageTests.swift
+++ b/Tests/Location/Geofence/Storage/GeofenceStorageTests.swift
@@ -453,6 +453,30 @@ struct GeofenceStorageTests {
     // MARK: - Concurrent safety
 
     @Test
+    func clearUserScopedState_expectCooldownsAndLastSyncCleared_workspaceCachePreserved() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        _ = await storage.tryAcquireCooldown(key: "g1:enter", now: Date(timeIntervalSince1970: 100), interval: 3600)
+        await storage.setCachedGeofences([
+            Geofence(id: "g1", latitude: 0, longitude: 0, radius: 100, name: "g1", transitionTypes: [.enter], lastUpdated: Date(timeIntervalSince1970: 0))
+        ])
+        await storage.setCachedConfig(.fallback)
+        await storage.recordSync(timestamp: Date(timeIntervalSince1970: 100), location: LocationData(latitude: 1, longitude: 2))
+
+        await storage.clearUserScopedState()
+
+        let cooldowns = await storage.getEventCooldowns()
+        let lastSync = await storage.getLastSync()
+        let regions = await storage.getCachedGeofences()
+        let config = await storage.getCachedConfig()
+        #expect(cooldowns.isEmpty)
+        #expect(lastSync == nil)
+        #expect(regions.map(\.id) == ["g1"])
+        #expect(config != nil)
+    }
+
+    @Test
     func concurrentOperations_expectNoCrash() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }


### PR DESCRIPTION
## Stack

Part of the geofence work. Stacks on top of MBL-1630 part 2. Merge in order:

- [#1060](https://github.com/customerio/customerio-ios/pull/1060) — geofence transition event delivery via EventBus
- [#1061](https://github.com/customerio/customerio-ios/pull/1061) — pending-metric file-backed queue
- [#1062](https://github.com/customerio/customerio-ios/pull/1062) — direct-HTTP `GeofenceDeliveryTracker`
- [#1064](https://github.com/customerio/customerio-ios/pull/1064) — `BackgroundDeliveryContextStore` in Common
- [#1065](https://github.com/customerio/customerio-ios/pull/1065) — three-layer geofence transition delivery wireup
- [#1066](https://github.com/customerio/customerio-ios/pull/1066) — opt-in `cdpApiKey` persistence
- [#1067](https://github.com/customerio/customerio-ios/pull/1067) — wire `CoreLocationGeofenceMonitor` to `GeofenceEventTracker`
- [#1068](https://github.com/customerio/customerio-ios/pull/1068) — drop MessagingPush `HttpClient` dependency
- [#1069](https://github.com/customerio/customerio-ios/pull/1069) — `LocationModule.bootstrapForBackgroundDelivery` cold-wake entry
- [#1070](https://github.com/customerio/customerio-ios/pull/1070) — relax permission gate + self-heal on auth change
- [#1071](https://github.com/customerio/customerio-ios/pull/1071) — `GeofenceConfig` model + `LastSyncRecord` storage
- [#1072](https://github.com/customerio/customerio-ios/pull/1072) — `GeofenceApiService` + wire response decoder
- [#1074](https://github.com/customerio/customerio-ios/pull/1074) — `GeofenceSyncCoordinator` with `refresh` + `applyCachedRegistration`
- [#1075](https://github.com/customerio/customerio-ios/pull/1075) — sync triggers (identify / foreground / movement EXIT) + `handleMovement` Tier A/B
- **This PR** — `reset()` + first-run rearm + userId recheck after API

## Ticket

[MBL-1630 — iOS Smart Geofence Updates](https://linear.app/customerio/issue/MBL-1630/ios-smart-geofence-updates) (part 3 of 3 — completes the smart-update work)

## Review surface

~115 production LOC net added across 6 files; ~170 test LOC. Each piece is small:
- `GeofenceSyncCoordinator.swift` (+38/-1) — `reset()` + userId-recheck inside `performRemoteRefresh` + protocol additions
- `LocationModuleState.swift` (+39/-2) — `ResetEvent` subscriber + first-run rearm flag + handler wiring
- `LocationSyncCoordinator.swift` (+10) — `onLocationProcessed` observer
- `GeofenceStorage.swift` (+13) — `clearUserScopedState()`
- `Logger+Geofence.swift` (+16) — four small log methods
- `GeofenceSyncStorage.swift` (+1) — protocol surface

## Summary

Closes two gaps left after MBL-1630b's trigger wiring:

1. **Sign-out cleanup.** A new `reset()` entry point on `GeofenceSyncCoordinator` is subscribed to `ResetEvent`. It stops OS-side geofence monitoring and wipes user-scoped store state (cooldowns + last-sync). The workspace cache (regions + config) is preserved — those are shared across users on the same workspace, and re-fetching them on every sign-in would waste an API call.
2. **First-run race.** On a fresh install, identify can fire ms after launch while GPS takes seconds. The identify trigger reads `LastLocationStorage.getCachedLocation()`, finds nil, and skips. Without a re-arm, the geofence registration would wait until the next foreground / movement / next identify. This PR adds a `Synchronized<Bool>` flag in `LocationModuleState`: armed on skip, CAS-rearmed on the first processed fix, fires one `refresh`.

A third smaller fix lands here too: **userId recheck after API**. `performRemoteRefresh` captures the userId before the fetch and verifies it's unchanged before registering / persisting. Drops the result if the user signed out or changed mid-fetch, so a stale fetch can't attribute geofences to whoever signs in next.

## `reset()` design

```
reset():
  acquireGate(); defer { releaseGate() }
  if contextStore.currentUserId is non-nil and non-empty:
    log "another user is signed in"; return .success  // re-login race
  await MainActor.run { monitor.stopMonitoringAll() }
  await storage.clearUserScopedState()
  return .success
```

Mirrors Android's `GeofenceRepository.reset(signedOutUserId:)` minus the parameter — on iOS the `BackgroundDeliveryContextStore.setUserId(nil)` write happens *before* `analytics.reset()` (so `ResetEvent` fires with `currentUserId == nil`), and the only thing the post-check needs to know is "did a different user sign in during the reset window."

`reset()` shares the existing `refreshInProgress` gate with `refresh` / `handleMovement` / `applyCachedRegistration` — no separate mutex. Concurrent caller sees `.alreadyInProgress` and short-circuits.

## First-run rearm

```
LocationModuleState.refreshGeofencesIfPossible:
  if no cached location:
    lastSkippedForNoLocation = true
    return

LocationModuleState.rearmFirstRunRefreshIfArmed (on every processed fix):
  wasArmed = lastSkippedForNoLocation.CAS(true -> false)
  if !wasArmed: return  // streaming-fix hosts don't trigger refresh storms
  fire refresh(latitude:longitude:)
```

The arm-side write is a plain `wrappedValue = true` (idempotent — multiple identifies in a row are fine). The fire-side is a true atomic CAS — only the first fix after an arming skip fires.

Wiring: new `LocationSyncCoordinator.setOnLocationProcessed(_:)` observer; the actor invokes the `@Sendable` handler after `storage.setCachedLocation` inside `processLocationUpdate`. Latest set value wins. The handler hops to `Task @MainActor` so no main-actor work runs on the location-tracking actor's executor.

## userId recheck

```
performRemoteRefresh(expectedUserId, ...):
  fetchResult = await api.fetchGeofences(...)
  if contextStore.currentUserId != expectedUserId:
    log "user changed during fetch"; return .success
  // ... register + persist
```

Returns `.success` (not a failure) — the work didn't error, it just didn't apply. Logged at `.info` so an operator can correlate the missing registration to a sign-out.

## Concurrency notes

All four coordinator entries share the existing `Synchronized<Bool>` gate. Reset uses the same primitive. The reset-during-refresh case is the same window Android has — reset returns `.alreadyInProgress` and doesn't re-run; refresh's userId recheck catches the signed-out state and drops the result so storage doesn't get written for the stale user. Self-heal on the next trigger.

The cooldown contamination across users in that window is also the same as Android — outside this PR's scope.

## Out of scope

- **`lastMovementTriggerLocation` persistence** — cold-wake re-centers to the API anchor; Tier A drift recovery on cold restart is suboptimal but functional. Future PR.
- **Sample app permissions** (NSLocationWhenInUseUsageDescription / NSLocationAlwaysAndWhenInUseUsageDescription / Background Modes capability) — small, last per user preference.
- **Reset that retries after gate release** — would require restructuring the gate semantics. Self-healing on next trigger is sufficient.

## Test plan

- [x] `make generate && make format && make lint` — 0 violations, 601 files
- [x] `GeofenceSyncCoordinatorTests` — 5 new cases pinning reset paths + userId recheck (no signed-in user → stop + clear / different user signed in → skip with cooldowns preserved / in-flight refresh → alreadyInProgress / signed-out mid-fetch → no writes / different user mid-fetch → no writes)
- [x] `GeofenceStorageTests` — `clearUserScopedState_expectCooldownsAndLastSyncCleared_workspaceCachePreserved`
- [x] `LocationSyncCoordinatorTests` — `processLocationUpdate_givenObserverRegistered_expectObserverCalledWithLocation`
- [x] Full `LocationTests` suite — 194 tests / 21 suites pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sign-out, OS geofence monitoring, and identity-sensitive sync persistence; mitigated by explicit user-id rechecks, reset supersede logic, and broad coordinator/storage tests.
> 
> **Overview**
> Adds **geofence sign-out cleanup**, **first-install registration rearm**, and **stale-user protection** after remote geofence fetches.
> 
> On **`ResetEvent`**, **`GeofenceSyncCoordinator.reset()`** stops Core Location monitoring and clears **user-scoped** persisted state (event cooldowns, last server sync) via **`clearUserScopedState()`**, while keeping the **workspace** geofence/config cache. Reset is skipped if another user is already signed in, and it shares the existing in-flight sync gate (concurrent reset → **alreadyInProgress**).
> 
> **`LocationModuleState`** arms a flag when identify/foreground refresh is skipped for **no cached location**; the first processed fix after that (via new **`LocationSyncCoordinator.setOnLocationProcessed`**) triggers a **single** geofence **`refresh`** (CAS so streaming updates don’t spam refreshes).
> 
> **`performRemoteRefresh`** now captures **`expectedUserId`** before the API call and **drops** register/persist if the identified user changed during the fetch, avoiding attributing regions/events to the wrong account.
> 
> Tests cover reset paths, mid-fetch user changes, storage clearing, and the location observer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e74bf8f6ab3feb0adac79ff3597393a64e9c869. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->