### PR TITLE
chore(geofence): make location fix event transient and gate lifecycle types with @_spi

### DIFF
--- a/Sources/Common/Communication/Event+Location.swift
+++ b/Sources/Common/Communication/Event+Location.swift
@@ -25,6 +25,10 @@ public struct LocationAcquiredEvent: EventRepresentable {
     public let location: LocationData
     public let timestamp: Date
 
+    /// Not persisted: a location fix is only useful in the moment, so it is dropped when unobserved
+    /// rather than written to disk for replay.
+    public var isPersistent: Bool { false }
+
     public init(storageId: String = UUID().uuidString, location: LocationData, timestamp: Date = Date(), params: [String: String] = [:]) {
         self.storageId = storageId
         self.location = location

--- a/Sources/Common/Communication/Event.swift
+++ b/Sources/Common/Communication/Event.swift
@@ -16,6 +16,10 @@ public protocol EventRepresentable: Equatable, Codable {
     var params: [String: String] { get }
     /// Timestamp indicating when the event was created.
     var timestamp: Date { get }
+    /// Whether the event should be persisted to disk when posted with no observers, so it can be
+    /// replayed once an observer registers. Defaults to `true`; transient events override to `false`
+    /// and are dropped when unobserved. The in-memory cache applies regardless.
+    var isPersistent: Bool { get }
 }
 
 // Default implementation for `EventRepresentable`
@@ -30,6 +34,8 @@ public extension EventRepresentable {
     var key: String {
         Self.key
     }
+
+    var isPersistent: Bool { true }
 }
 
 // MARK: - Event Types Registry

--- a/Sources/Common/Communication/EventBusHandler.swift
+++ b/Sources/Common/Communication/EventBusHandler.swift
@@ -127,7 +127,7 @@ public class CioEventBusHandler: EventBusHandler {
         let hasObservers = await eventBus.post(event)
         await eventCache.addEvent(event: event)
 
-        if !hasObservers {
+        if !hasObservers, event.isPersistent {
             logger.debug("EventBusHandler: Storing event in memory - \(event)")
             await storeEvent(event)
         }

--- a/Sources/Location/AppLifecycleNotifying.swift
+++ b/Sources/Location/AppLifecycleNotifying.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Token returned when registering a lifecycle observer. Retain the token; call `remove()` to unregister, or let it deallocate and the registration is removed automatically.
 ///
-/// SDK-internal infrastructure: `public` so the geofence module (which depends on Location)
-/// can reuse it. Not intended for app code.
-public protocol AppLifecycleObserverToken: AnyObject {
+/// SDK-internal infrastructure: `@_spi(Internal)` so the geofence module (which depends on Location)
+/// can reuse it without exposing it on the public API. Not intended for app code.
+@_spi(Internal) public protocol AppLifecycleObserverToken: AnyObject {
     /// Unregisters the observer. Safe to call multiple times; only the first call has effect.
     func remove()
 }
@@ -12,9 +12,9 @@ public protocol AppLifecycleObserverToken: AnyObject {
 /// Abstracts registration for app lifecycle notifications (didBecomeActive, didEnterBackground).
 /// Enables tests to simulate lifecycle events without NotificationCenter or run loop.
 ///
-/// SDK-internal infrastructure: `public` so the geofence module (which depends on Location)
-/// can reuse it. Not intended for app code.
-public protocol AppLifecycleNotifying: AnyObject {
+/// SDK-internal infrastructure: `@_spi(Internal)` so the geofence module (which depends on Location)
+/// can reuse it without exposing it on the public API. Not intended for app code.
+@_spi(Internal) public protocol AppLifecycleNotifying: AnyObject {
     /// Registers for UIApplication.didBecomeActiveNotification. The block is invoked when the app becomes active.
     /// - Parameter block: Called when the notification fires (production: on main queue).
     /// - Returns: Token to retain; call `remove()` to unregister or release the token to unregister on dealloc.

--- a/Sources/Location/RealAppLifecycleNotifying.swift
+++ b/Sources/Location/RealAppLifecycleNotifying.swift
@@ -4,7 +4,7 @@ import UIKit
 /// Production implementation that registers for app lifecycle notifications via NotificationCenter.
 /// Observers are invoked on the main queue.
 /// Uses `RegistrationToken` so that when the token is released, the observer is automatically removed.
-public final class RealAppLifecycleNotifying: AppLifecycleNotifying {
+@_spi(Internal) public final class RealAppLifecycleNotifying: AppLifecycleNotifying {
     private let notificationCenter: NotificationCenter
 
     public init(notificationCenter: NotificationCenter = .default) {

--- a/Sources/LocationGeofence/GeofenceModuleState.swift
+++ b/Sources/LocationGeofence/GeofenceModuleState.swift
@@ -1,5 +1,5 @@
 import CioInternalCommon
-import CioLocation
+@_spi(Internal) import CioLocation
 import Foundation
 
 /// Holds the Geofence module's runtime state and performs one-time setup.

--- a/Tests/Common/Communication/EventBusHandlerTests.swift
+++ b/Tests/Common/Communication/EventBusHandlerTests.swift
@@ -142,6 +142,25 @@ class EventBusHandlerTest: UnitTest {
         )
     }
 
+    func test_postEventAndWait_givenNoObserversAndTransientEvent_expectEventNotStored() async throws {
+        let eventBusHandler = initializeEventBusHandler()
+
+        // Given: a transient event (isPersistent == false) and an EventBus without observers
+        mockEventBus.postReturnValue = false
+        let event = LocationAcquiredEvent(location: LocationData(latitude: 0, longitude: 0))
+
+        // When: the event is posted and the full post/store sequence completes
+        await eventBusHandler.postEventAndWait(event)
+
+        // Then: it is posted but never written to persistent storage, even with no observers,
+        // so location-only apps don't accumulate undrained files on disk
+        XCTAssertEqual(mockEventBus.postCallsCount, 1, "post should be called once on EventBus")
+        XCTAssertEqual(
+            mockEventStorage.storeCallsCount, 0,
+            "Transient event should not be stored even when there are no observers"
+        )
+    }
+
     func test_postEvent_givenTimestampedEvent_expectObserverReceivesCorrectTimestamp() async throws {
         let eventBusHandler = initializeEventBusHandler()
         let eventPostedTimestamp = Date()

--- a/Tests/Location/LocationLifecycleObserverTest.swift
+++ b/Tests/Location/LocationLifecycleObserverTest.swift
@@ -1,4 +1,4 @@
-@testable import CioLocation
+@_spi(Internal) @testable import CioLocation
 import SharedTests
 import Testing
 

--- a/Tests/Location/LocationServicesImplementationTest.swift
+++ b/Tests/Location/LocationServicesImplementationTest.swift
@@ -1,5 +1,5 @@
 @testable import CioInternalCommon
-@testable import CioLocation
+@_spi(Internal) @testable import CioLocation
 import CoreLocation
 import SharedTests
 import Testing

--- a/Tests/Location/Stub/NoOpAppLifecycleNotifying.swift
+++ b/Tests/Location/Stub/NoOpAppLifecycleNotifying.swift
@@ -1,4 +1,4 @@
-@testable import CioLocation
+@_spi(Internal) @testable import CioLocation
 import Foundation
 
 /// No-op implementation of AppLifecycleNotifying for tests that don't need lifecycle behavior.

--- a/Tests/Location/Stub/StubAppLifecycleNotifying.swift
+++ b/Tests/Location/Stub/StubAppLifecycleNotifying.swift
@@ -1,4 +1,4 @@
-@testable import CioLocation
+@_spi(Internal) @testable import CioLocation
 import Foundation
 
 /// Stub implementation of AppLifecycleNotifying for tests. Holds registered blocks and exposes

--- a/Tests/LocationGeofence/GeofenceModuleSetupTests.swift
+++ b/Tests/LocationGeofence/GeofenceModuleSetupTests.swift
@@ -1,5 +1,5 @@
 @testable import CioInternalCommon
-import CioLocation
+@_spi(Internal) import CioLocation
 @testable import CioLocationGeofence
 import CoreLocation
 import Foundation

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -264,6 +264,7 @@ public interface CioInternalCommon.EventRepresentable {
 	public var storageId: String;
 	public var params: List<String : String>;
 	public var timestamp: Date;
+	public var isPersistent: Boolean;
 }
 public interface CioInternalCommon.EventStorage {
 	public fun func store(event: AnyEventRepresentable) async throws;
@@ -342,6 +343,7 @@ public final class CioInternalCommon.LocationAcquiredEvent {
 	public final val params: List<String : String>;
 	public final val location: LocationData;
 	public final val timestamp: Date;
+	public var isPersistent: Boolean;
 	public fun init(storageId: String = UUID().uuidString, location: LocationData, timestamp: Date = Date(), params: List<String: String> = List<:>);
 }
 public final class CioInternalCommon.LocationData {


### PR DESCRIPTION
Follow-up to the geofence module split stack (#1094, #1095, #1096) addressing two review items.

## Event persistence
`EventRepresentable` gains `isPersistent` (defaults to `true`); `LocationAcquiredEvent` overrides it to `false`. The EventBus persists an event to disk only when it has no observers, for later replay. A location fix is transient — in a location-only app (no geofence module observing it) there is no consumer, so persisting would accumulate undrained files on disk.

## `@_spi(Internal)` lifecycle types
`AppLifecycleNotifying`, `AppLifecycleObserverToken`, and `RealAppLifecycleNotifying` move from `public` to `@_spi(Internal) public` so the geofence module (which depends on Location) can reuse them without exposing SDK-internal infrastructure on the public API.

## Tests
- Added `test_postEventAndWait_givenNoObserversAndTransientEvent_expectEventNotStored` guarding the transient path. The persistent path is already covered by `test_postEvent_givenNoObservers_expectEventStoredInFile`.
- Test consumers of the lifecycle types now import via `@_spi(Internal)`.

## Notes
- `CioLocation.api` shows no diff: sourcekitten still lists `@_spi` symbols, so the baseline does not reflect the visibility change (the symbols are still hidden from a plain `import CioLocation`).
- `CioInternalCommon.api` updated for the new `isPersistent` requirement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted EventBus persistence behavior and SPI visibility tightening; existing persistent events keep default behavior and the change is covered by a new unit test.
> 
> **Overview**
> Adds **`isPersistent`** on `EventRepresentable` (default `true`) and gates **disk persistence** in `EventBusHandler` so unobserved events are stored only when `isPersistent` is true. **`LocationAcquiredEvent`** sets `isPersistent` to `false`, avoiding undrained on-disk event files in location-only apps with no geofence observer.
> 
> **`AppLifecycleNotifying`**, **`AppLifecycleObserverToken`**, and **`RealAppLifecycleNotifying`** are now **`@_spi(Internal) public`** instead of plain `public`; geofence and tests import them via `@_spi(Internal) import CioLocation`. **`CioInternalCommon.api`** documents the new protocol property; a test asserts transient events are not stored when there are no observers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1581cabe6a43f04471d2597aa6eec06165a50429. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->