### PR TITLE
chore: rename geofence wire events

### DIFF
--- a/Sources/Common/Service/BackgroundDeliveryHttpClient.swift
+++ b/Sources/Common/Service/BackgroundDeliveryHttpClient.swift
@@ -18,7 +18,7 @@ public enum BackgroundDeliveryHttpError: Error, Equatable {
 public protocol BackgroundDeliveryHttpClient: AutoMockable, Sendable {
     /// Sends one CDP `/track` event.
     /// - Parameters:
-    ///   - eventName: `track` event name (e.g. `"GeoFence Entered"`).
+    ///   - eventName: `track` event name (e.g. `"Geofence Entered"`).
     ///   - userId: Identified user id. Caller must validate non-empty before calling.
     ///   - properties: Event properties payload.
     ///   - completion: Called on URLSession's delegate queue with success or error.

--- a/Sources/Common/Type/GeofenceTransition.swift
+++ b/Sources/Common/Type/GeofenceTransition.swift
@@ -13,11 +13,11 @@ public enum GeofenceTransition: String, Codable, Sendable {
 
 public extension GeofenceTransition {
     /// Analytics event name for this transition. Matches the Android SDK's
-    /// `"GeoFence Entered"` / `"GeoFence Exited"` (capital F mid-word).
+    /// `"Geofence Entered"` / `"Geofence Exited"`.
     var trackEventName: String {
         switch self {
-        case .enter: return "GeoFence Entered"
-        case .exit: return "GeoFence Exited"
+        case .enter: return "CIO Geofence Entered"
+        case .exit: return "CIO Geofence Exited"
         }
     }
 }

--- a/Tests/Common/Service/BackgroundDeliveryHttpClientTests.swift
+++ b/Tests/Common/Service/BackgroundDeliveryHttpClientTests.swift
@@ -39,7 +39,7 @@ struct BackgroundDeliveryHttpClientTests {
 
         await withCheckedContinuation { continuation in
             client.sendTrackEvent(
-                eventName: "GeoFence Entered",
+                eventName: "CIO Geofence Entered",
                 userId: "user_42",
                 properties: ["geofence_id": "geo_1", "transition_type": "enter"]
             ) { _ in continuation.resume() }
@@ -52,7 +52,7 @@ struct BackgroundDeliveryHttpClientTests {
         #expect(params?.headers?["Content-Type"] == "application/json; charset=utf-8")
 
         let body = params?.body.flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] }
-        #expect(body?["event"] as? String == "GeoFence Entered")
+        #expect(body?["event"] as? String == "CIO Geofence Entered")
         #expect(body?["userId"] as? String == "user_42")
         let properties = body?["properties"] as? [String: Any]
         #expect(properties?["geofence_id"] as? String == "geo_1")

--- a/Tests/DataPipeline/DataPipelineEventBustTests.swift
+++ b/Tests/DataPipeline/DataPipelineEventBustTests.swift
@@ -78,7 +78,7 @@ class DataPipelineEventBustTests: IntegrationTest {
         }
 
         XCTAssertEqual(trackEvent.type, "track")
-        XCTAssertEqual(trackEvent.event, "GeoFence Entered")
+        XCTAssertEqual(trackEvent.event, "CIO Geofence Entered")
         let properties = trackEvent.properties?.dictionaryValue ?? [:]
         XCTAssertEqual(properties["geofence_id"] as? String, givenGeofenceId)
         XCTAssertEqual(properties["transition_type"] as? String, "enter")
@@ -105,7 +105,7 @@ class DataPipelineEventBustTests: IntegrationTest {
             return
         }
 
-        XCTAssertEqual(trackEvent.event, "GeoFence Exited")
+        XCTAssertEqual(trackEvent.event, "CIO Geofence Exited")
         let properties = trackEvent.properties?.dictionaryValue ?? [:]
         XCTAssertEqual(properties["geofence_id"] as? String, givenGeofenceId)
         XCTAssertEqual(properties["transition_type"] as? String, "exit")

--- a/Tests/Location/Geofence/Event/GeofenceDeliveryTrackerTests.swift
+++ b/Tests/Location/Geofence/Event/GeofenceDeliveryTrackerTests.swift
@@ -44,7 +44,7 @@ struct GeofenceDeliveryTrackerTests {
         }
 
         let args = httpClient.sendTrackEventReceivedArguments
-        #expect(args?.eventName == "GeoFence Entered")
+        #expect(args?.eventName == "CIO Geofence Entered")
         #expect(args?.userId == "user_42")
         let properties = args?.properties ?? [:]
         #expect(properties["geofence_id"] as? String == "geo_1")
@@ -65,7 +65,7 @@ struct GeofenceDeliveryTrackerTests {
             }
         }
 
-        #expect(httpClient.sendTrackEventReceivedArguments?.eventName == "GeoFence Exited")
+        #expect(httpClient.sendTrackEventReceivedArguments?.eventName == "CIO Geofence Exited")
     }
 
     @Test


### PR DESCRIPTION
## Summary

Renames the CDP track event names emitted by the geofence transition path:

- `"GeoFence Entered"` → `"CIO Geofence Entered"`
- `"GeoFence Exited"` → `"CIO Geofence Exited"`

Ports the same rename Android shipped in [customerio-android@006132fc](https://github.com/customerio/customerio-android/commit/006132fc4f1171255ace2fe69fb559a8bbac830b) so the two SDKs stay in lockstep on the wire format the backend sees.

Both delivery paths (direct-HTTP via `GeofenceDeliveryTracker`, EventBus via `DataPipelineImplementation+GeofenceObserver`) read the name from `GeofenceTransition.trackEventName`, so a single source-of-truth change covers both.

Ticket: https://linear.app/customerio/issue/MBL-1780/rename-geofence-events-in-mobile-sdks

## Test plan

- [x] `make generate && make format && make lint` — 0 violations
- [x] `CI=1 ./scripts/generate-api-docs.sh` — no baseline diff (string values aren't part of public signatures)
- [x] `xcodebuild build-for-testing` — clean
- [x] Touched test classes (`GeofenceDeliveryTrackerTests`, `BackgroundDeliveryHttpClientTests`, `DataPipelineEventBusTests`) — green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing analytics event names can break dashboards, journeys, or filters that still key on the old "GeoFence" strings until backends and customers migrate.
> 
> **Overview**
> Renames the CDP **track** event names for geofence enter/exit from `"GeoFence Entered"` / `"GeoFence Exited"` to **`"CIO Geofence Entered"`** / **`"CIO Geofence Exited"`**, aligning iOS with the Android SDK wire format.
> 
> The strings come from **`GeofenceTransition.trackEventName`**, so both delivery paths (direct HTTP via **`GeofenceDeliveryTracker`** and EventBus/DataPipeline) pick up the new names without separate call-site changes. Related doc comments and tests are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 281b9f83a158ca3e237336d26a8c05beb590fe65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->