### PR TITLE
chore(geofence): attribute direct-HTTP track events to transition time

### DIFF
--- a/Sources/Common/Service/BackgroundDeliveryHttpClient.swift
+++ b/Sources/Common/Service/BackgroundDeliveryHttpClient.swift
@@ -11,6 +11,28 @@ public enum BackgroundDeliveryHttpError: Error, Equatable {
     case transport
 }
 
+/// One CDP `/track` request for a background-delivery caller. Bundles the request-body fields
+/// into one value so the client signature stays stable as the payload grows.
+public struct BackgroundTrackRequest {
+    /// `track` event name (e.g. `"Geofence Entered"`).
+    public let eventName: String
+    /// Identified user id. Caller must validate non-empty before sending.
+    public let userId: String
+    /// Custom event properties payload.
+    public let properties: [String: Any]
+    /// When the event occurred. Serialized into the reserved top-level `timestamp` field so the
+    /// endpoint attributes the event to this instant rather than to when it was received; nil omits
+    /// the field. The client owns the wire format, keeping it identical to the analytics channel.
+    public let timestamp: Date?
+
+    public init(eventName: String, userId: String, properties: [String: Any] = [:], timestamp: Date? = nil) {
+        self.eventName = eventName
+        self.userId = userId
+        self.properties = properties
+        self.timestamp = timestamp
+    }
+}
+
 /// Direct-HTTP POST for background-delivery callers. Composes the `/track` URL from
 /// `apiHost` in `BackgroundDeliveryContextStore` and authenticates with `cdpApiKey`.
 /// Works in cold-wake state — no dependency on MessagingPush or any other module's
@@ -18,14 +40,10 @@ public enum BackgroundDeliveryHttpError: Error, Equatable {
 public protocol BackgroundDeliveryHttpClient: AutoMockable, Sendable {
     /// Sends one CDP `/track` event.
     /// - Parameters:
-    ///   - eventName: `track` event name (e.g. `"Geofence Entered"`).
-    ///   - userId: Identified user id. Caller must validate non-empty before calling.
-    ///   - properties: Event properties payload.
+    ///   - request: The event to deliver. See `BackgroundTrackRequest`.
     ///   - completion: Called on URLSession's delegate queue with success or error.
     func sendTrackEvent(
-        eventName: String,
-        userId: String,
-        properties: [String: Any],
+        _ request: BackgroundTrackRequest,
         completion: @escaping (Result<Void, BackgroundDeliveryHttpError>) -> Void
     )
 }
@@ -71,9 +89,7 @@ public final class BackgroundDeliveryHttpClientImpl: BackgroundDeliveryHttpClien
     }
 
     public func sendTrackEvent(
-        eventName: String,
-        userId: String,
-        properties: [String: Any],
+        _ request: BackgroundTrackRequest,
         completion: @escaping (Result<Void, BackgroundDeliveryHttpError>) -> Void
     ) {
         guard let apiHost = contextStore.currentApiHost, !apiHost.isEmpty else {
@@ -83,11 +99,15 @@ public final class BackgroundDeliveryHttpClientImpl: BackgroundDeliveryHttpClien
             return completion(.failure(.missingCdpApiKey))
         }
 
-        let body: [String: Any] = [
-            "event": eventName,
-            "userId": userId,
-            "properties": properties
+        var body: [String: Any] = [
+            "event": request.eventName,
+            "userId": request.userId,
+            "properties": request.properties
         ]
+        // Reserved top-level field: a bare integer here is read as milliseconds, so send the ISO-8601 string.
+        if let timestamp = request.timestamp {
+            body["timestamp"] = timestamp.string(format: .iso8601WithMilliseconds)
+        }
         guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else {
             return completion(.failure(.invalidRequest))
         }

--- a/Sources/Common/autogenerated/AutoMockable.generated.swift
+++ b/Sources/Common/autogenerated/AutoMockable.generated.swift
@@ -110,21 +110,21 @@ public class BackgroundDeliveryHttpClientMock: BackgroundDeliveryHttpClient, Moc
     }
 
     /// The arguments from the *last* time the function was called.
-    @Atomic public private(set) var sendTrackEventReceivedArguments: (eventName: String, userId: String, properties: [String: Any], completion: (Result<Void, BackgroundDeliveryHttpError>) -> Void)?
+    @Atomic public private(set) var sendTrackEventReceivedArguments: (request: BackgroundTrackRequest, completion: (Result<Void, BackgroundDeliveryHttpError>) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    @Atomic public private(set) var sendTrackEventReceivedInvocations: [(eventName: String, userId: String, properties: [String: Any], completion: (Result<Void, BackgroundDeliveryHttpError>) -> Void)] = []
+    @Atomic public private(set) var sendTrackEventReceivedInvocations: [(request: BackgroundTrackRequest, completion: (Result<Void, BackgroundDeliveryHttpError>) -> Void)] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    public var sendTrackEventClosure: ((String, String, [String: Any], @escaping (Result<Void, BackgroundDeliveryHttpError>) -> Void) -> Void)?
+    public var sendTrackEventClosure: ((BackgroundTrackRequest, @escaping (Result<Void, BackgroundDeliveryHttpError>) -> Void) -> Void)?
 
-    /// Mocked function for `sendTrackEvent(eventName: String, userId: String, properties: [String: Any], completion: @escaping (Result<Void, BackgroundDeliveryHttpError>) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
-    public func sendTrackEvent(eventName: String, userId: String, properties: [String: Any], completion: @escaping (Result<Void, BackgroundDeliveryHttpError>) -> Void) {
+    /// Mocked function for `sendTrackEvent(_ request: BackgroundTrackRequest, completion: @escaping (Result<Void, BackgroundDeliveryHttpError>) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func sendTrackEvent(_ request: BackgroundTrackRequest, completion: @escaping (Result<Void, BackgroundDeliveryHttpError>) -> Void) {
         mockCalled = true
         sendTrackEventCallsCount += 1
-        sendTrackEventReceivedArguments = (eventName: eventName, userId: userId, properties: properties, completion: completion)
-        sendTrackEventReceivedInvocations.append((eventName: eventName, userId: userId, properties: properties, completion: completion))
-        sendTrackEventClosure?(eventName, userId, properties, completion)
+        sendTrackEventReceivedArguments = (request: request, completion: completion)
+        sendTrackEventReceivedInvocations.append((request: request, completion: completion))
+        sendTrackEventClosure?(request, completion)
     }
 }
 

--- a/Sources/LocationGeofence/Event/GeofenceDeliveryTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceDeliveryTracker.swift
@@ -40,9 +40,12 @@ final class GeofenceDeliveryTrackerImpl: GeofenceDeliveryTracker {
         ]
 
         httpClient.sendTrackEvent(
-            eventName: metric.transition.trackEventName,
-            userId: userId,
-            properties: properties,
+            BackgroundTrackRequest(
+                eventName: metric.transition.trackEventName,
+                userId: userId,
+                properties: properties,
+                timestamp: metric.timestamp
+            ),
             completion: onComplete
         )
     }

