### PR TITLE
chore(location): publish location fixes via EventBus

### DIFF
--- a/Sources/Common/Communication/Event+Location.swift
+++ b/Sources/Common/Communication/Event+Location.swift
@@ -13,3 +13,22 @@ public struct LocationData: Codable, Sendable, Equatable {
         self.longitude = longitude
     }
 }
+
+/// Posted whenever the Location module finishes processing a fresh location fix
+/// (the fix has been cached and evaluated for sync). Observed by the geofence wiring
+/// to re-arm its first-run refresh after a fix arrives following an earlier
+/// "no cached location" skip. Routing this through the EventBus keeps geofence
+/// decoupled from `LocationSyncCoordinator`'s internals.
+public struct LocationAcquiredEvent: EventRepresentable {
+    public let storageId: String
+    public let params: [String: String]
+    public let location: LocationData
+    public let timestamp: Date
+
+    public init(storageId: String = UUID().uuidString, location: LocationData, timestamp: Date = Date(), params: [String: String] = [:]) {
+        self.storageId = storageId
+        self.location = location
+        self.timestamp = timestamp
+        self.params = params
+    }
+}

--- a/Sources/Common/Communication/Event.swift
+++ b/Sources/Common/Communication/Event.swift
@@ -51,7 +51,8 @@ public enum EventTypesRegistry {
             TrackGeofenceMetricEvent.self,
             RegisterDeviceTokenEvent.self,
             DeleteDeviceTokenEvent.self,
-            NewSubscriptionEvent.self
+            NewSubscriptionEvent.self,
+            LocationAcquiredEvent.self
         ]
     }
 

