### PR TITLE
chore: APN sample geofence UI and onAppStart sign-in rearm

### DIFF
--- a/Apps/APN-UIKit/APN UIKit.xcodeproj/project.pbxproj
+++ b/Apps/APN-UIKit/APN UIKit.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		669B9FC32D8B2D430087CC20 /* InlineInAppMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 669B9F902D8B2D430087CC20 /* InlineInAppMessageView.swift */; };
 		669B9FC42D8B2D430087CC20 /* InternalSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 669B9F922D8B2D430087CC20 /* InternalSettingsViewController.swift */; };
 		669B9FC52D8B2D430087CC20 /* MainSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 669B9F932D8B2D430087CC20 /* MainSettingsViewController.swift */; };
+		A1B1C1D100000017520A0001 /* MainSettingsViewController+Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B1C1D100000017520A0002 /* MainSettingsViewController+Location.swift */; };
 		669B9FC62D8B2D430087CC20 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 669B9F942D8B2D430087CC20 /* SettingsViewModel.swift */; };
 		669B9FC72D8B2D430087CC20 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 669B9F962D8B2D430087CC20 /* BaseViewController.swift */; };
 		669B9FC82D8B2D430087CC20 /* DashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 669B9F972D8B2D430087CC20 /* DashboardViewController.swift */; };
@@ -139,6 +140,7 @@
 		669B9F902D8B2D430087CC20 /* InlineInAppMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineInAppMessageView.swift; sourceTree = "<group>"; };
 		669B9F922D8B2D430087CC20 /* InternalSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalSettingsViewController.swift; sourceTree = "<group>"; };
 		669B9F932D8B2D430087CC20 /* MainSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSettingsViewController.swift; sourceTree = "<group>"; };
+		A1B1C1D100000017520A0002 /* MainSettingsViewController+Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainSettingsViewController+Location.swift"; sourceTree = "<group>"; };
 		669B9F942D8B2D430087CC20 /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		669B9F962D8B2D430087CC20 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		669B9F972D8B2D430087CC20 /* DashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewController.swift; sourceTree = "<group>"; };
@@ -336,6 +338,7 @@
 			children = (
 				669B9F922D8B2D430087CC20 /* InternalSettingsViewController.swift */,
 				669B9F932D8B2D430087CC20 /* MainSettingsViewController.swift */,
+				A1B1C1D100000017520A0002 /* MainSettingsViewController+Location.swift */,
 				669B9F942D8B2D430087CC20 /* SettingsViewModel.swift */,
 			);
 			path = Settings;
@@ -639,6 +642,7 @@
 				669B9FC32D8B2D430087CC20 /* InlineInAppMessageView.swift in Sources */,
 				669B9FC42D8B2D430087CC20 /* InternalSettingsViewController.swift in Sources */,
 				669B9FC52D8B2D430087CC20 /* MainSettingsViewController.swift in Sources */,
+				A1B1C1D100000017520A0001 /* MainSettingsViewController+Location.swift in Sources */,
 				669B9FC62D8B2D430087CC20 /* SettingsViewModel.swift in Sources */,
 				669B9FC72D8B2D430087CC20 /* BaseViewController.swift in Sources */,
 				669B9FC82D8B2D430087CC20 /* DashboardViewController.swift in Sources */,

--- a/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
@@ -58,7 +58,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if settings.internalSettings.testMode {
             config.flushAt(1)
         }
-        config.addModule(LocationModule(config: LocationConfig(mode: .onAppStart)))
+        let locationMode = settings.location?.trackingMode.toCIOMode() ?? .onAppStart
+        config.addModule(LocationModule(config: LocationConfig(mode: locationMode)))
         CustomerIO.initialize(withConfig: config.build())
 
         // Initialize messaging features after initializing Customer.io SDK

--- a/Apps/APN-UIKit/APN UIKit/Base.lproj/Main.storyboard
+++ b/Apps/APN-UIKit/APN UIKit/Base.lproj/Main.storyboard
@@ -1090,6 +1090,7 @@
                         <outlet property="screenNameLabel" destination="eB7-NK-Zkf" id="tNt-8s-HgI"/>
                         <outlet property="screenViewUseAllButton" destination="poz-pg-0GG" id="7AT-pC-G0p"/>
                         <outlet property="screenViewUseInAppButton" destination="KNI-sA-zNj" id="POr-vT-ChH"/>
