### PR TITLE
feat: dedup identify calls within a session when no traits supplied

### DIFF
--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -15,6 +15,13 @@ class DataPipelineImplementation: DataPipelineInstance, DataPipelineTracking {
     private let contextPlugin: Context
     private let profileStore: ProfileStore
 
+    /// Per-session tracker of the most recently identified userId. Used to dedup
+    /// no-traits identify calls against the same userId within a single process
+    /// lifetime. Reset by `clearIdentify()`. Not persisted across launches so
+    /// that the first identify per cold-start always runs the full path
+    /// (device-token re-registration + DCoU refresh).
+    private var lastIdentifiedUserIdThisSession: String?
+
     init(diGraph: DIGraphShared, moduleConfig: DataPipelineConfigOptions) {
         self.moduleConfig = moduleConfig
         self.logger = diGraph.logger
@@ -167,6 +174,17 @@ class DataPipelineImplementation: DataPipelineInstance, DataPipelineTracking {
             return
         }
 
+        // Per-session dedup: short-circuit when this exact userId was already
+        // identified during this process lifetime AND no traits are supplied.
+        // An explicit empty dict (`[:]`) is treated as "traits supplied" and
+        // passes through, because some integrations rely on the empty-traits
+        // identify call as an intentional no-op trait merge.
+        let hasNoTraits = attributesDict == nil && attributesCodable == nil
+        if hasNoTraits, let lastUserId = lastIdentifiedUserIdThisSession, lastUserId == userId {
+            logger.debug("identify(\(userId)) skipped — already identified this session, no traits")
+            return
+        }
+
         let currentlyIdentifiedProfile = registeredUserId
         let isChangingIdentifiedProfile = currentlyIdentifiedProfile != nil && currentlyIdentifiedProfile != userId
         let isFirstTimeIdentifying = currentlyIdentifiedProfile == nil
@@ -181,6 +199,11 @@ class DataPipelineImplementation: DataPipelineInstance, DataPipelineTracking {
         } else {
             analytics.identify(userId: userId, traits: attributesDict)
         }
+
+        // Update session tracker so subsequent no-traits same-userId calls
+        // within this session can dedup. Identify-with-traits passes through
+        // but still refreshes the session tracker.
+        lastIdentifiedUserIdThisSession = userId
 
         if isFirstTimeIdentifying || isChangingIdentifiedProfile {
             if let existingDeviceToken = registeredDeviceToken {
@@ -199,6 +222,10 @@ class DataPipelineImplementation: DataPipelineInstance, DataPipelineTracking {
         // reset all to default state
         logger.debug("resetting user profile")
         analytics.reset()
+
+        // Reset per-session identify dedup tracker so the next identify (even
+        // for the same userId) takes the full path.
+        lastIdentifiedUserIdThisSession = nil
     }
 
     func deleteDeviceToken() {

--- a/Tests/DataPipeline/DataPipelineImplementation+IdentifyDedupTests.swift
+++ b/Tests/DataPipeline/DataPipelineImplementation+IdentifyDedupTests.swift
@@ -1,0 +1,169 @@
+@testable import CioAnalytics
+@testable import CioDataPipelines
+@testable import CioInternalCommon
+import Foundation
+@testable import SharedTests
+import XCTest
+
+/// Tests for per-session identify dedup behavior added to
+/// `DataPipelineImplementation.commonIdentifyProfile`.
+///
+/// Dedup contract (PR 1 of Phase 1 — Auto-Event Volume Optimization):
+///   * Short-circuit only when the userId matches the last identified user
+///     **and** both `attributesDict` and `attributesCodable` are nil.
+///   * Empty dict (`[:]`) is NOT a short-circuit — it is an intentional
+///     "no-op trait merge" the customer may rely on for backend behavior.
+///   * Identify-with-traits passes through but updates the session tracker.
+///   * `clearIdentify()` resets the tracker so the next identify (even for
+///     the same userId) takes the full path including device-token
+///     re-registration.
+///   * The first identify per session always runs the full path so token
+///     rotation and DCoU cadence are preserved on cold start.
+class DataPipelineIdentifyDedupTests: IntegrationTest {
+    private var outputReader: OutputReaderPlugin!
+
+    private let deviceAttributesMock = DeviceAttributesProviderMock()
+    private let globalDataStoreMock = GlobalDataStoreMock()
+    private let dataPipelinesLoggerMock = DataPipelinesLoggerMock()
+
+    override func setUpDependencies() {
+        super.setUpDependencies()
+
+        mockCollection.add(mocks: [deviceAttributesMock, globalDataStoreMock, dataPipelinesLoggerMock])
+
+        diGraphShared.override(value: deviceAttributesMock, forType: DeviceAttributesProvider.self)
+        diGraphShared.override(value: globalDataStoreMock, forType: GlobalDataStore.self)
+        diGraphShared.override(value: dataPipelinesLoggerMock, forType: DataPipelinesLogger.self)
+    }
+
+    override func setUp() {
+        super.setUp()
+
+        outputReader = (customerIO.add(plugin: OutputReaderPlugin()) as? OutputReaderPlugin)
+    }
+
+    // MARK: - First identify per session always fires
+
+    func test_identify_givenFirstIdentifyNoTraits_expectAnalyticsIdentifyCalled() {
+        let givenIdentifier = String.random
+
+        XCTAssertNil(analytics.userId)
+
+        customerIO.identify(userId: givenIdentifier)
+
+        XCTAssertEqual(analytics.userId, givenIdentifier)
+        XCTAssertEqual(outputReader.identifyEvents.count, 1)
+        XCTAssertEqual(outputReader.identifyEvents.last?.userId, givenIdentifier)
+    }
+
+    // MARK: - Dedup short-circuit
+
+    func test_identify_givenSecondIdentifySameUserIdNoTraits_expectAnalyticsIdentifyNotCalled() {
+        let givenIdentifier = String.random
+
+        customerIO.identify(userId: givenIdentifier)
+        XCTAssertEqual(outputReader.identifyEvents.count, 1)
+        outputReader.resetPlugin()
+
+        // Second identify with the same userId and no traits should be deduped.
+        customerIO.identify(userId: givenIdentifier)
+
+        XCTAssertEqual(outputReader.identifyEvents.count, 0)
+        XCTAssertEqual(outputReader.events.count, 0)
+        XCTAssertEqual(analytics.userId, givenIdentifier)
+    }
+
+    // MARK: - Empty dict is NOT deduped
+
+    func test_identify_givenSecondIdentifySameUserIdEmptyDictTraits_expectAnalyticsIdentifyCalled() {
+        let givenIdentifier = String.random
+
+        customerIO.identify(userId: givenIdentifier)
+        outputReader.resetPlugin()
+
+        // Explicit empty-dict traits MUST pass through — customers may rely on
+        // the empty-traits identify as a no-op trait merge.
+        customerIO.identify(userId: givenIdentifier, traits: [String: Any]())
+
+        XCTAssertEqual(outputReader.identifyEvents.count, 1)
+        XCTAssertEqual(outputReader.identifyEvents.last?.userId, givenIdentifier)
+    }
+
+    // MARK: - With-traits passes through
+
+    func test_identify_givenSecondIdentifySameUserIdWithTraits_expectAnalyticsIdentifyCalled() {
+        let givenIdentifier = String.random
+        let givenBody: [String: Any] = ["first_name": "Dana", "age": 30]
+        let givenBodyTypeMap: [[String]: Any.Type] = [["age"]: Int.self]
+
+        customerIO.identify(userId: givenIdentifier)
+        outputReader.resetPlugin()
+
+        customerIO.identify(userId: givenIdentifier, traits: givenBody)
+
+        XCTAssertEqual(outputReader.identifyEvents.count, 1)
+        guard let identifyEvent = outputReader.identifyEvents.last else {
+            XCTFail("identify event must not be nil")
+            return
+        }
+        XCTAssertEqual(identifyEvent.userId, givenIdentifier)
+        XCTAssertMatches(identifyEvent.traits?.dictionaryValue, givenBody, withTypeMap: givenBodyTypeMap)
+    }
+
+    // MARK: - Profile change still fires
+
+    func test_identify_givenDifferentUserIdNoTraits_expectAnalyticsIdentifyCalled() {
+        let firstIdentifier = String.random
+        let secondIdentifier = String.random
+        XCTAssertNotEqual(firstIdentifier, secondIdentifier)
+
+        customerIO.identify(userId: firstIdentifier)
+        outputReader.resetPlugin()
+
+        customerIO.identify(userId: secondIdentifier)
+
+        XCTAssertEqual(outputReader.identifyEvents.count, 1)
+        XCTAssertEqual(outputReader.identifyEvents.last?.userId, secondIdentifier)
+        XCTAssertEqual(analytics.userId, secondIdentifier)
+    }
+
+    // MARK: - clearIdentify resets the session flag
+
+    func test_identify_givenSameUserIdAfterClearIdentify_expectAnalyticsIdentifyCalled() {
+        let givenIdentifier = String.random
+
+        customerIO.identify(userId: givenIdentifier)
+        customerIO.clearIdentify()
+        outputReader.resetPlugin()
+
+        // After clearIdentify, the same userId must be re-emitted (session flag reset).
+        customerIO.identify(userId: givenIdentifier)
+
+        XCTAssertEqual(outputReader.identifyEvents.count, 1)
+        XCTAssertEqual(outputReader.identifyEvents.last?.userId, givenIdentifier)
+    }
+
+    // MARK: - Regression guard: device-token re-registration runs on first identify
+
+    func test_identify_givenFirstIdentify_expectDeviceTokenReregistrationCalled() {
+        let givenIdentifier = String.random
+        let givenDeviceToken = String.random
+
+        globalDataStoreMock.underlyingPushDeviceToken = givenDeviceToken
+        mockDeviceAttributes()
+
+        customerIO.identify(userId: givenIdentifier)
+
+        // First identify with a registered device token must fire a
+        // "Device Created or Updated" event for the new profile.
+        let updatedEvents = outputReader.deviceUpdateEvents
+        XCTAssertEqual(updatedEvents.count, 1)
+        XCTAssertEqual(updatedEvents.first?.deviceToken, givenDeviceToken)
+    }
+
+    // MARK: - Helpers
+
+    private func mockDeviceAttributes(defaultAttributes: [String: Any] = [:]) {
+        deviceAttributesMock.getDefaultDeviceAttributesClosure = { $0(defaultAttributes) }
+    }
+}

--- a/Tests/DataPipeline/DataPipelineInteractionTests.swift
+++ b/Tests/DataPipeline/DataPipelineInteractionTests.swift
@@ -142,8 +142,10 @@ class CDPInteractionDefaultConfigTests: DataPipelineInteractionTests {
 
         customerIO.identify(userId: givenIdentifier)
 
-        XCTAssertEqual(outputReader.events.count, 1)
-        XCTAssertEqual(outputReader.identifyEvents.count, 1)
+        // Per-session dedup: a second no-traits identify against the same userId
+        // is short-circuited entirely, so no events should be emitted.
+        XCTAssertEqual(outputReader.events.count, 0)
+        XCTAssertEqual(outputReader.identifyEvents.count, 0)
     }
 
     func test_identify_givenNoProfilePreviouslyIdentified_expectPostProfileEventToEventBus() {


### PR DESCRIPTION
## What

Deduplicates redundant `identify` calls within a single process lifetime to reduce event volume.

When the same `userId` is identified again **and no traits are supplied**, the call is short-circuited instead of forwarding another `analytics.identify` event. This targets apps that call `identify(userId:)` repeatedly (e.g. on every app foreground / screen) with no new trait data.

### Behavior details
- A per-session tracker (`lastIdentifiedUserIdThisSession`) records the most recently identified `userId`.
- A no-traits identify for the same `userId` within the same session is skipped (debug-logged).
- An explicit empty dict (`[:]`) is treated as **traits supplied** and passes through (intentional no-op trait merge for some integrations).
- The tracker is **not** persisted across launches, so the first identify per cold-start always runs the full path (device-token re-registration + DCoU refresh).
- `clearIdentify()` resets the tracker so the next identify takes the full path.

## Why

Reduce events volume by avoiding duplicate identify events that carry no new information.

## Testing

- Added `DataPipelineImplementation+IdentifyDedupTests.swift` covering the dedup paths.
- Updated `DataPipelineInteractionTests`.

---

> [!NOTE]
> Draft — opened for CI validation and review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core identify emission semantics for the public SDK; edge cases (empty traits, clearIdentify, first launch) are covered by tests but integrators relying on every no-traits identify firing could see fewer events.
> 
> **Overview**
> Adds **in-process deduplication** for `identify(userId:)` when the same `userId` is identified again with **no traits** (`attributesDict` and `attributesCodable` both nil). Those repeat calls are skipped before `analytics.identify`, reducing duplicate identify events from apps that re-call identify on foreground or navigation.
> 
> **`[:]` traits still go through** (treated as supplied traits). Identifies with real traits, a different `userId`, the **first** identify after launch, and any identify after **`clearIdentify()`** still run the full path—including device-token handling on first/changed profile. A session-only flag is cleared on `clearIdentify()` so logout/login behavior stays correct.
> 
> New **`DataPipelineIdentifyDedupTests`** document the contract; **`DataPipelineInteractionTests`** expects zero events when re-identifying the same user with no traits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd5edec8f02c2546e7ce83e2296a3edd13e42e61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->