### PR TITLE
chore: add no-op regression tests for absent Location module

### DIFF
--- a/Tests/Location/LocationModuleAbsentTests.swift
+++ b/Tests/Location/LocationModuleAbsentTests.swift
@@ -1,0 +1,41 @@
+@testable import CioInternalCommon
+@testable import CioLocation
+import SharedTests
+import Testing
+
+/// Regression guard for the no-op invariant: when the host app never adds the
+/// Location module to `SDKConfigBuilder`, the Location target must contribute
+/// no runtime side effects. All Location work is gated behind
+/// `LocationModule.initialize()` → `LocationModuleState.shared.performInitialization`,
+/// which `CustomerIO.initialize(withConfig:)` only invokes for modules present
+/// in `config.modules`.
+///
+/// Builder-layer coverage that `SDKConfigBuilder` does not pre-load Location
+/// lives in `SDKConfigBuilderTest.test_buildWithoutAddModule_expectEmptyModules`.
+/// The tests below pin the Location-target half of that contract.
+@Suite("LocationModuleAbsent")
+struct LocationModuleAbsentTests {
+    @Test
+    func locationModuleStateCurrent_givenInitializeNotRun_expectUninitializedFacade() {
+        // `LocationModuleState.shared.current` defaults to `UninitializedLocationServices`
+        // and only flips once `performInitialization` runs on the main thread.
+        // No test in this target invokes that path, so the default is observable.
+        let current = LocationModuleState.shared.current
+
+        #expect(current is UninitializedLocationServices)
+    }
+
+    @Test
+    func uninitializedLocationServices_requestLocationUpdate_expectLogModuleNotInitialized() {
+        let loggerMock = LoggerMock()
+        let service = UninitializedLocationServices(logger: loggerMock)
+
+        service.requestLocationUpdate()
+
+        #expect(loggerMock.errorCallsCount == 1)
+        #expect(
+            loggerMock.errorReceivedInvocations.first?.message
+                == "Location module is not initialized. Add LocationModule via SDKConfigBuilder.addModule(LocationModule(config: ...)) before CustomerIO.initialize(withConfig:)."
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Pin the no-op invariant for the Location target: when a host app never adds `LocationModule` to `SDKConfigBuilder`, the Location target must contribute zero runtime side effects. All Location work is gated behind `LocationModule.initialize()` → `LocationModuleState.shared.performInitialization`, which `CustomerIO.initialize(withConfig:)` only invokes for modules present in `config.modules`.

Two tests in a new `LocationModuleAbsentTests` suite:
- `locationModuleStateCurrent_givenInitializeNotRun_expectUninitializedFacade` — `.shared.current` defaults to `UninitializedLocationServices` and only flips after `performInitialization`.
- `uninitializedLocationServices_requestLocationUpdate_expectLogModuleNotInitialized` — closes the `UninitializedLocationServices.requestLocationUpdate` coverage gap, asserting the error log fires with the expected guidance message.

Builder-layer coverage that `SDKConfigBuilder` does not pre-load Location already lives in `SDKConfigBuilderTest.test_buildWithoutAddModule_expectEmptyModules`; this PR pins the Location-target half.

Test-only — no `Sources/` changes, zero behavior change.

Linear: https://linear.app/customerio/issue/MBL-1770

## Stack
This PR is the tail of the 1770 series; parallel to #1087 (MBL-1774), both stacked on 1770-d:
1. PR #1081 — `mbl-1770-a-autogen-drift-fix` → `feature/geofence-on-device`
2. PR #1082 — `mbl-1770-b-storage-correctness` → 1770-a
3. PR #1083 — `mbl-1770-c-small-fixes-android-port` → 1770-b
4. PR #1084 — `mbl-1770-d-per-row-userid-stamping` → 1770-c
5. PR #1087 — `mbl-1774-a-refactor-locationmodulestate` → 1770-d (parallel)
6. **This PR** — `mbl-1770-e-no-op-regression-test` → 1770-d

Independent of #1087 — no shared file changes.

## Test plan
- [x] `xcodebuild build-for-testing -scheme Customer.io-Package` — clean
- [x] `LocationModuleAbsentTests` — 2/2 pass in 0.002s
- [x] `make lint` — 0 violations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with no production code or runtime behavior changes.
> 
> **Overview**
> Adds a new **`LocationModuleAbsent`** test suite to lock in the no-op behavior when the host app never registers **`LocationModule`** on **`SDKConfigBuilder`**.
> 
> One test asserts **`LocationModuleState.shared.current`** stays **`UninitializedLocationServices`** until **`performInitialization`** runs. The other verifies **`UninitializedLocationServices.requestLocationUpdate()`** logs the expected “module not initialized” guidance via **`LoggerMock`**.
> 
> **Test-only** — no **`Sources/`** changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b278de62f7393609c9d065e82bf7c7f46f110c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->