### PR TITLE
chore: regenerate autogen + reformat to current rules

### DIFF
--- a/Sources/DataPipeline/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/DataPipeline/autogenerated/AutoDependencyInjection.generated.swift
@@ -2,8 +2,8 @@
 // DO NOT EDIT
 // swiftlint:disable all
 
-import CioInternalCommon
 import Foundation
+import CioInternalCommon
 
 /**
  ######################################################

--- a/Sources/Location/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/Location/autogenerated/AutoDependencyInjection.generated.swift
@@ -2,8 +2,8 @@
 // DO NOT EDIT
 // swiftlint:disable all
 
-import CioInternalCommon
 import Foundation
+import CioInternalCommon
 
 /**
  ######################################################

--- a/Sources/MessagingInApp/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/MessagingInApp/autogenerated/AutoDependencyInjection.generated.swift
@@ -2,8 +2,8 @@
 // DO NOT EDIT
 // swiftlint:disable all
 
-import CioInternalCommon
 import Foundation
+import CioInternalCommon
 import UIKit
 
 /**

--- a/Sources/MessagingPush/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/MessagingPush/autogenerated/AutoDependencyInjection.generated.swift
@@ -2,8 +2,8 @@
 // DO NOT EDIT
 // swiftlint:disable all
 
-import CioInternalCommon
 import Foundation
+import CioInternalCommon
 
 /**
  ######################################################

--- a/Sources/MessagingPushAPN/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/MessagingPushAPN/autogenerated/AutoDependencyInjection.generated.swift
@@ -2,9 +2,9 @@
 // DO NOT EDIT
 // swiftlint:disable all
 
-import CioInternalCommon
-import CioMessagingPush
 import Foundation
+import CioMessagingPush
+import CioInternalCommon
 
 /**
  ######################################################

--- a/Sources/MessagingPushAPN/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingPushAPN/autogenerated/AutoMockable.generated.swift
@@ -9,8 +9,8 @@ import FoundationNetworking
 #if canImport(UserNotifications)
 import UserNotifications
 #endif
-import CioInternalCommon
 import CioMessagingPush
+import CioInternalCommon
 
 /**
  ######################################################

--- a/Sources/MessagingPushFCM/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/MessagingPushFCM/autogenerated/AutoDependencyInjection.generated.swift
@@ -2,9 +2,9 @@
 // DO NOT EDIT
 // swiftlint:disable all
 
-import CioInternalCommon
-import CioMessagingPush
 import Foundation
+import CioMessagingPush
+import CioInternalCommon
 
 /**
  ######################################################

--- a/Sources/MessagingPushFCM/autogenerated/AutoMockable.generated.swift
+++ b/Sources/MessagingPushFCM/autogenerated/AutoMockable.generated.swift
@@ -9,8 +9,8 @@ import FoundationNetworking
 #if canImport(UserNotifications)
 import UserNotifications
 #endif
-import CioInternalCommon
 import CioMessagingPush
+import CioInternalCommon
 
 /**
  ######################################################

--- a/Sources/Migration/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/Migration/autogenerated/AutoDependencyInjection.generated.swift
@@ -2,8 +2,8 @@
 // DO NOT EDIT
 // swiftlint:disable all
 
-import CioInternalCommon
 import Foundation
+import CioInternalCommon
 
 /**
  ######################################################

--- a/Tests/Common/Store/BackgroundDeliveryContextStoreTests.swift
+++ b/Tests/Common/Store/BackgroundDeliveryContextStoreTests.swift
@@ -172,6 +172,9 @@ struct BackgroundDeliveryContextStoreTests {
 
 private final class StubCdpApiKeyProvider: BackgroundDeliveryCdpApiKeyProvider {
     let value: String?
-    init(value: String?) { self.value = value }
+    init(value: String?) {
+        self.value = value
+    }
+
     var cdpApiKey: String? { value }
 }

--- a/Tests/Location/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/Location/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -454,7 +454,7 @@ struct GeofenceSyncCoordinatorTests {
     }
 
     @Test
-    func applyCachedRegistration_givenNoUserId_expectNoRegistration() async {
+    func applyCachedRegistration_givenNoUserId_expectNoRegistration() {
         let setup = makeCoordinator(storage: makeStorage())
 
         setup.coordinator.applyCachedRegistration(
@@ -468,7 +468,7 @@ struct GeofenceSyncCoordinatorTests {
     }
 
     @Test
-    func applyCachedRegistration_givenEmptyRegions_expectNoRegistration() async {
+    func applyCachedRegistration_givenEmptyRegions_expectNoRegistration() {
         let setup = makeCoordinator(storage: makeStorage())
 
         setup.coordinator.applyCachedRegistration(
@@ -482,7 +482,7 @@ struct GeofenceSyncCoordinatorTests {
     }
 
     @Test
-    func applyCachedRegistration_givenMissingAnchor_expectNoRegistration() async {
+    func applyCachedRegistration_givenMissingAnchor_expectNoRegistration() {
         // Without an anchor we can't distance-filter or place the movement trigger
         // sensibly — bail rather than re-using an arbitrary location.
         let setup = makeCoordinator(storage: makeStorage())
@@ -498,7 +498,7 @@ struct GeofenceSyncCoordinatorTests {
     }
 
     @Test
-    func applyCachedRegistration_givenAllInputs_expectNearestRegisteredPlusMovementTrigger() async {
+    func applyCachedRegistration_givenAllInputs_expectNearestRegisteredPlusMovementTrigger() {
         let config = GeofenceConfig(
             localRefreshTriggerRadius: 600,
             remoteFetchRefreshTriggerRadius: 3000,
@@ -537,7 +537,7 @@ struct GeofenceSyncCoordinatorTests {
     }
 
     @Test
-    func applyCachedRegistration_givenNilConfig_expectFallbackUsed() async {
+    func applyCachedRegistration_givenNilConfig_expectFallbackUsed() {
         let anchor = LocationData(latitude: 0, longitude: 0)
         let setup = makeCoordinator(storage: makeStorage())
 

--- a/Tests/Location/Geofence/GeofenceBootstrapTests.swift
+++ b/Tests/Location/Geofence/GeofenceBootstrapTests.swift
@@ -172,6 +172,9 @@ struct GeofenceBootstrapTests {
 
 private final class StubProvider: BackgroundDeliveryCdpApiKeyProvider {
     let value: String?
-    init(value: String?) { self.value = value }
+    init(value: String?) {
+        self.value = value
+    }
+
     var cdpApiKey: String? { value }
 }

--- a/Tests/Location/Geofence/GeofenceMonitorBinderTests.swift
+++ b/Tests/Location/Geofence/GeofenceMonitorBinderTests.swift
@@ -79,7 +79,9 @@ struct GeofenceMonitorBinderTests {
             transition: .enter,
             location: LocationData(latitude: 37.0, longitude: -122.0)
         )
-        for _ in 0 ..< 10 { await Task.yield() }
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
 
         #expect(coordinator.handleMovementCallsCount == 0)
         #expect(eventBus.postEventCallsCount == 0)
@@ -100,7 +102,9 @@ struct GeofenceMonitorBinderTests {
             transition: .exit,
             location: nil
         )
-        for _ in 0 ..< 10 { await Task.yield() }
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
 
         #expect(coordinator.handleMovementCallsCount == 0)
     }


### PR DESCRIPTION
## Summary

Drive-by drift cleanup, no source changes. The recent main merge into `feature/geofence-on-device` left two kinds of mismatch between baseline and current rules:

- **Stencil template vs. baseline import order.** Template emits `import Foundation` first, then arg-supplied imports — but the on-disk baseline still has the older order (alphabetical, `CioInternalCommon` first). `.swiftformat` has `--disable sortImports` so nothing was re-sorting.
- **Updated swiftformat rules.** Single-line initializers get expanded to multi-line blocks; `async` is removed from test funcs that don't actually await. Previous baseline pre-dates those rule changes.

Folded here as a precursor so this churn doesn't surface on every follow-up PR in the MBL-1770 stack.

## What's in the diff

- 9 `.generated.swift` files: import order rewritten to template's natural output (`Foundation` first, then arg-supplied imports).
- 4 test files: swiftformat reflows — single-line `init` expansions in `StubProvider`/`StubCdpApiKeyProvider`, `async` removed from non-awaiting tests.

No production source changes.

## Stack

This is the first PR in the MBL-1770 follow-up stack. Subsequent PRs build on this:

1. **this PR** — autogen + reformat drift
2. `mbl-1770-b-storage-correctness` — pending-store correctness across user changes
3. `mbl-1770-c-…` — small fixes + Android-port bug fixes
4. `mbl-1770-d-…` — cross-process exactly-once delivery
5. `mbl-1770-e-…` — no-op regression test for non-geofence apps

Linear: [MBL-1770](https://linear.app/customerio/issue/MBL-1770/ios-address-follow-up-reliability-lifecycle-and-platform-improvements)

## Test plan

- [x] `make generate && make format && make lint` — clean (0 violations)
- [x] `xcodebuild build-for-testing -scheme Customer.io-Package` — green
- [ ] Re-run on CI to confirm no further drift surfaces

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Generated DI/mock files and cosmetic test formatting only; no runtime or behavioral changes.
> 
> **Overview**
> **Drift-only cleanup** so later MBL-1770 PRs don’t carry formatting noise. There are **no production source changes**.
> 
> Sourcery output is refreshed across **nine** `AutoDependencyInjection.generated.swift` / `AutoMockable.generated.swift` files. **Import blocks** now match the stencil (`import Foundation` first, then module imports such as `CioMessagingPush` before `CioInternalCommon` where both appear).
> 
> **Four test files** are reformatted to current SwiftFormat rules: stub `init` bodies expanded to multi-line, `async` dropped from `applyCachedRegistration` tests that don’t await, and tight `for` loops in `GeofenceMonitorBinderTests` split across lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5947223fb3f001e45c246f33e586c9fb1301c52c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->