### PR TITLE
chore: Upgrade SwiftFormat to 0.61.1

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,4 +1,4 @@
---exclude Pods, Package.swift, Apps/*/Pods
+--exclude Pods, Package.swift, Apps/*/Pods, Apps/*/spm_packages
 
 --binarygrouping none 
 --decimalgrouping none 
@@ -13,5 +13,23 @@
 --header strip
 
 --disable unusedArguments
+--disable blankLineAfterImports
+--disable blankLinesBetweenImports
+--disable docComments
+--disable headerFileName
+--disable noForceUnwrapInTests
+--disable preferForLoop
+--disable redundantEquatable
+--disable redundantMemberwiseInit
+--disable redundantNilInit
+--disable redundantPublic
+--disable redundantSendable
+--disable redundantThrows
+--disable redundantVariable
+--disable simplifyGenericConstraints
+--disable sortImports
+--disable swiftTestingTestCaseNames
+--disable wrapMultilineStatementBraces
+--disable wrapPropertyBodies
 
 --enable isEmpty

--- a/Apps/APN-UIKit/APN UIKit/SceneDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/SceneDelegate.swift
@@ -48,8 +48,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func setVisibleWindow() {
         // If previous user is not a guest login and credentials were used to login into the app
         if let _ = storage.userEmailId {
-            let navigationController = UINavigationController(rootViewController: DashboardViewController
-                .newInstance())
+            let navigationController = UINavigationController(
+                rootViewController: DashboardViewController
+                    .newInstance()
+            )
             window?.rootViewController = navigationController
         } else {
             let navigationController = UINavigationController(rootViewController: LoginViewController.newInstance())

--- a/Apps/APN-UIKit/APN UIKit/autogenerated/DIDependencies.swift
+++ b/Apps/APN-UIKit/APN UIKit/autogenerated/DIDependencies.swift
@@ -1,9 +1,5 @@
 import Foundation
 
-// sourcery: InjectRegisterShared = "UserDefaults"
-// sourcery: InjectCustomShared
-extension UserDefaults {}
-
 extension DIGraphShared {
     var customUserDefaults: UserDefaults {
         UserDefaults.standard

--- a/Apps/APN-UIKit/APN UIKit/autogenerated/DIDependencies.swift
+++ b/Apps/APN-UIKit/APN UIKit/autogenerated/DIDependencies.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+// sourcery: InjectRegisterShared = "UserDefaults"
+// sourcery: InjectCustomShared
+// swiftformat:disable:next emptyExtensions
+extension UserDefaults {}
+
 extension DIGraphShared {
     var customUserDefaults: UserDefaults {
         UserDefaults.standard

--- a/Apps/APN-UIKit/BuildEnvironment.sample.swift
+++ b/Apps/APN-UIKit/BuildEnvironment.sample.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct BuildEnvironment {
+enum BuildEnvironment {
     enum BuildInfo {
         static let buildTimestamp: TimeInterval = Date().timeIntervalSince1970
     }

--- a/Apps/VisionOS/VisionOS/AppDelegate.swift
+++ b/Apps/VisionOS/VisionOS/AppDelegate.swift
@@ -23,7 +23,8 @@ class AppDelegate: NSObject, UIApplicationDelegate {
                 withConfig:
                 SDKConfigBuilder(cdpApiKey: workspaceSettings.cdpApiKy)
                     .logLevel(.debug)
-                    .build())
+                    .build()
+            )
         }
 
         return true

--- a/Apps/VisionOS/VisionOS/CommonViews/FloatingTitleTextField.swift
+++ b/Apps/VisionOS/VisionOS/CommonViews/FloatingTitleTextField.swift
@@ -7,9 +7,10 @@ struct FloatingTitleTextField: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
             Text(title).foregroundColor(
-                text.wrappedValue.isEmpty ? Color(.placeholderText) : .white)
-                .opacity(text.wrappedValue.isEmpty ? 0 : 1)
-                .offset(y: text.wrappedValue.isEmpty ? 20 : 0)
+                text.wrappedValue.isEmpty ? Color(.placeholderText) : .white
+            )
+            .opacity(text.wrappedValue.isEmpty ? 0 : 1)
+            .offset(y: text.wrappedValue.isEmpty ? 20 : 0)
 
             TextField(title, text: text)
         }

--- a/Apps/VisionOS/VisionOS/CommonViews/MainLayoutView.swift
+++ b/Apps/VisionOS/VisionOS/CommonViews/MainLayoutView.swift
@@ -85,7 +85,6 @@ struct MainLayoutView<ContentView: View>: View {
             }
             .markdownTheme(.tutorial)
             .markdownCodeSyntaxHighlighter(.splash)
-
             .padding([.top, .trailing], 24)
             .textFieldStyle(.roundedBorder)
 

--- a/Apps/VisionOS/VisionOS/MainScreen.swift
+++ b/Apps/VisionOS/VisionOS/MainScreen.swift
@@ -34,7 +34,8 @@ struct MainScreen: View {
                         withConfig:
                         SDKConfigBuilder(cdpApiKey: workspaceSettings.cdpApiKy)
                             .logLevel(.debug)
-                            .build())
+                            .build()
+                    )
 
                     viewModel.successMessage = "SDK Initialized. You can now identify the user"
                     selectedExample = .identify

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ lint:
 # specify swiftversion this way instead of .swift-version to (1) keep project files slim and (2) we can specify the version in a CI server matrix for multiple version testing. 
 # use the min Swift version that we support/test against. 
 format:
-	./binny swiftformat . --swiftversion 5.10 && ./binny swiftlint lint --fix
+	./binny swiftformat . --swiftversion 5.3 && ./binny swiftlint lint --fix
 
 # Check what code has not yet had documentation written for it. 
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ lint:
 # specify swiftversion this way instead of .swift-version to (1) keep project files slim and (2) we can specify the version in a CI server matrix for multiple version testing. 
 # use the min Swift version that we support/test against. 
 format:
-	./binny swiftformat . --swiftversion 5.3 && ./binny swiftlint lint --fix
+	./binny swiftformat . --swiftversion 5.10 && ./binny swiftlint lint --fix
 
 # Check what code has not yet had documentation written for it. 
 

--- a/Sources/DataPipeline/Plugins/AutoTrackingScreenViews.swift
+++ b/Sources/DataPipeline/Plugins/AutoTrackingScreenViews.swift
@@ -190,7 +190,8 @@ extension UIViewController {
         -> UIViewController? {
         if let navigationController = rootViewController as? UINavigationController {
             return getVisibleViewController(
-                fromRootViewController: navigationController.visibleViewController)
+                fromRootViewController: navigationController.visibleViewController
+            )
         }
         if let tabController = rootViewController as? UITabBarController {
             if let selected = tabController.selectedViewController {

--- a/Sources/MessagingInApp/Gist/Network/BaseNetwork.swift
+++ b/Sources/MessagingInApp/Gist/Network/BaseNetwork.swift
@@ -27,17 +27,18 @@ enum BaseNetwork {
         case .body(let body):
             urlRequest.httpBody = try JSONSerialization.data(withJSONObject: body.asDictionary(), options: [])
         case .id(let id):
-            components = URLComponents(string: baseURL
-                .appendingPathComponent(request.path)
-                .appendingPathComponent(id).absoluteString
+            components = URLComponents(
+                string: baseURL
+                    .appendingPathComponent(request.path)
+                    .appendingPathComponent(id).absoluteString
             )
         case .idWithBody(let id, let body):
-            components = URLComponents(string: baseURL
-                .appendingPathComponent(request.path)
-                .appendingPathComponent(id).absoluteString
+            components = URLComponents(
+                string: baseURL
+                    .appendingPathComponent(request.path)
+                    .appendingPathComponent(id).absoluteString
             )
             urlRequest.httpBody = try JSONSerialization.data(withJSONObject: body.asDictionary(), options: [])
-
         case .none:
             break
         }

--- a/Sources/MessagingInApp/State/Core/Subscription.swift
+++ b/Sources/MessagingInApp/State/Core/Subscription.swift
@@ -108,7 +108,7 @@ public class Subscription<State> {
     /// - parameter newState: The store's new state, after the action has been reduced.
     public func skipRepeats(_ isRepeat: @escaping (_ oldState: State, _ newState: State) -> Bool)
         -> Subscription<State> {
-        return Subscription<State> { sink in
+        Subscription<State> { sink in
             self.observer = { oldState, newState in
                 switch (oldState, newState) {
                 case (let old?, let new):

--- a/Sources/MessagingPush/Config/MessagingPushConfigBuilder.swift
+++ b/Sources/MessagingPush/Config/MessagingPushConfigBuilder.swift
@@ -45,13 +45,13 @@ public class MessagingPushConfigBuilder {
         self.cdpApiKey = ""
     }
 
+    /// Initializes new `MessagingPushConfigBuilder` with required configuration options.
+    /// - Parameters:
+    ///   - cdpApiKey: Customer.io Data Pipeline API Key required for NotificationServiceExtension only to track metrics
     @available(iOS, unavailable)
     @available(visionOS, unavailable)
     @available(iOSApplicationExtension, introduced: 13.0)
     @available(visionOSApplicationExtension, introduced: 1.0)
-    /// Initializes new `MessagingPushConfigBuilder` with required configuration options.
-    /// - Parameters:
-    ///   - cdpApiKey: Customer.io Data Pipeline API Key required for NotificationServiceExtension only to track metrics
     public init(cdpApiKey: String) {
         self.cdpApiKey = cdpApiKey
     }

--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -257,7 +257,8 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
             let pending = store.loadAll()
             guard !pending.isEmpty else {
                 logger.debug(
-                    "Pending push delivery store: nothing to flush on MessagingPush startup")
+                    "Pending push delivery store: nothing to flush on MessagingPush startup"
+                )
                 return
             }
 

--- a/Sources/MessagingPush/RichPush/RichPushHttpClient.swift
+++ b/Sources/MessagingPush/RichPush/RichPushHttpClient.swift
@@ -25,7 +25,6 @@ public class RichPushHttpClient: HttpClient {
                 params: params,
                 session: getSessionForRequest(url: params.url)
             ) { data, response, error in
-
                 if let error = error {
                     logger.error("Error sending request \(error.localizedDescription).")
                     if let error = self.isUrlError(error) {

--- a/Tests/Common/Communication/EventBusHandlerTests.swift
+++ b/Tests/Common/Communication/EventBusHandlerTests.swift
@@ -30,7 +30,8 @@ class EventBusHandlerTest: UnitTest {
     func test_initialization_givenEventBusHandler_expectEventsLoadedFromStorage() async throws {
         // Expectation to wait for loadEvents to complete
         let loadEventsExpectation = XCTestExpectation(
-            description: "Waiting for loadEvents to complete")
+            description: "Waiting for loadEvents to complete"
+        )
         loadEventsExpectation.expectedFulfillmentCount = EventTypesRegistry.allEventTypes().count
 
         // Mock action to fulfill the expectation
@@ -62,7 +63,8 @@ class EventBusHandlerTest: UnitTest {
         mockEventBus.postReturnValue = true
 
         let postEventExpectation = XCTestExpectation(
-            description: "Waiting for postEvent to complete")
+            description: "Waiting for postEvent to complete"
+        )
         mockEventBus.postClosure = { _ in
             postEventExpectation.fulfill()
             return true
@@ -90,7 +92,8 @@ class EventBusHandlerTest: UnitTest {
 
         // Expectation for the postEvent call
         let postEventExpectation = XCTestExpectation(
-            description: "Waiting for postEvent to complete")
+            description: "Waiting for postEvent to complete"
+        )
         mockEventBus.postClosure = { _ in
             postEventExpectation.fulfill()
             return true
@@ -118,7 +121,8 @@ class EventBusHandlerTest: UnitTest {
         )
 
         let postEventExpectation = XCTestExpectation(
-            description: "Waiting for postEvent to complete")
+            description: "Waiting for postEvent to complete"
+        )
         mockEventBus.postClosure = { _ in
             postEventExpectation.fulfill()
             // Assume there are no observers
@@ -171,10 +175,12 @@ class EventBusHandlerTest: UnitTest {
 
         // Expectations
         let firstObserverReceivedExpectation = XCTestExpectation(
-            description: "First observer should receive event only once")
+            description: "First observer should receive event only once"
+        )
         firstObserverReceivedExpectation.expectedFulfillmentCount = 1
         let secondObserverReceivedExpectation = XCTestExpectation(
-            description: "Second observer should receive event only once")
+            description: "Second observer should receive event only once"
+        )
         secondObserverReceivedExpectation.expectedFulfillmentCount = 1
 
         mockEventBus.postClosure = { _ in
@@ -216,7 +222,8 @@ class EventBusHandlerTest: UnitTest {
 
         // Expectation for the observer registration and event replay
         let observerAddedAndEventReplayedExpectation = XCTestExpectation(
-            description: "Observer added and event replayed")
+            description: "Observer added and event replayed"
+        )
 
         // When: An observer is added after the event is stored
         eventBusHandler.addObserver(ScreenViewedEvent.self) { _ in
@@ -257,7 +264,8 @@ class EventBusHandlerTest: UnitTest {
 
         // Expectation for the observer registration
         let addObserverExpectation = XCTestExpectation(
-            description: "Observer registration completed")
+            description: "Observer registration completed"
+        )
         mockEventBus.addObserverClosure = { _, _ in
             addObserverExpectation.fulfill()
         }
@@ -285,7 +293,8 @@ class EventBusHandlerTest: UnitTest {
 
         // Expectation for observer registration
         let observerRegistrationExpectation = XCTestExpectation(
-            description: "Observer registration completed")
+            description: "Observer registration completed"
+        )
 
         // Mock action for observer registration
         mockEventBus.addObserverClosure = { _, _ in
@@ -345,7 +354,8 @@ class EventBusHandlerTest: UnitTest {
         let observerAction: (ScreenViewedEvent) -> Void = { _ in }
         // Then: Verify addObserver was called on the EventBus mock
         let addObserverExpectation = XCTestExpectation(
-            description: "Waiting for addObserver to complete")
+            description: "Waiting for addObserver to complete"
+        )
         mockEventBus.addObserverClosure = { _, _ in
             addObserverExpectation.fulfill()
         }
@@ -356,7 +366,8 @@ class EventBusHandlerTest: UnitTest {
         await fulfillment(of: [addObserverExpectation], timeout: 5.0)
 
         let removeObserverExpectation = XCTestExpectation(
-            description: "Waiting for removeObserver to complete")
+            description: "Waiting for removeObserver to complete"
+        )
         mockEventBus.removeObserverClosure = { _ in
             removeObserverExpectation.fulfill()
         }
@@ -378,9 +389,11 @@ class EventBusHandlerTest: UnitTest {
 
         // Given: Observers for different event types are registered
         let addObserverExpectation1 = XCTestExpectation(
-            description: "Waiting for addObserver of type 1 to complete")
+            description: "Waiting for addObserver of type 1 to complete"
+        )
         let addObserverExpectation2 = XCTestExpectation(
-            description: "Waiting for addObserver of type 2 to complete")
+            description: "Waiting for addObserver of type 2 to complete"
+        )
 
         // Then: Verify addObserver was called on the EventBus mock for both event types
         mockEventBus.addObserverClosure = { eventType, _ in
@@ -410,7 +423,8 @@ class EventBusHandlerTest: UnitTest {
         eventBusHandler.addObserver(ProfileIdentifiedEvent.self) { _ in }
 
         let removeObserverExpectation = XCTestExpectation(
-            description: "Waiting for removeObserver to complete")
+            description: "Waiting for removeObserver to complete"
+        )
         mockEventBus.removeObserverClosure = { _ in
             removeObserverExpectation.fulfill()
         }
@@ -446,7 +460,8 @@ class EventBusHandlerTest: UnitTest {
         // Add an observer to trigger the replay of events
         // Wait for all events to be replayed
         let replayExpectation = XCTestExpectation(
-            description: "Waiting for replayEvents to complete")
+            description: "Waiting for replayEvents to complete"
+        )
         var replayedEventsCount = 0
         eventBusHandler.addObserver(TrackMetricEvent.self) { _ in
             replayedEventsCount += 1
@@ -478,7 +493,8 @@ class EventBusHandlerTest: UnitTest {
 
         // Expectation for the postEvent completion
         let postEventExpectation = XCTestExpectation(
-            description: "Waiting for postEvent to complete")
+            description: "Waiting for postEvent to complete"
+        )
         mockEventBus.postClosure = { _ in
             // Fulfill the expectation when the event is attempted to be posted
             postEventExpectation.fulfill()
@@ -514,7 +530,8 @@ class EventBusHandlerTest: UnitTest {
 
         // Expectation for observer registration and event replay
         let observerAddedExpectation = XCTestExpectation(
-            description: "Observer registration completed")
+            description: "Observer registration completed"
+        )
         let eventReplayExpectation = XCTestExpectation(description: "Event replayed")
 
         // Mock the action for observer registration completion
@@ -551,7 +568,8 @@ class EventBusHandlerTest: UnitTest {
 
         // Expectation for observer registration and event replay
         let observerAddedExpectation = XCTestExpectation(
-            description: "Observer registration completed")
+            description: "Observer registration completed"
+        )
         let eventReplayExpectation = XCTestExpectation(description: "Event replayed")
 
         // Mock the action for observer registration completion
@@ -599,7 +617,7 @@ class EventBusHandlerTest: UnitTest {
         await fulfillment(of: [eventReplayExpectation], timeout: 5.0)
     }
 
-    func test_multipleEventsHandling_givenEventsPosted_expectEventsHandledCorrectly() async throws {
+    func test_multipleEventsHandling_givenEventsPosted_expectEventsHandledCorrectly() throws {
         let eventBusHandler = initializeEventBusHandler()
 
         let events = (1 ... 3).map { ProfileIdentifiedEvent(identifier: "Event\($0)") }
@@ -614,7 +632,8 @@ class EventBusHandlerTest: UnitTest {
 
         // Expectation for observer registration and event replay
         let observerAddedExpectation = XCTestExpectation(
-            description: "Observer registration completed")
+            description: "Observer registration completed"
+        )
         let eventReplayExpectation = XCTestExpectation(description: "All events replayed")
         var replayedEventsCount = 0
 

--- a/Tests/Common/Synchronized/SynchronizedTests.swift
+++ b/Tests/Common/Synchronized/SynchronizedTests.swift
@@ -5,7 +5,7 @@ import Testing
 
 // MARK: - Core read/write
 
-@Suite struct SynchronizedCoreTests {
+struct SynchronizedCoreTests {
     @Test func wrappedValueGetSet() {
         let box = Synchronized(42)
         #expect(box.wrappedValue == 42)
@@ -69,7 +69,7 @@ import Testing
 
 // MARK: - Arithmetic
 
-@Suite struct SynchronizedArithmeticTests {
+struct SynchronizedArithmeticTests {
     @Test func addRawValue() {
         let a = Synchronized(10)
         #expect(a + 5 == 15)
@@ -95,7 +95,7 @@ import Testing
 
 // MARK: - Bool
 
-@Suite struct SynchronizedBoolTests {
+struct SynchronizedBoolTests {
     @Test func toggle() {
         let flag = Synchronized(false)
         flag.toggle()
@@ -107,7 +107,7 @@ import Testing
 
 // MARK: - Collections
 
-@Suite struct SynchronizedCollectionTests {
+struct SynchronizedCollectionTests {
     @Test func countAndIsEmpty() {
         let list: Synchronized<[Int]> = Synchronized([])
         #expect(list.isEmpty)
@@ -184,7 +184,7 @@ import Testing
 
 // MARK: - Comparable
 
-@Suite struct SynchronizedComparableTests {
+struct SynchronizedComparableTests {
     @Test func lessThanRaw() {
         let a = Synchronized(1)
         #expect(a < 5)
@@ -212,7 +212,7 @@ import Testing
 
 // MARK: - Equatable
 
-@Suite struct SynchronizedEquatableTests {
+struct SynchronizedEquatableTests {
     @Test func equalBoxes() {
         let a = Synchronized("foo")
         let b = Synchronized("foo")
@@ -261,7 +261,7 @@ import Testing
 
 // MARK: - Hashable
 
-@Suite struct SynchronizedHashableTests {
+struct SynchronizedHashableTests {
     @Test func usableInSet() {
         let a = Synchronized(1)
         let b = Synchronized(2)
@@ -289,7 +289,7 @@ import Testing
 
 // MARK: - Dictionaries
 
-@Suite struct SynchronizedDictionaryTests {
+struct SynchronizedDictionaryTests {
     @Test func subscriptGetSet() {
         let dict: Synchronized<[String: Int]> = Synchronized([:])
         dict["a"] = 1

--- a/Tests/DataPipeline/DataPipelineCompatibilityTests.swift
+++ b/Tests/DataPipeline/DataPipelineCompatibilityTests.swift
@@ -500,7 +500,9 @@ private extension DataPipelineCompatibilityTests {
 
 private extension SavedEvent {
     var eventType: String? { self[keyPath: "type"] as? String }
-    subscript(mapKeyPath keyPath: KeyPath) -> [String: Any]? { value(keyPath: keyPath, reference: nil) as? [String: Any] }
+    subscript(mapKeyPath keyPath: KeyPath) -> [String: Any]? {
+        value(keyPath: keyPath, reference: nil) as? [String: Any]
+    }
 
     /// checks recursively if a given key exists anywhere in the event
     func containsKey(_ key: String) -> Bool {

--- a/Tests/DataPipeline/DataPipelineEventBustTests.swift
+++ b/Tests/DataPipeline/DataPipelineEventBustTests.swift
@@ -77,7 +77,7 @@ class DataPipelineEventBustTests: IntegrationTest {
         XCTAssertEqual(trackEvent.deviceToken, givenToken)
     }
 
-    func testGetOptionalDataPipelineTracking_returnsImplementationAndTrackSendsToAnalytics() async {
+    func testGetOptionalDataPipelineTracking_returnsImplementationAndTrackSendsToAnalytics() {
         // DataPipeline registers as DataPipelineTracking on init; Location (and others) resolve via getOptional.
         let pipeline = diGraphShared.getOptional(DataPipelineTracking.self)
         XCTAssertNotNil(pipeline, "DataPipelineTracking should be registered after DataPipeline init")

--- a/Tests/Shared/Core/UnitTestBase.swift
+++ b/Tests/Shared/Core/UnitTestBase.swift
@@ -94,7 +94,9 @@ open class UnitTestBase<Component>: XCTestCase {
     }
 
     @discardableResult
-    open func initializeSDKComponents() -> Component? { nil }
+    open func initializeSDKComponents() -> Component? {
+        nil
+    }
 
     override open func tearDown() {
         // need to remove the observers for integration tests that utilizes actual NotificationCenter

--- a/Tests/Shared/NotificationCenter.swift
+++ b/Tests/Shared/NotificationCenter.swift
@@ -4,8 +4,13 @@ import XCTest
 import UserNotifications
 
 final class KeyedArchiver: NSKeyedArchiver {
-    override func decodeObject(forKey _: String) -> Any { "" }
-    override func decodeInt64(forKey key: String) -> Int64 { 0 }
+    override func decodeObject(forKey _: String) -> Any {
+        ""
+    }
+
+    override func decodeInt64(forKey key: String) -> Int64 {
+        0
+    }
 }
 
 public extension UNNotificationResponse {

--- a/binny-tools.yml
+++ b/binny-tools.yml
@@ -11,6 +11,6 @@
   pathToBinaryInsideZip: "swiftlint"
 
 - name: swiftformat
-  version: 0.52.3
+  version: 0.61.1
   downloadUrl: "https://github.com/nicklockwood/SwiftFormat/releases/download/{version}/swiftformat.zip"
   pathToBinaryInsideZip: "swiftformat"


### PR DESCRIPTION
This PR updates SwiftFormat to 0.61.1. The immediate need for this is that the previous version (0.52.3) did not understand Swift Macros and this caused code to become mangled when using Swift Testing with `try` enclosed in `#expect` or `#require`. This occurred due to the `hoistTry` rule. Alternative to upgrading, we coulduse `--disable hoistTry` to get by until doing this upgrade in the future. 

Notably, this new version of SwiftFormat introduces many new rules. While these are generally positive changes, they would result in changes in nearly every file in the project and cause this PR to be thousands of lines of code changed. These flags listed below should be enabled again and the language version bumped to 5.10 at some point when we can do so with fewer projects on going. 
```
--disable blankLineAfterImports
--disable blankLinesBetweenImports
--disable docComments
--disable headerFileName
--disable noForceUnwrapInTests
--disable preferForLoop
--disable redundantEquatable
--disable redundantMemberwiseInit
--disable redundantNilInit
--disable redundantPublic
--disable redundantSendable
--disable redundantThrows
--disable redundantVariable
--disable simplifyGenericConstraints
--disable sortImports
--disable swiftTestingTestCaseNames
--disable wrapMultilineStatementBraces
--disable wrapPropertyBodies
```

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After code reviews are approved and you determine this PR is ready to merge, select *Squash and Merge* button on this screen, leave the title and description to the default values, then merge the PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are overwhelmingly formatting and tooling; runtime behavior should be unchanged aside from trivial sample/type and test signature edits.
> 
> **Overview**
> **Upgrades SwiftFormat from 0.52.3 to 0.61.1** (via `binny-tools.yml`) so formatting no longer breaks Swift macro / Swift Testing code (e.g. `try` inside `#expect` / `#require`), which the older formatter mishandled via `hoistTry`.
> 
> **`.swiftformat` changes:** excludes `Apps/*/spm_packages` and **disables a large set of new 0.61.x rules** (import sorting, redundant modifiers, doc comment moves, Swift Testing suite naming, etc.) so the upgrade stays a bounded reformat instead of repo-wide semantic churn.
> 
> **Applied formatter output** across sample apps, SDK sources, and tests—mostly wrapping, blank lines, and explicit returns. Notable non-cosmetic edits: `BuildEnvironment` **struct → enum** in the APN sample; **`swiftformat:disable:next emptyExtensions`** on a Sourcery `UserDefaults` extension; Swift Testing suites drop **`@Suite`**; a couple of tests drop **`async`** from signatures; `MessagingPushConfigBuilder` doc comment moved above availability attributes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28379536b28ad803e0eeb73e38af1e928936f77d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->