+                        <outlet property="settingsStackView" destination="oLg-Ow-Mda" id="locsv-mbl-1752"/>
                         <outlet property="showPushAppInForegroundFalseButton" destination="9xp-jF-SLg" id="0h4-bq-saU"/>
                         <outlet property="showPushAppInForegroundTrueButton" destination="VPt-vy-qBG" id="PbR-px-CQ3"/>
                         <outlet property="siteIdTextField" destination="ZFn-ux-MwY" id="vrO-bK-65o"/>

--- a/Apps/APN-UIKit/APN UIKit/Info.plist
+++ b/Apps/APN-UIKit/APN UIKit/Info.plist
@@ -41,8 +41,11 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>
+		<string>location</string>
 	</array>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>This app uses your location to test the Customer.io Location module.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>This app uses your location to test the Customer.io Geofence module.</string>
 </dict>
 </plist>

--- a/Apps/APN-UIKit/APN UIKit/Model/Settings.swift
+++ b/Apps/APN-UIKit/APN UIKit/Model/Settings.swift
@@ -1,12 +1,44 @@
 import CioDataPipelines
 import CioInternalCommon
+import CioLocation
 import Foundation
 
 struct Settings: Codable {
     var dataPipelines: DataPipelinesSettings
     var messaging: MessagingPushAPNSettings
     var inApp: MessagingInAppSettings
+    /// Optional so existing serialized installs (which predate this field) still decode.
+    /// Callers fall back to `.onAppStart` to match the hardcoded behavior this replaced.
+    var location: LocationSettings?
     var internalSettings: InternalSettings
+}
+
+struct LocationSettings: Codable {
+    var trackingMode: LocationTrackingModeSetting
+}
+
+enum LocationTrackingModeSetting: String, Codable, CaseIterable {
+    case off
+    case manual
+    case onAppStart
+}
+
+extension LocationTrackingModeSetting {
+    func toCIOMode() -> LocationTrackingMode {
+        switch self {
+        case .off: return .off
+        case .manual: return .manual
+        case .onAppStart: return .onAppStart
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .off: return "OFF"
+        case .manual: return "MANUAL"
+        case .onAppStart: return "ON_APP_START"
+        }
+    }
 }
 
 struct DataPipelinesSettings: Codable {

--- a/Apps/APN-UIKit/APN UIKit/Service/SettingsService.swift
+++ b/Apps/APN-UIKit/APN UIKit/Service/SettingsService.swift
@@ -32,6 +32,7 @@ class SettingsService {
                 siteId: BuildEnvironment.CustomerIO.siteId,
                 region: .US
             ),
+            location: LocationSettings(trackingMode: .onAppStart),
             internalSettings: InternalSettings(
                 cdnHost: "cdp.customer.io/v1",
                 apiHost: "cdp.customer.io/v1",

--- a/Apps/APN-UIKit/APN UIKit/View/Settings/MainSettingsViewController+Location.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/Settings/MainSettingsViewController+Location.swift
@@ -1,0 +1,63 @@
+import CioInternalCommon
+import UIKit
+
+// MARK: - Location Section
+
+extension MainSettingsViewController {
+    func setupLocationSection() {
+        let topSpacer = UIView()
+        topSpacer.heightAnchor.constraint(equalToConstant: 16).isActive = true
+        settingsStackView.addArrangedSubview(topSpacer)
+
+        let sectionStack = UIStackView()
+        sectionStack.axis = .vertical
+        sectionStack.spacing = 8
+
+        let headerLabel = UILabel()
+        headerLabel.text = "CioLocation"
+        headerLabel.font = UIFont(name: "Avenir-Black", size: 18) ?? .boldSystemFont(ofSize: 18)
+        headerLabel.textColor = UIColor(white: 0.243, alpha: 1.0)
+        sectionStack.addArrangedSubview(headerLabel)
+
+        let modeLabel = UILabel()
+        modeLabel.text = "trackingMode"
+        modeLabel.font = .systemFont(ofSize: 15)
+        modeLabel.textColor = UIColor(white: 0.243, alpha: 1.0)
+        sectionStack.addArrangedSubview(modeLabel)
+
+        let buttonRow = UIStackView()
+        buttonRow.axis = .horizontal
+        buttonRow.spacing = 8
+        buttonRow.distribution = .fillEqually
+
+        locationTrackingModeButtons = LocationTrackingModeSetting.allCases.map { mode in
+            let button = ThemeButton()
+            button.setTitle(mode.displayName, for: .normal)
+            button.titleLabel?.font = .systemFont(ofSize: 13)
+            button.tag = LocationTrackingModeSetting.allCases.firstIndex(of: mode) ?? 0
+            button.heightAnchor.constraint(equalToConstant: 40).isActive = true
+            button.addTarget(self, action: #selector(locationTrackingModeButtonTapped(_:)), for: .touchUpInside)
+            buttonRow.addArrangedSubview(button)
+            return button
+        }
+        sectionStack.addArrangedSubview(buttonRow)
+
+        settingsStackView.addArrangedSubview(sectionStack)
+    }
+
+    func setLocationInitialValues() {
+        let active = settingsViewModel.settings.location?.trackingMode ?? .onAppStart
+        for button in locationTrackingModeButtons {
+            let mode = LocationTrackingModeSetting.allCases[button.tag]
+            button.isSelected = mode == active
+            button.alpha = mode == active ? 1.0 : 0.5
+        }
+    }
+
+    @objc func locationTrackingModeButtonTapped(_ sender: UIButton) {
+        guard sender.tag >= 0, sender.tag < LocationTrackingModeSetting.allCases.count else { return }
+        let selected = LocationTrackingModeSetting.allCases[sender.tag]
+        settingsViewModel.locationTrackingModeUpdated(selected)
+        setLocationInitialValues()
+    }
+}

--- a/Apps/APN-UIKit/APN UIKit/View/Settings/MainSettingsViewController.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/Settings/MainSettingsViewController.swift
@@ -60,6 +60,11 @@ class MainSettingsViewController: BaseViewController {
 
     @IBOutlet var screenNameLabel: UILabel!
 
+    /// Parent stackview of the Settings screen. The Location section is appended programmatically
+    /// to avoid storyboard surgery for what is otherwise a tracking-mode picker.
+    @IBOutlet var settingsStackView: UIStackView!
+    var locationTrackingModeButtons: [UIButton] = []
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -69,6 +74,7 @@ class MainSettingsViewController: BaseViewController {
         screenNameLabel.text = screenName
 
         configureButtonActions()
+        setupLocationSection()
         setInitialValues()
     }
 
@@ -83,6 +89,7 @@ class MainSettingsViewController: BaseViewController {
         setDataPipelineInitialValues()
         setMessagingPushAPNInitialValues()
         setMessagingInAppInitialValues()
+        setLocationInitialValues()
     }
 
     private func setDataPipelineInitialValues() {

--- a/Apps/APN-UIKit/APN UIKit/View/Settings/SettingsViewModel.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/Settings/SettingsViewModel.swift
@@ -76,6 +76,12 @@ class SettingsViewModel {
         settings.messaging.showPushAppInForeground = value
     }
 
+    // -- Location
+
+    func locationTrackingModeUpdated(_ mode: LocationTrackingModeSetting) {
+        settings.location = LocationSettings(trackingMode: mode)
+    }
+
     // -- Messaging In App
 
     func inAppSideIdUpdated(_ siteId: String) {

--- a/Apps/APN-UIKit/APN UIKit/View/location/LocationTestViewController+Actions.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/location/LocationTestViewController+Actions.swift
@@ -1,8 +1,13 @@
+import CioInternalCommon
 import UIKit
 
 // MARK: - Click Handlers
 
 extension LocationTestViewController {
+    @objc func grantBackgroundLocationTapped() {
+        handleGrantBackgroundLocationTap()
+    }
+
     @objc func presetButtonTapped(_ sender: UIButton) {
         let index = sender.tag
         guard index >= 0, index < presetLocations.count else { return }

--- a/Apps/APN-UIKit/APN UIKit/View/location/LocationTestViewController+BuildingUI.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/location/LocationTestViewController+BuildingUI.swift
@@ -73,6 +73,27 @@ extension LocationTestViewController {
         return button
     }
 
+    func createGrantBackgroundLocationButton() -> UIView {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 8
+
+        grantBackgroundLocationButton = ThemeButton()
+        grantBackgroundLocationButton.setTitle("Grant background location", for: .normal)
+        grantBackgroundLocationButton.titleLabel?.font = .systemFont(ofSize: 14)
+        grantBackgroundLocationButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
+        grantBackgroundLocationButton.addTarget(self, action: #selector(grantBackgroundLocationTapped), for: .touchUpInside)
+        stackView.addArrangedSubview(grantBackgroundLocationButton)
+
+        grantBackgroundStatusLabel = UILabel()
+        grantBackgroundStatusLabel.font = .systemFont(ofSize: 12)
+        grantBackgroundStatusLabel.textColor = .darkGray
+        grantBackgroundStatusLabel.numberOfLines = 0
+        stackView.addArrangedSubview(grantBackgroundStatusLabel)
+
+        return stackView
+    }
+
     func createSdkLocationButtons() -> UIView {
         let stackView = UIStackView()
         stackView.axis = .vertical

--- a/Apps/APN-UIKit/APN UIKit/View/location/LocationTestViewController+CLLocationManagerDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/location/LocationTestViewController+CLLocationManagerDelegate.swift
@@ -54,37 +54,55 @@ extension LocationTestViewController: @MainActor CLLocationManagerDelegate {
     }
 
     private func handleAuthorizationChange(_ status: CLAuthorizationStatus) {
-        // Handle "Request location once (SDK)" flow: user was waiting for permission, now call SDK.
-        if userRequestedSdkLocationUpdate {
-            userRequestedSdkLocationUpdate = false
-            switch status {
-            case .authorizedWhenInUse, .authorizedAlways:
-                lastSetLocationLabel.text = "Requested location once (SDK)..."
-                CustomerIO.location.requestLocationUpdate()
-                showToast(withMessage: "SDK requested location update")
-            case .denied, .restricted:
-                showLocationPermissionAlert()
-            case .notDetermined:
-                break
-            @unknown default:
-                break
-            }
+        refreshGrantBackgroundLocationUI()
+
+        if userRequestedAlwaysUpgrade {
+            userRequestedAlwaysUpgrade = false
+            handleAlwaysUpgradeResult(status)
             return
         }
-
-        // Only start fetching when the user explicitly tapped "Use Current Location" and we were waiting for permission.
-        // This avoids auto-fetching location when the screen opens and auth was already granted (e.g. returning to the app).
+        if userRequestedSdkLocationUpdate {
+            userRequestedSdkLocationUpdate = false
+            handleSdkLocationUpdateResult(status)
+            return
+        }
         guard userRequestedCurrentLocation else { return }
         userRequestedCurrentLocation = false
+        handleCurrentLocationResult(status)
+    }
 
+    /// WhenInUse here is the precondition; the rationale and the Always prompt fire in sequence.
+    private func handleAlwaysUpgradeResult(_ status: CLAuthorizationStatus) {
+        switch status {
+        case .authorizedWhenInUse:
+            presentAlwaysRationale()
+        case .denied, .restricted:
+            showLocationPermissionAlert()
+        default:
+            break
+        }
+    }
+
+    private func handleSdkLocationUpdateResult(_ status: CLAuthorizationStatus) {
+        switch status {
+        case .authorizedWhenInUse, .authorizedAlways:
+            lastSetLocationLabel.text = "Requested location once (SDK)..."
+            CustomerIO.location.requestLocationUpdate()
+            showToast(withMessage: "SDK requested location update")
+        case .denied, .restricted:
+            showLocationPermissionAlert()
+        default:
+            break
+        }
+    }
+
+    private func handleCurrentLocationResult(_ status: CLAuthorizationStatus) {
         switch status {
         case .authorizedWhenInUse, .authorizedAlways:
             startFetchingLocation()
         case .denied, .restricted:
             showLocationPermissionAlert()
-        case .notDetermined:
-            break
-        @unknown default:
+        default:
             break
         }
     }

--- a/Apps/APN-UIKit/APN UIKit/View/location/LocationTestViewController+Location.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/location/LocationTestViewController+Location.swift
@@ -1,4 +1,5 @@
 import CioDataPipelines
+import CioInternalCommon
 import CioLocation
 import CoreLocation
 import UIKit
@@ -9,6 +10,85 @@ extension LocationTestViewController {
     func setupLocationManager() {
         locationManager.delegate = self
         locationManager.desiredAccuracy = kCLLocationAccuracyThreeKilometers
+    }
+
+    // MARK: - Background-location upgrade
+
+    func refreshGrantBackgroundLocationUI() {
+        guard grantBackgroundLocationButton != nil else { return }
+        let status = currentAuthorizationStatus()
+        switch status {
+        case .notDetermined:
+            grantBackgroundLocationButton.setTitle("Grant location access", for: .normal)
+            grantBackgroundLocationButton.isEnabled = true
+            grantBackgroundLocationButton.alpha = 1.0
+            grantBackgroundStatusLabel.text = "Current: Not determined. Tap to grant 'When In Use' first."
+        case .authorizedWhenInUse:
+            grantBackgroundLocationButton.setTitle("Upgrade to 'Always'", for: .normal)
+            grantBackgroundLocationButton.isEnabled = true
+            grantBackgroundLocationButton.alpha = 1.0
+            grantBackgroundStatusLabel.text = "Current: When In Use. Background geofence delivery requires 'Always'."
+        case .authorizedAlways:
+            grantBackgroundLocationButton.setTitle("Always — granted", for: .normal)
+            grantBackgroundLocationButton.isEnabled = false
+            grantBackgroundLocationButton.alpha = 0.6
+            grantBackgroundStatusLabel.text = "Current: Always. Background geofence delivery is enabled."
+        case .denied, .restricted:
+            grantBackgroundLocationButton.setTitle("Open Settings", for: .normal)
+            grantBackgroundLocationButton.isEnabled = true
+            grantBackgroundLocationButton.alpha = 1.0
+            grantBackgroundStatusLabel.text = "Current: Denied / Restricted. Enable location access in Settings."
+        @unknown default:
+            grantBackgroundLocationButton.setTitle("Grant background location", for: .normal)
+            grantBackgroundStatusLabel.text = "Current: Unknown status (\(status.rawValue))."
+        }
+    }
+
+    func handleGrantBackgroundLocationTap() {
+        let status = currentAuthorizationStatus()
+        switch status {
+        case .notDetermined:
+            // Foreground first; the auth-change delegate prompts for Always on success.
+            userRequestedAlwaysUpgrade = true
+            locationManager.requestWhenInUseAuthorization()
+        case .authorizedWhenInUse:
+            presentAlwaysRationale()
+        case .authorizedAlways:
+            return
+        case .denied, .restricted:
+            openSystemSettings()
+        @unknown default:
+            return
+        }
+    }
+
+    func presentAlwaysRationale() {
+        let alert = UIAlertController(
+            title: "Allow background location?",
+            message: "Geofence transitions only fire while the app is backgrounded if 'Always' authorization is granted. iOS shows this prompt at most once — after that, granting Always means opening the Settings app.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        alert.addAction(UIAlertAction(title: "Continue", style: .default) { [weak self] _ in
+            self?.locationManager.requestAlwaysAuthorization()
+        })
+        alert.addAction(UIAlertAction(title: "Open Settings", style: .default) { [weak self] _ in
+            self?.openSystemSettings()
+        })
+        present(alert, animated: true)
+    }
+
+    func openSystemSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        UIApplication.shared.open(url)
+    }
+
+    func currentAuthorizationStatus() -> CLAuthorizationStatus {
+        if #available(iOS 14.0, *) {
+            return locationManager.authorizationStatus
+        } else {
+            return CLLocationManager.authorizationStatus()
+        }
     }
 
     func setLocation(latitude: Double, longitude: Double, sourceName: String? = nil) {

--- a/Apps/APN-UIKit/APN UIKit/View/location/LocationTestViewController.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/location/LocationTestViewController.swift
@@ -26,6 +26,12 @@ class LocationTestViewController: BaseViewController {
     var setManualLocationButton: ThemeButton!
     var useCurrentLocationButton: ThemeButton!
     var requestSdkLocationOnceButton: ThemeButton!
+    var grantBackgroundLocationButton: ThemeButton!
+    var grantBackgroundStatusLabel: UILabel!
+
+    /// Tracks if we're mid-Always-upgrade so the auth-change callback knows to skip
+    /// the WhenInUse-only flows (which both also live on this delegate).
+    var userRequestedAlwaysUpgrade = false
 
     /// Tracks if we're in the "user tapped Use Current Location and we're waiting for permission" flow.
     /// Used to avoid auto-starting a location fetch when the screen opens and auth is already granted.
@@ -52,6 +58,7 @@ class LocationTestViewController: BaseViewController {
         // Start with empty manual entry fields once when the screen loads
         latitudeTextField?.text = ""
         longitudeTextField?.text = ""
+        refreshGrantBackgroundLocationUI()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -120,6 +127,13 @@ class LocationTestViewController: BaseViewController {
     }
 
     private func addOptionSections(to stackView: UIStackView) {
+        stackView.addArrangedSubview(createOptionSection(
+            title: "BACKGROUND LOCATION",
+            description: "Geofence background delivery requires 'Always' location authorization. Grant 'When In Use' first; iOS allows the in-app upgrade prompt once before falling back to the Settings app.",
+            content: createGrantBackgroundLocationButton()
+        ))
+        stackView.addArrangedSubview(createOrSeparator())
+
         stackView.addArrangedSubview(createOptionSection(
             title: "OPTION 1: QUICK PRESETS",
             description: "Tap a city to set its coordinates",

--- a/Sources/Location/LocationModuleState.swift
+++ b/Sources/Location/LocationModuleState.swift
@@ -41,7 +41,7 @@ final class LocationModuleState {
         )
         let locationEnrichmentProvider = LocationProfileEnrichmentProvider(storage: storage, config: config)
         di.profileEnrichmentRegistry.register(locationEnrichmentProvider)
-        registerEventSubscriptions(coordinator: coordinator, lastLocationStorage: storage, di: di)
+        registerEventSubscriptions(coordinator: coordinator, lastLocationStorage: storage, mode: config.mode, di: di)
         Task { await di.geofenceEventTracker.flushPending() }
         let lifecycleNotifying = RealAppLifecycleNotifying()
         // Foreground geofence refresh is intentionally mode-independent — geofence
@@ -76,12 +76,20 @@ final class LocationModuleState {
     private func registerEventSubscriptions(
         coordinator: LocationSyncCoordinator,
         lastLocationStorage: LastLocationStorage,
+        mode: LocationTrackingMode,
         di: DIGraphShared
     ) {
         di.eventBusHandler.addObserver(ProfileIdentifiedEvent.self) { [weak self] _ in
             Task { await coordinator.syncCachedLocationIfNeeded() }
             Task { await di.geofenceEventTracker.flushPending() }
             self?.refreshGeofencesIfPossible(lastLocationStorage: lastLocationStorage)
+            // `.onAppStart`'s lifecycle one-shot fires per process, but `resetContext()`
+            // wipes the cached location on sign-out — a subsequent identify in the same
+            // process otherwise leaves the first-run rearm armed indefinitely. Forcing a
+            // fresh fix here lets `onLocationProcessed` drive the geofence rearm.
+            if mode == .onAppStart, lastLocationStorage.getCachedLocation() == nil {
+                self?.current.requestLocationUpdate()
+            }
         }
         di.eventBusHandler.addObserver(ResetEvent.self) { _ in
             Task { @MainActor in


### PR DESCRIPTION
## Summary

Two pieces, both serving end-to-end geofence testing:

**APN sample app** — adds the UI parity with the Android sample so geofence flows can be exercised against the live SDK.
- Tracking-mode picker (off / manual / onAppStart) on the main Settings screen under a new CioLocation section. Selection persists through `Settings` and takes effect on next launch (init is one-shot per process).
- Background-location upgrade flow on the Location Test screen. Uses the iOS authorization model: request When In Use → in-app rationale → request Always (allowed once by iOS) → Settings deep-link fallback. Button label adapts to current `CLAuthorizationStatus`.
- Info.plist: `location` in `UIBackgroundModes` + `NSLocationAlwaysAndWhenInUseUsageDescription` referencing the Geofence module.
- `Settings.location` is optional in the `Codable` schema so installs predating this PR still decode.

**SDK** — `LocationModuleState` identify subscriber now requests a fresh location update when `mode == .onAppStart` and the cached anchor is absent. The cold-start lifecycle fetch is one-shot per process, and `resetContext()` wipes the cached anchor on sign-out, so a sign-in in the same process otherwise leaves the first-run rearm armed indefinitely. With the nudge, the next processed fix drives the geofence rearm via `setOnLocationProcessed`.

## Out of scope (under same ticket)

- CocoaPods-FCM sample app — same set of UI changes, deferred to a follow-up.

## Stack

Merge from the bottom up:
1. #1060 — geofence transition events
2. #1061 — pending metric file-backed queue
3. #1062 — direct-HTTP geofence delivery tracker
4. #1064 — `BackgroundDeliveryContextStore` in Common
5. #1065 — wire three-layer geofence transition delivery
6. #1066 — opt-in `cdpApiKey` persistence for background delivery
7. #1067 — wire `CoreLocationGeofenceMonitor` to `GeofenceEventTracker`
8. #1068 — drop MessagingPush HttpClient dependency
9. #1069 — `LocationModule.bootstrapForBackgroundDelivery` cold-wake
10. #1070 — relax geofence permission gate + self-heal on auth change
11. #1071 — `GeofenceConfig` model + `LastSyncRecord` storage
12. #1072 — `GeofenceApiService` and response decoder
13. #1074 — `GeofenceSyncCoordinator` refresh entry point
14. #1075 — geofence sync triggers + `handleMovement` Tier A/B
15. #1076 — geofence sign-out reset + first-run rearm
16. **this PR** — APN sample UI + onAppStart sign-in rearm

## Test plan

- [x] `make format && make lint` clean
- [x] APN sample builds; CioLocation section renders in main Settings, Background-Location section renders on Location Test screen
- [x] Tracking-mode picker persists across launches; SDK initializes with the selected mode
- [x] Grant flow: notDetermined → When In Use prompt → rationale → Always prompt; status label and button label update through each step
- [x] `LocationTests` green (re-run `concurrentFlushPending` in isolation if it flakes under suite load)
- [x] After identify→reset→identify in same process with `onAppStart`, a fresh GPS fix triggers `GeofenceSyncCoordinator.refresh`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Sample-only UI/plist changes are low risk; the SDK identify hook affects location/geofence behavior after sign-out/sign-in in the same process when mode is onAppStart.
> 
> **Overview**
> Adds **APN UIKit sample** controls and plist support for end-to-end geofence testing, and a small **Location SDK** fix for re-identify after sign-out.
> 
> On the sample app, **Settings** gains optional persisted **CioLocation** `trackingMode` (off / manual / onAppStart) with a programmatic picker on the main Settings screen; **AppDelegate** wires `LocationModule` to that value (default `.onAppStart` when missing). **Info.plist** adds background `location` mode and **Always** usage text. The **Location Test** screen adds a background-authorization flow (When In Use → rationale → Always, with Settings fallback) and refactors auth-change handling into separate paths.
> 
> In **LocationModuleState**, on `ProfileIdentifiedEvent`, when mode is `.onAppStart` and the cached location was cleared by reset, the module now calls **`requestLocationUpdate()`** so a new fix can drive geofence rearm in the same process after sign-in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80d2e34a58c6627b87ee32e183039fefdb947d83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