--- a/Tests/Common/Service/BackgroundDeliveryHttpClientTests.swift
+++ b/Tests/Common/Service/BackgroundDeliveryHttpClientTests.swift
@@ -39,9 +39,12 @@ struct BackgroundDeliveryHttpClientTests {
 
         await withCheckedContinuation { continuation in
             client.sendTrackEvent(
-                eventName: "CIO Geofence Entered",
-                userId: "user_42",
-                properties: ["geofence_id": "geo_1", "transition_type": "enter"]
+                BackgroundTrackRequest(
+                    eventName: "CIO Geofence Entered",
+                    userId: "user_42",
+                    properties: ["geofence_id": "geo_1", "transition_type": "enter"],
+                    timestamp: Date(timeIntervalSince1970: 1700000000)
+                )
             ) { _ in continuation.resume() }
         }
 
@@ -54,9 +57,26 @@ struct BackgroundDeliveryHttpClientTests {
         let body = params?.body.flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] }
         #expect(body?["event"] as? String == "CIO Geofence Entered")
         #expect(body?["userId"] as? String == "user_42")
+        #expect(body?["timestamp"] as? String == "2023-11-14T22:13:20.000Z")
         let properties = body?["properties"] as? [String: Any]
         #expect(properties?["geofence_id"] as? String == "geo_1")
         #expect(properties?["transition_type"] as? String == "enter")
+    }
+
+    @Test
+    func sendTrackEvent_givenNilTimestamp_expectTimestampOmittedFromBody() async {
+        let (client, runner) = makeClient(store: makeStore())
+        runner.requestClosure = { _, _, onComplete in onComplete(Data(), makeOkResponse(), nil) }
+
+        await withCheckedContinuation { continuation in
+            client.sendTrackEvent(BackgroundTrackRequest(eventName: "event", userId: "user")) { _ in
+                continuation.resume()
+            }
+        }
+
+        let body = runner.requestReceivedArguments?.params.body
+            .flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] }
+        #expect(body?["timestamp"] == nil)
     }
 
     @Test
