### PR TITLE
chore: geofence reliability fixes + logger tag dispatch

### DIFF
--- a/Sources/Common/Util/Log.swift
+++ b/Sources/Common/Util/Log.swift
@@ -114,8 +114,9 @@ public class LoggerImpl: Logger {
     private func printMessage(_ message: String, _ level: CioLogLevel, _ tag: String?, _ error: Error?) {
         if !logLevel.shouldLog(level) { return }
 
+        // Tag prefix and error suffix prepended once so dispatcher and systemLogger see the same final message.
         let formattedMessage = formatMessage(message, tag, error)
-        logDispatcher?(level, message) ?? systemLogger.log(formattedMessage, level)
+        logDispatcher?(level, formattedMessage) ?? systemLogger.log(formattedMessage, level)
     }
 
     private func formatMessage(_ message: String, _ tag: String? = nil, _ error: Error? = nil) -> String {

--- a/Sources/Location/Geofence/Coordinator/GeofenceSyncCoordinator.swift
+++ b/Sources/Location/Geofence/Coordinator/GeofenceSyncCoordinator.swift
@@ -88,8 +88,14 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
 
         let cachedConfig = await storage.getCachedConfig()
         if let lastSync = await storage.getLastSync() {
-            let expiry = cachedConfig?.remoteFetchRefreshExpiry ?? GeofenceConstants.staleSyncInterval
-            if dateUtil.now.timeIntervalSince(lastSync.timestamp) < expiry {
+            // Time-fresh alone isn't enough: if the app was killed while the user
+            // travelled far, no movement EXIT fired to update the cache.
+            let effectiveConfig = cachedConfig ?? .fallback
+            let timeSinceLastSync = dateUtil.now.timeIntervalSince(lastSync.timestamp)
+            let distanceFromAnchor = CLLocation(latitude: lastSync.location.latitude, longitude: lastSync.location.longitude)
+                .distance(from: CLLocation(latitude: latitude, longitude: longitude))
+            if timeSinceLastSync < effectiveConfig.remoteFetchRefreshExpiry,
+               distanceFromAnchor < effectiveConfig.remoteFetchRefreshTriggerRadius {
                 logger.geofenceSyncSkippedFresh()
                 return .success(())
             }
@@ -319,6 +325,9 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
                 transitionTypes: region.transitionTypes
             )
         }
+        // With no business regions, a movement trigger would just refetch and get the
+        // same empty result — leave it off until the next identify / foreground refresh.
+        guard !businessRegions.isEmpty else { return }
         monitor.startMonitoring(
             identifier: GeofenceConstants.movementTriggerIdentifier,
             center: movementTriggerLocation,

--- a/Sources/Location/Geofence/Event/GeofenceDeliveryTracker.swift
+++ b/Sources/Location/Geofence/Event/GeofenceDeliveryTracker.swift
@@ -4,10 +4,10 @@ import Foundation
 /// Sends a single geofence transition event over direct HTTP to `/track`.
 ///
 /// This is the primary delivery path in the three-layer design. Callers persist
-/// the metric to `PendingGeofenceMetricStore` *before* calling `deliver`, then
+/// the metric to `PendingGeofenceMetricStore` *before* calling `trackMetric`, then
 /// remove it from the queue only after this returns success.
 protocol GeofenceDeliveryTracker: AutoMockable {
-    func deliver(
+    func trackMetric(
         metric: PendingGeofenceMetric,
         userId: String,
         onComplete: @escaping (Result<Void, BackgroundDeliveryHttpError>) -> Void
@@ -23,7 +23,7 @@ final class GeofenceDeliveryTrackerImpl: GeofenceDeliveryTracker {
         self.logger = logger
     }
 
-    func deliver(
+    func trackMetric(
         metric: PendingGeofenceMetric,
         userId: String,
         onComplete: @escaping (Result<Void, BackgroundDeliveryHttpError>) -> Void

--- a/Sources/Location/Geofence/Event/GeofenceEventTracker.swift
+++ b/Sources/Location/Geofence/Event/GeofenceEventTracker.swift
@@ -116,7 +116,7 @@ final class GeofenceEventTracker: @unchecked Sendable {
         }
 
         let success = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
-            deliveryTracker.deliver(metric: metric, userId: userId) { result in
+            deliveryTracker.trackMetric(metric: metric, userId: userId) { result in
                 switch result {
                 case .success:
                     continuation.resume(returning: true)

--- a/Sources/Location/autogenerated/AutoMockable.generated.swift
+++ b/Sources/Location/autogenerated/AutoMockable.generated.swift
@@ -143,38 +143,38 @@ class GeofenceDeliveryTrackerMock: GeofenceDeliveryTracker, Mock {
     init() {}
 
     public func resetMock() {
-        deliverCallsCount = 0
-        deliverReceivedArguments = nil
-        deliverReceivedInvocations = []
+        trackMetricCallsCount = 0
+        trackMetricReceivedArguments = nil
+        trackMetricReceivedInvocations = []
 
         mockCalled = false // do last as resetting properties above can make this true
     }
 
-    // MARK: - deliver
+    // MARK: - trackMetric
 
     /// Number of times the function was called.
-    @Atomic private(set) var deliverCallsCount = 0
+    @Atomic private(set) var trackMetricCallsCount = 0
     /// `true` if the function was ever called.
-    var deliverCalled: Bool {
-        deliverCallsCount > 0
+    var trackMetricCalled: Bool {
+        trackMetricCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    @Atomic private(set) var deliverReceivedArguments: (metric: PendingGeofenceMetric, userId: String, onComplete: (Result<Void, BackgroundDeliveryHttpError>) -> Void)?
+    @Atomic private(set) var trackMetricReceivedArguments: (metric: PendingGeofenceMetric, userId: String, onComplete: (Result<Void, BackgroundDeliveryHttpError>) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    @Atomic private(set) var deliverReceivedInvocations: [(metric: PendingGeofenceMetric, userId: String, onComplete: (Result<Void, BackgroundDeliveryHttpError>) -> Void)] = []
+    @Atomic private(set) var trackMetricReceivedInvocations: [(metric: PendingGeofenceMetric, userId: String, onComplete: (Result<Void, BackgroundDeliveryHttpError>) -> Void)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    var deliverClosure: ((PendingGeofenceMetric, String, @escaping (Result<Void, BackgroundDeliveryHttpError>) -> Void) -> Void)?
+    var trackMetricClosure: ((PendingGeofenceMetric, String, @escaping (Result<Void, BackgroundDeliveryHttpError>) -> Void) -> Void)?
 
-    /// Mocked function for `deliver(metric: PendingGeofenceMetric, userId: String, onComplete: @escaping (Result<Void, BackgroundDeliveryHttpError>) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
-    func deliver(metric: PendingGeofenceMetric, userId: String, onComplete: @escaping (Result<Void, BackgroundDeliveryHttpError>) -> Void) {
+    /// Mocked function for `trackMetric(metric: PendingGeofenceMetric, userId: String, onComplete: @escaping (Result<Void, BackgroundDeliveryHttpError>) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
+    func trackMetric(metric: PendingGeofenceMetric, userId: String, onComplete: @escaping (Result<Void, BackgroundDeliveryHttpError>) -> Void) {
         mockCalled = true
-        deliverCallsCount += 1
-        deliverReceivedArguments = (metric: metric, userId: userId, onComplete: onComplete)
-        deliverReceivedInvocations.append((metric: metric, userId: userId, onComplete: onComplete))
-        deliverClosure?(metric, userId, onComplete)
+        trackMetricCallsCount += 1
+        trackMetricReceivedArguments = (metric: metric, userId: userId, onComplete: onComplete)
+        trackMetricReceivedInvocations.append((metric: metric, userId: userId, onComplete: onComplete))
+        trackMetricClosure?(metric, userId, onComplete)
     }
 }
 

--- a/Tests/Common/Util/LoggerTest.swift
+++ b/Tests/Common/Util/LoggerTest.swift
@@ -238,6 +238,38 @@ class LoggerTest: UnitTest {
         XCTAssertEqual(errorInvocation.first?.level, .error)
         XCTAssertEqual(errorInvocation.first?.message, errorMessage)
     }
+
+    func test_dispatcherWithTag_expectTagPrefixedMessage() {
+        let dispatcherMock = DispatcherMock()
+        logger.setLogLevel(.debug)
+        logger.setLogDispatcher(dispatcherMock.closure)
+
+        logger.debug("Test debug message", "MyTag")
+        logger.info("Test info message", "MyTag")
+        logger.error("Test error message", "MyTag", nil)
+
+        XCTAssertEqual(dispatcherMock.invocations(for: .debug).first?.message, "[MyTag] Test debug message")
+        XCTAssertEqual(dispatcherMock.invocations(for: .info).first?.message, "[MyTag] Test info message")
+        XCTAssertEqual(dispatcherMock.invocations(for: .error).first?.message, "[MyTag] Test error message")
+    }
+
+    func test_dispatcherWithTagAndError_expectTagPrefixedAndErrorSuffixedMessage() {
+        let dispatcherMock = DispatcherMock()
+        let error = NSError(
+            domain: "io.customer",
+            code: 12,
+            userInfo: [NSLocalizedDescriptionKey: "Localized error"]
+        )
+        logger.setLogLevel(.error)
+        logger.setLogDispatcher(dispatcherMock.closure)
+
+        logger.error("Test error message", "MyTag", error)
+
+        XCTAssertEqual(
+            dispatcherMock.invocations(for: .error).first?.message,
+            "[MyTag] Test error message Error: Localized error"
+        )
+    }
 }
 
 class DispatcherMock {

--- a/Tests/Location/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/Location/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -130,11 +130,71 @@ struct GeofenceSyncCoordinatorTests {
         )
 
         let setup = makeCoordinator(storage: storage, dateUtil: dateUtil)
-        let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
+        // Same anchor → distance is 0; freshness gate skips API.
+        let result = await setup.coordinator.refresh(latitude: 0, longitude: 0)
 
         #expect(result.isSuccess)
         #expect(setup.api.fetchGeofencesCallsCount == 0)
         #expect(setup.monitor.startedRegions.isEmpty)
+    }
+
+    @Test
+    func refresh_givenTimeFreshButFarFromAnchor_expectApiCalled() async {
+        let storage = makeStorage()
+        let dateUtil = DateUtilStub()
+        // Time-fresh (100s ago vs 1h expiry) but caller is well beyond the 3km trigger radius.
+        let oneHour: TimeInterval = 60 * 60
+        await storage.setCachedConfig(GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 3000,
+            remoteFetchRefreshExpiry: oneHour,
+            duplicateEventsExpiry: 60,
+            maxBusinessGeofences: 10
+        ))
+        await storage.recordSync(
+            timestamp: dateUtil.givenNow.addingTimeInterval(-100),
+            location: LocationData(latitude: 0, longitude: 0)
+        )
+        let api = GeofenceApiServiceMock()
+        api.fetchGeofencesClosure = { _, _, completion in
+            completion(.success(makeApiResponse(regions: [])))
+        }
+        let setup = makeCoordinator(api: api, storage: storage, dateUtil: dateUtil)
+
+        // (1.0, 2.0) is ~248km from (0, 0) — way beyond 3km.
+        let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
+
+        #expect(result.isSuccess)
+        #expect(api.fetchGeofencesCallsCount == 1)
+    }
+
+    @Test
+    func refresh_givenTimeStaleButNearAnchor_expectApiCalled() async {
+        let storage = makeStorage()
+        let dateUtil = DateUtilStub()
+        // Time-stale (2h ago vs 1h expiry) at the same anchor (distance = 0).
+        let oneHour: TimeInterval = 60 * 60
+        await storage.setCachedConfig(GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 3000,
+            remoteFetchRefreshExpiry: oneHour,
+            duplicateEventsExpiry: 60,
+            maxBusinessGeofences: 10
+        ))
+        await storage.recordSync(
+            timestamp: dateUtil.givenNow.addingTimeInterval(-2 * oneHour),
+            location: LocationData(latitude: 0, longitude: 0)
+        )
+        let api = GeofenceApiServiceMock()
+        api.fetchGeofencesClosure = { _, _, completion in
+            completion(.success(makeApiResponse(regions: [])))
+        }
+        let setup = makeCoordinator(api: api, storage: storage, dateUtil: dateUtil)
+
+        let result = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+
+        #expect(result.isSuccess)
+        #expect(api.fetchGeofencesCallsCount == 1)
     }
 
     @Test
@@ -179,7 +239,8 @@ struct GeofenceSyncCoordinatorTests {
         )
         let setup = makeCoordinator(storage: storage, dateUtil: dateUtil)
 
-        let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
+        // Same anchor → distance is 0; freshness gate skips even without a cached config.
+        let result = await setup.coordinator.refresh(latitude: 0, longitude: 0)
 
         #expect(result.isSuccess)
         #expect(setup.api.fetchGeofencesCallsCount == 0)
@@ -327,8 +388,9 @@ struct GeofenceSyncCoordinatorTests {
         )
         await storage.setCachedConfig(config)
         let api = GeofenceApiServiceMock()
+        let region = makeRegion(id: "g1", latitude: 37.7749, longitude: -122.4194)
         api.fetchGeofencesClosure = { _, _, completion in
-            completion(.success(makeApiResponse(regions: [])))
+            completion(.success(makeApiResponse(regions: [region])))
         }
 
         let setup = makeCoordinator(api: api, storage: storage)
@@ -341,6 +403,21 @@ struct GeofenceSyncCoordinatorTests {
         #expect(movementTrigger?.center.longitude == -122.4194)
         #expect(movementTrigger?.radius == 750)
         #expect(movementTrigger?.transitionTypes == [.exit])
+    }
+
+    @Test
+    func refresh_givenEmptyBusinessRegions_expectNoMovementTriggerRegistered() async {
+        let storage = makeStorage()
+        let api = GeofenceApiServiceMock()
+        api.fetchGeofencesClosure = { _, _, completion in
+            completion(.success(makeApiResponse(regions: [])))
+        }
+
+        let setup = makeCoordinator(api: api, storage: storage)
+        _ = await setup.coordinator.refresh(latitude: 37.7749, longitude: -122.4194)
+
+        // No business regions ⇒ no movement trigger either; refetch-on-move would just hit the same empty result.
+        #expect(setup.monitor.startedRegions.isEmpty)
     }
 
     @Test

--- a/Tests/Location/Geofence/Event/GeofenceDeliveryTrackerTests.swift
+++ b/Tests/Location/Geofence/Event/GeofenceDeliveryTrackerTests.swift
@@ -32,12 +32,12 @@ struct GeofenceDeliveryTrackerTests {
     // MARK: - Argument shaping
 
     @Test
-    func deliver_givenEnterTransition_expectAndroidWireFormat() async {
+    func trackMetric_givenEnterTransition_expectAndroidWireFormat() async {
         let (tracker, httpClient) = makeTracker()
         httpClient.sendTrackEventClosure = { _, _, _, completion in completion(.success(())) }
 
         await withCheckedContinuation { continuation in
-            tracker.deliver(metric: makeMetric(), userId: "user_42") { _ in
+            tracker.trackMetric(metric: makeMetric(), userId: "user_42") { _ in
                 continuation.resume()
             }
         }
@@ -54,12 +54,12 @@ struct GeofenceDeliveryTrackerTests {
     }
 
     @Test
-    func deliver_givenExitTransition_expectExitedEventName() async {
+    func trackMetric_givenExitTransition_expectExitedEventName() async {
         let (tracker, httpClient) = makeTracker()
         httpClient.sendTrackEventClosure = { _, _, _, completion in completion(.success(())) }
 
         await withCheckedContinuation { continuation in
-            tracker.deliver(metric: makeMetric(transition: .exit), userId: "user_42") { _ in
+            tracker.trackMetric(metric: makeMetric(transition: .exit), userId: "user_42") { _ in
                 continuation.resume()
             }
         }
@@ -68,12 +68,12 @@ struct GeofenceDeliveryTrackerTests {
     }
 
     @Test
-    func deliver_givenNilCoordinates_expectOmittedFromProperties() async {
+    func trackMetric_givenNilCoordinates_expectOmittedFromProperties() async {
         let (tracker, httpClient) = makeTracker()
         httpClient.sendTrackEventClosure = { _, _, _, completion in completion(.success(())) }
 
         await withCheckedContinuation { continuation in
-            tracker.deliver(
+            tracker.trackMetric(
                 metric: makeMetric(latitude: nil, longitude: nil),
                 userId: "user_42"
             ) { _ in continuation.resume() }
@@ -87,11 +87,11 @@ struct GeofenceDeliveryTrackerTests {
     // MARK: - Guard clauses
 
     @Test
-    func deliver_givenEmptyUserId_expectFailureAndNoHttpCall() async {
+    func trackMetric_givenEmptyUserId_expectFailureAndNoHttpCall() async {
         let (tracker, httpClient) = makeTracker()
 
         let result: Result<Void, BackgroundDeliveryHttpError> = await withCheckedContinuation { continuation in
-            tracker.deliver(metric: makeMetric(), userId: "") { result in
+            tracker.trackMetric(metric: makeMetric(), userId: "") { result in
                 continuation.resume(returning: result)
             }
         }
@@ -103,14 +103,14 @@ struct GeofenceDeliveryTrackerTests {
     // MARK: - Result propagation
 
     @Test
-    func deliver_givenHttpFailure_expectFailurePropagated() async {
+    func trackMetric_givenHttpFailure_expectFailurePropagated() async {
         let (tracker, httpClient) = makeTracker()
         httpClient.sendTrackEventClosure = { _, _, _, completion in
             completion(.failure(.http(statusCode: 500)))
         }
 
         let result: Result<Void, BackgroundDeliveryHttpError> = await withCheckedContinuation { continuation in
-            tracker.deliver(metric: makeMetric(), userId: "user_42") { result in
+            tracker.trackMetric(metric: makeMetric(), userId: "user_42") { result in
                 continuation.resume(returning: result)
             }
         }

--- a/Tests/Location/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/Location/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -61,7 +61,7 @@ struct GeofenceEventTrackerTests {
         defer { try? FileManager.default.removeItem(at: dir) }
         let pending = makePendingStore(directory: dir)
         let delivery = GeofenceDeliveryTrackerMock()
-        delivery.deliverClosure = { _, _, onComplete in onComplete(.success(())) }
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
         let bus = EventBusHandlerMock()
         let tracker = makeTracker(
             storage: makeStorage(directory: dir),
@@ -73,8 +73,8 @@ struct GeofenceEventTrackerTests {
 
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
 
-        #expect(delivery.deliverCallsCount == 1)
-        #expect(delivery.deliverReceivedArguments?.userId == "user_42")
+        #expect(delivery.trackMetricCallsCount == 1)
+        #expect(delivery.trackMetricReceivedArguments?.userId == "user_42")
         #expect(await pending.loadAll().isEmpty)
         #expect(postedGeofenceEvents(from: bus).isEmpty)
     }
@@ -85,7 +85,7 @@ struct GeofenceEventTrackerTests {
         defer { try? FileManager.default.removeItem(at: dir) }
         let pending = makePendingStore(directory: dir)
         let delivery = GeofenceDeliveryTrackerMock()
-        delivery.deliverClosure = { _, _, onComplete in
+        delivery.trackMetricClosure = { _, _, onComplete in
             onComplete(.failure(.http(statusCode: 503)))
         }
         let bus = EventBusHandlerMock()
@@ -120,7 +120,7 @@ struct GeofenceEventTrackerTests {
 
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
 
-        #expect(delivery.deliverCallsCount == 0)
+        #expect(delivery.trackMetricCallsCount == 0)
         #expect(await pending.loadAll().count == 1)
         #expect(postedGeofenceEvents(from: bus).isEmpty)
     }
@@ -153,7 +153,7 @@ struct GeofenceEventTrackerTests {
         defer { try? FileManager.default.removeItem(at: dir) }
         let pending = makePendingStore(directory: dir)
         let delivery = GeofenceDeliveryTrackerMock()
-        delivery.deliverClosure = { _, _, onComplete in onComplete(.success(())) }
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
         let dateUtil = DateUtilStub()
         let baseTime = Date(timeIntervalSince1970: 1700000000)
         dateUtil.givenNow = baseTime
@@ -168,12 +168,12 @@ struct GeofenceEventTrackerTests {
         )
 
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
-        #expect(delivery.deliverCallsCount == 1)
+        #expect(delivery.trackMetricCallsCount == 1)
 
         dateUtil.givenNow = baseTime.addingTimeInterval(1800)
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
 
-        #expect(delivery.deliverCallsCount == 1)
+        #expect(delivery.trackMetricCallsCount == 1)
         #expect(await pending.loadAll().isEmpty)
     }
 
@@ -183,7 +183,7 @@ struct GeofenceEventTrackerTests {
         defer { try? FileManager.default.removeItem(at: dir) }
         let pending = makePendingStore(directory: dir)
         let delivery = GeofenceDeliveryTrackerMock()
-        delivery.deliverClosure = { _, _, onComplete in onComplete(.success(())) }
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
         let dateUtil = DateUtilStub()
         let baseTime = Date(timeIntervalSince1970: 1700000000)
         dateUtil.givenNow = baseTime
@@ -201,7 +201,7 @@ struct GeofenceEventTrackerTests {
         dateUtil.givenNow = baseTime.addingTimeInterval(cooldownInterval)
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
 
-        #expect(delivery.deliverCallsCount == 2)
+        #expect(delivery.trackMetricCallsCount == 2)
     }
 
     @Test
@@ -210,7 +210,7 @@ struct GeofenceEventTrackerTests {
         defer { try? FileManager.default.removeItem(at: dir) }
         let pending = makePendingStore(directory: dir)
         let delivery = GeofenceDeliveryTrackerMock()
-        delivery.deliverClosure = { _, _, onComplete in onComplete(.success(())) }
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
         let bus = EventBusHandlerMock()
         let tracker = makeTracker(
             storage: makeStorage(directory: dir),
@@ -223,7 +223,7 @@ struct GeofenceEventTrackerTests {
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
         await tracker.trackTransition(geofenceId: "geo_1", transition: .exit)
 
-        #expect(delivery.deliverCallsCount == 2)
+        #expect(delivery.trackMetricCallsCount == 2)
     }
 
     @Test
@@ -243,7 +243,7 @@ struct GeofenceEventTrackerTests {
         ))
         let pending = makePendingStore(directory: dir)
         let delivery = GeofenceDeliveryTrackerMock()
-        delivery.deliverClosure = { _, _, onComplete in onComplete(.success(())) }
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
         let dateUtil = DateUtilStub()
         let baseTime = Date(timeIntervalSince1970: 1700000000)
         dateUtil.givenNow = baseTime
@@ -262,12 +262,12 @@ struct GeofenceEventTrackerTests {
         // the constructor's 1h default were in effect).
         dateUtil.givenNow = baseTime.addingTimeInterval(serverCooldown / 2)
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
-        #expect(delivery.deliverCallsCount == 1)
+        #expect(delivery.trackMetricCallsCount == 1)
 
         // Past the server cooldown but still within the constructor default → allowed.
         dateUtil.givenNow = baseTime.addingTimeInterval(serverCooldown + 1)
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
-        #expect(delivery.deliverCallsCount == 2)
+        #expect(delivery.trackMetricCallsCount == 2)
     }
 
     // MARK: - flushPending
@@ -278,7 +278,7 @@ struct GeofenceEventTrackerTests {
         defer { try? FileManager.default.removeItem(at: dir) }
         let pending = makePendingStore(directory: dir)
         let failingDelivery = GeofenceDeliveryTrackerMock()
-        failingDelivery.deliverClosure = { _, _, onComplete in
+        failingDelivery.trackMetricClosure = { _, _, onComplete in
             onComplete(.failure(.http(statusCode: 503)))
         }
         let priorTracker = makeTracker(
@@ -293,7 +293,7 @@ struct GeofenceEventTrackerTests {
         #expect(await pending.loadAll().count == 2)
 
         let delivery = GeofenceDeliveryTrackerMock()
-        delivery.deliverClosure = { _, _, onComplete in onComplete(.success(())) }
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
         let tracker = makeTracker(
             storage: makeStorage(directory: dir),
             pendingStore: pending,
@@ -304,7 +304,7 @@ struct GeofenceEventTrackerTests {
 
         await tracker.flushPending()
 
-        #expect(delivery.deliverCallsCount == 2)
+        #expect(delivery.trackMetricCallsCount == 2)
         #expect(await pending.loadAll().isEmpty)
     }
 
@@ -314,7 +314,7 @@ struct GeofenceEventTrackerTests {
         defer { try? FileManager.default.removeItem(at: dir) }
         let pending = makePendingStore(directory: dir)
         let failingDelivery = GeofenceDeliveryTrackerMock()
-        failingDelivery.deliverClosure = { _, _, onComplete in
+        failingDelivery.trackMetricClosure = { _, _, onComplete in
             onComplete(.failure(.http(statusCode: 503)))
         }
         let priorTracker = makeTracker(
@@ -347,7 +347,7 @@ struct GeofenceEventTrackerTests {
         defer { try? FileManager.default.removeItem(at: dir) }
         let pending = makePendingStore(directory: dir)
         let failingDelivery = GeofenceDeliveryTrackerMock()
-        failingDelivery.deliverClosure = { _, _, onComplete in
+        failingDelivery.trackMetricClosure = { _, _, onComplete in
             onComplete(.failure(.http(statusCode: 503)))
         }
         let priorTracker = makeTracker(
@@ -361,7 +361,7 @@ struct GeofenceEventTrackerTests {
         await priorTracker.trackTransition(geofenceId: "geo_2", transition: .enter)
 
         let delivery = GeofenceDeliveryTrackerMock()
-        delivery.deliverClosure = { _, _, onComplete in onComplete(.success(())) }
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
         let tracker = makeTracker(
             storage: makeStorage(directory: dir),
             pendingStore: pending,
@@ -376,7 +376,7 @@ struct GeofenceEventTrackerTests {
         async let flush2: Void = tracker.flushPending()
         _ = await(flush1, flush2)
 
-        #expect(delivery.deliverCallsCount == 2)
+        #expect(delivery.trackMetricCallsCount == 2)
         #expect(await pending.loadAll().isEmpty)
     }
 
@@ -386,7 +386,7 @@ struct GeofenceEventTrackerTests {
         defer { try? FileManager.default.removeItem(at: dir) }
         let pending = makePendingStore(directory: dir)
         let delivery = GeofenceDeliveryTrackerMock()
-        delivery.deliverClosure = { _, _, onComplete in onComplete(.success(())) }
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
         let contextStore = makeContextStore()
         let bus = EventBusHandlerMock()
         let tracker = makeTracker(
@@ -398,14 +398,14 @@ struct GeofenceEventTrackerTests {
         )
 
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
-        #expect(delivery.deliverCallsCount == 0)
+        #expect(delivery.trackMetricCallsCount == 0)
         #expect(await pending.loadAll().count == 1)
 
         contextStore.setUserId("user_42")
         await tracker.flushPending()
 
-        #expect(delivery.deliverCallsCount == 1)
-        #expect(delivery.deliverReceivedArguments?.userId == "user_42")
+        #expect(delivery.trackMetricCallsCount == 1)
+        #expect(delivery.trackMetricReceivedArguments?.userId == "user_42")
         #expect(await pending.loadAll().isEmpty)
         #expect(postedGeofenceEvents(from: bus).isEmpty)
     }


### PR DESCRIPTION
## Summary

Three localized fixes from the review backlog plus two ports from the Android geofence stack (#717). None change public API; mocks regenerated.

**`GeofenceDeliveryTracker`: rename `deliver` → `trackMetric`**
- Aligns with the other "tracker" APIs in the SDK. Internal-only protocol; no public-surface impact. `AutoMockable.generated.swift` regenerated.

**`GeofenceSyncCoordinator`: skip movement trigger when business regions are empty**
- When the server returns zero regions, registering a movement trigger just arms a refetch that hits the same empty result. Leave it off; the next identify / foreground refresh will retry.

**`GeofenceSyncCoordinator`: freshness check is time AND distance (port of Android #717)**
- Time-fresh alone leaves a gap: app gets killed while the user travels far, no movement EXIT fires to update the cache, next foreground refresh skips the API because the timestamp is still fresh — but the cached regions belong to a place the user no longer is. Adds a distance-from-anchor check next to the existing time check, gated by `remoteFetchRefreshTriggerRadius`.

**`Logger`: dispatcher receives the formatted (tagged + errored) message (port of Android #717)**
- `logDispatcher?(level, message)` was passing the raw message while `systemLogger.log(formattedMessage, level)` got the `[Tag] msg Error: …` prefix/suffix. Customer-provided dispatchers got inconsistent output. Both branches now receive `formattedMessage`. Android had the same bug on the same line.

## Stack

Merge order (top-down):
1. #1081 — `chore: regenerate autogen + reformat to current rules` (MBL-1770-a)
2. #1082 — `chore: geofence pending-store correctness across user changes` (MBL-1770-b)
3. **this PR** — `chore: geofence small fixes + Android #717 port` (MBL-1770-c)
4. MBL-1770-d — cross-process exactly-once via per-row userId stamping [coming]
5. MBL-1770-e — no-op regression test for non-geofence apps [coming]

Ticket: https://linear.app/customerio/issue/MBL-1770

## Test plan

- [x] `make generate && make format && make lint` — 0 violations
- [x] `xcodebuild build-for-testing` — clean
- [x] `GeofenceSyncCoordinatorTests` — green (incl. new `refresh_givenTimeFreshButFarFromAnchor_expectApiCalled`, `refresh_givenTimeStaleButNearAnchor_expectApiCalled`, `refresh_givenEmptyBusinessRegions_expectNoMovementTriggerRegistered`; updated `refresh_givenFreshLastSync_…` and `refresh_givenNoCachedConfigAndSyncWithinFallback_…` to keep the caller at the anchor)
- [x] `LoggerTest` — green (incl. new `test_dispatcherWithTag_expectTagPrefixedMessage`, `test_dispatcherWithTagAndError_expectTagPrefixedAndErrorSuffixedMessage`)
- [x] `GeofenceDeliveryTrackerTests`, `GeofenceEventTrackerTests` — green after rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes geofence sync skip logic and OS monitoring registration, which can alter API fetch frequency and background behavior; logger dispatcher output changes for integrators using custom dispatchers.
> 
> **Overview**
> Geofence reliability and logging consistency fixes with no public API changes.
> 
> **Logger:** Custom `logDispatcher` callbacks now receive the same **tag-prefixed / error-suffixed** string as the system logger, instead of the raw message.
> 
> **Geofence sync:** `refresh` skips the remote fetch only when the last sync is **both** within `remoteFetchRefreshExpiry` **and** within `remoteFetchRefreshTriggerRadius` of the caller—fixing stale caches after travel with no movement EXIT. OS registration **does not** start the movement trigger when there are zero business regions.
> 
> **Geofence delivery:** Internal protocol method **`deliver` → `trackMetric`** (mocks regenerated); call sites and tests updated.
> 
> Tests cover the new freshness/distance gates, empty-region movement trigger behavior, dispatcher formatting, and the rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04278cd4071b2bd0c49954c8b793cb8e0cf7e551. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->