### PR TITLE
feat: Added StorageManger and associated tests

### DIFF
--- a/CustomerIOCommon.podspec
+++ b/CustomerIOCommon.podspec
@@ -22,5 +22,5 @@ Pod::Spec.new do |spec|
 
   spec.module_name = "CioInternalCommon" # the `import X` name when using SDK in Swift files
 
-  spec.dependency 'SyncSqlCipher', '1.0.0'
+  spec.dependency 'SyncSqlCipher', '1.1.0'
 end

--- a/CustomerIOCommon.podspec
+++ b/CustomerIOCommon.podspec
@@ -21,4 +21,6 @@ Pod::Spec.new do |spec|
   spec.exclude_files = "Sources/**/*{.md}"
 
   spec.module_name = "CioInternalCommon" # the `import X` name when using SDK in Swift files
+
+  spec.dependency 'SyncSqlCipher', '1.0.0'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -50,7 +50,7 @@ let package = Package(
         
         // SSE (Server-Sent Events) client for real-time in-app messaging
         .package(url: "https://github.com/LaunchDarkly/swift-eventsource.git", .upToNextMajor(from: "3.3.0")),
-        .package(url: "https://github.com/customerio/SyncSqlCipher.git", from: "1.0.0")
+        .package(url: "https://github.com/customerio/SyncSqlCipher.git", from: "1.1.0")
     ],
     targets: [ 
         // Common - Code used by multiple modules in the SDK project.

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.10
 
 /**
  Manifest file for Swift Package Manager. This file defines our Swift Package for customers to install our SDK modules into their app. 
@@ -49,12 +49,14 @@ let package = Package(
         .package(name: "CioAnalytics", url: "https://github.com/customerio/cdp-analytics-swift.git", .exact("1.7.3+cio.1")),
         
         // SSE (Server-Sent Events) client for real-time in-app messaging
-        .package(url: "https://github.com/LaunchDarkly/swift-eventsource.git", .upToNextMajor(from: "3.3.0"))
+        .package(url: "https://github.com/LaunchDarkly/swift-eventsource.git", .upToNextMajor(from: "3.3.0")),
+        .package(url: "https://github.com/customerio/SyncSqlCipher.git", from: "1.0.0")
     ],
     targets: [ 
         // Common - Code used by multiple modules in the SDK project.
-        // this module is *not* exposed to the public. It's used internally. 
+        // this module is *not* exposed to the public. It's used internally.
         .target(name: "CioInternalCommon",
+                dependencies: [.product(name: "SyncSqlCipher", package: "SyncSqlCipher")],
                 path: "Sources/Common"),
         .testTarget(name: "CommonTests",
                     dependencies: ["CioInternalCommon", "SharedTests"],

--- a/Package.swift
+++ b/Package.swift
@@ -50,7 +50,7 @@ let package = Package(
         
         // SSE (Server-Sent Events) client for real-time in-app messaging
         .package(url: "https://github.com/LaunchDarkly/swift-eventsource.git", .upToNextMajor(from: "3.3.0")),
-        .package(url: "https://github.com/customerio/SyncSqlCipher.git", from: "1.1.0")
+        .package(url: "https://github.com/customerio/SyncSqlCipher.git", exact: "1.1.0")
     ],
     targets: [ 
         // Common - Code used by multiple modules in the SDK project.

--- a/Sources/Common/DIGraphShared+StorageManager.swift
+++ b/Sources/Common/DIGraphShared+StorageManager.swift
@@ -14,10 +14,6 @@ public extension DIGraphShared {
     /// gracefully; the aggregation engine will be a no-op in that case.
     @discardableResult
     func registerStorageManager(cdpApiKey: String) -> StorageManager? {
-        if let existing: StorageManager = getOptional(StorageManager.self) {
-            return existing
-        }
-
         do {
             let path = Self.databasePath(for: cdpApiKey)
             let db = try Database(path: path, key: cdpApiKey)

--- a/Sources/Common/DIGraphShared+StorageManager.swift
+++ b/Sources/Common/DIGraphShared+StorageManager.swift
@@ -1,0 +1,49 @@
+import Foundation
+import SyncSqlCipher
+
+public extension DIGraphShared {
+    /// Creates, migrates, and registers the ``StorageManager`` for a given CDP API key.
+    ///
+    /// Follows the same pattern as ``registerPendingPushDeliveryStore(appGroupId:)``
+    /// — call this once from ``DataPipeline.initialize(moduleConfig:)`` before
+    /// creating ``DataPipelineImplementation``, so the graph has a live instance
+    /// ready for any code that calls ``storageManager``.
+    ///
+    /// Returns `nil` and logs an error if the database cannot be opened or
+    /// migrations fail. Callers that depend on storage must handle a nil result
+    /// gracefully; the aggregation engine will be a no-op in that case.
+    @discardableResult
+    func registerStorageManager(cdpApiKey: String) -> StorageManager? {
+        if let existing: StorageManager = getOptional(StorageManager.self) {
+            return existing
+        }
+
+        do {
+            let path = Self.databasePath(for: cdpApiKey)
+            let db = try Database(path: path, key: cdpApiKey)
+            let storage = StorageManager(db: db)
+            try storage.runMigrations()
+            register(storage, forType: StorageManager.self)
+            return storage
+        } catch {
+            logger.error("CIO StorageManager failed to initialize: \(error)")
+            return nil
+        }
+    }
+
+    /// The registered ``StorageManager``, or `nil` if ``registerStorageManager(cdpApiKey:)``
+    /// has not been called yet or failed.
+    var storageManager: StorageManager? {
+        getOptional(StorageManager.self)
+    }
+
+    private static func databasePath(for cdpApiKey: String) -> String {
+        let appSupport = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        let dir = appSupport
+            .appendingPathComponent("io.customer", isDirectory: true)
+            .appendingPathComponent(cdpApiKey, isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("cio.db").path
+    }
+}

--- a/Sources/Common/Storage/StorageManager.swift
+++ b/Sources/Common/Storage/StorageManager.swift
@@ -31,7 +31,7 @@ public struct StorageManager: Sendable {
         if let value {
             _ = try db.save(SdkMetaRecord(key: key, value: value))
         } else {
-            try db.execute("DELETE FROM sdk_meta WHERE key = ?", key)
+            _ = try db.delete(from: SdkMetaRecord.self, id: key)
         }
     }
 }

--- a/Sources/Common/Storage/StorageManager.swift
+++ b/Sources/Common/Storage/StorageManager.swift
@@ -1,0 +1,67 @@
+import Foundation
+@preconcurrency import SyncSqlCipher
+
+/// Gateway for all encrypted on-disk storage used by the aggregation engine.
+///
+/// Implemented as a `struct` because `SyncSqlCipher.Database` is internally
+/// thread-safe (DispatchQueue-serialized), so `StorageManager` carries no
+/// mutable state of its own.
+public struct StorageManager: Sendable {
+    // public so per-module StorageManager+X.swift extensions can reach it directly.
+    // Restrict to `package` once CocoaPods support is dropped.
+    public let db: Database
+
+    public init(db: Database) {
+        self.db = db
+    }
+
+    /// Apply schema migrations. Must be called once before any other method.
+    /// Pass `extra` migrations from modules that extend the schema.
+    public func runMigrations(extra: [any Migration] = []) throws {
+        try db.migrate([CreateSdkMetaSchema()] + extra)
+    }
+
+    // MARK: - sdk_meta (utility key/value table)
+
+    public func getMetaValue(_ key: String) throws -> String? {
+        try db.fetchOne(SdkMetaRecord.self, id: key)?.value
+    }
+
+    public func setMetaValue(_ value: String?, for key: String) throws {
+        if let value {
+            _ = try db.save(SdkMetaRecord(key: key, value: value))
+        } else {
+            try db.execute("DELETE FROM sdk_meta WHERE key = ?", key)
+        }
+    }
+}
+
+// MARK: - Schema
+
+private struct CreateSdkMetaSchema: Migration {
+    let id = "001-create-sdk-meta"
+
+    func up(_ ctx: MigrationContext) throws {
+        try ctx.execute(
+            """
+            CREATE TABLE IF NOT EXISTS sdk_meta (
+                key   TEXT NOT NULL PRIMARY KEY,
+                value TEXT NOT NULL
+            )
+            """
+        )
+    }
+
+    func down(_ ctx: MigrationContext) throws {}
+}
+
+// MARK: - Entity Records
+
+private struct SdkMetaRecord: Entity {
+    static let tableName = TableName("sdk_meta")
+    static let primaryKeyName = "key"
+    static let primaryKey: WritableKeyPath<SdkMetaRecord, String> & Sendable = \.key
+
+    var key: String
+    var value: String
+}

--- a/Sources/DataPipeline/DataPipeline.swift
+++ b/Sources/DataPipeline/DataPipeline.swift
@@ -59,6 +59,7 @@ public class DataPipeline: ModuleTopLevelObject<DataPipelineInstance>, DataPipel
         shared.initializeModuleIfNotAlready {
             Self.moduleConfig = moduleConfig
 
+            DIGraphShared.shared.registerStorageManager(cdpApiKey: moduleConfig.cdpApiKey)
             return DataPipelineImplementation(diGraph: DIGraphShared.shared, moduleConfig: moduleConfig)
         }
 

--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -1,5 +1,6 @@
 import CioAnalytics
 import CioInternalCommon
+import Foundation
 
 class DataPipelineImplementation: DataPipelineInstance, DataPipelineTracking {
     private let moduleConfig: DataPipelineConfigOptions
@@ -14,6 +15,7 @@ class DataPipelineImplementation: DataPipelineInstance, DataPipelineTracking {
     private let deviceInfo: DeviceInfo
     private let contextPlugin: Context
     private let profileStore: ProfileStore
+    let storageManager: StorageManager?
 
     /// Per-session tracker of the most recently identified userId. Used to dedup
     /// no-traits identify calls against the same userId within a single process
@@ -34,6 +36,7 @@ class DataPipelineImplementation: DataPipelineInstance, DataPipelineTracking {
         self.dateUtil = diGraph.dateUtil
         self.deviceInfo = diGraph.deviceInfo
         self.profileStore = diGraph.profileStore
+        self.storageManager = diGraph.storageManager
 
         self.contextPlugin = Context(diGraph: diGraph)
 

--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -9,7 +9,7 @@ disabled_rules:
   # let foo = try? ...
   # XCTAssertNotNil(foo)
   # XCTAssertEqual(foo?.bar, "")
-  # - force_try
+  - force_try
 
   # `as!` in a test can result in tests being halted and not finish executing. Instead, we would rather have a test fail and continue executing the suite. 
   # Instead of `as!` use: 

--- a/Tests/Common/Storage/StorageManagerTests.swift
+++ b/Tests/Common/Storage/StorageManagerTests.swift
@@ -1,0 +1,60 @@
+@testable import CioInternalCommon
+import SyncSqlCipher
+import XCTest
+
+// StorageManager is tested against an in-memory SQLCipher database so there
+// is no file-system state to clean up between runs.
+class StorageManagerTests: XCTestCase {
+    private var storage: StorageManager!
+
+    override func setUp() {
+        super.setUp()
+        let db = try! Database(path: ":memory:", key: "testkey", walMode: false)
+        storage = StorageManager(db: db)
+        try! storage.runMigrations()
+    }
+
+    // MARK: - Schema
+
+    func test_runMigrations_isIdempotent() throws {
+        XCTAssertNoThrow(try storage.runMigrations())
+    }
+
+    // MARK: - sdk_meta
+
+    func test_getMetaValue_forUnknownKey_returnsNil() throws {
+        XCTAssertNil(try storage.getMetaValue("nonexistent"))
+    }
+
+    func test_setAndGetMetaValue_roundTrip() throws {
+        try storage.setMetaValue("hello", for: "greeting")
+
+        XCTAssertEqual(try storage.getMetaValue("greeting"), "hello")
+    }
+
+    func test_setMetaValue_overwritesExistingValue() throws {
+        try storage.setMetaValue("first", for: "key")
+        try storage.setMetaValue("second", for: "key")
+
+        XCTAssertEqual(try storage.getMetaValue("key"), "second")
+    }
+
+    func test_setMetaValue_withNil_deletesExistingValue() throws {
+        try storage.setMetaValue("value", for: "key")
+        try storage.setMetaValue(nil, for: "key")
+
+        XCTAssertNil(try storage.getMetaValue("key"))
+    }
+
+    func test_setMetaValue_withNil_whenKeyAbsent_doesNotThrow() {
+        XCTAssertNoThrow(try storage.setMetaValue(nil, for: "nonexistent"))
+    }
+
+    func test_metaValues_areIsolatedByKey() throws {
+        try storage.setMetaValue("a", for: "key-a")
+        try storage.setMetaValue("b", for: "key-b")
+
+        XCTAssertEqual(try storage.getMetaValue("key-a"), "a")
+        XCTAssertEqual(try storage.getMetaValue("key-b"), "b")
+    }
+}

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -507,6 +507,13 @@ public interface CioInternalCommon.SharedKeyValueStorage {
 	public fun func setData(_ value: Data?, forKey key: KeyValueStorageKey);
 	public fun func deleteAll();
 }
+public final class CioInternalCommon.StorageManager {
+	public final val db: Database;
+	public fun init(db: Database);
+	public fun func runMigrations(extra: List<any Migration> = []) throws;
+	public fun func getMetaValue(_ key: String) throws -> String?;
+	public fun func setMetaValue(_ value: String?, for key: String) throws;
+}
 public final class CioInternalCommon.StringAnyEncodable {
 	public fun init(logger: Logger, _ data: List<String: Any>);
 	public fun func encode(to encoder: Encoder) throws;


### PR DESCRIPTION
Replaces PR #1089.

Created StorageManager and associated chain in a branch so we can add other features discussed before merging it to the main branch. Future PRs include:
- Using Keychain to store DB Key instead of using the CDP API Key directly.
- Caching the CDP API Key to disk to allow it the Database to be used when DataPipelines isn't initialized.
- The remaining components of EventFiltering.

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After code reviews are approved and you determine this PR is ready to merge, select *Squash and Merge* button on this screen, leave the title and description to the default values, then merge the PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new encrypted local database on the Data Pipeline init path and temporarily derives the DB key from the CDP API key; init failures are handled as nil storage but dependency and tooling changes affect all Common/DataPipeline consumers.
> 
> **Overview**
> Introduces **encrypted on-disk storage** for upcoming aggregation/event-filtering work by adding **SyncSqlCipher** (SPM + CocoaPods) and a new **`StorageManager`** in internal common code.
> 
> **`StorageManager`** opens a SQLCipher database, runs migrations (initial **`sdk_meta`** key/value table), and exposes **`getMetaValue` / `setMetaValue`**. **`DIGraphShared.registerStorageManager(cdpApiKey:)`** creates the DB under Application Support (`io.customer/<cdpApiKey>/cio.db`), uses the CDP API key as the encryption key for now, registers the instance on the DI graph, and returns **`nil`** on failure (logged) so callers can degrade gracefully.
> 
> **`DataPipeline.initialize`** now registers storage **before** constructing **`DataPipelineImplementation`**, which holds an optional **`storageManager`** reference from the graph (no consumer logic in this PR yet). Swift tools version is bumped to **5.10**, **`StorageManagerTests`** cover migrations and meta APIs, and internal API docs are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbde881a1c354fd21f07e109034452f37b000f39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->