### PR TITLE
chore(geofence): fetch all geofences without sending location

### DIFF
--- a/Sources/LocationGeofence/Api/GeofenceApiService.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiService.swift
@@ -11,9 +11,16 @@ enum GeofenceApiError: Error, Equatable {
     case decoding
 }
 
-/// Fetches nearby geofences + workspace config from the CDP API.
+/// Fetches geofences + workspace config from the CDP API.
 protocol GeofenceApiService: AutoMockable, Sendable {
-    func fetchGeofences(
+    /// Fetch-all: returns the full (capped) set with no location sent.
+    func fetchAllGeofences(
+        completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void
+    )
+
+    /// Nearby: sends the location (coarsened before it leaves the device) so the backend returns
+    /// only nearby geofences.
+    func fetchNearbyGeofences(
         latitude: Double,
         longitude: Double,
         completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void
@@ -45,9 +52,30 @@ final class GeofenceApiServiceImpl: GeofenceApiService, @unchecked Sendable {
         self.logger = logger
     }
 
-    func fetchGeofences(
+    func fetchAllGeofences(
+        completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void
+    ) {
+        request(queryItems: [], completion: completion)
+    }
+
+    func fetchNearbyGeofences(
         latitude: Double,
         longitude: Double,
+        completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void
+    ) {
+        // Coarsened to a ~1km grid so the exact device position never leaves the device; on-device
+        // proximity logic keeps using the precise location.
+        request(
+            queryItems: [
+                URLQueryItem(name: "latitude", value: "\(GeofenceCoordinateCoarsener.coarsen(latitude))"),
+                URLQueryItem(name: "longitude", value: "\(GeofenceCoordinateCoarsener.coarsen(longitude))")
+            ],
+            completion: completion
+        )
+    }
+
+    private func request(
+        queryItems: [URLQueryItem],
         completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void
     ) {
         guard let apiHost = contextStore.currentApiHost, !apiHost.isEmpty else {
@@ -56,7 +84,7 @@ final class GeofenceApiServiceImpl: GeofenceApiService, @unchecked Sendable {
         guard let cdpApiKey = contextStore.currentCdpApiKey, !cdpApiKey.isEmpty else {
             return completion(.failure(.missingCdpApiKey))
         }
-        guard let url = Self.composeUrl(apiHost: apiHost, latitude: latitude, longitude: longitude) else {
+        guard let url = Self.composeUrl(apiHost: apiHost, queryItems: queryItems) else {
             return completion(.failure(.invalidRequest))
         }
 
@@ -90,14 +118,11 @@ final class GeofenceApiServiceImpl: GeofenceApiService, @unchecked Sendable {
         }
     }
 
-    /// Composes `https://{apiHost}/geofences/nearby?latitude=…&longitude=…`.
-    /// URLComponents handles percent-encoding for the query values.
-    static func composeUrl(apiHost: String, latitude: Double, longitude: Double) -> URL? {
+    /// Composes `https://{apiHost}/geofences/nearby` with the given query items (empty for
+    /// fetch-all). URLComponents handles percent-encoding for the query values.
+    static func composeUrl(apiHost: String, queryItems: [URLQueryItem]) -> URL? {
         var components = URLComponents(string: BackgroundDeliveryHttp.absoluteHost(apiHost) + endpointPath)
-        components?.queryItems = [
-            URLQueryItem(name: "latitude", value: "\(latitude)"),
-            URLQueryItem(name: "longitude", value: "\(longitude)")
-        ]
+        components?.queryItems = queryItems.isEmpty ? nil : queryItems
         return components?.url
     }
 }

--- a/Sources/LocationGeofence/Api/GeofenceCoordinateCoarsener.swift
+++ b/Sources/LocationGeofence/Api/GeofenceCoordinateCoarsener.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Snaps the coordinates sent to `/geofences/nearby` (the `nearby` sync mode) to a ~1km grid
+/// (rounding to 2 decimals; 0.01° ≈ 1.1km latitude) so the SDK never transmits the device's exact
+/// position. Precise location stays on-device for proximity and movement-trigger logic.
+///
+/// Snapping is deterministic, not jittered: repeated syncs from the same area send the same value,
+/// so averaging many requests can't recover the true position. The server fetch radius must cover
+/// the re-sync displacement plus this cell, or a geofence near a cell boundary can be missed.
+enum GeofenceCoordinateCoarsener {
+    /// 2 decimal places ≈ a 1.1km grid in latitude (narrower east-west toward the poles).
+    private static let gridScale = 100.0
+
+    static func coarsen(_ coordinate: Double) -> Double {
+        // Round-half-to-even matches the Android SDK's `HALF_EVEN`, keeping both platforms on the
+        // same grid and avoiding the directional bias of always rounding up. Scaling by 100 and
+        // dividing back yields the clean canonical double for the 2-decimal value (unlike
+        // `NSDecimalNumber.doubleValue`, which can land one ULP off and re-leak precision).
+        (coordinate * gridScale).rounded(.toNearestOrEven) / gridScale
+    }
+}

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+RefreshDecision.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+RefreshDecision.swift
@@ -1,0 +1,47 @@
+import CioInternalCommon
+import CoreLocation
+import Foundation
+
+/// The `refresh` decision table, split out to keep the coordinator's core flow readable.
+/// Methods are `internal` (not `private`) only because they live in a separate file from their
+/// callers; they remain coordinator implementation detail.
+extension GeofenceSyncCoordinatorImpl {
+    /// Decision table for an identify / app-launch refresh, independent of what triggered it.
+    /// Only the re-fetch question depends on the sync mode; time-staleness, ranking-staleness,
+    /// and OS-registration gaps are mode-agnostic.
+    func refreshAction(location: LocationData, config: GeofenceConfig) async -> RefreshAction {
+        let lastSync = await storage.getLastSync()
+        // Each distance is measured from its own reference: re-fetch from the last API fetch,
+        // re-rank from the last registration. Nil (never set) → 0 → treated as within radius.
+        let distanceFromLastFetch = lastSync.map { distance(from: $0.location, to: location) } ?? 0
+        let distanceFromLastRegistration = (await storage.getLastRegistrationCenter()).map { distance(from: $0, to: location) } ?? 0
+
+        if isStaleInTime(lastSync: lastSync, config: config) { return .remote }
+        if syncMode.movementRequiresRemoteFetch(distanceFromAnchor: distanceFromLastFetch, config: config) {
+            return .remote
+        }
+        // Device left the trigger radius since the nearest-set was last ranked — re-rank locally,
+        // no network. This is the EXIT the live movement trigger fires on; refresh() catches one
+        // missed while the app was dead (no boundary crossing to wake it).
+        if distanceFromLastRegistration >= config.localRefreshTriggerRadius { return .local }
+        if await hasUnregisteredCache() { return .local }
+        return .skip
+    }
+
+    /// Cache aged out of its freshness window (or was never fetched).
+    func isStaleInTime(lastSync: LastSyncRecord?, config: GeofenceConfig) -> Bool {
+        guard let lastSync else { return true }
+        return dateUtil.now.timeIntervalSince(lastSync.timestamp) >= config.remoteFetchRefreshExpiry
+    }
+
+    /// Cache holds regions but none are registered with the OS (e.g. regs lost on sign-out) → re-register.
+    func hasUnregisteredCache() async -> Bool {
+        guard !(await storage.getCachedGeofences()).isEmpty else { return false }
+        return await storage.getRegisteredBusinessIds().isEmpty
+    }
+
+    func distance(from: LocationData, to: LocationData) -> Double {
+        CLLocation(latitude: from.latitude, longitude: from.longitude)
+            .distance(from: CLLocation(latitude: to.latitude, longitude: to.longitude))
+    }
+}

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
@@ -11,23 +11,26 @@ enum GeofenceSyncError: Error, Equatable {
 
 /// Which branch `handleMovement` took for the current EXIT.
 enum HandleMovementTier: String, Sendable {
-    /// Re-rank cached regions for the new location; no API call.
+    /// Re-rank cached regions for the new location; no API call. The only `fetchAll` movement path.
     case localRerank
-    /// Anchor moved beyond `remoteFetchRefreshTriggerRadius` (or absent) — refetch from server.
+    /// Refetch from the server — when no anchor exists yet (first EXIT after install / clearAll /
+    /// sign-out), or in `nearby` mode once the device outruns its location-bound set.
     case remoteRefresh
 }
 
 /// Sync pipeline for the on-device geofence cache. Entry points:
 ///
-/// - `refresh(latitude:longitude:)` — fetch from the server, distance-filter, register,
-///   persist. Gated on identified user, in-flight dedup, and freshness.
-/// - `handleMovement(latitude:longitude:)` — movement-trigger EXIT entry. Two-tier:
-///   re-rank cache when within `remoteFetchRefreshTriggerRadius` of the API anchor,
-///   otherwise refetch from the server. Shares the same dedup gate as `refresh`.
+/// - `refresh(latitude:longitude:)` — identify / app-launch entry. Routes through `refreshAction`:
+///   re-fetch when stale (or `nearby` outran its set), re-rank locally when the ranking is stale or
+///   the cache is unregistered, else skip. Gated on identified user and in-flight dedup.
+/// - `handleMovement(latitude:longitude:)` — movement-trigger EXIT entry. Re-ranks the cached set
+///   for the new location; bootstraps from the server when there's no anchor, and in `nearby` mode
+///   re-fetches once the device outruns its set. Shares the same dedup gate as `refresh`.
 /// - `applyCachedRegistration(...)` — synchronously register from caller-fetched state,
 ///   used by cold-wake / boot / auth-change paths. Synchronous on the main actor so
 ///   `ownedRegionIdentifiers` is populated before the next yield — otherwise the OS may
-///   deliver a queued cold-wake transition into an empty filter set.
+///   deliver a queued cold-wake transition into an empty filter set. Returns what it
+///   registered so the caller can persist it once the no-await window has closed.
 /// - `reset()` — sign-out cleanup. Stops OS-side monitoring and clears user-scoped store
 ///   state (cooldowns, last-sync). Preserves the workspace cache.
 protocol GeofenceSyncCoordinator: AutoMockable, AnyObject, Sendable {
@@ -40,7 +43,7 @@ protocol GeofenceSyncCoordinator: AutoMockable, AnyObject, Sendable {
         anchor: LocationData?,
         config: GeofenceConfig?,
         userId: String?
-    )
+    ) -> GeofenceRegistration?
 }
 
 /// `@unchecked Sendable`: stored `Logger` and `DateUtil` are existentials of protocols
@@ -48,12 +51,17 @@ protocol GeofenceSyncCoordinator: AutoMockable, AnyObject, Sendable {
 /// the only mutable state is the `Synchronized<Bool>` dedup gate.
 final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sendable {
     private let apiService: GeofenceApiService
-    private let storage: GeofenceSyncStorage
     private let monitor: GeofenceRegionMonitoring
     private let contextStore: BackgroundDeliveryContextStore
     private let distanceFilter: GeofenceDistanceFilter
-    private let dateUtil: DateUtil
     private let logger: Logger
+    // Internal (not private) so the `+RefreshDecision` extension in its own file can read them;
+    // all are immutable injected deps.
+    let storage: GeofenceSyncStorage
+    let dateUtil: DateUtil
+    /// Defaults to `GeofenceSyncMode.active` (the shipped mode); injectable so tests can exercise
+    /// the retained `nearby` path without flipping the global default.
+    let syncMode: GeofenceSyncMode
     private let refreshInProgress = Synchronized<Bool>(false)
 
     init(
@@ -63,7 +71,8 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         contextStore: BackgroundDeliveryContextStore,
         distanceFilter: GeofenceDistanceFilter = GeofenceDistanceFilter(),
         dateUtil: DateUtil,
-        logger: Logger
+        logger: Logger,
+        syncMode: GeofenceSyncMode = .active
     ) {
         self.apiService = apiService
         self.storage = storage
@@ -72,6 +81,7 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         self.distanceFilter = distanceFilter
         self.dateUtil = dateUtil
         self.logger = logger
+        self.syncMode = syncMode
     }
 
     func refresh(latitude: Double, longitude: Double) async -> Result<Void, GeofenceSyncError> {
@@ -87,26 +97,28 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         }
 
         let cachedConfig = await storage.getCachedConfig()
-        if let lastSync = await storage.getLastSync() {
-            // Time-fresh alone isn't enough: if the app was killed while the user
-            // travelled far, no movement EXIT fired to update the cache.
-            let effectiveConfig = cachedConfig ?? .fallback
-            let timeSinceLastSync = dateUtil.now.timeIntervalSince(lastSync.timestamp)
-            let distanceFromAnchor = CLLocation(latitude: lastSync.location.latitude, longitude: lastSync.location.longitude)
-                .distance(from: CLLocation(latitude: latitude, longitude: longitude))
-            if timeSinceLastSync < effectiveConfig.remoteFetchRefreshExpiry,
-               distanceFromAnchor < effectiveConfig.remoteFetchRefreshTriggerRadius {
-                logger.geofenceSyncSkippedFresh()
-                return .success(())
-            }
+        let effectiveConfig = cachedConfig ?? .fallback
+        let location = LocationData(latitude: latitude, longitude: longitude)
+        switch await refreshAction(location: location, config: effectiveConfig) {
+        case .remote:
+            return await performRemoteRefresh(
+                expectedUserId: userId,
+                latitude: latitude,
+                longitude: longitude,
+                cachedConfig: cachedConfig
+            )
+        case .local:
+            let cachedRegions = await storage.getCachedGeofences()
+            return await performLocalRefresh(
+                latitude: latitude,
+                longitude: longitude,
+                config: effectiveConfig,
+                cachedRegions: cachedRegions
+            )
+        case .skip:
+            logger.geofenceSyncSkippedFresh()
+            return .success(())
         }
-
-        return await performRemoteRefresh(
-            expectedUserId: userId,
-            latitude: latitude,
-            longitude: longitude,
-            cachedConfig: cachedConfig
-        )
     }
 
     func handleMovement(latitude: Double, longitude: Double) async -> Result<Void, GeofenceSyncError> {
@@ -124,12 +136,13 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         let cachedConfig = await storage.getCachedConfig()
         let anchor = await storage.getLastSync()?.location
         let effectiveConfig = cachedConfig ?? .fallback
-        // No anchor → no Tier A reference; fall through to remote.
+        // No anchor (first EXIT after install / clearAll / sign-out) bootstraps from the server.
+        // Otherwise the mode decides: NEARBY re-fetches once the device outruns its set; FETCH_ALL
+        // never re-fetches on movement (the cached set is the complete workspace) and re-ranks locally.
         let needsRemoteFetch: Bool = {
             guard let anchor else { return true }
-            let distance = CLLocation(latitude: anchor.latitude, longitude: anchor.longitude)
-                .distance(from: CLLocation(latitude: latitude, longitude: longitude))
-            return distance >= effectiveConfig.remoteFetchRefreshTriggerRadius
+            let distanceFromAnchor = distance(from: anchor, to: LocationData(latitude: latitude, longitude: longitude))
+            return syncMode.movementRequiresRemoteFetch(distanceFromAnchor: distanceFromAnchor, config: effectiveConfig)
         }()
 
         if needsRemoteFetch {
@@ -179,24 +192,24 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         anchor: LocationData?,
         config: GeofenceConfig?,
         userId: String?
-    ) {
+    ) -> GeofenceRegistration? {
         guard let userId, !userId.isEmpty else {
             logger.geofenceSyncSkipped(reason: "no identified user")
-            return
+            return nil
         }
         guard !cachedRegions.isEmpty else {
             logger.geofenceSyncSkipped(reason: "no cached regions to restore")
-            return
+            return nil
         }
         // Need an anchor to distance-filter and to center the movement trigger. Skipping
         // when absent is safer than re-using an arbitrary location.
         guard let anchor else {
             logger.geofenceSyncSkipped(reason: "no last-sync anchor to restore from")
-            return
+            return nil
         }
         guard acquireGate() else {
             logger.geofenceSyncSkipped(reason: "restore already in progress")
-            return
+            return nil
         }
         defer { releaseGate() }
 
@@ -208,6 +221,10 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
             movementTriggerRadius: effectiveConfig.localRefreshTriggerRadius
         )
         logger.geofenceSyncCompleted(registeredCount: nearest.count)
+        // Return the registration so the caller persists it (async, after the no-await window) as
+        // the ranking-staleness reference — otherwise a later fresh refresh measures from a stale
+        // anchor and may skip while the OS holds the wrong nearest-set.
+        return GeofenceRegistration(center: anchor, businessIds: Set(nearest.map(\.id)))
     }
 
     /// Returns false when another call already holds the gate; the caller short-circuits.
@@ -270,13 +287,15 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
             await storage.setCachedConfig(parsedConfig)
         }
         await storage.recordSync(timestamp: dateUtil.now, location: anchor)
+        await storage.recordRegistration(center: anchor, businessIds: Set(nearest.map(\.id)))
         logger.geofenceSyncCompleted(registeredCount: nearest.count)
         return .success(())
     }
 
-    /// Re-rank cached regions for the new location and re-register with the OS. No API call,
-    /// no cache or `lastSync` writes — the API anchor is what `handleMovement` compared
-    /// against, so leaving it intact preserves the next Tier B threshold.
+    /// Re-rank cached regions for the new location and re-register with the OS. No API call and no
+    /// `lastSync` write — the API-fetch anchor is what the re-fetch decision compares against, so
+    /// leaving it intact preserves the next threshold. Records the registration anchor so the
+    /// ranking-staleness reference follows the device after a local re-rank.
     private func performLocalRefresh(
         latitude: Double,
         longitude: Double,
@@ -292,17 +311,27 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
                 movementTriggerRadius: config.localRefreshTriggerRadius
             )
         }
+        await storage.recordRegistration(center: anchor, businessIds: Set(nearest.map(\.id)))
         logger.geofenceSyncCompleted(registeredCount: nearest.count)
         return .success(())
     }
+}
 
-    private func awaitApiFetch(
+// MARK: - OS registration & fetch plumbing
+
+private extension GeofenceSyncCoordinatorImpl {
+    /// `fetchAll` sends no location; `nearby` sends it (coarsened at the API boundary). Either way
+    /// the precise `latitude`/`longitude` drive on-device ranking and the anchor — they never leave here.
+    func awaitApiFetch(
         latitude: Double,
         longitude: Double
     ) async -> Result<GeofenceApiResponse, GeofenceApiError> {
         await withCheckedContinuation { continuation in
-            apiService.fetchGeofences(latitude: latitude, longitude: longitude) { result in
-                continuation.resume(returning: result)
+            switch syncMode {
+            case .fetchAll:
+                apiService.fetchAllGeofences { continuation.resume(returning: $0) }
+            case .nearby:
+                apiService.fetchNearbyGeofences(latitude: latitude, longitude: longitude) { continuation.resume(returning: $0) }
             }
         }
     }
@@ -311,7 +340,7 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
     /// `@MainActor`-isolated so a same-actor caller (e.g. `applyCachedRegistration`)
     /// can register without yielding — see the protocol doc for why that matters.
     @MainActor
-    private func registerWithOsSync(
+    func registerWithOsSync(
         businessRegions: [Geofence],
         movementTriggerLocation: LocationData,
         movementTriggerRadius: Double

--- a/Sources/LocationGeofence/GeofenceBootstrap.swift
+++ b/Sources/LocationGeofence/GeofenceBootstrap.swift
@@ -15,6 +15,10 @@ enum GeofenceBootstrap {
         let cachedRegions = await di.geofenceStorage.getCachedGeofences()
         let cachedConfig = await di.geofenceStorage.getCachedConfig()
         let lastSync = await di.geofenceStorage.getLastSync()
+        // Prefer the last registration center over the fetch anchor: a local re-rank moves the
+        // registration center but leaves lastSync at the fetch point, so restoring from lastSync
+        // would revert the OS to the older nearest-set. Falls back to lastSync before any re-rank.
+        let restoreAnchor = await di.geofenceStorage.getLastRegistrationCenter() ?? lastSync?.location
         let userId = di.backgroundDeliveryContextStore.currentUserId
 
         // Phase 2: synchronous on the main actor. No `await` between handler-bind and
@@ -24,12 +28,21 @@ enum GeofenceBootstrap {
         let tracker = di.geofenceEventTracker
         let coordinator = di.geofenceSyncCoordinator
         GeofenceMonitorBinder.bind(monitor: monitor, tracker: tracker, coordinator: coordinator)
-        coordinator.applyCachedRegistration(
+        let registration = coordinator.applyCachedRegistration(
             cachedRegions: cachedRegions,
-            anchor: lastSync?.location,
+            anchor: restoreAnchor,
             config: cachedConfig,
             userId: userId
         )
+        // Persist what was registered as the ranking-staleness reference. The await is safe here:
+        // applyCachedRegistration already ran startMonitoring synchronously, so the cold-wake
+        // no-await window has closed and a queued transition can't land in an empty filter.
+        if let registration {
+            await di.geofenceStorage.recordRegistration(
+                center: registration.center,
+                businessIds: registration.businessIds
+            )
+        }
 
         // Self-heal mid-process permission changes (Settings toggle, late prompt response).
         // The handler replaces any prior one — no stacking when both foreground init and

--- a/Sources/LocationGeofence/GeofenceConstants.swift
+++ b/Sources/LocationGeofence/GeofenceConstants.swift
@@ -9,11 +9,14 @@ enum GeofenceConstants {
     /// iOS allows 20 total monitored regions; 1 is reserved for the movement trigger.
     static let maxMonitoredGeofences = 19
 
-    /// Radius of the Movement Trigger Geofence in meters.
-    static let movementTriggerRadius: Double = 1000
+    /// Fallback for `localRefreshTriggerRadius` (meters) — the movement-trigger geofence radius and
+    /// the ranking-staleness threshold. Server config overrides it.
+    static let movementTriggerRadius: Double = 3000
 
-    /// Distance from last server sync (in meters) that triggers a new server fetch.
-    static let serverFetchDistance: Double = 3000
+    /// Fallback for `remoteFetchRefreshTriggerRadius` (meters) — distance from the last API fetch at
+    /// which the `nearby` mode re-fetches. Unused by `fetchAll` (movement never re-fetches). Server
+    /// config overrides it.
+    static let serverFetchDistance: Double = 20000
 
     /// Cooldown interval (in seconds) for suppressing duplicate enter/exit events for the same geofence.
     static let eventCooldownInterval: TimeInterval = 1 * 60 * 60

--- a/Sources/LocationGeofence/GeofenceSyncMode.swift
+++ b/Sources/LocationGeofence/GeofenceSyncMode.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// The kind of refresh a signal calls for, decided independently of what triggered it.
+///
+/// - `remote` — fetch a fresh set from the API.
+/// - `local`  — re-rank / re-register the cached set on-device, no network.
+/// - `skip`   — cache is current; do nothing.
+enum RefreshAction: Equatable {
+    case remote
+    case local
+    case skip
+}
+
+/// How the SDK fetches a user's geofences.
+///
+/// `fetchAll` is the active default: the backend returns the full (capped) set and the SDK never
+/// sends device location to fetch.
+///
+/// `nearby` sends coarse location and lets the backend return only nearby geofences. It is retained
+/// and tested so location-based fetch can be re-enabled in a later phase by changing `active` — that
+/// also needs backend support and is a deliberate SDK release, never a runtime or server-pushed
+/// toggle (which would re-introduce the ability to silently start sending location).
+enum GeofenceSyncMode: Equatable {
+    case fetchAll
+    case nearby
+
+    /// `nearby`'s set is location-bound, so it re-fetches once the device outruns it; `fetchAll`
+    /// holds the full set, so movement never re-fetches.
+    func movementRequiresRemoteFetch(distanceFromAnchor: Double, config: GeofenceConfig) -> Bool {
+        switch self {
+        case .nearby: return distanceFromAnchor >= config.remoteFetchRefreshTriggerRadius
+        case .fetchAll: return false
+        }
+    }
+
+    /// The mode the SDK ships with. Compile-time only — see the type doc.
+    static let active: GeofenceSyncMode = .fetchAll
+}

--- a/Sources/LocationGeofence/Model/GeofenceRegistration.swift
+++ b/Sources/LocationGeofence/Model/GeofenceRegistration.swift
@@ -1,0 +1,10 @@
+import CioInternalCommon
+import Foundation
+
+/// What `applyCachedRegistration` registered with the OS, returned so the caller can persist it
+/// as the ranking-staleness reference. `nil` when registration was skipped (no user, no regions,
+/// no anchor, or another sync in flight).
+struct GeofenceRegistration: Equatable, Sendable {
+    let center: LocationData
+    let businessIds: Set<String>
+}

--- a/Sources/LocationGeofence/Storage/GeofenceStorage.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage.swift
@@ -93,6 +93,8 @@ actor GeofenceStorage {
         state.eventCooldowns = nil
         state.lastServerSyncTimestamp = nil
         state.lastServerSyncLocation = nil
+        state.movementTriggerCenter = nil
+        state.monitoredGeofenceIds = nil
         saveToDisk(state)
     }
 
@@ -141,6 +143,33 @@ actor GeofenceStorage {
         var state = loadFromDisk() ?? GeofenceState()
         state.lastServerSyncTimestamp = timestamp
         state.lastServerSyncLocation = location
+        saveToDisk(state)
+    }
+
+    // MARK: - Last Registration
+
+    /// Center of the most recent OS registration (the movement-trigger center). The sync
+    /// decision measures distance from here to detect a stale ranking — the device moved
+    /// beyond the trigger radius while the app was dead, so the registered nearest-set is
+    /// no longer the closest geofences and needs a local re-rank.
+    func getLastRegistrationCenter() -> LocationData? {
+        loadFromDisk()?.movementTriggerCenter
+    }
+
+    /// Business geofence IDs registered with the OS at the last registration. Lets the sync
+    /// decision spot a cache that holds regions while nothing is registered (e.g. regs lost
+    /// on sign-out) and re-register instead of skipping.
+    func getRegisteredBusinessIds() -> Set<String> {
+        loadFromDisk()?.monitoredGeofenceIds ?? []
+    }
+
+    /// Records the registration anchor + business IDs in one load-modify-save. Updated on every
+    /// registration, including a local re-rank, so the ranking-staleness reference follows the
+    /// device. Distinct from `recordSync` (the API-fetch anchor), which a local re-rank leaves intact.
+    func recordRegistration(center: LocationData, businessIds: Set<String>) {
+        var state = loadFromDisk() ?? GeofenceState()
+        state.movementTriggerCenter = center
+        state.monitoredGeofenceIds = businessIds
         saveToDisk(state)
     }
 

--- a/Sources/LocationGeofence/Storage/GeofenceSyncStorage.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceSyncStorage.swift
@@ -8,9 +8,12 @@ protocol GeofenceSyncStorage: Sendable {
     func getCachedConfig() async -> GeofenceConfig?
     func getCachedGeofences() async -> [Geofence]
     func getLastSync() async -> LastSyncRecord?
+    func getLastRegistrationCenter() async -> LocationData?
+    func getRegisteredBusinessIds() async -> Set<String>
     func setCachedGeofences(_ regions: [Geofence]) async
     func setCachedConfig(_ config: GeofenceConfig) async
     func recordSync(timestamp: Date, location: LocationData) async
+    func recordRegistration(center: LocationData, businessIds: Set<String>) async
     func clearUserScopedState() async
 }
 

--- a/Sources/LocationGeofence/autogenerated/AutoMockable.generated.swift
+++ b/Sources/LocationGeofence/autogenerated/AutoMockable.generated.swift
@@ -95,38 +95,70 @@ class GeofenceApiServiceMock: GeofenceApiService, Mock {
     init() {}
 
     public func resetMock() {
-        fetchGeofencesCallsCount = 0
-        fetchGeofencesReceivedArguments = nil
-        fetchGeofencesReceivedInvocations = []
+        fetchAllGeofencesCallsCount = 0
+        fetchAllGeofencesReceivedArguments = nil
+        fetchAllGeofencesReceivedInvocations = []
+
+        mockCalled = false // do last as resetting properties above can make this true
+        fetchNearbyGeofencesCallsCount = 0
+        fetchNearbyGeofencesReceivedArguments = nil
+        fetchNearbyGeofencesReceivedInvocations = []
 
         mockCalled = false // do last as resetting properties above can make this true
     }
 
-    // MARK: - fetchGeofences
+    // MARK: - fetchAllGeofences
 
     /// Number of times the function was called.
-    @Atomic private(set) var fetchGeofencesCallsCount = 0
+    @Atomic private(set) var fetchAllGeofencesCallsCount = 0
     /// `true` if the function was ever called.
-    var fetchGeofencesCalled: Bool {
-        fetchGeofencesCallsCount > 0
+    var fetchAllGeofencesCalled: Bool {
+        fetchAllGeofencesCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    @Atomic private(set) var fetchGeofencesReceivedArguments: (latitude: Double, longitude: Double, completion: (Result<GeofenceApiResponse, GeofenceApiError>) -> Void)?
+    @Atomic private(set) var fetchAllGeofencesReceivedArguments: ((Result<GeofenceApiResponse, GeofenceApiError>) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    @Atomic private(set) var fetchGeofencesReceivedInvocations: [(latitude: Double, longitude: Double, completion: (Result<GeofenceApiResponse, GeofenceApiError>) -> Void)] = []
+    @Atomic private(set) var fetchAllGeofencesReceivedInvocations: [(Result<GeofenceApiResponse, GeofenceApiError>) -> Void] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    var fetchGeofencesClosure: ((Double, Double, @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void) -> Void)?
+    var fetchAllGeofencesClosure: ((@escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void) -> Void)?
 
-    /// Mocked function for `fetchGeofences(latitude: Double, longitude: Double, completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
-    func fetchGeofences(latitude: Double, longitude: Double, completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void) {
+    /// Mocked function for `fetchAllGeofences(completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
+    func fetchAllGeofences(completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void) {
         mockCalled = true
-        fetchGeofencesCallsCount += 1
-        fetchGeofencesReceivedArguments = (latitude: latitude, longitude: longitude, completion: completion)
-        fetchGeofencesReceivedInvocations.append((latitude: latitude, longitude: longitude, completion: completion))
-        fetchGeofencesClosure?(latitude, longitude, completion)
+        fetchAllGeofencesCallsCount += 1
+        fetchAllGeofencesReceivedArguments = completion
+        fetchAllGeofencesReceivedInvocations.append(completion)
+        fetchAllGeofencesClosure?(completion)
+    }
+
+    // MARK: - fetchNearbyGeofences
+
+    /// Number of times the function was called.
+    @Atomic private(set) var fetchNearbyGeofencesCallsCount = 0
+    /// `true` if the function was ever called.
+    var fetchNearbyGeofencesCalled: Bool {
+        fetchNearbyGeofencesCallsCount > 0
+    }
+
+    /// The arguments from the *last* time the function was called.
+    @Atomic private(set) var fetchNearbyGeofencesReceivedArguments: (latitude: Double, longitude: Double, completion: (Result<GeofenceApiResponse, GeofenceApiError>) -> Void)?
+    /// Arguments from *all* of the times that the function was called.
+    @Atomic private(set) var fetchNearbyGeofencesReceivedInvocations: [(latitude: Double, longitude: Double, completion: (Result<GeofenceApiResponse, GeofenceApiError>) -> Void)] = []
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     */
+    var fetchNearbyGeofencesClosure: ((Double, Double, @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void) -> Void)?
+
+    /// Mocked function for `fetchNearbyGeofences(latitude: Double, longitude: Double, completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
+    func fetchNearbyGeofences(latitude: Double, longitude: Double, completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void) {
+        mockCalled = true
+        fetchNearbyGeofencesCallsCount += 1
+        fetchNearbyGeofencesReceivedArguments = (latitude: latitude, longitude: longitude, completion: completion)
+        fetchNearbyGeofencesReceivedInvocations.append((latitude: latitude, longitude: longitude, completion: completion))
+        fetchNearbyGeofencesClosure?(latitude, longitude, completion)
     }
 }
 
@@ -313,19 +345,23 @@ class GeofenceSyncCoordinatorMock: GeofenceSyncCoordinator, Mock {
     @Atomic private(set) var applyCachedRegistrationReceivedArguments: (cachedRegions: [Geofence], anchor: LocationData?, config: GeofenceConfig?, userId: String?)?
     /// Arguments from *all* of the times that the function was called.
     @Atomic private(set) var applyCachedRegistrationReceivedInvocations: [(cachedRegions: [Geofence], anchor: LocationData?, config: GeofenceConfig?, userId: String?)] = []
+    /// Value to return from the mocked function.
+    var applyCachedRegistrationReturnValue: GeofenceRegistration?
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     The closure has first priority to return a value for the mocked function. If the closure returns `nil`,
+     then the mock will attempt to return the value for `applyCachedRegistrationReturnValue`
      */
-    var applyCachedRegistrationClosure: (([Geofence], LocationData?, GeofenceConfig?, String?) -> Void)?
+    var applyCachedRegistrationClosure: (([Geofence], LocationData?, GeofenceConfig?, String?) -> GeofenceRegistration?)?
 
     /// Mocked function for `applyCachedRegistration(cachedRegions: [Geofence], anchor: LocationData?, config: GeofenceConfig?, userId: String?)`. Your opportunity to return a mocked value and check result of mock in test code.
     @MainActor
-    func applyCachedRegistration(cachedRegions: [Geofence], anchor: LocationData?, config: GeofenceConfig?, userId: String?) {
+    func applyCachedRegistration(cachedRegions: [Geofence], anchor: LocationData?, config: GeofenceConfig?, userId: String?) -> GeofenceRegistration? {
         mockCalled = true
         applyCachedRegistrationCallsCount += 1
         applyCachedRegistrationReceivedArguments = (cachedRegions: cachedRegions, anchor: anchor, config: config, userId: userId)
         applyCachedRegistrationReceivedInvocations.append((cachedRegions: cachedRegions, anchor: anchor, config: config, userId: userId))
-        applyCachedRegistrationClosure?(cachedRegions, anchor, config, userId)
+        return applyCachedRegistrationClosure.map { $0(cachedRegions, anchor, config, userId) } ?? applyCachedRegistrationReturnValue
     }
 }
 

--- a/Tests/LocationGeofence/Geofence/Api/GeofenceApiServiceTests.swift
+++ b/Tests/LocationGeofence/Geofence/Api/GeofenceApiServiceTests.swift
@@ -34,19 +34,41 @@ struct GeofenceApiServiceTests {
     // MARK: - Request shaping
 
     @Test
-    func fetchGeofences_givenStoreState_expectGetRequestWithQueryAndAuth() async {
+    func fetchAllGeofences_givenStoreState_expectGetRequestWithNoQueryAndAuth() async {
         let (service, runner) = makeService(store: makeStore())
         runner.requestClosure = { _, _, onComplete in
             onComplete("{\"geofences\":[]}".data(using: .utf8), makeOkResponse(), nil)
         }
 
         await withCheckedContinuation { continuation in
-            service.fetchGeofences(latitude: 37.7749, longitude: -122.4194) { _ in continuation.resume() }
+            service.fetchAllGeofences { _ in continuation.resume() }
         }
 
         let params = runner.requestReceivedArguments?.params
         #expect(params?.method == "GET")
-        #expect(params?.url.absoluteString == "https://cdp.customer.io/v1/geofences/nearby?latitude=37.7749&longitude=-122.4194")
+        // Fetch-all sends no location — the URL carries no query string at all.
+        #expect(params?.url.absoluteString == "https://cdp.customer.io/v1/geofences/nearby")
+        #expect(params?.headers?["Authorization"] == "Basic c2tfdGVzdF9hYmM6")
+        #expect(params?.headers?["Accept"] == "application/json")
+        #expect(params?.body == nil)
+    }
+
+    @Test
+    func fetchNearbyGeofences_givenStoreState_expectCoarsenedQueryAndAuth() async {
+        let (service, runner) = makeService(store: makeStore())
+        runner.requestClosure = { _, _, onComplete in
+            onComplete("{\"geofences\":[]}".data(using: .utf8), makeOkResponse(), nil)
+        }
+
+        await withCheckedContinuation { continuation in
+            service.fetchNearbyGeofences(latitude: 37.7749, longitude: -122.4194) { _ in continuation.resume() }
+        }
+
+        let params = runner.requestReceivedArguments?.params
+        #expect(params?.method == "GET")
+        // Coordinates are coarsened to a ~1km grid before they reach the URL: 37.7749 → 37.77,
+        // -122.4194 → -122.42. The exact device position never leaves the device.
+        #expect(params?.url.absoluteString == "https://cdp.customer.io/v1/geofences/nearby?latitude=37.77&longitude=-122.42")
         #expect(params?.headers?["Authorization"] == "Basic c2tfdGVzdF9hYmM6")
         #expect(params?.headers?["Accept"] == "application/json")
         #expect(params?.body == nil)
@@ -60,7 +82,7 @@ struct GeofenceApiServiceTests {
         }
 
         await withCheckedContinuation { continuation in
-            service.fetchGeofences(latitude: 1.0, longitude: 2.0) { _ in continuation.resume() }
+            service.fetchNearbyGeofences(latitude: 1.0, longitude: 2.0) { _ in continuation.resume() }
         }
 
         let urlString = runner.requestReceivedArguments?.params.url.absoluteString
@@ -75,7 +97,7 @@ struct GeofenceApiServiceTests {
         let (service, _) = makeService(store: makeStore(host: nil))
 
         let result: Result<GeofenceApiResponse, GeofenceApiError> = await withCheckedContinuation { continuation in
-            service.fetchGeofences(latitude: 1.0, longitude: 2.0) { result in
+            service.fetchNearbyGeofences(latitude: 1.0, longitude: 2.0) { result in
                 continuation.resume(returning: result)
             }
         }
@@ -88,7 +110,7 @@ struct GeofenceApiServiceTests {
         let (service, _) = makeService(store: makeStore(cdpApiKey: nil))
 
         let result: Result<GeofenceApiResponse, GeofenceApiError> = await withCheckedContinuation { continuation in
-            service.fetchGeofences(latitude: 1.0, longitude: 2.0) { result in
+            service.fetchNearbyGeofences(latitude: 1.0, longitude: 2.0) { result in
                 continuation.resume(returning: result)
             }
         }
@@ -104,7 +126,7 @@ struct GeofenceApiServiceTests {
         runner.requestClosure = { _, _, onComplete in onComplete(nil, makeOkResponse(statusCode: 500), nil) }
 
         let result: Result<GeofenceApiResponse, GeofenceApiError> = await withCheckedContinuation { continuation in
-            service.fetchGeofences(latitude: 1.0, longitude: 2.0) { result in
+            service.fetchNearbyGeofences(latitude: 1.0, longitude: 2.0) { result in
                 continuation.resume(returning: result)
             }
         }
@@ -118,7 +140,7 @@ struct GeofenceApiServiceTests {
         runner.requestClosure = { _, _, onComplete in onComplete(nil, nil, URLError(.notConnectedToInternet)) }
 
         let result: Result<GeofenceApiResponse, GeofenceApiError> = await withCheckedContinuation { continuation in
-            service.fetchGeofences(latitude: 1.0, longitude: 2.0) { result in
+            service.fetchNearbyGeofences(latitude: 1.0, longitude: 2.0) { result in
                 continuation.resume(returning: result)
             }
         }
@@ -132,7 +154,7 @@ struct GeofenceApiServiceTests {
         runner.requestClosure = { _, _, onComplete in onComplete("not json".data(using: .utf8), makeOkResponse(), nil) }
 
         let result: Result<GeofenceApiResponse, GeofenceApiError> = await withCheckedContinuation { continuation in
-            service.fetchGeofences(latitude: 1.0, longitude: 2.0) { result in
+            service.fetchNearbyGeofences(latitude: 1.0, longitude: 2.0) { result in
                 continuation.resume(returning: result)
             }
         }
@@ -170,7 +192,7 @@ struct GeofenceApiServiceTests {
         runner.requestClosure = { _, _, onComplete in onComplete(json.data(using: .utf8), makeOkResponse(), nil) }
 
         let result: Result<GeofenceApiResponse, GeofenceApiError> = await withCheckedContinuation { continuation in
-            service.fetchGeofences(latitude: 1.0, longitude: 2.0) { result in
+            service.fetchNearbyGeofences(latitude: 1.0, longitude: 2.0) { result in
                 continuation.resume(returning: result)
             }
         }

--- a/Tests/LocationGeofence/Geofence/Api/GeofenceCoordinateCoarsenerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Api/GeofenceCoordinateCoarsenerTests.swift
@@ -1,0 +1,27 @@
+@testable import CioLocationGeofence
+import Foundation
+import Testing
+
+@Suite("GeofenceCoordinateCoarsener")
+struct GeofenceCoordinateCoarsenerTests {
+    @Test
+    func coarsen_snapsToTwoDecimalGrid() {
+        #expect(GeofenceCoordinateCoarsener.coarsen(37.7749) == 37.77)
+        #expect(GeofenceCoordinateCoarsener.coarsen(-122.4194) == -122.42)
+        // Already on the grid — unchanged.
+        #expect(GeofenceCoordinateCoarsener.coarsen(10.0) == 10.0)
+    }
+
+    @Test
+    func coarsen_mapsNearbyPointsToTheSameCell() {
+        // Two precise points inside the same ~1km cell produce an identical coarse value, so
+        // repeated syncs send the same coordinate and can't be averaged back to the true point.
+        #expect(GeofenceCoordinateCoarsener.coarsen(37.7701) == GeofenceCoordinateCoarsener.coarsen(37.7749))
+    }
+
+    @Test
+    func coarsen_roundsHalfToEven() {
+        // Banker's rounding (parity with Android's HALF_EVEN): 0.125 → 0.12, not 0.13.
+        #expect(GeofenceCoordinateCoarsener.coarsen(0.125) == 0.12)
+    }
+}

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -34,7 +34,8 @@ struct GeofenceSyncCoordinatorTests {
         storage: GeofenceSyncStorage,
         monitor: MockGeofenceRegionMonitor? = nil,
         contextStore: BackgroundDeliveryContextStore? = nil,
-        dateUtil: DateUtilStub = DateUtilStub()
+        dateUtil: DateUtilStub = DateUtilStub(),
+        syncMode: GeofenceSyncMode = .fetchAll
     ) -> Setup {
         let resolvedContextStore = contextStore ?? makeContextStore()
         let resolvedMonitor = monitor ?? MockGeofenceRegionMonitor()
@@ -44,7 +45,8 @@ struct GeofenceSyncCoordinatorTests {
             monitor: resolvedMonitor,
             contextStore: resolvedContextStore,
             dateUtil: dateUtil,
-            logger: LoggerMock()
+            logger: LoggerMock(),
+            syncMode: syncMode
         )
         return Setup(
             coordinator: coordinator,
@@ -107,7 +109,7 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
 
         #expect(result.errorOrNil == .noIdentifiedUser)
-        #expect(setup.api.fetchGeofencesCallsCount == 0)
+        #expect(setup.api.fetchAllGeofencesCallsCount == 0)
         #expect(setup.monitor.startedRegions.isEmpty)
     }
 
@@ -134,15 +136,16 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.refresh(latitude: 0, longitude: 0)
 
         #expect(result.isSuccess)
-        #expect(setup.api.fetchGeofencesCallsCount == 0)
+        #expect(setup.api.fetchAllGeofencesCallsCount == 0)
         #expect(setup.monitor.startedRegions.isEmpty)
     }
 
     @Test
-    func refresh_givenTimeFreshButFarFromAnchor_expectApiCalled() async {
+    func refresh_givenNearbyModeTimeFreshButFarFromAnchor_expectApiCalled() async {
+        // NEARBY's set is location-bound, so outrunning the fetch anchor forces a re-fetch even
+        // when time-fresh. (Under fetchAll this same scenario skips — see the fetchAll test below.)
         let storage = makeStorage()
         let dateUtil = DateUtilStub()
-        // Time-fresh (100s ago vs 1h expiry) but caller is well beyond the 3km trigger radius.
         let oneHour: TimeInterval = 60 * 60
         await storage.setCachedConfig(GeofenceConfig(
             localRefreshTriggerRadius: 1000,
@@ -156,16 +159,99 @@ struct GeofenceSyncCoordinatorTests {
             location: LocationData(latitude: 0, longitude: 0)
         )
         let api = GeofenceApiServiceMock()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchNearbyGeofencesClosure = { _, _, completion in
             completion(.success(makeApiResponse(regions: [])))
         }
-        let setup = makeCoordinator(api: api, storage: storage, dateUtil: dateUtil)
+        let setup = makeCoordinator(api: api, storage: storage, dateUtil: dateUtil, syncMode: .nearby)
 
         // (1.0, 2.0) is ~248km from (0, 0) — way beyond 3km.
         let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
 
         #expect(result.isSuccess)
-        #expect(api.fetchGeofencesCallsCount == 1)
+        #expect(api.fetchNearbyGeofencesCallsCount == 1)
+    }
+
+    @Test
+    func refresh_givenFetchAllTimeFreshAndFarFromFetchAnchor_expectSkipNoApiCall() async {
+        // The fetchAll counterpart to the nearby test above: outrunning the fetch anchor does NOT
+        // force a re-fetch (the cached set is complete), and with no ranking staleness it skips.
+        let storage = makeStorage()
+        let dateUtil = DateUtilStub()
+        let oneHour: TimeInterval = 60 * 60
+        await storage.setCachedConfig(GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 3000,
+            remoteFetchRefreshExpiry: oneHour,
+            duplicateEventsExpiry: 60,
+            maxBusinessGeofences: 10
+        ))
+        // Fetch anchor is far (~248km), but the registration anchor is at the refresh location, so
+        // ranking is fresh. Only the fetch-anchor distance differs from the nearby test — isolating
+        // that fetchAll ignores it. Registered IDs non-empty → not an unregistered-cache case.
+        await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-100), location: LocationData(latitude: 0, longitude: 0))
+        await storage.recordRegistration(center: LocationData(latitude: 1.0, longitude: 2.0), businessIds: ["a"])
+        let setup = makeCoordinator(storage: storage, dateUtil: dateUtil, syncMode: .fetchAll)
+
+        let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
+
+        #expect(result.isSuccess)
+        #expect(setup.api.fetchAllGeofencesCallsCount == 0)
+        // Genuinely skipped (not a local re-rank): no regions registered this call.
+        #expect(setup.monitor.startedRegions.isEmpty)
+    }
+
+    @Test
+    func refresh_givenTimeFreshButRankingStale_expectLocalRerankNoApiCall() async {
+        // Kill-then-travel: the app was dead so no movement EXIT fired, but the device is now beyond
+        // the trigger radius from the last registration. Re-rank the cached set locally — no fetch.
+        let storage = makeStorage()
+        let dateUtil = DateUtilStub()
+        let oneHour: TimeInterval = 60 * 60
+        await storage.setCachedConfig(GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 3000,
+            remoteFetchRefreshExpiry: oneHour,
+            duplicateEventsExpiry: 60,
+            maxBusinessGeofences: 10
+        ))
+        await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-100), location: LocationData(latitude: 0, longitude: 0))
+        await storage.recordRegistration(center: LocationData(latitude: 0, longitude: 0), businessIds: ["old"])
+        await storage.setCachedGeofences([makeRegion(id: "near", latitude: 1, longitude: 2)])
+        let setup = makeCoordinator(storage: storage, dateUtil: dateUtil, syncMode: .fetchAll)
+
+        // ~248km from the registration center — well beyond the 1km ranking radius.
+        let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
+
+        #expect(result.isSuccess)
+        #expect(setup.api.fetchAllGeofencesCallsCount == 0)
+        #expect(setup.monitor.startedRegions.contains { $0.identifier == "near" })
+    }
+
+    @Test
+    func refresh_givenTimeFreshAndRankingFreshButUnregisteredCache_expectLocalRerankNoApiCall() async {
+        // Cache holds regions but nothing is registered (e.g. OS regs lost) → re-register locally
+        // rather than skip, so the user isn't left with no monitored geofences until staleness.
+        let storage = makeStorage()
+        let dateUtil = DateUtilStub()
+        let oneHour: TimeInterval = 60 * 60
+        await storage.setCachedConfig(GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 3000,
+            remoteFetchRefreshExpiry: oneHour,
+            duplicateEventsExpiry: 60,
+            maxBusinessGeofences: 10
+        ))
+        await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-100), location: LocationData(latitude: 0, longitude: 0))
+        await storage.recordRegistration(center: LocationData(latitude: 0, longitude: 0), businessIds: [])
+        await storage.setCachedGeofences([makeRegion(id: "cached", latitude: 0, longitude: 0)])
+        let setup = makeCoordinator(storage: storage, dateUtil: dateUtil, syncMode: .fetchAll)
+
+        // Same location as anchors → time-fresh + ranking-fresh, but registered IDs are empty.
+        let result = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+
+        #expect(result.isSuccess)
+        #expect(setup.api.fetchAllGeofencesCallsCount == 0)
+        #expect(setup.monitor.startedRegions.contains { $0.identifier == "cached" })
     }
 
     @Test
@@ -186,7 +272,7 @@ struct GeofenceSyncCoordinatorTests {
             location: LocationData(latitude: 0, longitude: 0)
         )
         let api = GeofenceApiServiceMock()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.success(makeApiResponse(regions: [])))
         }
         let setup = makeCoordinator(api: api, storage: storage, dateUtil: dateUtil)
@@ -194,7 +280,7 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.refresh(latitude: 0, longitude: 0)
 
         #expect(result.isSuccess)
-        #expect(api.fetchGeofencesCallsCount == 1)
+        #expect(api.fetchAllGeofencesCallsCount == 1)
     }
 
     @Test
@@ -211,7 +297,7 @@ struct GeofenceSyncCoordinatorTests {
         )
         let api = GeofenceApiServiceMock()
         let region = makeRegion(id: "g1", latitude: 1.0, longitude: 2.0)
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.success(makeApiResponse(regions: [region])))
         }
 
@@ -219,7 +305,7 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
 
         #expect(result.isSuccess)
-        #expect(api.fetchGeofencesCallsCount == 1)
+        #expect(api.fetchAllGeofencesCallsCount == 1)
         let cached = await storage.getCachedGeofences()
         #expect(cached.map(\.id) == ["g1"])
         let lastSync = await storage.getLastSync()
@@ -243,7 +329,7 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.refresh(latitude: 0, longitude: 0)
 
         #expect(result.isSuccess)
-        #expect(setup.api.fetchGeofencesCallsCount == 0)
+        #expect(setup.api.fetchAllGeofencesCallsCount == 0)
     }
 
     @Test
@@ -252,7 +338,7 @@ struct GeofenceSyncCoordinatorTests {
         // API is called regardless of cached-config state.
         let storage = makeStorage()
         let api = GeofenceApiServiceMock()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.success(makeApiResponse(regions: [])))
         }
         let setup = makeCoordinator(api: api, storage: storage)
@@ -260,7 +346,7 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
 
         #expect(result.isSuccess)
-        #expect(api.fetchGeofencesCallsCount == 1)
+        #expect(api.fetchAllGeofencesCallsCount == 1)
         #expect(await storage.getLastSync() != nil)
     }
 
@@ -274,7 +360,7 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
 
         #expect(result.errorOrNil == .noIdentifiedUser)
-        #expect(setup.api.fetchGeofencesCallsCount == 0)
+        #expect(setup.api.fetchAllGeofencesCallsCount == 0)
     }
 
     // MARK: - Fetch outcomes
@@ -283,7 +369,7 @@ struct GeofenceSyncCoordinatorTests {
     func refresh_givenApiTransportError_expectFailureAndNoCacheWritten() async {
         let storage = makeStorage()
         let api = GeofenceApiServiceMock()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.failure(.transport))
         }
 
@@ -310,7 +396,7 @@ struct GeofenceSyncCoordinatorTests {
         )
         await storage.setCachedConfig(priorConfig)
         let api = GeofenceApiServiceMock()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.success(makeApiResponse(regions: [])))
         }
 
@@ -332,7 +418,7 @@ struct GeofenceSyncCoordinatorTests {
             maxBusinessGeofences: 8
         )
         let api = GeofenceApiServiceMock()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.success(makeApiResponse(regions: [], config: newConfig)))
         }
 
@@ -361,7 +447,7 @@ struct GeofenceSyncCoordinatorTests {
             makeRegion(id: "g\(i)", latitude: Double(i) * 0.1, longitude: 0)
         }
         let api = GeofenceApiServiceMock()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.success(makeApiResponse(regions: regions)))
         }
 
@@ -389,7 +475,7 @@ struct GeofenceSyncCoordinatorTests {
         await storage.setCachedConfig(config)
         let api = GeofenceApiServiceMock()
         let region = makeRegion(id: "g1", latitude: 37.7749, longitude: -122.4194)
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.success(makeApiResponse(regions: [region])))
         }
 
@@ -409,7 +495,7 @@ struct GeofenceSyncCoordinatorTests {
     func refresh_givenEmptyBusinessRegions_expectNoMovementTriggerRegistered() async {
         let storage = makeStorage()
         let api = GeofenceApiServiceMock()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.success(makeApiResponse(regions: [])))
         }
 
@@ -425,7 +511,7 @@ struct GeofenceSyncCoordinatorTests {
         let storage = makeStorage()
         let api = GeofenceApiServiceMock()
         let region = makeRegion(id: "g1", latitude: 1.0, longitude: 2.0)
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.success(makeApiResponse(regions: [region])))
         }
 
@@ -448,7 +534,7 @@ struct GeofenceSyncCoordinatorTests {
         let api = GeofenceApiServiceMock()
         let firstReachedApi = AsyncSignal()
         let allowFinish = AsyncSignal()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             Task {
                 await firstReachedApi.fire()
                 await allowFinish.wait()
@@ -467,7 +553,7 @@ struct GeofenceSyncCoordinatorTests {
 
         #expect(second.errorOrNil == .alreadyInProgress)
         #expect(firstResult.isSuccess)
-        #expect(api.fetchGeofencesCallsCount == 1)
+        #expect(api.fetchAllGeofencesCallsCount == 1)
     }
 
     // MARK: - Storage invariants
@@ -489,7 +575,7 @@ struct GeofenceSyncCoordinatorTests {
             maxBusinessGeofences: 8
         )
         let region = makeRegion(id: "g1", latitude: 1.0, longitude: 2.0)
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.success(makeApiResponse(regions: [region], config: newConfig)))
         }
         let setup = makeCoordinator(api: api, storage: spy)
@@ -514,7 +600,7 @@ struct GeofenceSyncCoordinatorTests {
         )
         await storage.setCachedConfig(priorConfig)
         let api = GeofenceApiServiceMock()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.failure(.transport))
         }
         let setup = makeCoordinator(api: api, storage: storage)
@@ -534,7 +620,7 @@ struct GeofenceSyncCoordinatorTests {
     func applyCachedRegistration_givenNoUserId_expectNoRegistration() {
         let setup = makeCoordinator(storage: makeStorage())
 
-        setup.coordinator.applyCachedRegistration(
+        _ = setup.coordinator.applyCachedRegistration(
             cachedRegions: [sampleRegion()],
             anchor: LocationData(latitude: 0, longitude: 0),
             config: .fallback,
@@ -548,7 +634,7 @@ struct GeofenceSyncCoordinatorTests {
     func applyCachedRegistration_givenEmptyRegions_expectNoRegistration() {
         let setup = makeCoordinator(storage: makeStorage())
 
-        setup.coordinator.applyCachedRegistration(
+        _ = setup.coordinator.applyCachedRegistration(
             cachedRegions: [],
             anchor: LocationData(latitude: 0, longitude: 0),
             config: .fallback,
@@ -564,7 +650,7 @@ struct GeofenceSyncCoordinatorTests {
         // sensibly — bail rather than re-using an arbitrary location.
         let setup = makeCoordinator(storage: makeStorage())
 
-        setup.coordinator.applyCachedRegistration(
+        _ = setup.coordinator.applyCachedRegistration(
             cachedRegions: [sampleRegion()],
             anchor: nil,
             config: .fallback,
@@ -590,7 +676,7 @@ struct GeofenceSyncCoordinatorTests {
         }
         let setup = makeCoordinator(storage: makeStorage())
 
-        setup.coordinator.applyCachedRegistration(
+        _ = setup.coordinator.applyCachedRegistration(
             cachedRegions: regions,
             anchor: anchor,
             config: config,
@@ -614,11 +700,53 @@ struct GeofenceSyncCoordinatorTests {
     }
 
     @Test
+    func applyCachedRegistration_givenAllInputs_expectReturnsRegisteredCenterAndIds() {
+        // The caller persists this as the ranking-staleness reference, so the returned center/ids
+        // must match what was registered with the OS (the nearest set, capped at maxBusinessGeofences).
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 600,
+            remoteFetchRefreshTriggerRadius: 3000,
+            remoteFetchRefreshExpiry: 86400,
+            duplicateEventsExpiry: 60,
+            maxBusinessGeofences: 3
+        )
+        let anchor = LocationData(latitude: 37.7749, longitude: -122.4194)
+        let regions = (0 ..< 5).map { i in
+            makeRegion(id: "g\(i)", latitude: anchor.latitude + Double(i) * 0.01, longitude: anchor.longitude)
+        }
+        let setup = makeCoordinator(storage: makeStorage())
+
+        let registration = setup.coordinator.applyCachedRegistration(
+            cachedRegions: regions,
+            anchor: anchor,
+            config: config,
+            userId: "user-1"
+        )
+
+        #expect(registration?.center == anchor)
+        #expect(registration?.businessIds == ["g0", "g1", "g2"])
+    }
+
+    @Test
+    func applyCachedRegistration_givenSkipped_expectNilReturn() {
+        let setup = makeCoordinator(storage: makeStorage())
+
+        let registration = setup.coordinator.applyCachedRegistration(
+            cachedRegions: [sampleRegion()],
+            anchor: LocationData(latitude: 0, longitude: 0),
+            config: .fallback,
+            userId: nil
+        )
+
+        #expect(registration == nil)
+    }
+
+    @Test
     func applyCachedRegistration_givenNilConfig_expectFallbackUsed() {
         let anchor = LocationData(latitude: 0, longitude: 0)
         let setup = makeCoordinator(storage: makeStorage())
 
-        setup.coordinator.applyCachedRegistration(
+        _ = setup.coordinator.applyCachedRegistration(
             cachedRegions: [sampleRegion(offset: 0.1)],
             anchor: anchor,
             config: nil,
@@ -637,7 +765,7 @@ struct GeofenceSyncCoordinatorTests {
         let api = GeofenceApiServiceMock()
         let firstReachedApi = AsyncSignal()
         let allowFinish = AsyncSignal()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             Task {
                 await firstReachedApi.fire()
                 await allowFinish.wait()
@@ -651,7 +779,7 @@ struct GeofenceSyncCoordinatorTests {
         // Refresh holds the dedup gate. ApplyCachedRegistration must bail without touching
         // the monitor.
         let monitorCallsBefore = setup.monitor.startedRegions.count
-        setup.coordinator.applyCachedRegistration(
+        _ = setup.coordinator.applyCachedRegistration(
             cachedRegions: [sampleRegion()],
             anchor: LocationData(latitude: 0, longitude: 0),
             config: .fallback,
@@ -672,7 +800,7 @@ struct GeofenceSyncCoordinatorTests {
         let storage = makeStorage()
         let contextStore = makeContextStore(userId: nil)
         let api = GeofenceApiServiceMock()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.success(makeApiResponse(regions: [])))
         }
         let setup = makeCoordinator(api: api, storage: storage, contextStore: contextStore)
@@ -685,7 +813,7 @@ struct GeofenceSyncCoordinatorTests {
         let second = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
 
         #expect(second.isSuccess)
-        #expect(api.fetchGeofencesCallsCount == 1)
+        #expect(api.fetchAllGeofencesCallsCount == 1)
     }
 
     // MARK: - handleMovement
@@ -698,7 +826,7 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.handleMovement(latitude: 1.0, longitude: 2.0)
 
         #expect(result.errorOrNil == .noIdentifiedUser)
-        #expect(setup.api.fetchGeofencesCallsCount == 0)
+        #expect(setup.api.fetchAllGeofencesCallsCount == 0)
         #expect(setup.monitor.startedRegions.isEmpty)
     }
 
@@ -708,7 +836,7 @@ struct GeofenceSyncCoordinatorTests {
         // Matches Android's `anchor == null` branch.
         let storage = makeStorage()
         let api = GeofenceApiServiceMock()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.success(makeApiResponse(regions: [makeRegion(id: "g1", latitude: 0, longitude: 0)])))
         }
         let setup = makeCoordinator(api: api, storage: storage)
@@ -716,7 +844,7 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.handleMovement(latitude: 1.0, longitude: 2.0)
 
         #expect(result.isSuccess)
-        #expect(setup.api.fetchGeofencesCallsCount == 1)
+        #expect(setup.api.fetchAllGeofencesCallsCount == 1)
     }
 
     @Test
@@ -743,13 +871,15 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
 
         #expect(result.isSuccess)
-        #expect(setup.api.fetchGeofencesCallsCount == 0)
+        #expect(setup.api.fetchAllGeofencesCallsCount == 0)
         let businessRegistered = setup.monitor.startedRegions.filter { $0.identifier != GeofenceConstants.movementTriggerIdentifier }
         #expect(businessRegistered.map(\.identifier) == ["near", "far"])
     }
 
     @Test
-    func handleMovement_givenMovementBeyondThreshold_expectTierBRemoteFetch() async {
+    func handleMovement_givenNearbyModeMovementBeyondThreshold_expectRemoteFetch() async {
+        // NEARBY re-fetches once the device outruns its location-bound set. (Under fetchAll the same
+        // move re-ranks locally with no API call — see the fetchAll test below.)
         let storage = makeStorage()
         let config = GeofenceConfig(
             localRefreshTriggerRadius: 1000,
@@ -761,16 +891,41 @@ struct GeofenceSyncCoordinatorTests {
         await storage.setCachedConfig(config)
         await storage.recordSync(timestamp: Date(timeIntervalSince1970: 100), location: LocationData(latitude: 0, longitude: 0))
         let api = GeofenceApiServiceMock()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchNearbyGeofencesClosure = { _, _, completion in
             completion(.success(makeApiResponse(regions: [makeRegion(id: "fresh", latitude: 1, longitude: 1)])))
         }
-        let setup = makeCoordinator(api: api, storage: storage)
+        let setup = makeCoordinator(api: api, storage: storage, syncMode: .nearby)
 
-        // ~157 km from anchor — well beyond 5 km Tier B threshold.
+        // ~157 km from anchor — well beyond the 5 km threshold.
         let result = await setup.coordinator.handleMovement(latitude: 1.0, longitude: 1.0)
 
         #expect(result.isSuccess)
-        #expect(setup.api.fetchGeofencesCallsCount == 1)
+        #expect(setup.api.fetchNearbyGeofencesCallsCount == 1)
+    }
+
+    @Test
+    func handleMovement_givenFetchAllMovementBeyondThreshold_expectLocalRerankNoApiCall() async {
+        // fetchAll holds the complete set, so even a large move never re-fetches — it re-ranks the
+        // cached regions on-device. This is the privacy-critical difference from nearby mode.
+        let storage = makeStorage()
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 5000,
+            remoteFetchRefreshExpiry: 3600,
+            duplicateEventsExpiry: 3600,
+            maxBusinessGeofences: 10
+        )
+        await storage.setCachedConfig(config)
+        await storage.recordSync(timestamp: Date(timeIntervalSince1970: 100), location: LocationData(latitude: 0, longitude: 0))
+        await storage.setCachedGeofences([makeRegion(id: "cached", latitude: 1, longitude: 1)])
+        let setup = makeCoordinator(storage: storage, syncMode: .fetchAll)
+
+        // ~157 km from anchor — would be "beyond threshold" in nearby mode.
+        let result = await setup.coordinator.handleMovement(latitude: 1.0, longitude: 1.0)
+
+        #expect(result.isSuccess)
+        #expect(setup.api.fetchAllGeofencesCallsCount == 0)
+        #expect(setup.monitor.startedRegions.contains { $0.identifier == "cached" })
     }
 
     @Test
@@ -833,7 +988,7 @@ struct GeofenceSyncCoordinatorTests {
         let api = GeofenceApiServiceMock()
         let suspendUntil = AsyncSignal()
         let arrived = AsyncSignal()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             Task {
                 await arrived.fire()
                 await suspendUntil.wait()
@@ -902,7 +1057,7 @@ struct GeofenceSyncCoordinatorTests {
         let api = GeofenceApiServiceMock()
         let suspendUntil = AsyncSignal()
         let arrived = AsyncSignal()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             Task {
                 await arrived.fire()
                 await suspendUntil.wait()
@@ -929,7 +1084,7 @@ struct GeofenceSyncCoordinatorTests {
         let api = GeofenceApiServiceMock()
         let suspendUntil = AsyncSignal()
         let arrived = AsyncSignal()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             Task {
                 await arrived.fire()
                 await suspendUntil.wait()
@@ -961,7 +1116,7 @@ struct GeofenceSyncCoordinatorTests {
         let api = GeofenceApiServiceMock()
         let suspendUntil = AsyncSignal()
         let arrived = AsyncSignal()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             Task {
                 await arrived.fire()
                 await suspendUntil.wait()
@@ -992,7 +1147,7 @@ struct GeofenceSyncCoordinatorTests {
         let api = GeofenceApiServiceMock()
         let suspendUntil = AsyncSignal()
         let arrived = AsyncSignal()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             Task {
                 await arrived.fire()
                 await suspendUntil.wait()
@@ -1032,9 +1187,12 @@ private actor SpyGeofenceSyncStorage: GeofenceSyncStorage {
         case getCachedConfig
         case getCachedGeofences
         case getLastSync
+        case getLastRegistrationCenter
+        case getRegisteredBusinessIds
         case setCachedGeofences
         case setCachedConfig
         case recordSync
+        case recordRegistration
         case clearUserScopedState
     }
 
@@ -1060,6 +1218,16 @@ private actor SpyGeofenceSyncStorage: GeofenceSyncStorage {
         return await underlying.getLastSync()
     }
 
+    func getLastRegistrationCenter() async -> LocationData? {
+        operations.append(.getLastRegistrationCenter)
+        return await underlying.getLastRegistrationCenter()
+    }
+
+    func getRegisteredBusinessIds() async -> Set<String> {
+        operations.append(.getRegisteredBusinessIds)
+        return await underlying.getRegisteredBusinessIds()
+    }
+
     func setCachedGeofences(_ regions: [Geofence]) async {
         operations.append(.setCachedGeofences)
         await underlying.setCachedGeofences(regions)
@@ -1073,6 +1241,11 @@ private actor SpyGeofenceSyncStorage: GeofenceSyncStorage {
     func recordSync(timestamp: Date, location: LocationData) async {
         operations.append(.recordSync)
         await underlying.recordSync(timestamp: timestamp, location: location)
+    }
+
+    func recordRegistration(center: LocationData, businessIds: Set<String>) async {
+        operations.append(.recordRegistration)
+        await underlying.recordRegistration(center: center, businessIds: businessIds)
     }
 
     func clearUserScopedState() async {

--- a/Tests/LocationGeofence/Geofence/GeofenceBootstrapTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceBootstrapTests.swift
@@ -118,6 +118,97 @@ struct GeofenceBootstrapTests {
     }
 
     @Test
+    func wireMonitor_givenRegistrationCenterAndLastSync_expectAnchorFromRegistrationCenter() async {
+        // A local re-rank moved the registration center past the fetch anchor. Restore must use
+        // the registration center so cold boot reproduces the last-monitored set, not the older one.
+        let di = DIGraphShared.shared
+        let storage = GeofenceStorage(
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        await storage.recordSync(timestamp: Date(), location: LocationData(latitude: 0, longitude: 0))
+        await storage.recordRegistration(center: LocationData(latitude: 10, longitude: 20), businessIds: ["g1"])
+        di.override(value: storage, forType: GeofenceStorage.self)
+        let monitor = MockGeofenceRegionMonitor()
+        di.override(value: monitor as GeofenceRegionMonitoring, forType: GeofenceRegionMonitoring.self)
+        let coordinator = GeofenceSyncCoordinatorMock()
+        di.override(value: coordinator as GeofenceSyncCoordinator, forType: GeofenceSyncCoordinator.self)
+        defer { di.reset() }
+
+        await GeofenceBootstrap.wireMonitor(di: di)
+
+        let anchor = coordinator.applyCachedRegistrationReceivedArguments?.anchor
+        #expect(anchor?.latitude == 10)
+        #expect(anchor?.longitude == 20)
+    }
+
+    @Test
+    func wireMonitor_givenNoRegistrationCenter_expectAnchorFromLastSync() async {
+        // First restore after a remote fetch (no local re-rank yet): fall back to the fetch anchor.
+        let di = DIGraphShared.shared
+        let storage = GeofenceStorage(
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        await storage.recordSync(timestamp: Date(), location: LocationData(latitude: 5, longitude: 6))
+        di.override(value: storage, forType: GeofenceStorage.self)
+        let monitor = MockGeofenceRegionMonitor()
+        di.override(value: monitor as GeofenceRegionMonitoring, forType: GeofenceRegionMonitoring.self)
+        let coordinator = GeofenceSyncCoordinatorMock()
+        di.override(value: coordinator as GeofenceSyncCoordinator, forType: GeofenceSyncCoordinator.self)
+        defer { di.reset() }
+
+        await GeofenceBootstrap.wireMonitor(di: di)
+
+        let anchor = coordinator.applyCachedRegistrationReceivedArguments?.anchor
+        #expect(anchor?.latitude == 5)
+        #expect(anchor?.longitude == 6)
+    }
+
+    @Test
+    func wireMonitor_givenCoordinatorReturnsRegistration_expectPersistedAsReference() async {
+        // The registration applyCachedRegistration reports is persisted as the ranking-staleness
+        // reference so a later refresh measures distance from the actually-registered set.
+        let di = DIGraphShared.shared
+        let storage = GeofenceStorage(
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        di.override(value: storage, forType: GeofenceStorage.self)
+        let monitor = MockGeofenceRegionMonitor()
+        di.override(value: monitor as GeofenceRegionMonitoring, forType: GeofenceRegionMonitoring.self)
+        let coordinator = GeofenceSyncCoordinatorMock()
+        coordinator.applyCachedRegistrationReturnValue = GeofenceRegistration(
+            center: LocationData(latitude: 12, longitude: 34),
+            businessIds: ["g1"]
+        )
+        di.override(value: coordinator as GeofenceSyncCoordinator, forType: GeofenceSyncCoordinator.self)
+        defer { di.reset() }
+
+        await GeofenceBootstrap.wireMonitor(di: di)
+
+        let persisted = await storage.getLastRegistrationCenter()
+        #expect(persisted == LocationData(latitude: 12, longitude: 34))
+        #expect(await storage.getRegisteredBusinessIds() == ["g1"])
+    }
+
+    @Test
+    func wireMonitor_givenCoordinatorReturnsNil_expectNoRegistrationPersisted() async {
+        let di = DIGraphShared.shared
+        let storage = GeofenceStorage(
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        di.override(value: storage, forType: GeofenceStorage.self)
+        let monitor = MockGeofenceRegionMonitor()
+        di.override(value: monitor as GeofenceRegionMonitoring, forType: GeofenceRegionMonitoring.self)
+        let coordinator = GeofenceSyncCoordinatorMock()
+        coordinator.applyCachedRegistrationReturnValue = nil
+        di.override(value: coordinator as GeofenceSyncCoordinator, forType: GeofenceSyncCoordinator.self)
+        defer { di.reset() }
+
+        await GeofenceBootstrap.wireMonitor(di: di)
+
+        #expect(await storage.getLastRegistrationCenter() == nil)
+    }
+
+    @Test
     func geofenceSyncCoordinator_givenRepeatedResolution_expectSameInstance() {
         let di = DIGraphShared.shared
         let first = di.geofenceSyncCoordinator as? GeofenceSyncCoordinatorImpl

--- a/Tests/LocationGeofence/Geofence/GeofenceSyncModeTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceSyncModeTests.swift
@@ -1,0 +1,28 @@
+@testable import CioLocationGeofence
+import Foundation
+import Testing
+
+@Suite("GeofenceSyncMode")
+struct GeofenceSyncModeTests {
+    private let config = GeofenceConfig.fallback
+
+    @Test
+    func active_isFetchAll() {
+        // The shipped default sends no location. Flipping this is a deliberate SDK release.
+        #expect(GeofenceSyncMode.active == .fetchAll)
+    }
+
+    @Test
+    func fetchAll_neverRequiresRemoteFetchOnMovement() {
+        // The full set is cached, so movement only re-ranks on-device — no distance ever forces a fetch.
+        #expect(GeofenceSyncMode.fetchAll.movementRequiresRemoteFetch(distanceFromAnchor: 0, config: config) == false)
+        #expect(GeofenceSyncMode.fetchAll.movementRequiresRemoteFetch(distanceFromAnchor: 1000000, config: config) == false)
+    }
+
+    @Test
+    func nearby_requiresRemoteFetchBeyondTriggerRadius() {
+        let radius = config.remoteFetchRefreshTriggerRadius
+        #expect(GeofenceSyncMode.nearby.movementRequiresRemoteFetch(distanceFromAnchor: radius - 1, config: config) == false)
+        #expect(GeofenceSyncMode.nearby.movementRequiresRemoteFetch(distanceFromAnchor: radius, config: config) == true)
+    }
+}

--- a/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
@@ -453,7 +453,20 @@ struct GeofenceStorageTests {
     // MARK: - Concurrent safety
 
     @Test
-    func clearUserScopedState_expectCooldownsAndLastSyncCleared_workspaceCachePreserved() async {
+    func recordRegistration_thenGet_expectRoundTrip() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let center = LocationData(latitude: 37.7749, longitude: -122.4194)
+
+        await storage.recordRegistration(center: center, businessIds: ["g1", "g2"])
+
+        #expect(await storage.getLastRegistrationCenter() == center)
+        #expect(await storage.getRegisteredBusinessIds() == ["g1", "g2"])
+    }
+
+    @Test
+    func clearUserScopedState_expectCooldownsLastSyncAndRegistrationCleared_workspaceCachePreserved() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let storage = makeStorage(directory: dir)
@@ -463,6 +476,7 @@ struct GeofenceStorageTests {
         ])
         await storage.setCachedConfig(.fallback)
         await storage.recordSync(timestamp: Date(timeIntervalSince1970: 100), location: LocationData(latitude: 1, longitude: 2))
+        await storage.recordRegistration(center: LocationData(latitude: 1, longitude: 2), businessIds: ["g1"])
 
         await storage.clearUserScopedState()
 
@@ -472,6 +486,10 @@ struct GeofenceStorageTests {
         let config = await storage.getCachedConfig()
         #expect(cooldowns.isEmpty)
         #expect(lastSync == nil)
+        // Registration is user-scoped — cleared so the next user re-registers from their own refresh.
+        #expect(await storage.getLastRegistrationCenter() == nil)
+        #expect(await storage.getRegisteredBusinessIds().isEmpty)
+        // Workspace cache is shared across users — preserved.
         #expect(regions.map(\.id) == ["g1"])
         #expect(config != nil)
     }


### PR DESCRIPTION
Ports the Android mode-based sync design (`85cf1e9`) to iOS. The sync fetch (`GET /geofences`) stops sending `latitude`/`longitude` and instead retrieves the full workspace set (≤100, a per-workspace total cap), ranking nearest on-device. Precise location stays on-device only.

## Changes
- **`GeofenceSyncMode` enum** — `fetchAll` (active) / `nearby` (retained, coarsened). Compile-time/release-only switch (`static let active`), never wire- or server-driven, so location-send can't be silently re-enabled.
- **`RefreshAction` decision table** drives both `refresh` and movement: stale-time → remote; ranking-stale (distance from last registration ≥ trigger radius) → local re-rank; unregistered cache → local; else skip. Under `fetchAll`, movement never re-fetches — it re-ranks the cached complete set.
- **`isRankingStale`** closes the kill-then-travel gap (app dead → no OS EXIT → `refresh()` re-ranks locally without a network call).
- **API split** `fetchAllGeofences()` / `fetchNearbyGeofences(latitude:longitude:)` — renamed, not overloaded (Sourcery mock template names members by base name only).
- **Coarsener** (`GeofenceCoordinateCoarsener`) retained for the `nearby` path — banker's rounding to 2 dp.
- Wired two previously-dead `GeofenceState` fields (`movementTriggerCenter`, `monitoredGeofenceIds`) via `recordRegistration`, cleared in `clearUserScopedState`.

## Privacy
With `fetchAll` active the SDK sends no coordinates for sync → privacy manifest becomes "no location" (separate PR once this lands).

## Testing
New: `GeofenceSyncModeTests`, `GeofenceCoordinateCoarsenerTests`. Updated: `GeofenceApiServiceTests` (fetch-all no-query + nearby coarsened), `GeofenceSyncCoordinatorTests` (distance-tier tests split across modes + ranking-stale/unregistered-cache cases), `GeofenceStorageTests` (registration round-trip + clear). All affected suites green; format/lint clean; no public-API/api-docs change.

Linear: MBL-1843

## Stack
Targets `feature/geofence-on-device`. Builds on the merged geofence stack (#1103, #1105, #1106). Privacy-manifest PR (no-location) follows once this merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core geofence sync, cold-boot OS registration, and persisted anchors—behavior changes (especially refresh skip vs local re-rank) could affect monitoring correctness if thresholds are wrong, but privacy default improves and coverage is extensive.
> 
> **Overview**
> Geofence sync now defaults to **`fetchAll`**: the CDP request returns the full capped workspace set with **no latitude/longitude** on the wire, while precise location still drives on-device nearest ranking and OS registration. The legacy **`nearby`** path remains (coarsened coords via `GeofenceCoordinateCoarsener`); mode is **compile-time** (`GeofenceSyncMode.active`), not runtime-configurable.
> 
> **`refresh`** no longer uses a simple time+distance-from-last-sync skip. A **`RefreshAction`** table chooses **remote fetch**, **local re-rank**, or **skip** using time staleness, mode-specific fetch distance, **ranking staleness** (distance from last **registration** center), and **unregistered cache** (regions cached but no OS IDs). **`handleMovement`** in `fetchAll` never re-fetches on distance—only local re-rank unless there is no anchor.
> 
> **API** splits into `fetchAllGeofences()` vs `fetchNearbyGeofences(latitude:longitude:)`. **Storage** persists last registration center + monitored business IDs (`recordRegistration`), cleared on sign-out; **bootstrap** restores from registration center when present and persists what `applyCachedRegistration` returns. Fallback movement/server-fetch radii in constants are updated (3 km / 20 km).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5776c6a6e3f1e0d7eae50408c5ff12ec726f60b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->