@@ -65,7 +85,7 @@ struct BackgroundDeliveryHttpClientTests {
         runner.requestClosure = { _, _, onComplete in onComplete(Data(), makeOkResponse(), nil) }
 
         await withCheckedContinuation { continuation in
-            client.sendTrackEvent(eventName: "event", userId: "user", properties: [:]) { _ in
+            client.sendTrackEvent(BackgroundTrackRequest(eventName: "event", userId: "user")) { _ in
                 continuation.resume()
             }
         }
@@ -80,7 +100,7 @@ struct BackgroundDeliveryHttpClientTests {
         let (client, runner) = makeClient(store: makeStore(host: nil))
 
         let result: Result<Void, BackgroundDeliveryHttpError> = await withCheckedContinuation { continuation in
-            client.sendTrackEvent(eventName: "event", userId: "user", properties: [:]) { continuation.resume(returning: $0) }
+            client.sendTrackEvent(BackgroundTrackRequest(eventName: "event", userId: "user")) { continuation.resume(returning: $0) }
         }
 
         #expect(runner.requestCallsCount == 0)
@@ -96,7 +116,7 @@ struct BackgroundDeliveryHttpClientTests {
         let (client, runner) = makeClient(store: makeStore(cdpApiKey: nil))
 
         let result: Result<Void, BackgroundDeliveryHttpError> = await withCheckedContinuation { continuation in
-            client.sendTrackEvent(eventName: "event", userId: "user", properties: [:]) { continuation.resume(returning: $0) }
+            client.sendTrackEvent(BackgroundTrackRequest(eventName: "event", userId: "user")) { continuation.resume(returning: $0) }
         }
 
         #expect(runner.requestCallsCount == 0)
@@ -115,7 +135,7 @@ struct BackgroundDeliveryHttpClientTests {
         runner.requestClosure = { _, _, onComplete in onComplete(nil, makeOkResponse(statusCode: 500), nil) }
 
         let result: Result<Void, BackgroundDeliveryHttpError> = await withCheckedContinuation { continuation in
-            client.sendTrackEvent(eventName: "event", userId: "user", properties: [:]) { continuation.resume(returning: $0) }
+            client.sendTrackEvent(BackgroundTrackRequest(eventName: "event", userId: "user")) { continuation.resume(returning: $0) }
         }
 
         if case .failure(let error) = result {
@@ -131,7 +151,7 @@ struct BackgroundDeliveryHttpClientTests {
         runner.requestClosure = { _, _, onComplete in onComplete(nil, makeOkResponse(statusCode: 204), nil) }
 
         let result: Result<Void, BackgroundDeliveryHttpError> = await withCheckedContinuation { continuation in
-            client.sendTrackEvent(eventName: "event", userId: "user", properties: [:]) { continuation.resume(returning: $0) }
+            client.sendTrackEvent(BackgroundTrackRequest(eventName: "event", userId: "user")) { continuation.resume(returning: $0) }
         }
 
         if case .failure = result { Issue.record("expected success for 204") }
@@ -143,7 +163,7 @@ struct BackgroundDeliveryHttpClientTests {
         runner.requestClosure = { _, _, onComplete in onComplete(nil, nil, URLError(.notConnectedToInternet)) }
 
         let result: Result<Void, BackgroundDeliveryHttpError> = await withCheckedContinuation { continuation in
-            client.sendTrackEvent(eventName: "event", userId: "user", properties: [:]) { continuation.resume(returning: $0) }
+            client.sendTrackEvent(BackgroundTrackRequest(eventName: "event", userId: "user")) { continuation.resume(returning: $0) }
         }
 
         if case .failure(let error) = result {

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceDeliveryTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceDeliveryTrackerTests.swift
@@ -31,7 +31,7 @@ struct GeofenceDeliveryTrackerTests {
     @Test
     func trackMetric_givenEnterTransition_expectAndroidWireFormat() async {
         let (tracker, httpClient) = makeTracker()
-        httpClient.sendTrackEventClosure = { _, _, _, completion in completion(.success(())) }
+        httpClient.sendTrackEventClosure = { _, completion in completion(.success(())) }
 
         await withCheckedContinuation { continuation in
             tracker.trackMetric(metric: makeMetric(), userId: "user_42") { _ in
@@ -40,9 +40,10 @@ struct GeofenceDeliveryTrackerTests {
         }
 
         let args = httpClient.sendTrackEventReceivedArguments
-        #expect(args?.eventName == "CIO Geofence Entered")
-        #expect(args?.userId == "user_42")
-        let properties = args?.properties ?? [:]
+        #expect(args?.request.eventName == "CIO Geofence Entered")
+        #expect(args?.request.userId == "user_42")
+        #expect(args?.request.timestamp == Date(timeIntervalSince1970: 1700000000))
+        let properties = args?.request.properties ?? [:]
         #expect(properties["geofence_id"] as? String == "geo_1")
         #expect(properties["transition_type"] as? String == "enter")
         #expect(properties["timestamp"] as? Int == 1700000000)
@@ -53,7 +54,7 @@ struct GeofenceDeliveryTrackerTests {
     @Test
     func trackMetric_givenExitTransition_expectExitedEventName() async {
         let (tracker, httpClient) = makeTracker()
-        httpClient.sendTrackEventClosure = { _, _, _, completion in completion(.success(())) }
+        httpClient.sendTrackEventClosure = { _, completion in completion(.success(())) }
 
         await withCheckedContinuation { continuation in
             tracker.trackMetric(metric: makeMetric(transition: .exit), userId: "user_42") { _ in
@@ -61,7 +62,7 @@ struct GeofenceDeliveryTrackerTests {
             }
         }
 
-        #expect(httpClient.sendTrackEventReceivedArguments?.eventName == "CIO Geofence Exited")
+        #expect(httpClient.sendTrackEventReceivedArguments?.request.eventName == "CIO Geofence Exited")
     }
 
     // MARK: - Guard clauses
@@ -85,7 +86,7 @@ struct GeofenceDeliveryTrackerTests {
     @Test
     func trackMetric_givenHttpFailure_expectFailurePropagated() async {
         let (tracker, httpClient) = makeTracker()
-        httpClient.sendTrackEventClosure = { _, _, _, completion in
+        httpClient.sendTrackEventClosure = { _, completion in
             completion(.failure(.http(statusCode: 500)))
         }
 

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -55,13 +55,20 @@ public enum CioInternalCommon.BackgroundDeliveryHttp {
 	public fun func basicAuthValue(cdpApiKey: String) -> String;
 }
 public interface CioInternalCommon.BackgroundDeliveryHttpClient {
-	public fun func sendTrackEvent(eventName: String, userId: String, properties: List<String: Any>, completion: @escaping (Result<Unit, BackgroundDeliveryHttpError>) -> Unit);
+	public fun func sendTrackEvent(_ request: BackgroundTrackRequest, completion: @escaping (Result<Unit, BackgroundDeliveryHttpError>) -> Unit);
 }
 public final class CioInternalCommon.BackgroundDeliveryHttpClientImpl {
 	public fun convenience init(contextStore: BackgroundDeliveryContextStore, requestRunner: HttpRequestRunner, logger: Logger);
-	public fun func sendTrackEvent(eventName: String, userId: String, properties: List<String: Any>, completion: @escaping (Result<Unit, BackgroundDeliveryHttpError>) -> Unit);
+	public fun func sendTrackEvent(_ request: BackgroundTrackRequest, completion: @escaping (Result<Unit, BackgroundDeliveryHttpError>) -> Unit);
 }
 public enum CioInternalCommon.BackgroundDeliveryHttpError {
+}
+public final class CioInternalCommon.BackgroundTrackRequest {
+	public final val eventName: String;
+	public final val userId: String;
+	public final val properties: Map<String, Any>;
+	public final val timestamp: Date?;
+	public fun init(eventName: String, userId: String, properties: List<String: Any> = List<:>, timestamp: Date? = nil);
 }
 public enum CioInternalCommon.CIOApiEndpoint {
 }


### PR DESCRIPTION
## What
The geofence direct-HTTP `/track` send now includes the reserved top-level `timestamp` (ISO-8601 string), so a transition delivered after a delay (cold-wake, retry) is attributed to when it occurred rather than when it was received. The analytics/EventBus channel already set this, so the two delivery paths now agree.

## Why
The CDP `/track` endpoint reads a bare integer in the reserved `timestamp` field as milliseconds, so the string form is sent. The client owns the format (`.iso8601WithMilliseconds`), so the direct-HTTP and analytics channels can't drift.

## Notes
`sendTrackEvent`'s parameters are bundled into a `BackgroundTrackRequest` value type, keeping the client's public signature stable as more background-delivery callers and fields are added. The client takes a `Date?` and formats it internally.

## Stack
Both target `feature/geofence-on-device`, merge in order:
1. #1105 — remove precise location from geofence events
2. #1106 — attribute direct-HTTP track events to transition time (this PR)

MBL-1831

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CDP `/track` payload shape and a public internal client API; incorrect timestamp formatting would mis-attribute geofence analytics, but behavior is covered by wire-format tests.
> 
> **Overview**
> Background direct-HTTP CDP `/track` calls now accept a **`BackgroundTrackRequest`** instead of separate `eventName` / `userId` / `properties` parameters, so the client API can grow without more signature churn. When `timestamp` is set, **`BackgroundDeliveryHttpClientImpl`** adds a reserved top-level **`timestamp`** field as an ISO-8601 string (`.iso8601WithMilliseconds`); when it is `nil`, the field is omitted.
> 
> **Geofence** delivery now passes the transition’s **`metric.timestamp`** through that request, so events delivered after cold-wake or retry are attributed to when the transition happened, aligned with the analytics/EventBus path. Mocks, tests, and internal API docs were updated for the new shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28020d1a1ace23ab58b9a488bab9b2a0615c41b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->