### PR TITLE
refactor: Fixed flaky unit tests

### DIFF
--- a/Sources/MessagingInApp/MessagingInAppImplementation.swift
+++ b/Sources/MessagingInApp/MessagingInAppImplementation.swift
@@ -36,25 +36,27 @@ class MessagingInAppImplementation: MessagingInAppInstance {
     private func subscribeToEventBus() {
         // if identifier is already present, set the userToken again so in case if the customer was already identified and
         // module was added later on, we can notify gist about it.
-        eventBusHandler.addObserver(ProfileIdentifiedEvent.self) { event in
+        eventBusHandler.addObserver(ProfileIdentifiedEvent.self) { [weak self] event in
+            guard let self else { return }
             self.logger.logWithModuleTag("registering profile \(event.identifier) for in-app", level: .debug)
             self.gist.setUserToken(event.identifier)
         }
 
-        eventBusHandler.addObserver(AnonymousProfileIdentifiedEvent.self) { event in
+        eventBusHandler.addObserver(AnonymousProfileIdentifiedEvent.self) { [weak self] event in
+            guard let self else { return }
             self.logger.logWithModuleTag("registering anonymous profile \(event.identifier) for in-app", level: .debug)
             self.gist.setAnonymousId(event.identifier)
         }
 
-        eventBusHandler.addObserver(ScreenViewedEvent.self) { event in
+        eventBusHandler.addObserver(ScreenViewedEvent.self) { [weak self] event in
+            guard let self else { return }
             self.logger.logWithModuleTag("setting route for in-app to \(event.name)", level: .debug)
-
             self.gist.setCurrentRoute(event.name)
         }
 
-        eventBusHandler.addObserver(ResetEvent.self) { _ in
+        eventBusHandler.addObserver(ResetEvent.self) { [weak self] _ in
+            guard let self else { return }
             self.logger.logWithModuleTag("removing profile for in-app", level: .debug)
-
             self.gist.resetState()
         }
     }

--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -251,9 +251,12 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
     /// the correct app group. Skipped entirely when ``DataPipelineTracking`` is unavailable — metrics
     /// are preserved in the store for a future launch where DataPipeline is present.
     private static func schedulePendingPushDeliveryMetricsFlush() {
+        // Capture store and logger at call time so they are snapshotted to the correct registrations
+        // before the task runs. Resolving these inside the Task body risks picking up a mutated DI
+        // graph if initialize() is called concurrently with other DI graph setup.
+        let store = DIGraphShared.shared.pendingPushDeliveryStore
+        let logger = DIGraphShared.shared.logger
         Task.detached(priority: .utility) {
-            let store = DIGraphShared.shared.pendingPushDeliveryStore
-            let logger = DIGraphShared.shared.logger
             let pending = store.loadAll()
             guard !pending.isEmpty else {
                 logger.debug(
@@ -262,6 +265,11 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
                 return
             }
 
+            // DataPipelineTracking is resolved inside the Task intentionally. On Flutter and
+            // React Native, MessagingPush.initialize() is called from the native AppDelegate
+            // before the cross-platform runtime has started, so DataPipeline may not be
+            // registered yet at call time. The scheduler delay gives the runtime time to
+            // complete its own initialization before we check for DataPipeline's presence.
             guard let pipeline = DIGraphShared.shared.getOptional(DataPipelineTracking.self) else {
                 logger.debug(
                     "Pending push delivery store: DataPipeline unavailable, skipping flush to preserve \(pending.count) metric(s)"

--- a/Tests/MessagingInApp/Gist/Network/GistQueueNetworkTest.swift
+++ b/Tests/MessagingInApp/Gist/Network/GistQueueNetworkTest.swift
@@ -30,7 +30,7 @@ class GistQueueNetworkTest: UnitTest {
             expectation.fulfill()
         }))
 
-        waitForExpectations(timeout: 1.0)
+        waitForExpectations(timeout: 5.0)
     }
 
     // Flake-fix: drop the `waitForExpectations` and `expectation` — the
@@ -66,7 +66,7 @@ class GistQueueNetworkTest: UnitTest {
             expectation.fulfill()
         }))
 
-        waitForExpectations(timeout: 1.0)
+        waitForExpectations(timeout: 5.0)
     }
 
     func test_request_withNoIdentifiers_expectThrowsMissingUserIdentifier() {

--- a/Tests/MessagingInApp/MessagingInAppImplementationTest.swift
+++ b/Tests/MessagingInApp/MessagingInAppImplementationTest.swift
@@ -66,10 +66,12 @@ class MessagingInAppImplementationTest: IntegrationTest {
         let createDefaultExpectation: (String, Bool) -> XCTestExpectation = { description, expectToHappen in
             let expectation = self.expectation(description: description)
 
-            // Setup expectation to only assert that the event happened or did not.
-            // The number of times the expectation is called is not checked as it has been unreliable.
-            // Instead, have the test function check the number of times a mock was called.
-            expectation.assertForOverFulfill = false
+            // Previously set to false because over-fulfillment was occurring intermittently.
+            // Root cause was a retain cycle in MessagingInAppImplementation's event bus observer
+            // closures (strong self capture → NotificationCenter retained the closure → prevented
+            // deallocation between tests, leaving stale observers registered). Fixed by using
+            // [weak self] in all observer closures, so this can now be enforced again.
+            expectation.assertForOverFulfill = true
             expectation.isInverted = !expectToHappen
 
             return expectation

--- a/Tests/MessagingPush/PushDeliveryFlushTests.swift
+++ b/Tests/MessagingPush/PushDeliveryFlushTests.swift
@@ -38,7 +38,7 @@ final class MessagingPushPendingPushFlushTests: UnitTest {
         // Override store so registerPendingPushDeliveryStore() inside initialize() doesn't replace it
         diGraphShared.override(value: pendingStoreMock, forType: PendingPushDeliveryStore.self)
 
-        mockCollection.add(mocks: [pendingStoreMock, pipelineMock])
+        mockCollection.add(mock: pendingStoreMock)
     }
 
     override func initializeSDKComponents() -> MessagingPushInstance? {

--- a/Tests/MessagingPush/PushDeliveryFlushTests.swift
+++ b/Tests/MessagingPush/PushDeliveryFlushTests.swift
@@ -32,12 +32,13 @@ final class MessagingPushPendingPushFlushTests: UnitTest {
         pendingStoreMock.underlyingAppGroupSuiteName = "group.test.app.cio"
         pipelineMock = DataPipelineTrackingMock()
 
-        // Register pipeline mock before initialize() so getOptional(DataPipelineTracking.self) returns it
-        diGraphShared.register(pipelineMock, forType: DataPipelineTracking.self)
+        // Override pipeline mock so it is scoped to this test and cleaned up between tests,
+        // preventing a stale Task.detached from a prior test resolving the wrong mock instance.
+        diGraphShared.override(value: pipelineMock, forType: DataPipelineTracking.self)
         // Override store so registerPendingPushDeliveryStore() inside initialize() doesn't replace it
         diGraphShared.override(value: pendingStoreMock, forType: PendingPushDeliveryStore.self)
 
-        mockCollection.add(mock: pendingStoreMock)
+        mockCollection.add(mocks: [pendingStoreMock, pipelineMock])
     }
 
     override func initializeSDKComponents() -> MessagingPushInstance? {


### PR DESCRIPTION
MBL-1736: Several tests were behaving badly. Some were inconsistent due to memory retention problems. Others had network requests that were timing out under load in the CI environment. 

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 


- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After code reviews are approved and you determine this PR is ready to merge, select *Squash and Merge* button on this screen, leave the title and description to the default values, then merge the PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small production hardening (weak observers, earlier DI snapshot for push flush) with no auth or data-model changes; behavior should match intent with less cross-test leakage.
> 
> **Overview**
> Addresses **flaky unit tests** by fixing real lifecycle/DI issues and tightening test setup, not only loosening assertions.
> 
> **In-app messaging:** Event bus observers in `MessagingInAppImplementation` now capture **`[weak self]`** so observer closures no longer retain the module (stale observers and double event delivery across tests). Related tests turn **`assertForOverFulfill`** back on.
> 
> **Push startup flush:** Pending delivery metric flush **snapshots** `pendingPushDeliveryStore` and `logger` before `Task.detached`, so a concurrent `initialize()` / DI setup cannot resolve the wrong graph inside the background task. **`DataPipelineTracking`** is still resolved inside the task (documented for Flutter/RN startup order). Push flush tests use **`override`** for the pipeline mock so detached tasks from earlier tests do not hit a stale registration.
> 
> **Network tests:** Gist queue tests that still wait on async completion use a **longer expectation timeout** (5s) for CI load; other cases avoid unnecessary network waits where only sync validation is under test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af3fc3a4292515909192f9f0f39a4ced810bd58a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->