### PR TITLE
chore: stamp userId on pending geofence metric for stable attribution

### DIFF
--- a/Sources/Common/Communication/Event.swift
+++ b/Sources/Common/Communication/Event.swift
@@ -162,13 +162,25 @@ public struct TrackGeofenceMetricEvent: EventRepresentable {
     public let geofenceId: String
     public let transition: GeofenceTransition
     public let timestamp: Date
+    public let latitude: Double?
+    public let longitude: Double?
 
-    public init(storageId: String = UUID().uuidString, geofenceId: String, transition: GeofenceTransition, timestamp: Date = Date(), params: [String: String] = [:]) {
+    public init(
+        storageId: String = UUID().uuidString,
+        geofenceId: String,
+        transition: GeofenceTransition,
+        timestamp: Date = Date(),
+        latitude: Double? = nil,
+        longitude: Double? = nil,
+        params: [String: String] = [:]
+    ) {
         self.storageId = storageId
         self.params = params
         self.geofenceId = geofenceId
         self.transition = transition
         self.timestamp = timestamp
+        self.latitude = latitude
+        self.longitude = longitude
     }
 }
 

--- a/Sources/DataPipeline/DataPipelineImplementation+GeofenceObserver.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation+GeofenceObserver.swift
@@ -1,0 +1,24 @@
+import CioAnalytics
+import CioInternalCommon
+
+extension DataPipelineImplementation {
+    /// Tracks a geofence transition forwarded via EventBus from `GeofenceEventTracker`
+    /// when the row carries no stamped userId (anonymous capture path).
+    ///
+    /// Mirrors the property shape of the direct-HTTP path so both delivery channels
+    /// record the same set of fields. The `TrackEvent.timestamp` is set from
+    /// `metric.timestamp` so a flush replayed hours after capture still attributes
+    /// the transition to when it happened, not when it was sent.
+    func processGeofenceMetricEvent(_ metric: TrackGeofenceMetricEvent) {
+        var properties: [String: Any] = [
+            "geofence_id": metric.geofenceId,
+            "transition_type": metric.transition.rawValue,
+            "timestamp": Int(metric.timestamp.timeIntervalSince1970)
+        ]
+        if let latitude = metric.latitude { properties["latitude"] = latitude }
+        if let longitude = metric.longitude { properties["longitude"] = longitude }
+        var trackEvent = TrackEvent(event: metric.transition.trackEventName, properties: try? JSON(properties))
+        trackEvent.timestamp = metric.timestamp.string(format: .iso8601WithMilliseconds)
+        analytics.process(event: trackEvent)
+    }
+}

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -121,7 +121,7 @@ class DataPipelineImplementation: DataPipelineInstance, DataPipelineTracking, Ba
         }
 
         eventBusHandler.addObserver(TrackGeofenceMetricEvent.self) { metric in
-            self.track(name: metric.transition.trackEventName, properties: ["geofence_id": metric.geofenceId])
+            self.processGeofenceMetricEvent(metric)
         }
 
         eventBusHandler.addObserver(RegisterDeviceTokenEvent.self) { event in

--- a/Sources/Location/Geofence/Event/GeofenceEventTracker.swift
+++ b/Sources/Location/Geofence/Event/GeofenceEventTracker.swift
@@ -5,11 +5,15 @@ import Foundation
 // sourcery: InjectCustomShared
 /// Sends geofence transition events through a three-layer delivery flow:
 /// 1. Cooldown-based deduplication (keyed by "geofenceId:transitionType")
-/// 2. Persist to `PendingGeofenceMetricStore` before any send attempt
+/// 2. Persist to `PendingGeofenceMetricStore` before any send attempt, stamping
+///    the currently-identified userId so A's transitions always attribute to A
 /// 3. Dispatch in `deliver`:
-///    - No HttpClient → EventBus, drain row
-///    - No userId yet → retain row for the next flush
-///    - HTTP attempt → success drains; failure retains for retry
+///    - Stamped userId → direct-HTTP path with that userId; success drains the
+///      row, failure retains it for the next flush
+///    - No stamped userId → post to EventBus and drain; DataPipeline records
+///      the transition under its current identity (anonymous tracking when no
+///      one is identified). The captured timestamp + coordinates flow through
+///      the event so both paths attribute the transition to when it happened
 ///
 /// `flushPending()` replays queued rows on module init and on every `ProfileIdentifiedEvent`.
 /// Concurrent deliveries for the same row are deduplicated in-process via the active-delivery
@@ -20,7 +24,7 @@ import Foundation
 final class GeofenceEventTracker: @unchecked Sendable {
     private let storage: GeofenceStorage
     private let pendingStore: PendingGeofenceMetricStore
-    private let deliveryTracker: GeofenceDeliveryTracker?
+    private let deliveryTracker: GeofenceDeliveryTracker
     private let contextStore: BackgroundDeliveryContextStore
     private let eventBusHandler: EventBusHandler
     private let dateUtil: DateUtil
@@ -31,7 +35,7 @@ final class GeofenceEventTracker: @unchecked Sendable {
     init(
         storage: GeofenceStorage,
         pendingStore: PendingGeofenceMetricStore,
-        deliveryTracker: GeofenceDeliveryTracker?,
+        deliveryTracker: GeofenceDeliveryTracker,
         contextStore: BackgroundDeliveryContextStore,
         eventBusHandler: EventBusHandler,
         dateUtil: DateUtil,
@@ -49,8 +53,7 @@ final class GeofenceEventTracker: @unchecked Sendable {
     }
 
     /// Tracks a geofence transition event, suppressing duplicates within the cooldown window.
-    /// Persists the metric, then dispatches to one of the three delivery paths
-    /// (EventBus drain / queue-retain / direct HTTP) per the rules in `deliver`.
+    /// Persists the metric, then hands it to `deliver`.
     func trackTransition(
         geofenceId: String,
         transition: GeofenceTransition,
@@ -67,12 +70,18 @@ final class GeofenceEventTracker: @unchecked Sendable {
             return
         }
 
+        // Stamp the current userId so a row captured under user A always delivers
+        // as A — even if B signs in before the flush replays it. Nil when no user
+        // is identified at capture time; `deliver` routes nil-stamped rows to EventBus.
+        let liveUserId = contextStore.currentUserId
+        let stampedUserId: String? = (liveUserId?.isEmpty == false) ? liveUserId : nil
         let metric = PendingGeofenceMetric(
             geofenceId: geofenceId,
             transition: transition,
             latitude: location?.latitude,
             longitude: location?.longitude,
-            timestamp: now
+            timestamp: now,
+            userId: stampedUserId
         )
         _ = await pendingStore.append(metric)
 
@@ -98,25 +107,17 @@ final class GeofenceEventTracker: @unchecked Sendable {
         guard activeDeliveryKeys.mutating({ $0.insert(metric.key).inserted }) else { return }
         defer { activeDeliveryKeys.mutating { _ = $0.remove(metric.key) } }
 
-        guard let deliveryTracker else {
-            // No HTTP path will ever be available in this process (MessagingPush not
-            // initialized). Deliver via EventBus and drain; nothing would recover this
-            // row otherwise.
+        // Rows without a stamped userId (anonymous capture or legacy pre-stamping)
+        // route through EventBus instead — DataPipeline tracks anonymously under
+        // whatever identity is current at consume time.
+        guard let stampedUserId = metric.userId, !stampedUserId.isEmpty else {
             postEventBus(metric: metric)
             _ = await pendingStore.remove(key: metric.key)
             return
         }
 
-        guard let userId = contextStore.currentUserId, !userId.isEmpty else {
-            // No userId yet (signed out / not yet identified). Leave the row so a later
-            // ProfileIdentifiedEvent → flushPending can deliver it via direct HTTP with
-            // the right userId. No EventBus — that would attribute the event to the
-            // anonymous profile and duplicate when the flush succeeds.
-            return
-        }
-
         let success = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
-            deliveryTracker.trackMetric(metric: metric, userId: userId) { result in
+            deliveryTracker.trackMetric(metric: metric, userId: stampedUserId) { result in
                 switch result {
                 case .success:
                     continuation.resume(returning: true)
@@ -130,14 +131,20 @@ final class GeofenceEventTracker: @unchecked Sendable {
             _ = await pendingStore.remove(key: metric.key)
             logger.geofenceEventTracked(geofenceId: metric.geofenceId, transition: metric.transition)
         }
-        // HTTP failure: row stays for next flush. No EventBus — same duplicate
-        // risk if a later flush succeeds.
+        // HTTP failure: row stays for next flush.
     }
 
+    /// Anonymous-attribution fallback used when a row carries no stamped userId.
+    /// The captured `timestamp` and coordinates flow through the event so DataPipeline
+    /// can record the transition under the moment it actually happened, not the
+    /// moment the flush ran.
     private func postEventBus(metric: PendingGeofenceMetric) {
         eventBusHandler.postEvent(TrackGeofenceMetricEvent(
             geofenceId: metric.geofenceId,
-            transition: metric.transition
+            transition: metric.transition,
+            timestamp: metric.timestamp,
+            latitude: metric.latitude,
+            longitude: metric.longitude
         ))
         logger.geofenceEventTracked(geofenceId: metric.geofenceId, transition: metric.transition)
     }

--- a/Sources/Location/Geofence/Storage/PendingGeofenceMetric.swift
+++ b/Sources/Location/Geofence/Storage/PendingGeofenceMetric.swift
@@ -27,7 +27,7 @@ struct PendingGeofenceMetric: Codable, Equatable, Sendable {
         latitude: Double?,
         longitude: Double?,
         timestamp: Date,
-        userId: String? = nil
+        userId: String?
     ) {
         self.geofenceId = geofenceId
         self.transition = transition

--- a/Sources/Location/Geofence/Storage/PendingGeofenceMetric.swift
+++ b/Sources/Location/Geofence/Storage/PendingGeofenceMetric.swift
@@ -1,13 +1,16 @@
 import CioInternalCommon
 import Foundation
 
-/// A geofence transition queued for direct-HTTP delivery.
+/// A geofence transition queued for delivery (direct-HTTP when stamped with a
+/// userId, EventBus → DataPipeline anonymous when not).
 struct PendingGeofenceMetric: Codable, Equatable, Sendable {
     let geofenceId: String
     let transition: GeofenceTransition
     let latitude: Double?
     let longitude: Double?
     let timestamp: Date
+    /// The userId identified at capture time, or `nil` if none was identified.
+    let userId: String?
 
     /// Composite key over `(geofenceId, transition, timestamp_sec)` used for
     /// storage-layer dedup. Matches Android's `PendingGeofenceDelivery.key`.
@@ -23,13 +26,15 @@ struct PendingGeofenceMetric: Codable, Equatable, Sendable {
         transition: GeofenceTransition,
         latitude: Double?,
         longitude: Double?,
-        timestamp: Date
+        timestamp: Date,
+        userId: String? = nil
     ) {
         self.geofenceId = geofenceId
         self.transition = transition
         self.latitude = latitude
         self.longitude = longitude
         self.timestamp = timestamp
+        self.userId = userId
     }
 
     enum CodingKeys: String, CodingKey {
@@ -38,5 +43,6 @@ struct PendingGeofenceMetric: Codable, Equatable, Sendable {
         case latitude
         case longitude
         case timestamp
+        case userId = "user_id"
     }
 }

--- a/Tests/DataPipeline/DataPipelineEventBustTests.swift
+++ b/Tests/DataPipeline/DataPipelineEventBustTests.swift
@@ -60,9 +60,16 @@ class DataPipelineEventBustTests: IntegrationTest {
 
     func testSubscribeToJourneyEvents_DataPipelineHandlesTrackGeofenceMetricEvent_enter() async {
         let givenGeofenceId = String.random
+        let capturedAt = Date(timeIntervalSince1970: 1700000000)
 
         await eventBusHandler.postEventAndWait(
-            TrackGeofenceMetricEvent(geofenceId: givenGeofenceId, transition: .enter)
+            TrackGeofenceMetricEvent(
+                geofenceId: givenGeofenceId,
+                transition: .enter,
+                timestamp: capturedAt,
+                latitude: 12.34,
+                longitude: 56.78
+            )
         )
 
         guard let trackEvent = outputReader.lastEvent as? TrackEvent else {
@@ -72,17 +79,25 @@ class DataPipelineEventBustTests: IntegrationTest {
 
         XCTAssertEqual(trackEvent.type, "track")
         XCTAssertEqual(trackEvent.event, "GeoFence Entered")
-        XCTAssertMatches(
-            trackEvent.properties,
-            ["geofence_id": givenGeofenceId]
-        )
+        let properties = trackEvent.properties?.dictionaryValue ?? [:]
+        XCTAssertEqual(properties["geofence_id"] as? String, givenGeofenceId)
+        XCTAssertEqual(properties["transition_type"] as? String, "enter")
+        XCTAssertEqual(properties["timestamp"] as? Int, Int(capturedAt.timeIntervalSince1970))
+        XCTAssertEqual(properties["latitude"] as? Double ?? 0, 12.34, accuracy: 0.0001)
+        XCTAssertEqual(properties["longitude"] as? Double ?? 0, 56.78, accuracy: 0.0001)
+        XCTAssertEqual(trackEvent.timestamp, capturedAt.string(format: .iso8601WithMilliseconds))
     }
 
     func testSubscribeToJourneyEvents_DataPipelineHandlesTrackGeofenceMetricEvent_exit() async {
         let givenGeofenceId = String.random
+        let capturedAt = Date(timeIntervalSince1970: 1700000000)
 
         await eventBusHandler.postEventAndWait(
-            TrackGeofenceMetricEvent(geofenceId: givenGeofenceId, transition: .exit)
+            TrackGeofenceMetricEvent(
+                geofenceId: givenGeofenceId,
+                transition: .exit,
+                timestamp: capturedAt
+            )
         )
 
         guard let trackEvent = outputReader.lastEvent as? TrackEvent else {
@@ -91,10 +106,13 @@ class DataPipelineEventBustTests: IntegrationTest {
         }
 
         XCTAssertEqual(trackEvent.event, "GeoFence Exited")
-        XCTAssertMatches(
-            trackEvent.properties,
-            ["geofence_id": givenGeofenceId]
-        )
+        let properties = trackEvent.properties?.dictionaryValue ?? [:]
+        XCTAssertEqual(properties["geofence_id"] as? String, givenGeofenceId)
+        XCTAssertEqual(properties["transition_type"] as? String, "exit")
+        XCTAssertEqual(properties["timestamp"] as? Int, Int(capturedAt.timeIntervalSince1970))
+        XCTAssertNil(properties["latitude"])
+        XCTAssertNil(properties["longitude"])
+        XCTAssertEqual(trackEvent.timestamp, capturedAt.string(format: .iso8601WithMilliseconds))
     }
 
     func testSubscribeToJourneyEvents_DataPipelineHandlesRegisterDeviceEvent() async {

--- a/Tests/Location/Geofence/Event/GeofenceDeliveryTrackerTests.swift
+++ b/Tests/Location/Geofence/Event/GeofenceDeliveryTrackerTests.swift
@@ -25,7 +25,8 @@ struct GeofenceDeliveryTrackerTests {
             transition: transition,
             latitude: latitude,
             longitude: longitude,
-            timestamp: timestamp
+            timestamp: timestamp,
+            userId: nil
         )
     }
 

--- a/Tests/Location/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/Location/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -32,9 +32,9 @@ struct GeofenceEventTrackerTests {
     private func makeTracker(
         storage: GeofenceStorage,
         pendingStore: PendingGeofenceMetricStore,
-        deliveryTracker: GeofenceDeliveryTracker?,
+        deliveryTracker: GeofenceDeliveryTracker,
         contextStore: BackgroundDeliveryContextStore,
-        eventBus: EventBusHandlerMock,
+        eventBus: EventBusHandlerMock = EventBusHandlerMock(),
         dateUtil: DateUtil = DateUtilStub()
     ) -> GeofenceEventTracker {
         GeofenceEventTracker(
@@ -62,13 +62,11 @@ struct GeofenceEventTrackerTests {
         let pending = makePendingStore(directory: dir)
         let delivery = GeofenceDeliveryTrackerMock()
         delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
-        let bus = EventBusHandlerMock()
         let tracker = makeTracker(
             storage: makeStorage(directory: dir),
             pendingStore: pending,
             deliveryTracker: delivery,
-            contextStore: makeContextStore(userId: "user_42"),
-            eventBus: bus
+            contextStore: makeContextStore(userId: "user_42")
         )
 
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
@@ -76,7 +74,6 @@ struct GeofenceEventTrackerTests {
         #expect(delivery.trackMetricCallsCount == 1)
         #expect(delivery.trackMetricReceivedArguments?.userId == "user_42")
         #expect(await pending.loadAll().isEmpty)
-        #expect(postedGeofenceEvents(from: bus).isEmpty)
     }
 
     @Test
@@ -88,61 +85,56 @@ struct GeofenceEventTrackerTests {
         delivery.trackMetricClosure = { _, _, onComplete in
             onComplete(.failure(.http(statusCode: 503)))
         }
-        let bus = EventBusHandlerMock()
         let tracker = makeTracker(
             storage: makeStorage(directory: dir),
             pendingStore: pending,
             deliveryTracker: delivery,
-            contextStore: makeContextStore(userId: "user_42"),
-            eventBus: bus
+            contextStore: makeContextStore(userId: "user_42")
         )
 
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
 
         #expect(await pending.loadAll().count == 1)
-        #expect(postedGeofenceEvents(from: bus).isEmpty)
     }
 
     @Test
-    func trackTransition_givenNoUserId_expectQueueRetainedNoEventBus() async {
+    func trackTransition_givenNoUserId_expectEventBusAndQueueDrained() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let pending = makePendingStore(directory: dir)
         let delivery = GeofenceDeliveryTrackerMock()
         let bus = EventBusHandlerMock()
+        let dateUtil = DateUtilStub()
+        let captureTime = Date(timeIntervalSince1970: 1700000000)
+        dateUtil.givenNow = captureTime
         let tracker = makeTracker(
             storage: makeStorage(directory: dir),
             pendingStore: pending,
             deliveryTracker: delivery,
             contextStore: makeContextStore(),
-            eventBus: bus
+            eventBus: bus,
+            dateUtil: dateUtil
         )
 
-        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+        await tracker.trackTransition(
+            geofenceId: "geo_1",
+            transition: .enter,
+            location: LocationData(latitude: 12.34, longitude: 56.78)
+        )
 
+        // Anonymous capture: stamped userId is nil. HTTP path can't attribute,
+        // so the row is handed off to EventBus → DataPipeline (anonymous track)
+        // and drained from disk.
         #expect(delivery.trackMetricCallsCount == 0)
-        #expect(await pending.loadAll().count == 1)
-        #expect(postedGeofenceEvents(from: bus).isEmpty)
-    }
-
-    @Test
-    func trackTransition_givenNoDeliveryTracker_expectEventBusAndQueueDrained() async {
-        let dir = makeTempDirectory()
-        defer { try? FileManager.default.removeItem(at: dir) }
-        let pending = makePendingStore(directory: dir)
-        let bus = EventBusHandlerMock()
-        let tracker = makeTracker(
-            storage: makeStorage(directory: dir),
-            pendingStore: pending,
-            deliveryTracker: nil,
-            contextStore: makeContextStore(userId: "user_42"),
-            eventBus: bus
-        )
-
-        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
-
         #expect(await pending.loadAll().isEmpty)
-        #expect(postedGeofenceEvents(from: bus).count == 1)
+
+        let posted = postedGeofenceEvents(from: bus)
+        #expect(posted.count == 1)
+        #expect(posted.first?.geofenceId == "geo_1")
+        #expect(posted.first?.transition == .enter)
+        #expect(posted.first?.timestamp == captureTime)
+        #expect(posted.first?.latitude == 12.34)
+        #expect(posted.first?.longitude == 56.78)
     }
 
     // MARK: - Cooldown
@@ -157,13 +149,11 @@ struct GeofenceEventTrackerTests {
         let dateUtil = DateUtilStub()
         let baseTime = Date(timeIntervalSince1970: 1700000000)
         dateUtil.givenNow = baseTime
-        let bus = EventBusHandlerMock()
         let tracker = makeTracker(
             storage: makeStorage(directory: dir),
             pendingStore: pending,
             deliveryTracker: delivery,
             contextStore: makeContextStore(userId: "user_42"),
-            eventBus: bus,
             dateUtil: dateUtil
         )
 
@@ -187,13 +177,11 @@ struct GeofenceEventTrackerTests {
         let dateUtil = DateUtilStub()
         let baseTime = Date(timeIntervalSince1970: 1700000000)
         dateUtil.givenNow = baseTime
-        let bus = EventBusHandlerMock()
         let tracker = makeTracker(
             storage: makeStorage(directory: dir),
             pendingStore: pending,
             deliveryTracker: delivery,
             contextStore: makeContextStore(userId: "user_42"),
-            eventBus: bus,
             dateUtil: dateUtil
         )
 
@@ -211,13 +199,11 @@ struct GeofenceEventTrackerTests {
         let pending = makePendingStore(directory: dir)
         let delivery = GeofenceDeliveryTrackerMock()
         delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
-        let bus = EventBusHandlerMock()
         let tracker = makeTracker(
             storage: makeStorage(directory: dir),
             pendingStore: pending,
             deliveryTracker: delivery,
-            contextStore: makeContextStore(userId: "user_42"),
-            eventBus: bus
+            contextStore: makeContextStore(userId: "user_42")
         )
 
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
@@ -247,13 +233,11 @@ struct GeofenceEventTrackerTests {
         let dateUtil = DateUtilStub()
         let baseTime = Date(timeIntervalSince1970: 1700000000)
         dateUtil.givenNow = baseTime
-        let bus = EventBusHandlerMock()
         let tracker = makeTracker(
             storage: storage,
             pendingStore: pending,
             deliveryTracker: delivery,
             contextStore: makeContextStore(userId: "user_42"),
-            eventBus: bus,
             dateUtil: dateUtil
         )
 
@@ -285,8 +269,7 @@ struct GeofenceEventTrackerTests {
             storage: makeStorage(directory: dir),
             pendingStore: pending,
             deliveryTracker: failingDelivery,
-            contextStore: makeContextStore(userId: "user_42"),
-            eventBus: EventBusHandlerMock()
+            contextStore: makeContextStore(userId: "user_42")
         )
         await priorTracker.trackTransition(geofenceId: "geo_1", transition: .enter)
         await priorTracker.trackTransition(geofenceId: "geo_2", transition: .enter)
@@ -298,8 +281,7 @@ struct GeofenceEventTrackerTests {
             storage: makeStorage(directory: dir),
             pendingStore: pending,
             deliveryTracker: delivery,
-            contextStore: makeContextStore(userId: "user_42"),
-            eventBus: EventBusHandlerMock()
+            contextStore: makeContextStore(userId: "user_42")
         )
 
         await tracker.flushPending()
@@ -321,24 +303,20 @@ struct GeofenceEventTrackerTests {
             storage: makeStorage(directory: dir),
             pendingStore: pending,
             deliveryTracker: failingDelivery,
-            contextStore: makeContextStore(userId: "user_42"),
-            eventBus: EventBusHandlerMock()
+            contextStore: makeContextStore(userId: "user_42")
         )
         await priorTracker.trackTransition(geofenceId: "geo_1", transition: .enter)
 
-        let bus = EventBusHandlerMock()
         let tracker = makeTracker(
             storage: makeStorage(directory: dir),
             pendingStore: pending,
             deliveryTracker: failingDelivery,
-            contextStore: makeContextStore(userId: "user_42"),
-            eventBus: bus
+            contextStore: makeContextStore(userId: "user_42")
         )
 
         await tracker.flushPending()
 
         #expect(await pending.loadAll().count == 1)
-        #expect(postedGeofenceEvents(from: bus).isEmpty)
     }
 
     @Test
@@ -354,8 +332,7 @@ struct GeofenceEventTrackerTests {
             storage: makeStorage(directory: dir),
             pendingStore: pending,
             deliveryTracker: failingDelivery,
-            contextStore: makeContextStore(userId: "user_42"),
-            eventBus: EventBusHandlerMock()
+            contextStore: makeContextStore(userId: "user_42")
         )
         await priorTracker.trackTransition(geofenceId: "geo_1", transition: .enter)
         await priorTracker.trackTransition(geofenceId: "geo_2", transition: .enter)
@@ -366,8 +343,7 @@ struct GeofenceEventTrackerTests {
             storage: makeStorage(directory: dir),
             pendingStore: pending,
             deliveryTracker: delivery,
-            contextStore: makeContextStore(userId: "user_42"),
-            eventBus: EventBusHandlerMock()
+            contextStore: makeContextStore(userId: "user_42")
         )
 
         // Fire two flushPending calls in parallel; active-delivery dedup must prevent
@@ -381,7 +357,10 @@ struct GeofenceEventTrackerTests {
     }
 
     @Test
-    func flushPending_givenNoUserIdTransitionThenIdentify_expectDeliveredAndDrained() async {
+    func flushPending_givenAnonymousCaptureThenIdentify_expectNoHttpBackfill() async {
+        // Regression: anonymous transitions must NOT auto-deliver as the next
+        // identified user via HTTP — they go through EventBus at capture time,
+        // not through HTTP after identify (which would mis-attribute).
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let pending = makePendingStore(directory: dir)
@@ -398,15 +377,129 @@ struct GeofenceEventTrackerTests {
         )
 
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
-        #expect(delivery.trackMetricCallsCount == 0)
-        #expect(await pending.loadAll().count == 1)
+        // Anonymous capture posts to EventBus and drains the queue at capture time.
+        #expect(await pending.loadAll().isEmpty)
+        #expect(postedGeofenceEvents(from: bus).count == 1)
 
         contextStore.setUserId("user_42")
         await tracker.flushPending()
 
+        // No HTTP backfill, no second EventBus post — the row is already gone.
+        #expect(delivery.trackMetricCallsCount == 0)
+        #expect(postedGeofenceEvents(from: bus).count == 1)
+    }
+
+    // MARK: - userId stamping
+
+    @Test
+    func trackTransition_givenIdentifiedUser_expectMetricStampedWithUserId() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pending = makePendingStore(directory: dir)
+        let delivery = GeofenceDeliveryTrackerMock()
+        // Fail the HTTP send so the row survives on disk to inspect.
+        delivery.trackMetricClosure = { _, _, onComplete in
+            onComplete(.failure(.http(statusCode: 503)))
+        }
+        let tracker = makeTracker(
+            storage: makeStorage(directory: dir),
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_A")
+        )
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+
+        let queued = await pending.loadAll()
+        #expect(queued.first?.userId == "user_A")
+    }
+
+    @Test
+    func flushPending_givenRowStampedDifferentFromCurrent_expectStampedUserIdUsed() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pending = makePendingStore(directory: dir)
+        // Row was captured under user_A; current user is now user_B (after sign-out + new sign-in).
+        _ = await pending.append(PendingGeofenceMetric(
+            geofenceId: "geo_1", transition: .enter,
+            latitude: nil, longitude: nil,
+            timestamp: Date(timeIntervalSince1970: 1),
+            userId: "user_A"
+        ))
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
+        let tracker = makeTracker(
+            storage: makeStorage(directory: dir),
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_B")
+        )
+
+        await tracker.flushPending()
+
         #expect(delivery.trackMetricCallsCount == 1)
-        #expect(delivery.trackMetricReceivedArguments?.userId == "user_42")
+        #expect(delivery.trackMetricReceivedArguments?.userId == "user_A")
+    }
+
+    @Test
+    func flushPending_givenStampedUserId_andNoCurrent_expectDeliveredWithStamped() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pending = makePendingStore(directory: dir)
+        _ = await pending.append(PendingGeofenceMetric(
+            geofenceId: "geo_1", transition: .enter,
+            latitude: nil, longitude: nil,
+            timestamp: Date(timeIntervalSince1970: 1),
+            userId: "user_A"
+        ))
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
+        let tracker = makeTracker(
+            storage: makeStorage(directory: dir),
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore()
+        )
+
+        await tracker.flushPending()
+
+        #expect(delivery.trackMetricReceivedArguments?.userId == "user_A")
+    }
+
+    @Test
+    func flushPending_givenNilUserIdOnRow_expectEventBusPostNoHttpCall() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pending = makePendingStore(directory: dir)
+        // Row with no stamped userId (anonymous capture or legacy pre-upgrade).
+        let capturedAt = Date(timeIntervalSince1970: 1700000000)
+        _ = await pending.append(PendingGeofenceMetric(
+            geofenceId: "geo_1", transition: .enter,
+            latitude: 12.34, longitude: 56.78,
+            timestamp: capturedAt,
+            userId: nil
+        ))
+        let delivery = GeofenceDeliveryTrackerMock()
+        let bus = EventBusHandlerMock()
+        let tracker = makeTracker(
+            storage: makeStorage(directory: dir),
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            // Current user is set — proving that the live userId is NOT used as a fallback;
+            // the row is anonymous-tracked via EventBus instead.
+            contextStore: makeContextStore(userId: "user_current"),
+            eventBus: bus
+        )
+
+        await tracker.flushPending()
+
+        #expect(delivery.trackMetricCallsCount == 0)
         #expect(await pending.loadAll().isEmpty)
-        #expect(postedGeofenceEvents(from: bus).isEmpty)
+
+        let posted = postedGeofenceEvents(from: bus)
+        #expect(posted.count == 1)
+        #expect(posted.first?.timestamp == capturedAt)
+        #expect(posted.first?.latitude == 12.34)
+        #expect(posted.first?.longitude == 56.78)
     }
 }

--- a/Tests/Location/Geofence/GeofenceMonitorBinderTests.swift
+++ b/Tests/Location/Geofence/GeofenceMonitorBinderTests.swift
@@ -7,7 +7,7 @@ import Testing
 @Suite("GeofenceMonitorBinder")
 @MainActor
 struct GeofenceMonitorBinderTests {
-    private func makeTracker(eventBusHandler: EventBusHandler) -> GeofenceEventTracker {
+    private func makeTracker(deliveryTracker: GeofenceDeliveryTracker) -> GeofenceEventTracker {
         let contextStore = BackgroundDeliveryContextStore(
             fileManager: .default,
             directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
@@ -20,9 +20,9 @@ struct GeofenceMonitorBinderTests {
         return GeofenceEventTracker(
             storage: storage,
             pendingStore: PendingGeofenceMetricStore(),
-            deliveryTracker: nil,
+            deliveryTracker: deliveryTracker,
             contextStore: contextStore,
-            eventBusHandler: eventBusHandler,
+            eventBusHandler: EventBusHandlerMock(),
             dateUtil: DateUtilStub(),
             logger: LoggerMock()
         )
@@ -44,12 +44,17 @@ struct GeofenceMonitorBinderTests {
         }
     }
 
+    private func makeDeliveryMock() -> GeofenceDeliveryTrackerMock {
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
+        return delivery
+    }
+
     @Test
     func bind_givenMovementTriggerExit_expectCoordinatorHandleMovementCalledWithLocation() async {
         let monitor = MockGeofenceRegionMonitor()
         let coordinator = makeCoordinatorMock()
-        let eventBus = EventBusHandlerMock()
-        let tracker = makeTracker(eventBusHandler: eventBus)
+        let tracker = makeTracker(deliveryTracker: makeDeliveryMock())
 
         GeofenceMonitorBinder.bind(monitor: monitor, tracker: tracker, coordinator: coordinator)
         monitor.simulateTransition(
@@ -70,8 +75,8 @@ struct GeofenceMonitorBinderTests {
     func bind_givenMovementTriggerEnter_expectNeitherDispatchPathFires() async {
         let monitor = MockGeofenceRegionMonitor()
         let coordinator = makeCoordinatorMock()
-        let eventBus = EventBusHandlerMock()
-        let tracker = makeTracker(eventBusHandler: eventBus)
+        let delivery = makeDeliveryMock()
+        let tracker = makeTracker(deliveryTracker: delivery)
 
         GeofenceMonitorBinder.bind(monitor: monitor, tracker: tracker, coordinator: coordinator)
         monitor.simulateTransition(
@@ -84,7 +89,7 @@ struct GeofenceMonitorBinderTests {
         }
 
         #expect(coordinator.handleMovementCallsCount == 0)
-        #expect(eventBus.postEventCallsCount == 0)
+        #expect(delivery.trackMetricCallsCount == 0)
     }
 
     /// Skip rather than guess at a location — `handleMovement` needs a real position to
@@ -93,8 +98,7 @@ struct GeofenceMonitorBinderTests {
     func bind_givenMovementTriggerExitWithNilLocation_expectCoordinatorNotCalled() async {
         let monitor = MockGeofenceRegionMonitor()
         let coordinator = makeCoordinatorMock()
-        let eventBus = EventBusHandlerMock()
-        let tracker = makeTracker(eventBusHandler: eventBus)
+        let tracker = makeTracker(deliveryTracker: makeDeliveryMock())
 
         GeofenceMonitorBinder.bind(monitor: monitor, tracker: tracker, coordinator: coordinator)
         monitor.simulateTransition(
@@ -113,8 +117,8 @@ struct GeofenceMonitorBinderTests {
     func bind_givenBusinessGeofenceTransition_expectTrackerDispatchedAndCoordinatorIdle() async {
         let monitor = MockGeofenceRegionMonitor()
         let coordinator = makeCoordinatorMock()
-        let eventBus = EventBusHandlerMock()
-        let tracker = makeTracker(eventBusHandler: eventBus)
+        let delivery = makeDeliveryMock()
+        let tracker = makeTracker(deliveryTracker: delivery)
 
         GeofenceMonitorBinder.bind(monitor: monitor, tracker: tracker, coordinator: coordinator)
         monitor.simulateTransition(
@@ -122,11 +126,10 @@ struct GeofenceMonitorBinderTests {
             transition: .enter,
             location: LocationData(latitude: 37.0, longitude: -122.0)
         )
-        // With no deliveryTracker and a set userId, trackTransition posts a fallback event
-        // on the EventBus — observable signal that the binder routed to the tracker.
-        await awaitDispatch(eventBus.postEventCallsCount > 0)
+        // Tracker dispatch is observable via the delivery mock's call count.
+        await awaitDispatch(delivery.trackMetricCallsCount > 0)
 
-        #expect(eventBus.postEventCallsCount == 1)
+        #expect(delivery.trackMetricCallsCount == 1)
         #expect(coordinator.handleMovementCallsCount == 0)
     }
 }

--- a/Tests/Location/Geofence/Storage/PendingGeofenceMetricStoreTests.swift
+++ b/Tests/Location/Geofence/Storage/PendingGeofenceMetricStoreTests.swift
@@ -20,7 +20,8 @@ struct PendingGeofenceMetricStoreTests {
             transition: transition,
             latitude: 12.34,
             longitude: 56.78,
-            timestamp: Date(timeIntervalSince1970: 1700000000)
+            timestamp: Date(timeIntervalSince1970: 1700000000),
+            userId: nil
         )
     }
 
@@ -262,7 +263,8 @@ struct PendingGeofenceMetricStoreTests {
                                 transition: .enter,
                                 latitude: nil,
                                 longitude: nil,
-                                timestamp: Date()
+                                timestamp: Date(),
+                                userId: nil
                             ))
                         case 1:
                             _ = await store.loadAll()

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -585,7 +585,9 @@ public final class CioInternalCommon.TrackGeofenceMetricEvent {
 	public final val geofenceId: String;
 	public final val transition: GeofenceTransition;
 	public final val timestamp: Date;
-	public fun init(storageId: String = UUID().uuidString, geofenceId: String, transition: GeofenceTransition, timestamp: Date = Date(), params: List<String: String> = List<:>);
+	public final val latitude: Double?;
+	public final val longitude: Double?;
+	public fun init(storageId: String = UUID().uuidString, geofenceId: String, transition: GeofenceTransition, timestamp: Date = Date(), latitude: Double? = nil, longitude: Double? = nil, params: List<String: String> = List<:>);
 }
 public final class CioInternalCommon.TrackInAppMetricEvent {
 	public final val storageId: String;


### PR DESCRIPTION
## Summary

A geofence transition queued while user A is identified could be delivered as user B if A signs out and B signs in before the flush runs. Both delivery channels resolved the userId at delivery time — the direct-HTTP path via `contextStore.currentUserId`, and the EventBus path via DataPipeline's current identity.

This PR snapshots the userId on `PendingGeofenceMetric` at capture time and routes delivery off it.

**Stamp at capture** ([GeofenceEventTracker.trackTransition](Sources/Location/Geofence/Event/GeofenceEventTracker.swift)):
- Read `contextStore.currentUserId` when the transition fires; empty → nil. Persist on the row.

**Dispatch in `deliver`**:
- **Stamped userId → direct-HTTP path with that userId.** Success drains the row, failure retains it for the next flush. Cross-user attribution is now stable across sign-out / sign-in / process restarts.
- **No stamped userId → post to EventBus and drain.** DataPipeline records the transition under its current identity (anonymous tracking when no one is identified). The captured `timestamp` + `latitude` / `longitude` flow through `TrackGeofenceMetricEvent` so the transition attributes to **when** it happened, not when the flush ran.

Falling back to the live `contextStore.currentUserId` on the HTTP path would reproduce the mis-attribution being fixed (anonymous capture would still get attributed to the next identified user), so nil-stamped rows are not eligible for the HTTP path.

## Drive-by cleanup

`deliveryTracker: GeofenceDeliveryTracker?` → non-optional. The DI accessor has unconditionally constructed `GeofenceDeliveryTrackerImpl` from the Common HTTP client since #1068, so the optional + the `guard let deliveryTracker else { postEventBus(…) }` branch were dead code in production. Dropped the optional and tightened the gate to `metric.userId == nil` instead.

## Type additions

- `PendingGeofenceMetric.userId: String?` (optional, backward-compat — legacy rows decode to nil and route through EventBus on next flush).
- `TrackGeofenceMetricEvent.latitude: Double?` / `longitude: Double?` so the EventBus path's payload matches the direct-HTTP path's properties. `timestamp` was already on the event but ignored by the DataPipeline subscriber; now honored.
- DataPipeline's `TrackGeofenceMetricEvent` subscriber rewritten to construct `TrackEvent` explicitly (matching the BGQ pattern in `DataPipelineImplementation+BGQ`) so `TrackEvent.timestamp` is set from `metric.timestamp` and the full property shape mirrors HTTP.

## Stack

Merge order (top-down):
1. #1081 — `chore: regenerate autogen + reformat to current rules` (MBL-1770-a)
2. #1082 — `chore: geofence pending-store correctness across user changes` (MBL-1770-b)
3. #1083 — `chore: geofence reliability fixes + logger tag dispatch` (MBL-1770-c)
4. **this PR** — `chore: stamp userId on pending geofence metric for stable attribution` (MBL-1770-d)
5. MBL-1770-e — no-op regression test for non-geofence apps [coming]

Ticket: https://linear.app/customerio/issue/MBL-1770

## Cross-platform

Mirrors Android's [MBL-1760 / 6c0712a5](https://github.com/customerio/customerio-android/commit/6c0712a5):
- Same field added (`userId: String?` on the pending entry)
- Same capture-time snapshot
- Same "stamped → direct HTTP; null → analytics pipeline / EventBus" routing
- Same boundary: doesn't fix cross-process exactly-once (separate ticket; Android uses `claim()`, iOS deferred)

## Test plan

- [x] `make generate && make format && make lint` — 0 violations
- [x] `xcodebuild build-for-testing` — clean
- [x] `GeofenceEventTrackerTests` — 18 tests green, incl. `trackTransition_givenIdentifiedUser_expectMetricStampedWithUserId`, `trackTransition_givenNoUserId_expectEventBusAndQueueDrained`, `flushPending_givenRowStampedDifferentFromCurrent_expectStampedUserIdUsed`, `flushPending_givenStampedUserId_andNoCurrent_expectDeliveredWithStamped`, `flushPending_givenNilUserIdOnRow_expectEventBusPostNoHttpCall`, `flushPending_givenAnonymousCaptureThenIdentify_expectNoHttpBackfill`
- [x] `GeofenceMonitorBinderTests` — 3 tests green (binder now observes routing via `GeofenceDeliveryTrackerMock`)
- [x] `DataPipelineEventBustTests` — 5 tests green, verifying `TrackEvent.timestamp` and property shape on both `.enter` (with coords) and `.exit` (without coords)
- [x] `api-docs/internal/CioInternalCommon.api` regenerated (`TrackGeofenceMetricEvent` adds `latitude`, `longitude`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes geofence event attribution and delivery routing (identified vs anonymous), affecting analytics identity and when events are sent; behavior is heavily tested but touches customer-facing tracking semantics.
> 
> **Overview**
> Fixes **cross-user mis-attribution** for queued geofence transitions by **snapshotting `userId` on `PendingGeofenceMetric` at capture** and routing delivery from that stamp instead of the live identity at flush time.
> 
> **`GeofenceEventTracker`:** On capture, persists `contextStore.currentUserId` on the pending row. In `deliver`, rows with a stamped user go **direct HTTP** with that user (success drains, failure retries); rows with **no stamp** post **`TrackGeofenceMetricEvent` on EventBus**, drain immediately, and do **not** wait for a later identify or fall back to the current user for HTTP. `GeofenceDeliveryTracker` is now **required** (optional + nil-tracker EventBus branch removed).
> 
> **EventBus / DataPipeline path:** `TrackGeofenceMetricEvent` gains optional **latitude/longitude**; DataPipeline handles geofence metrics via **`processGeofenceMetricEvent`**, aligning properties with the HTTP path and setting **`TrackEvent.timestamp`** from the captured transition time.
> 
> Tests and internal API docs updated for stamping, anonymous EventBus delivery, and no HTTP backfill after identify.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cd14658a846a41d0b5f1c49e1fb3f09ab3d88f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->