### PR TITLE
Raise minimum iOS deployment target to 15

### DIFF
--- a/CustomerIO.podspec
+++ b/CustomerIO.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |spec|
   spec.cocoapods_version = '>= 1.11.0'
 
   spec.platform = :ios # platforms SDK supports. Leave blank and it's assumed SDK supports all platforms. 
-  spec.ios.deployment_target = "13.0"
+  spec.ios.deployment_target = "15.0"
   # spec.osx.deployment_target = "10.15"
   # spec.tvos.deployment_target = '13.0'
 

--- a/CustomerIOCommon.podspec
+++ b/CustomerIOCommon.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.cocoapods_version = '>= 1.11.0'
 
   spec.platform = :ios # platforms SDK supports. Leave blank and it's assumed SDK supports all platforms. 
-  spec.ios.deployment_target = "13.0"
+  spec.ios.deployment_target = "15.0"
   # spec.osx.deployment_target = "10.15"
   # spec.tvos.deployment_target = '13.0'
 

--- a/CustomerIODataPipelines.podspec
+++ b/CustomerIODataPipelines.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.cocoapods_version = '>= 1.11.0'
 
   spec.platform = :ios # platforms SDK supports. Leave blank and it's assumed SDK supports all platforms.
-  spec.ios.deployment_target = "13.0"
+  spec.ios.deployment_target = "15.0"
   # spec.osx.deployment_target = "10.15"
   # spec.tvos.deployment_target = '13.0'
 

--- a/CustomerIOLocation.podspec
+++ b/CustomerIOLocation.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.cocoapods_version = '>= 1.11.0'
 
   spec.platform = :ios
-  spec.ios.deployment_target = "13.0"
+  spec.ios.deployment_target = "15.0"
 
   path_to_source_for_module = "Sources/Location"
   spec.source_files = "#{path_to_source_for_module}/**/*{.swift}"

--- a/CustomerIOMessagingInApp.podspec
+++ b/CustomerIOMessagingInApp.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.cocoapods_version = '>= 1.11.0'
 
   spec.platform = :ios # platforms SDK supports. Leave blank and it's assumed SDK supports all platforms. 
-  spec.ios.deployment_target = "13.0"
+  spec.ios.deployment_target = "15.0"
   # spec.osx.deployment_target = "10.15"
   # spec.tvos.deployment_target = '13.0'
 

--- a/CustomerIOMessagingPush.podspec
+++ b/CustomerIOMessagingPush.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.cocoapods_version = '>= 1.11.0'
 
   spec.platform = :ios # platforms SDK supports. Leave blank and it's assumed SDK supports all platforms. 
-  spec.ios.deployment_target = "13.0"
+  spec.ios.deployment_target = "15.0"
   # spec.osx.deployment_target = "10.15"
   # spec.tvos.deployment_target = '13.0'
 

--- a/CustomerIOMessagingPushAPN.podspec
+++ b/CustomerIOMessagingPushAPN.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.cocoapods_version = '>= 1.11.0'
 
   spec.platform = :ios # platforms SDK supports. Leave blank and it's assumed SDK supports all platforms. 
-  spec.ios.deployment_target = "13.0"
+  spec.ios.deployment_target = "15.0"
   # spec.osx.deployment_target = "10.15"
   # spec.tvos.deployment_target = '13.0'
 

--- a/CustomerIOMessagingPushFCM.podspec
+++ b/CustomerIOMessagingPushFCM.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.cocoapods_version = '>= 1.11.0'
 
   spec.platform = :ios # platforms SDK supports. Leave blank and it's assumed SDK supports all platforms. 
-  spec.ios.deployment_target = "13.0"
+  spec.ios.deployment_target = "15.0"
   # spec.osx.deployment_target = "10.15"
   # spec.tvos.deployment_target = '13.0'
 

--- a/CustomerIOTrackingMigration.podspec
+++ b/CustomerIOTrackingMigration.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.cocoapods_version = '>= 1.11.0'
 
   spec.platform = :ios # platforms SDK supports. Leave blank and it's assumed SDK supports all platforms. 
-  spec.ios.deployment_target = "13.0"
+  spec.ios.deployment_target = "15.0"
   # spec.osx.deployment_target = "10.15"
   # spec.tvos.deployment_target = '13.0'
 

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ if (ProcessInfo.processInfo.environment["CI"] != nil) { // true if running on a 
 let package = Package(
     name: "Customer.io",
     platforms: [
-        .iOS(.v13)
+        .iOS(.v15)
     ],
     products: products,
     dependencies: [


### PR DESCRIPTION
Resolves #1085.

Xcode 27 beta no longer supports iOS deployment targets below **iOS 15**. The current `.iOS(.v13)` / `spec.ios.deployment_target = "13.0"` declarations emit a `the iOS deployment target ... is set to 13.0, but the range of supported deployment target versions is 15.0 to ...` warning when building under Xcode 27.

### Changes
- `Package.swift`: `.iOS(.v13)` → `.iOS(.v15)`
- All nine podspecs (`CustomerIO`, `CustomerIODataPipelines`, `CustomerIOLocation`, `CustomerIOCommon`, `CustomerIOMessagingInApp`, `CustomerIOMessagingPush`, `CustomerIOMessagingPushAPN`, `CustomerIOMessagingPushFCM`, `CustomerIOTrackingMigration`): `ios.deployment_target` `13.0` → `15.0`

### Verification
Built the full `Customer.io-Package` scheme (all products, including the FCM/Firebase target) clean against the **iOS 27 SDK (Xcode 27.0 beta, 27A5194q)** for `generic/platform=iOS Simulator` — `** BUILD SUCCEEDED **`, no deployment-target warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for apps targeting iOS 13–14; packaging-only but affects all SPM/CocoaPods consumers on upgrade.
> 
> **Overview**
> Raises the **minimum supported iOS version from 13 to 15** across Swift Package Manager and CocoaPods packaging so builds align with **Xcode 27**, which no longer accepts deployment targets below iOS 15.
> 
> `Package.swift` updates the package platform from `.iOS(.v13)` to `.iOS(.v15)`. All nine Customer.io podspecs change `spec.ios.deployment_target` from `"13.0"` to `"15.0"` (umbrella `CustomerIO` plus Common, DataPipelines, Location, MessagingInApp, MessagingPush, MessagingPushAPN, MessagingPushFCM, and TrackingMigration). **No SDK source or runtime logic is modified**—only declared minimum OS for integrators.
> 
> **Integrator impact:** Apps that must run on iOS 13–14 need to stay on an older SDK release or raise their own deployment target to 15+.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb76d8095c80e8632e85193868ac05b18f46d869. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->