--- a/Sources/Location/Coordinator/LocationSyncCoordinator.swift
+++ b/Sources/Location/Coordinator/LocationSyncCoordinator.swift
@@ -8,27 +8,30 @@ actor LocationSyncCoordinator {
     private let dataPipeline: DataPipelineTracking?
     private let dateUtil: DateUtil
     private let logger: Logger
-    private var onLocationProcessed: (@Sendable (LocationData) -> Void)?
+    private let eventBusHandler: EventBusHandler
 
     init(
         storage: LastLocationStorage,
         filter: LocationFilter,
         dataPipeline: DataPipelineTracking?,
         dateUtil: DateUtil,
-        logger: Logger
+        logger: Logger,
+        eventBusHandler: EventBusHandler
     ) {
         self.storage = storage
         self.filter = filter
         self.dataPipeline = dataPipeline
         self.dateUtil = dateUtil
         self.logger = logger
+        self.eventBusHandler = eventBusHandler
     }
 
     /// Called for every new location (from setLastKnownLocation or requestLocationUpdate). Always updates cache; sends track via pipeline when filter allows and user is identified.
     func processLocationUpdate(_ location: LocationData) {
         storage.setCachedLocation(location)
-        // Used by the geofence first-run race rearm in `LocationModuleState`.
-        onLocationProcessed?(location)
+        // Signals the geofence first-run-refresh re-arm. Routed through the EventBus so
+        // geofence can observe fixes without a direct reference to this coordinator.
+        eventBusHandler.postEvent(LocationAcquiredEvent(location: location))
 
         guard filter.shouldSyncToServer(newLocation: location) else {
             logger.locationSyncFiltered()
@@ -36,12 +39,6 @@ actor LocationSyncCoordinator {
         }
 
         trySendLocationTrack(location)
-    }
-
-    /// Registers an observer for every processed location. Used by the geofence module to
-    /// re-arm a refresh that previously skipped due to no cached location.
-    func setOnLocationProcessed(_ handler: (@Sendable (LocationData) -> Void)?) {
-        onLocationProcessed = handler
     }
 
     /// Called when ProfileIdentifiedEvent is received. Syncs cached location if present and the 24h + 1 km filter allows.

--- a/Sources/Location/LocationModuleState.swift
+++ b/Sources/Location/LocationModuleState.swift
@@ -38,7 +38,8 @@ final class LocationModuleState {
             filter: filter,
             dataPipeline: dataPipeline,
             dateUtil: di.dateUtil,
-            logger: di.logger
+            logger: di.logger,
+            eventBusHandler: di.eventBusHandler
         )
         let locationEnrichmentProvider = LocationProfileEnrichmentProvider(storage: storage, config: config)
         di.profileEnrichmentRegistry.register(locationEnrichmentProvider)
@@ -84,10 +85,8 @@ final class LocationModuleState {
             self?.refreshGeofencesIfPossible(lastLocationStorage: lastLocationStorage)
         }
         // Rearm first-run refresh on the first fresh fix after an identify/foreground skip.
-        Task {
-            await coordinator.setOnLocationProcessed { [weak self] location in
-                self?.rearmFirstRunRefreshIfArmed(location: location, di: di)
-            }
+        di.eventBusHandler.addObserver(LocationAcquiredEvent.self) { [weak self] event in
+            self?.rearmFirstRunRefreshIfArmed(location: event.location, di: di)
         }
         Task { @MainActor in
             await GeofenceBootstrap.wireMonitor(di: di)
@@ -107,7 +106,7 @@ final class LocationModuleState {
             // `.onAppStart`'s lifecycle one-shot fires per process, but `resetContext()`
             // wipes the cached location on sign-out — a subsequent identify in the same
             // process otherwise leaves the first-run rearm armed indefinitely. Forcing a
-            // fresh fix here lets `onLocationProcessed` drive the geofence rearm.
+            // fresh fix here lets the `LocationAcquiredEvent` observer drive the geofence rearm.
             if mode == .onAppStart, lastLocationStorage.getCachedLocation() == nil {
                 self?.current.requestLocationUpdate()
             }

--- a/Tests/Common/Communication/EventTypesRegistryTests.swift
+++ b/Tests/Common/Communication/EventTypesRegistryTests.swift
@@ -50,6 +50,11 @@ class EventTypesRegistryTests: UnitTest {
         XCTAssertEqual(eventType.key, NewSubscriptionEvent.key)
     }
 
+    func test_getEventType_whenKeyIsLocationAcquiredEvent_expectReturnsLocationAcquiredEventType() throws {
+        let eventType = try EventTypesRegistry.getEventType(for: LocationAcquiredEvent.key)
+        XCTAssertEqual(eventType.key, LocationAcquiredEvent.key)
+    }
+
     // MARK: - getEventType(for:) - Unknown key
 
     func test_getEventType_whenKeyIsUnknown_expectThrowsInvalidEventType() {

--- a/Tests/Location/Coordinator/LocationSyncCoordinatorTests.swift
+++ b/Tests/Location/Coordinator/LocationSyncCoordinatorTests.swift
@@ -9,7 +9,8 @@ struct LocationSyncCoordinatorTests {
     private func makeCoordinator(
         dataPipeline: DataPipelineTrackingMock? = DataPipelineTrackingMock(),
         storage: LastLocationStorageImpl? = nil,
-        dateUtil: DateUtilStub? = nil
+        dateUtil: DateUtilStub? = nil,
+        eventBusHandler: EventBusHandler = EventBusHandlerMock()
     ) -> (LocationSyncCoordinator, LastLocationStorageImpl) {
         let store = storage ?? LastLocationStorageImpl(stateStore: InMemoryLastLocationStateStore())
         let util = dateUtil ?? DateUtilStub()
@@ -19,7 +20,8 @@ struct LocationSyncCoordinatorTests {
             filter: filter,
             dataPipeline: dataPipeline,
             dateUtil: util,
-            logger: LoggerMock()
+            logger: LoggerMock(),
+            eventBusHandler: eventBusHandler
         )
         return (coordinator, store)
     }
@@ -128,15 +130,13 @@ struct LocationSyncCoordinatorTests {
     }
 
     @Test
-    func processLocationUpdate_givenObserverRegistered_expectObserverCalledWithLocation() async {
-        let (coordinator, _) = makeCoordinator()
-        let received = Synchronized<[LocationData]>([])
-        await coordinator.setOnLocationProcessed { location in
-            received.mutating { $0.append(location) }
-        }
+    func processLocationUpdate_expectLocationAcquiredEventPosted() async {
+        let bus = EventBusHandlerMock()
+        let (coordinator, _) = makeCoordinator(eventBusHandler: bus)
         let location = LocationData(latitude: 37, longitude: -122)
         await coordinator.processLocationUpdate(location)
-        #expect(received.wrappedValue == [location])
+        let postedLocations = bus.postEventReceivedInvocations.compactMap { ($0 as? LocationAcquiredEvent)?.location }
+        #expect(postedLocations == [location])
     }
 
     @Test

--- a/Tests/Location/LocationModuleStateGeofenceTests.swift
+++ b/Tests/Location/LocationModuleStateGeofenceTests.swift
@@ -112,7 +112,8 @@ private struct Fixture {
             filter: LocationFilter(storage: lastLocationStorage, dateUtil: DateUtilStub()),
             dataPipeline: nil,
             dateUtil: DateUtilStub(),
-            logger: LoggerMock()
+            logger: LoggerMock(),
+            eventBusHandler: bus
         )
         self.state = LocationModuleState()
     }

--- a/Tests/Location/LocationServicesImplementationTest.swift
+++ b/Tests/Location/LocationServicesImplementationTest.swift
@@ -15,7 +15,8 @@ struct LocationServicesImplementationTests {
             filter: filter,
             dataPipeline: dataPipeline,
             dateUtil: dateUtil,
-            logger: LoggerMock()
+            logger: LoggerMock(),
+            eventBusHandler: EventBusHandlerMock()
         )
     }
 

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -337,6 +337,13 @@ public final class CioInternalCommon.JsonAdapter {
 }
 public enum CioInternalCommon.KeyValueStorageKey {
 }
+public final class CioInternalCommon.LocationAcquiredEvent {
+	public final val storageId: String;
+	public final val params: List<String : String>;
+	public final val location: LocationData;
+	public final val timestamp: Date;
+	public fun init(storageId: String = UUID().uuidString, location: LocationData, timestamp: Date = Date(), params: List<String: String> = List<:>);
+}
 public final class CioInternalCommon.LocationData {
 	public final val latitude: Double;
 	public final val longitude: Double;


### PR DESCRIPTION
Replaces the `LocationSyncCoordinator.onLocationProcessed` closure with a `LocationAcquiredEvent` published on the EventBus (added to `CioInternalCommon`) — the seam the geofence module subscribes to in the next PR.

The location module's observable behavior is unchanged — it still consumes every fix — though the fix now travels over the EventBus rather than a direct callback (so the event participates in the bus's per-type cache/replay, like other events).

### Stack — merge in order
1. #1094 — scaffold CioLocationGeofence module
2. **#1095 — publish location fixes via EventBus ⟵ this PR**
3. #1096 — move geofence implementation into CioLocationGeofence

[MBL-1782](https://linear.app/customerio/issue/MBL-1782/ios-extract-geofencing-into-a-dedicated-module)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Geofence re-arm now depends on EventBus delivery (cache/replay when observers register late) instead of a synchronous closure, which could shift timing slightly though the PR intends parity.
> 
> **Overview**
> Replaces the direct **`LocationSyncCoordinator` → geofence** callback with a shared **`LocationAcquiredEvent`** on the EventBus, so geofence wiring can react to processed fixes without holding a reference to the coordinator.
> 
> **`LocationAcquiredEvent`** is added in `CioInternalCommon` (carrying `LocationData`) and registered in **`EventTypesRegistry`**. On every processed fix, **`LocationSyncCoordinator`** now **`postEvent`s** that event and drops **`setOnLocationProcessed`**. **`LocationModuleState`** subscribes to **`LocationAcquiredEvent`** for the same first-run geofence re-arm path that used the closure.
> 
> Location caching, sync filtering, and pipeline tracking are unchanged; tests now assert the bus post instead of the observer callback, and the internal API surface is updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dab90aee99f8d343f988ce762cb3d02036dcc9b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->