### PR TITLE
chore(geofence): declare data collection in privacy manifest

### DIFF
--- a/Sources/LocationGeofence/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/LocationGeofence/Resources/PrivacyInfo.xcprivacy
@@ -6,10 +6,13 @@
 	Docs for this section: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests
 	This section describes what information this module collects about the app user.
 
-	NOTE: the data-use declaration is intentionally left empty for now. The geofence module
-	collects precise location (linked to the identified profile) and sends it to Customer.io;
-	the NSPrivacyCollectedDataTypes entry below must be completed, after privacy review, before
-	this module is released.
+	The geofence module reports region entry/exit to Customer.io as a "Geofence
+	Entered/Exited" event (geofence id + transition type) tied to the identified
+	user — product-interaction + user-id data. It does not send the device's
+	coordinates, so no location data type is collected.
+
+	`NSPrivacyCollectedDataTypeLinked` is false because anonymous profiles make
+	linkage to a person optional.
 
 	The SDK does NOT request location permissions - host apps are responsible for:
 	- Adding NSLocationWhenInUseUsageDescription / NSLocationAlwaysAndWhenInUseUsageDescription to their Info.plist
@@ -17,6 +20,34 @@
 	-->
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeProductInteraction</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+				<string>NSPrivacyCollectedDataTypePurposeProductPersonalization</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeUserID</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+				<string>NSPrivacyCollectedDataTypePurposeProductPersonalization</string>
+			</array>
+		</dict>
 	</array>
 
 	<!--


### PR DESCRIPTION
[MBL-1782](https://linear.app/customerio/issue/MBL-1782)

## Summary
Sets the geofence module's `PrivacyInfo.xcprivacy` to its intended release state.

| Data type | Linked | Tracking | Purposes |
|---|---|---|---|
| `ProductInteraction` | false | false | App Functionality, Analytics, Product Personalization |
| `UserID` | false | false | App Functionality, Analytics, Product Personalization |

No location data type; `NSPrivacyTracking=false`.

## Rationale
- **Product Interaction** — the SDK auto-generates the "Geofence Entered/Exited" event.
- **User ID** — the module transmits the `userId` in its own `/track` call.
- **No location data type** — the geofence events carry no coordinates ([MBL-1831](https://linear.app/customerio/issue/MBL-1831)), and the SDK will not transmit the device coordinate in the nearby-geofence fetch either (it can fetch the workspace's geofence set and filter to the nearest on-device; on-device location use is not "collection"). So nothing the SDK sends conveys device location.
- `Linked=false` and the purpose set (`App Functionality + Analytics + Product Personalization`) match the other SDK modules (DataPipeline, MessagingInApp, Push) for consistency.

## ⚠️ Depends on two code changes before merge
This manifest reflects the **final** state and assumes both have landed on `feature/geofence-on-device`:
1. **MBL-1831** — geofence events no longer include lat/long (in progress).
2. **Nearby-fetch without a coordinate** — the sync currently sends `GET /geofences/nearby?latitude=…&longitude=…`. Pending team confirmation that fetching the full set (within the cap) and filtering on-device is viable.

If (2) is deferred, a location data type must be added back before this merges (`PreciseLocation` if the fetch keeps sending the exact coordinate, `CoarseLocation` if it sends a reduced one) — a one-line change. Both PRs target `feature/geofence-on-device`; nothing ships until that branch merges, so temporary misalignment is fine.

## Bugbot
- "Purposes inconsistent with other modules" — fixed (aligned to App Functionality / Analytics / Product Personalization).
- "PreciseLocation vs no-location" — resolved; the location declaration is removed.

## Scope / test plan
- `Sources/LocationGeofence/Resources/PrivacyInfo.xcprivacy` only. No code, no API, no behavior change.
- `plutil -lint` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Privacy manifest metadata only; no runtime code, API, or behavior changes.
> 
> **Overview**
> Fills in **LocationGeofence** `PrivacyInfo.xcprivacy` for release: it now declares **Product Interaction** and **User ID** (both not linked, not used for tracking, with App Functionality / Analytics / Product Personalization purposes), aligned with other SDK modules.
> 
> Inline documentation is updated to state that geofence enter/exit events report geofence id and transition to Customer.io for the identified user **without** device coordinates, so **no location data type** is declared. The previous placeholder note that collection types were intentionally empty pending review is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05974605d7b0319ca84d98658444a3054ecc0e54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->