### PR TITLE
chore: APN-UIKit kicks SDK location update on auth grant

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/View/location/LocationTestViewController+CLLocationManagerDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/location/LocationTestViewController+CLLocationManagerDelegate.swift
@@ -42,14 +42,23 @@ extension LocationTestViewController: @MainActor CLLocationManagerDelegate {
         showToast(withMessage: "Failed to get location: \(error.localizedDescription)")
     }
 
-    // iOS 14+ authorization change callback
+    /// **Customer integration pattern.** Call `CustomerIO.location.requestLocationUpdate()`
+    /// when permission lands in a granted state — the SDK uses that fix to bootstrap its
+    /// geofence sync. The call is idempotent, so it's safe to invoke on every delegate
+    /// firing.
     @available(iOS 14.0, *)
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
-        handleAuthorizationChange(manager.authorizationStatus)
+        let status = manager.authorizationStatus
+        if status == .authorizedWhenInUse || status == .authorizedAlways {
+            CustomerIO.location.requestLocationUpdate()
+        }
+        handleAuthorizationChange(status)
     }
 
-    // iOS 13 authorization change callback
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        if status == .authorizedWhenInUse || status == .authorizedAlways {
+            CustomerIO.location.requestLocationUpdate()
+        }
         handleAuthorizationChange(status)
     }
 


### PR DESCRIPTION
## Summary

Surfaced during MBL-1761 validation testing. In the APN-UIKit sample, granting location permission in the in-app flow alone wasn't kicking off geofence registration — the SDK had no anchor for the initial `/geofences/nearby` fetch until a separate user action (e.g., "Set location" or "SDK Request Location Once") pushed a fix into the pipeline.

The fix: in `locationManagerDidChangeAuthorization` (and its iOS 13 sibling), call `CustomerIO.location.requestLocationUpdate()` whenever auth lands in `.authorizedWhenInUse` / `.authorizedAlways`. The same pattern customers should follow in their own apps to bootstrap geofence sync on first-run permission grant.

Mirrors the Android fix shipped in https://github.com/customerio/customerio-android/pull/728.

## Why the SDK's existing auto-fetch doesn't catch this

`LocationLifecycleObserver` already calls `requestLocationUpdate()` on `didBecomeActive`. But an in-app permission prompt is modal — granting it doesn't trigger a foreground transition. By the time the user grants, the lifecycle hook has already fired once at app start (and no-op'd because permission wasn't granted yet).

## Why this is safe to call on every delegate firing

`requestLocationUpdate()` is idempotent — `guard currentTask == nil else { return }` at [LocationServices.swift:166](https://github.com/customerio/customerio-ios/blob/feature/geofence-on-device/Sources/Location/LocationServices.swift#L166). Multiple grants (WhenInUse → Always upgrade, Settings round-trips) all flow through the same gated entry point, so no first-grant flag is needed in the customer's code.

Ticket: https://linear.app/customerio/issue/MBL-1761/ios-execute-geofencing-validation-and-lifecycle-testing

## Stack

Base: `feature/geofence-on-device` (geofence stack PRs #1081, #1082, #1083, #1084, #1087, #1090 already merged into base).

## Test plan

- [x] `make format && make lint` — 0 violations
- [x] APN-UIKit sample app build — SUCCEEDED
- [x] Manual: fresh install → identify → tap "Grant location" → grant WhenInUse → expect geofence sync to fire without further user action
- [x] Manual: continue rationale → grant Always → no spurious second fetch (SDK in-flight gating)
- [x] Manual: deny in Settings, then re-grant → fetch fires on next delegate callback

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sample-app delegate wiring and documentation only; no SDK or production app behavior changes.
> 
> **Overview**
> Updates the **APN-UIKit** sample’s `CLLocationManagerDelegate` so that when location authorization becomes **When In Use** or **Always**, it calls **`CustomerIO.location.requestLocationUpdate()`** before the existing `handleAuthorizationChange` flow.
> 
> This documents the **recommended customer integration**: bootstrap geofence sync on first in-app permission grant, since a modal grant does not re-fire the SDK’s foreground lifecycle hook. The same call is wired on both **iOS 14+** `locationManagerDidChangeAuthorization` and the **iOS 13** `didChangeAuthorization` path, with comments noting the API is **idempotent** and safe on every delegate callback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3232d4cde7aacd9cf4499fc0a0e0fae9e08e4f54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->