### PR TITLE
chore(geofence): remove precise location from geofence events

### DIFF
--- a/Sources/Common/Communication/Event.swift
+++ b/Sources/Common/Communication/Event.swift
@@ -163,16 +163,12 @@ public struct TrackGeofenceMetricEvent: EventRepresentable {
     public let geofenceId: String
     public let transition: GeofenceTransition
     public let timestamp: Date
-    public let latitude: Double?
-    public let longitude: Double?
 
     public init(
         storageId: String = UUID().uuidString,
         geofenceId: String,
         transition: GeofenceTransition,
         timestamp: Date = Date(),
-        latitude: Double? = nil,
-        longitude: Double? = nil,
         params: [String: String] = [:]
     ) {
         self.storageId = storageId
@@ -180,8 +176,6 @@ public struct TrackGeofenceMetricEvent: EventRepresentable {
         self.geofenceId = geofenceId
         self.transition = transition
         self.timestamp = timestamp
-        self.latitude = latitude
-        self.longitude = longitude
     }
 }
 

--- a/Sources/DataPipeline/DataPipelineImplementation+GeofenceObserver.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation+GeofenceObserver.swift
@@ -10,13 +10,11 @@ extension DataPipelineImplementation {
     /// `metric.timestamp` so a flush replayed hours after capture still attributes
     /// the transition to when it happened, not when it was sent.
     func processGeofenceMetricEvent(_ metric: TrackGeofenceMetricEvent) {
-        var properties: [String: Any] = [
+        let properties: [String: Any] = [
             "geofence_id": metric.geofenceId,
             "transition_type": metric.transition.rawValue,
             "timestamp": Int(metric.timestamp.timeIntervalSince1970)
         ]
-        if let latitude = metric.latitude { properties["latitude"] = latitude }
-        if let longitude = metric.longitude { properties["longitude"] = longitude }
         var trackEvent = TrackEvent(event: metric.transition.trackEventName, properties: try? JSON(properties))
         trackEvent.timestamp = metric.timestamp.string(format: .iso8601WithMilliseconds)
         analytics.process(event: trackEvent)

--- a/Sources/LocationGeofence/Event/GeofenceDeliveryTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceDeliveryTracker.swift
@@ -33,13 +33,11 @@ final class GeofenceDeliveryTrackerImpl: GeofenceDeliveryTracker {
             return onComplete(.failure(.invalidRequest))
         }
 
-        var properties: [String: Any] = [
+        let properties: [String: Any] = [
             "geofence_id": metric.geofenceId,
             "transition_type": metric.transition.rawValue,
             "timestamp": Int(metric.timestamp.timeIntervalSince1970)
         ]
-        if let latitude = metric.latitude { properties["latitude"] = latitude }
-        if let longitude = metric.longitude { properties["longitude"] = longitude }
 
         httpClient.sendTrackEvent(
             eventName: metric.transition.trackEventName,

--- a/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
@@ -12,8 +12,8 @@ import Foundation
 ///      row, failure retains it for the next flush
 ///    - No stamped userId → post to EventBus and drain; DataPipeline records
 ///      the transition under its current identity (anonymous tracking when no
-///      one is identified). The captured timestamp + coordinates flow through
-///      the event so both paths attribute the transition to when it happened
+///      one is identified). The captured timestamp flows through the event so
+///      both paths attribute the transition to when it happened
 ///
 /// `flushPending()` replays queued rows on module init and on every `ProfileIdentifiedEvent`.
 /// Concurrent deliveries for the same row are deduplicated in-process via the active-delivery
@@ -56,8 +56,7 @@ final class GeofenceEventTracker: @unchecked Sendable {
     /// Persists the metric, then hands it to `deliver`.
     func trackTransition(
         geofenceId: String,
-        transition: GeofenceTransition,
-        location: LocationData? = nil
+        transition: GeofenceTransition
     ) async {
         let cooldownKey = "\(geofenceId):\(transition.rawValue)"
         let now = dateUtil.now
@@ -78,8 +77,6 @@ final class GeofenceEventTracker: @unchecked Sendable {
         let metric = PendingGeofenceMetric(
             geofenceId: geofenceId,
             transition: transition,
-            latitude: location?.latitude,
-            longitude: location?.longitude,
             timestamp: now,
             userId: stampedUserId
         )
@@ -135,16 +132,14 @@ final class GeofenceEventTracker: @unchecked Sendable {
     }
 
     /// Anonymous-attribution fallback used when a row carries no stamped userId.
-    /// The captured `timestamp` and coordinates flow through the event so DataPipeline
-    /// can record the transition under the moment it actually happened, not the
-    /// moment the flush ran.
+    /// The captured `timestamp` flows through the event so DataPipeline can record
+    /// the transition under the moment it actually happened, not the moment the
+    /// flush ran.
     private func postEventBus(metric: PendingGeofenceMetric) {
         eventBusHandler.postEvent(TrackGeofenceMetricEvent(
             geofenceId: metric.geofenceId,
             transition: metric.transition,
-            timestamp: metric.timestamp,
-            latitude: metric.latitude,
-            longitude: metric.longitude
+            timestamp: metric.timestamp
         ))
         logger.geofenceEventTracked(geofenceId: metric.geofenceId, transition: metric.transition)
     }

--- a/Sources/LocationGeofence/GeofenceMonitorBinder.swift
+++ b/Sources/LocationGeofence/GeofenceMonitorBinder.swift
@@ -27,7 +27,7 @@ enum GeofenceMonitorBinder {
                 Task { _ = await coordinator?.handleMovement(latitude: location.latitude, longitude: location.longitude) }
                 return
             }
-            Task { await tracker?.trackTransition(geofenceId: identifier, transition: transition, location: location) }
+            Task { await tracker?.trackTransition(geofenceId: identifier, transition: transition) }
         }
     }
 }

--- a/Sources/LocationGeofence/Storage/PendingGeofenceMetric.swift
+++ b/Sources/LocationGeofence/Storage/PendingGeofenceMetric.swift
@@ -6,8 +6,6 @@ import Foundation
 struct PendingGeofenceMetric: Codable, Equatable, Sendable {
     let geofenceId: String
     let transition: GeofenceTransition
-    let latitude: Double?
-    let longitude: Double?
     let timestamp: Date
     /// The userId identified at capture time, or `nil` if none was identified.
     let userId: String?
@@ -24,15 +22,11 @@ struct PendingGeofenceMetric: Codable, Equatable, Sendable {
     init(
         geofenceId: String,
         transition: GeofenceTransition,
-        latitude: Double?,
-        longitude: Double?,
         timestamp: Date,
         userId: String?
     ) {
         self.geofenceId = geofenceId
         self.transition = transition
-        self.latitude = latitude
-        self.longitude = longitude
         self.timestamp = timestamp
         self.userId = userId
     }
@@ -40,8 +34,6 @@ struct PendingGeofenceMetric: Codable, Equatable, Sendable {
     enum CodingKeys: String, CodingKey {
         case geofenceId = "geofence_id"
         case transition
-        case latitude
-        case longitude
         case timestamp
         case userId = "user_id"
     }

--- a/Tests/DataPipeline/DataPipelineEventBustTests.swift
+++ b/Tests/DataPipeline/DataPipelineEventBustTests.swift
@@ -66,9 +66,7 @@ class DataPipelineEventBustTests: IntegrationTest {
             TrackGeofenceMetricEvent(
                 geofenceId: givenGeofenceId,
                 transition: .enter,
-                timestamp: capturedAt,
-                latitude: 12.34,
-                longitude: 56.78
+                timestamp: capturedAt
             )
         )
 
@@ -83,8 +81,8 @@ class DataPipelineEventBustTests: IntegrationTest {
         XCTAssertEqual(properties["geofence_id"] as? String, givenGeofenceId)
         XCTAssertEqual(properties["transition_type"] as? String, "enter")
         XCTAssertEqual(properties["timestamp"] as? Int, Int(capturedAt.timeIntervalSince1970))
-        XCTAssertEqual(properties["latitude"] as? Double ?? 0, 12.34, accuracy: 0.0001)
-        XCTAssertEqual(properties["longitude"] as? Double ?? 0, 56.78, accuracy: 0.0001)
+        XCTAssertNil(properties["latitude"])
+        XCTAssertNil(properties["longitude"])
         XCTAssertEqual(trackEvent.timestamp, capturedAt.string(format: .iso8601WithMilliseconds))
     }
 

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceDeliveryTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceDeliveryTrackerTests.swift
@@ -16,15 +16,11 @@ struct GeofenceDeliveryTrackerTests {
     private func makeMetric(
         geofenceId: String = "geo_1",
         transition: GeofenceTransition = .enter,
-        latitude: Double? = 12.34,
-        longitude: Double? = 56.78,
         timestamp: Date = Date(timeIntervalSince1970: 1700000000)
     ) -> PendingGeofenceMetric {
         PendingGeofenceMetric(
             geofenceId: geofenceId,
             transition: transition,
-            latitude: latitude,
-            longitude: longitude,
             timestamp: timestamp,
             userId: nil
         )
@@ -49,9 +45,9 @@ struct GeofenceDeliveryTrackerTests {
         let properties = args?.properties ?? [:]
         #expect(properties["geofence_id"] as? String == "geo_1")
         #expect(properties["transition_type"] as? String == "enter")
-        #expect(properties["latitude"] as? Double == 12.34)
-        #expect(properties["longitude"] as? Double == 56.78)
         #expect(properties["timestamp"] as? Int == 1700000000)
+        #expect(properties["latitude"] == nil)
+        #expect(properties["longitude"] == nil)
     }
 
     @Test
@@ -66,23 +62,6 @@ struct GeofenceDeliveryTrackerTests {
         }
 
         #expect(httpClient.sendTrackEventReceivedArguments?.eventName == "CIO Geofence Exited")
-    }
-
-    @Test
-    func trackMetric_givenNilCoordinates_expectOmittedFromProperties() async {
-        let (tracker, httpClient) = makeTracker()
-        httpClient.sendTrackEventClosure = { _, _, _, completion in completion(.success(())) }
-
-        await withCheckedContinuation { continuation in
-            tracker.trackMetric(
-                metric: makeMetric(latitude: nil, longitude: nil),
-                userId: "user_42"
-            ) { _ in continuation.resume() }
-        }
-
-        let properties = httpClient.sendTrackEventReceivedArguments?.properties ?? [:]
-        #expect(properties["latitude"] == nil)
-        #expect(properties["longitude"] == nil)
     }
 
     // MARK: - Guard clauses

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -116,11 +116,7 @@ struct GeofenceEventTrackerTests {
             dateUtil: dateUtil
         )
 
-        await tracker.trackTransition(
-            geofenceId: "geo_1",
-            transition: .enter,
-            location: LocationData(latitude: 12.34, longitude: 56.78)
-        )
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
 
         // Anonymous capture: stamped userId is nil. HTTP path can't attribute,
         // so the row is handed off to EventBus → DataPipeline (anonymous track)
@@ -133,8 +129,6 @@ struct GeofenceEventTrackerTests {
         #expect(posted.first?.geofenceId == "geo_1")
         #expect(posted.first?.transition == .enter)
         #expect(posted.first?.timestamp == captureTime)
-        #expect(posted.first?.latitude == 12.34)
-        #expect(posted.first?.longitude == 56.78)
     }
 
     // MARK: - Cooldown
@@ -422,7 +416,6 @@ struct GeofenceEventTrackerTests {
         // Row was captured under user_A; current user is now user_B (after sign-out + new sign-in).
         _ = await pending.append(PendingGeofenceMetric(
             geofenceId: "geo_1", transition: .enter,
-            latitude: nil, longitude: nil,
             timestamp: Date(timeIntervalSince1970: 1),
             userId: "user_A"
         ))
@@ -448,7 +441,6 @@ struct GeofenceEventTrackerTests {
         let pending = makePendingStore(directory: dir)
         _ = await pending.append(PendingGeofenceMetric(
             geofenceId: "geo_1", transition: .enter,
-            latitude: nil, longitude: nil,
             timestamp: Date(timeIntervalSince1970: 1),
             userId: "user_A"
         ))
@@ -475,7 +467,6 @@ struct GeofenceEventTrackerTests {
         let capturedAt = Date(timeIntervalSince1970: 1700000000)
         _ = await pending.append(PendingGeofenceMetric(
             geofenceId: "geo_1", transition: .enter,
-            latitude: 12.34, longitude: 56.78,
             timestamp: capturedAt,
             userId: nil
         ))
@@ -499,7 +490,5 @@ struct GeofenceEventTrackerTests {
         let posted = postedGeofenceEvents(from: bus)
         #expect(posted.count == 1)
         #expect(posted.first?.timestamp == capturedAt)
-        #expect(posted.first?.latitude == 12.34)
-        #expect(posted.first?.longitude == 56.78)
     }
 }

--- a/Tests/LocationGeofence/Geofence/Storage/PendingGeofenceMetricStoreTests.swift
+++ b/Tests/LocationGeofence/Geofence/Storage/PendingGeofenceMetricStoreTests.swift
@@ -18,8 +18,6 @@ struct PendingGeofenceMetricStoreTests {
         PendingGeofenceMetric(
             geofenceId: geofenceId,
             transition: transition,
-            latitude: 12.34,
-            longitude: 56.78,
             timestamp: Date(timeIntervalSince1970: 1700000000),
             userId: nil
         )
@@ -261,8 +259,6 @@ struct PendingGeofenceMetricStoreTests {
                             _ = await store.append(PendingGeofenceMetric(
                                 geofenceId: "geo_\(i)_\(j)",
                                 transition: .enter,
-                                latitude: nil,
-                                longitude: nil,
                                 timestamp: Date(),
                                 userId: nil
                             ))

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -592,9 +592,7 @@ public final class CioInternalCommon.TrackGeofenceMetricEvent {
 	public final val geofenceId: String;
 	public final val transition: GeofenceTransition;
 	public final val timestamp: Date;
-	public final val latitude: Double?;
-	public final val longitude: Double?;
-	public fun init(storageId: String = UUID().uuidString, geofenceId: String, transition: GeofenceTransition, timestamp: Date = Date(), latitude: Double? = nil, longitude: Double? = nil, params: List<String: String> = List<:>);
+	public fun init(storageId: String = UUID().uuidString, geofenceId: String, transition: GeofenceTransition, timestamp: Date = Date(), params: List<String: String> = List<:>);
 }
 public final class CioInternalCommon.TrackInAppMetricEvent {
 	public final val storageId: String;


### PR DESCRIPTION
[MBL-1831](https://linear.app/customerio/issue/MBL-1831)

## Summary
Geofence `Entered`/`Exited` events no longer carry the device's latitude/longitude. A consumer only needs the geofence id + transition type to act, so emitting the user's exact coordinates added needless privacy/legal/compliance burden. The triggering location is still read on-device to drive the movement-trigger re-sync — it is just no longer attached to the event.

Ports the Android change (`customerio-android` `b2c260f5`, PR #739).

## Changes
- Drop `latitude`/`longitude` from `TrackGeofenceMetricEvent` (public — api-docs baseline regenerated), `PendingGeofenceMetric` (incl. `CodingKeys`), and both delivery channels:
  - direct HTTP — `GeofenceDeliveryTracker`
  - EventBus → analytics — `DataPipelineImplementation+GeofenceObserver`
- Drop the now-unused `location` parameter from `GeofenceEventTracker.trackTransition` and the `GeofenceMonitorBinder` call site (the movement-trigger branch still reads the location).

Both delivery channels now emit `geofence_id + transition_type + timestamp` only.

## Scope
Coordinate removal from the **events** only. Android also bundled a top-level `timestamp` tweak ("related to MBL-1780") — handled separately in the follow-up #1106.

## Test plan
- `LocationGeofenceTests` — 153 tests / 13 suites pass.
- `DataPipelineEventBustTests` — 5/5 pass; asserts both channels exclude `latitude`/`longitude`.
- Updated tests to assert coordinates are absent; removed the now-moot null-coordinate tests.
- `make format` / `make lint` clean; api-docs baseline regenerated for the `TrackGeofenceMetricEvent` change.

## Notes
- Backward-compatible with queued data: a `PendingGeofenceMetric` persisted by an older SDK still has `latitude`/`longitude` on disk; the decoder ignores unknown keys, so those rows still decode (coordinates dropped, as intended).
- The privacy manifest update is tracked separately (not in this PR).

## Stack
Both target `feature/geofence-on-device`, merge in order:
1. #1105 — remove precise location from geofence events (this PR)
2. #1106 — attribute direct-HTTP track events to transition time

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Privacy-focused payload reduction with no auth or delivery-flow changes; movement-trigger still uses coordinates locally.
> 
> **Overview**
> Geofence **Entered** / **Exited** analytics and HTTP payloads no longer include device **latitude** / **longitude**—only `geofence_id`, `transition_type`, and `timestamp`, aligned with the Android SDK change.
> 
> **`TrackGeofenceMetricEvent`**, **`PendingGeofenceMetric`** (including persistence `CodingKeys`), **`GeofenceEventTracker.trackTransition`**, and both send paths (**`GeofenceDeliveryTracker`** direct HTTP and **DataPipeline** EventBus handling) drop coordinate fields. **`GeofenceMonitorBinder`** still passes location into the movement-trigger re-sync path; business geofence tracking no longer accepts a `location` argument.
> 
> Tests and **`CioInternalCommon.api`** were updated to assert coordinates are absent; redundant nil-coordinate coverage was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22e0d4acd60c82c9b9346bd067b749b0ad00f966. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
