### PR TITLE
feat: visual notification inbox overlay UI (chrome + Jist rendering)

### DIFF
--- a/Apps/APN-UIKit/APN UIKit.xcodeproj/project.pbxproj
+++ b/Apps/APN-UIKit/APN UIKit.xcodeproj/project.pbxproj
@@ -723,7 +723,7 @@
 				INFOPLIST_FILE = NotificationServiceExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = NotificationServiceExtension;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -754,7 +754,7 @@
 				INFOPLIST_FILE = NotificationServiceExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = NotificationServiceExtension;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -822,7 +822,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -877,7 +877,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -906,7 +906,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -941,7 +941,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -967,7 +967,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.customer.ios-sample.apn-spm.APN-UIKitTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -988,7 +988,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.customer.ios-sample.apn-spm.APN-UIKitTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/CustomerIOMessagingInbox.podspec
+++ b/CustomerIOMessagingInbox.podspec
@@ -1,0 +1,33 @@
+Pod::Spec.new do |spec|
+  spec.name         = "CustomerIOMessagingInbox"
+  spec.version      = "4.5.1" # Don't modify this line - it's automatically updated
+  spec.summary      = "Official Customer.io SDK for iOS."
+  spec.homepage     = "https://github.com/customerio/customerio-ios"
+  spec.documentation_url = 'https://customer.io/docs/sdk/ios/'
+  spec.changelog    = "https://github.com/customerio/customerio-ios/blob/#{spec.version.to_s}/CHANGELOG.md"
+  spec.license      = { :type => "MIT", :file => "LICENSE" }
+  spec.author       = { "CustomerIO Team" => "win@customer.io" }
+  spec.source       = { :git => 'https://github.com/customerio/customerio-ios.git', :tag => spec.version.to_s }
+
+  spec.swift_version = '5.3'
+  spec.cocoapods_version = '>= 1.11.0'
+
+  spec.platform = :ios # platforms SDK supports. Leave blank and it's assumed SDK supports all platforms.
+  spec.ios.deployment_target = "13.0"
+  # spec.osx.deployment_target = "10.15"
+  # spec.tvos.deployment_target = '13.0'
+
+  path_to_source_for_module = "Sources/MessagingInbox"
+  spec.source_files = "#{path_to_source_for_module}/**/*{.swift}"
+  spec.resource_bundle = {
+    "#{spec.module_name}_Privacy" => "#{path_to_source_for_module}/Resources/PrivacyInfo.xcprivacy"
+  }
+
+  spec.module_name = "CioMessagingInbox"  # the `import X` name when using SDK in Swift files
+
+  spec.dependency "CustomerIOMessagingInApp", "= #{spec.version.to_s}"
+  spec.dependency "CustomerIOCommon", "= #{spec.version.to_s}"
+  # TODO: switch to published Jist once available. The overlay renders messages via the Jist
+  # SwiftUI package; add it here (e.g. spec.dependency "Jist", "~> x.y.z") when it is published to
+  # CocoaPods. The SPM build consumes it as a local path dependency in the meantime.
+ end

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ var products: [PackageDescription.Product] = [
     .library(name: "MessagingPushAPN", targets: ["CioMessagingPushAPN"]),
     .library(name: "MessagingPushFCM", targets: ["CioMessagingPushFCM"]),
     .library(name: "MessagingInApp", targets: ["CioMessagingInApp"]),
+    .library(name: "MessagingInbox", targets: ["CioMessagingInbox"]),
     .library(name: "Location", targets: ["CioLocation"])
 ]
 
@@ -35,7 +36,14 @@ if (ProcessInfo.processInfo.environment["CI"] != nil) { // true if running on a 
 let package = Package(
     name: "Customer.io",
     platforms: [
-        .iOS(.v13)
+        // NOTE (Visual Inbox / Jist): SwiftPM enforces a platform floor package-wide, and the
+        // Jist product currently declares a minimum of iOS 15. Because the Visual Inbox overlay
+        // (`CioMessagingInbox`) links Jist, the package floor is raised to iOS 15 here.
+        // This is a TEMPORARY consequence of the Jist dependency — the documented Milestone-0
+        // item is to lower Jist's iOS floor to 13, after which this should revert to `.iOS(.v13)`.
+        // All SDK *source* remains iOS 13-compatible (Jist usage is `@available(iOS 15, *)`-gated).
+        // TODO: revert to `.iOS(.v13)` once Jist's iOS deployment target is lowered to 13.
+        .iOS(.v15)
     ],
     products: products,
     dependencies: [
@@ -49,7 +57,12 @@ let package = Package(
         .package(name: "CioAnalytics", url: "https://github.com/customerio/cdp-analytics-swift.git", .exact("1.7.3+cio.1")),
         
         // SSE (Server-Sent Events) client for real-time in-app messaging
-        .package(url: "https://github.com/LaunchDarkly/swift-eventsource.git", .upToNextMajor(from: "3.3.0"))
+        .package(url: "https://github.com/LaunchDarkly/swift-eventsource.git", .upToNextMajor(from: "3.3.0")),
+
+        // Jist SwiftUI renderer used by the Visual Inbox overlay (`CioMessagingInbox`).
+        // Consumed from the published Jist repo on `main` (its root Package.swift exposes the `Jist` product).
+        // TODO: pin to a tagged release once Jist cuts one.
+        .package(url: "https://github.com/customerio/jist.git", branch: "main")
     ],
     targets: [ 
         // Common - Code used by multiple modules in the SDK project.
@@ -157,6 +170,23 @@ let package = Package(
         .testTarget(name: "MessagingInAppTests",
                     dependencies: ["CioMessagingInApp", "SharedTests", "CioInternalCommonMocks", "CioMessagingInAppMocks"],
                     path: "Tests/MessagingInApp"),
+
+        // Messaging Inbox (Visual Inbox overlay UI)
+        // SwiftUI overlay that renders the visual inbox via Jist. Wraps the headless data layer
+        // exposed by CioMessagingInApp through the @_spi(VisualInbox) facade.
+        .target(name: "CioMessagingInbox",
+                dependencies: [
+                    "CioMessagingInApp",
+                    "CioInternalCommon",
+                    .product(name: "Jist", package: "jist")
+                ],
+                path: "Sources/MessagingInbox",
+                resources: [
+                    .process("Resources/PrivacyInfo.xcprivacy"),
+                ]),
+        .testTarget(name: "MessagingInboxTests",
+                    dependencies: ["CioMessagingInbox", "CioMessagingInApp", "SharedTests", "CioInternalCommonMocks"],
+                    path: "Tests/MessagingInbox"),
 
         // Location
         .target(name: "CioLocation",

--- a/Sources/MessagingInApp/Inbox/Data/VisualInboxLoadStateObservers.swift
+++ b/Sources/MessagingInApp/Inbox/Data/VisualInboxLoadStateObservers.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// A tiny registry of live `loadState`-change observers backing
+/// ``VisualInboxRepository/loadStateChanges()``.
+///
+/// Each observer is an `AsyncStream<Void>` continuation. The registry is a value type owned and
+/// mutated exclusively from inside `VisualInboxRepositoryImpl` (an `actor`), so actor isolation
+/// already serializes every `add`/`remove`/`notify` — there is no manual locking here.
+///
+/// Emissions are **signal-only** (carry no payload): a tick means "loadState changed, re-read the
+/// current cached state". The registry never triggers a network fetch.
+struct VisualInboxLoadStateObservers {
+    private var observers: [UUID: AsyncStream<Void>.Continuation] = [:]
+
+    /// Registers a continuation and immediately yields once, so a late subscriber gets the current
+    /// state right away (the overlay's one-shot load may have resolved before it subscribed).
+    mutating func add(id: UUID, continuation: AsyncStream<Void>.Continuation) {
+        observers[id] = continuation
+        continuation.yield(())
+    }
+
+    /// Drops a continuation (called on stream termination).
+    mutating func remove(id: UUID) {
+        observers[id] = nil
+    }
+
+    /// Fans a change signal out to every live observer.
+    func notify() {
+        for continuation in observers.values {
+            continuation.yield(())
+        }
+    }
+}

--- a/Sources/MessagingInApp/Inbox/Data/VisualInboxRepository.swift
+++ b/Sources/MessagingInApp/Inbox/Data/VisualInboxRepository.swift
@@ -49,26 +49,26 @@ protocol VisualInboxRepository: AnyObject, Sendable {
     ///   so callers can detect a `false → true` transition.
     @discardableResult
     func setInboxEnabled(_ enabled: Bool) async -> Bool
+
+    /// Emits once every time `loadState` is (re)computed. The overlay subscribes to react to
+    /// enablement/visibility changes without polling; emissions are signals only (the subscriber
+    /// reads current cached state) and never trigger a network fetch.
+    func loadStateChanges() async -> AsyncStream<Void>
 }
 
 // sourcery: InjectRegisterShared = "VisualInboxRepository"
 // sourcery: InjectSingleton
-/// Default actor-isolated implementation of the visual-inbox data layer.
-///
-/// Thread safety: implemented as an `actor` so all cache reads/writes and load-state transitions
-/// are serialized without manual locking.
+/// Default actor-isolated implementation of the visual-inbox data layer. Implemented as an `actor`
+/// so all cache reads/writes and load-state transitions are serialized without manual locking.
 ///
 /// Freshness model (matches Android): templates/branding are revalidated against the server
-/// **once per session** — the first `enableAndLoad()` of the process performs the network GET
-/// through the existing `GistQueueNetwork` path; later same-session loads serve the stored payload
-/// without a network call. There is no wall-clock TTL. Because the repository is a DI singleton,
-/// the in-memory gate naturally resets on process restart (= new session) and only then; a logout
-/// clears the persisted assets elsewhere.
+/// **once per session** (first `enableAndLoad()` of the process, via `GistQueueNetwork`); later
+/// same-session loads serve the stored payload with no network call. No wall-clock TTL — the
+/// in-memory gate resets only on process restart (DI singleton); logout clears persisted assets.
 ///
-/// Serve-stale: messages are served stale by the headless layer itself — a failed poll never
-/// dispatches new inbox messages, so the in-app store retains its last-known-good set (persisted
-/// across launches via the headless 304 cache). Templates/branding are served stale here by
-/// returning the last stored payload through a failed revalidation.
+/// Serve-stale: a failed poll never dispatches new inbox messages, so the store retains its
+/// last-known-good set (persisted via the headless 304 cache); templates/branding fall back to the
+/// last stored payload on failed revalidation.
 actor VisualInboxRepositoryImpl: VisualInboxRepository {
     private let networkClient: InboxNetworkClient
     private let inAppMessageManager: InAppMessageManager
@@ -80,23 +80,26 @@ actor VisualInboxRepositoryImpl: VisualInboxRepository {
     /// source and same-session payload source).
     private let assetsCache: InboxRenderAssetsCache
 
-    private var currentLoadState: VisualInboxLoadState = .idle
+    private var currentLoadState: VisualInboxLoadState = .idle {
+        didSet { loadStateObservers.notify() }
+    }
 
-    /// In-flight guard: true while a network revalidation (templates+branding) is running, so
-    /// overlapping polls don't launch duplicate concurrent fetches. Actor isolation makes the
-    /// check+set atomic.
+    /// Live observers of `loadState` changes (see `loadStateChanges()`); actor isolation serializes
+    /// add/remove/notify, so no manual locking.
+    private var loadStateObservers = VisualInboxLoadStateObservers()
+
+    /// In-flight guard: true while a templates+branding revalidation runs, so overlapping polls
+    /// don't launch duplicate fetches (actor isolation makes check+set atomic).
     private var isFetchInFlight = false
 
-    /// Session-scoped revalidation gate. False until the first successful-or-attempted revalidation
-    /// of this session; once true, same-session loads serve the stored payload without a network
-    /// call. The repository is a DI singleton, so this resets to false on process restart — i.e. a
-    /// new session always revalidates exactly once. It resets ONLY on process restart.
+    /// Session-scoped revalidation gate: false until this session's first revalidation, then
+    /// same-session loads serve the stored payload with no network call. Resets ONLY on process
+    /// restart (DI singleton) — i.e. a new session revalidates exactly once.
     private var didRevalidateThisSession = false
 
-    /// Strong reference to the in-app store subscriber for inbox-message changes. The store holds the
-    /// subscriber weakly, so we must retain it for the lifetime of the repository. Kept so that
-    /// inbox messages arriving via the SSE path (`processInboxMessages`, which never runs the queue
-    /// HTTP pipeline) still trigger a `loadState` recompute. See `subscribeToInboxMessageChanges`.
+    /// Strong reference to the weakly-held in-app store subscriber for inbox-message changes, so
+    /// messages arriving via the SSE path (`processInboxMessages`, which skips the queue HTTP
+    /// pipeline) still trigger a `loadState` recompute. See `subscribeToInboxMessageChanges`.
     private var messagesSubscriber: InAppMessageStoreSubscriber?
 
     /// Current time, sourced from the injectable `DateUtil` so tests can control it.
@@ -180,6 +183,27 @@ actor VisualInboxRepositoryImpl: VisualInboxRepository {
 
     var isInboxVisible: Bool {
         get async { currentLoadState.isInboxVisible }
+    }
+
+    // MARK: - Reactive observation
+
+    func loadStateChanges() async -> AsyncStream<Void> {
+        AsyncStream { continuation in
+            let id = UUID()
+            // Stream builder runs synchronously on the caller; defer register/unregister onto the actor.
+            Task { await self.addLoadStateObserver(id: id, continuation: continuation) }
+            continuation.onTermination = { @Sendable _ in
+                Task { await self.removeLoadStateObserver(id: id) }
+            }
+        }
+    }
+
+    private func addLoadStateObserver(id: UUID, continuation: AsyncStream<Void>.Continuation) {
+        loadStateObservers.add(id: id, continuation: continuation)
+    }
+
+    private func removeLoadStateObserver(id: UUID) {
+        loadStateObservers.remove(id: id)
     }
 
     // MARK: - Loading

--- a/Sources/MessagingInApp/Inbox/Data/VisualInboxSPI.swift
+++ b/Sources/MessagingInApp/Inbox/Data/VisualInboxSPI.swift
@@ -1,0 +1,354 @@
+import CioInternalCommon
+import Foundation
+
+// MARK: - Visual Inbox cross-module SPI
+
+// The ONLY bridge the Visual Inbox overlay UI module (`CioMessagingInbox`) uses to reach the in-app
+// data layer. It is gated behind `@_spi(VisualInbox)` so it stays off the public SDK surface (only a
+// sibling module that writes `@_spi(VisualInbox) import CioMessagingInApp` can see it). The internal
+// data-layer types stay `internal`; this layer exposes plain Foundation value types instead, leaving
+// the headless public `NotificationInbox` API untouched.
+
+/// Visibility/loading signal the overlay renders from. Mirrors the internal `VisualInboxLoadState`
+/// but is a self-contained SPI value type (no internal types leak across the module boundary).
+@_spi(VisualInbox)
+public enum VisualInboxState: Equatable {
+    /// Nothing fetched yet for the current user.
+    case idle
+    /// A fetch is in flight — the overlay shows a loading affordance.
+    case loading
+    /// Fully renderable: enabled, with messages + templates + branding all available.
+    case visible(messageCount: Int)
+    /// Not renderable (disabled, or any of messages/templates/branding missing). The overlay hides
+    /// all chrome. `reason` is diagnostic only. This is NOT an error state.
+    case hidden(reason: String)
+
+    /// Whether the overlay should show the inbox chrome (bell + panel).
+    public var isVisible: Bool {
+        if case .visible = self { return true }
+        return false
+    }
+}
+
+/// A single inbox message, flattened to the minimum the overlay needs to render it via Jist.
+///
+/// `properties` is preserved as a typed `[String: Any]` (nested objects/arrays/numbers/bools/dates
+/// intact — no string flattening) so the overlay can decode it into Jist's `[String: JistValue]`.
+@_spi(VisualInbox)
+public struct VisualInboxMessageSnapshot: Identifiable {
+    /// Stable identifier (the underlying message's queueId).
+    public let id: String
+    /// Jist message type — selects a template from the registry.
+    public let type: String
+    /// Typed, nested-preserving properties handed to the Jist renderer.
+    public let properties: [String: Any]
+    /// Whether the user has opened this message.
+    public let opened: Bool
+    /// Original send time.
+    public let sentAt: Date
+
+    public init(id: String, type: String, properties: [String: Any], opened: Bool, sentAt: Date) {
+        self.id = id
+        self.type = type
+        self.properties = properties
+        self.opened = opened
+        self.sentAt = sentAt
+    }
+}
+
+/// A single coalesced snapshot of everything the overlay renders from, emitted by
+/// ``VisualInboxProvider/observe()`` whenever the underlying data layer changes.
+///
+/// Bundling state + messages + count + rendering inputs into one value lets the overlay model
+/// publish atomically (one `@Published` write per emission) and lets the provider de-dupe emissions
+/// (only forward an emission when the snapshot actually differs from the last one).
+@_spi(VisualInbox)
+public struct VisualInboxSnapshot: Equatable {
+    public let state: VisualInboxState
+    public let messages: [VisualInboxMessageSnapshot]
+    public let unopenedCount: Int
+    /// Raw templates registry JSON, decoded by the overlay into Jist types.
+    public let templatesJSON: [String: Any]?
+    /// Raw branding theme JSON, decoded by the overlay into Jist types.
+    public let themeJSON: [String: Any]?
+
+    public init(
+        state: VisualInboxState,
+        messages: [VisualInboxMessageSnapshot],
+        unopenedCount: Int,
+        templatesJSON: [String: Any]?,
+        themeJSON: [String: Any]?
+    ) {
+        self.state = state
+        self.messages = messages
+        self.unopenedCount = unopenedCount
+        self.templatesJSON = templatesJSON
+        self.themeJSON = themeJSON
+    }
+
+    /// Structural equality used purely to de-dupe emissions. Compares every render-affecting field:
+    /// state, count, per-message identity/opened/type AND the render payload (each message's
+    /// `properties` plus the raw `templatesJSON`/`themeJSON`). Content-only changes — e.g. a Jist row's
+    /// properties or an updated template/theme arriving while `state`/ids are unchanged — must count as
+    /// DIFFERENT so `emitSnapshot` forwards them; otherwise `VisualInboxModel.apply` keeps rendering
+    /// stale rows/theme. The `[String: Any]` dictionaries aren't `Equatable`, so they're compared via
+    /// `NSDictionary(dictionary:).isEqual`, mirroring `InboxBranding`/`InboxTemplatesRegistry`.
+    public static func == (lhs: VisualInboxSnapshot, rhs: VisualInboxSnapshot) -> Bool {
+        lhs.state == rhs.state &&
+            lhs.unopenedCount == rhs.unopenedCount &&
+            lhs.messages.count == rhs.messages.count &&
+            zip(lhs.messages, rhs.messages).allSatisfy { l, r in
+                l.id == r.id && l.opened == r.opened && l.type == r.type &&
+                    NSDictionary(dictionary: l.properties).isEqual(to: r.properties)
+            } &&
+            jsonEqual(lhs.templatesJSON, rhs.templatesJSON) &&
+            jsonEqual(lhs.themeJSON, rhs.themeJSON)
+    }
+
+    /// Compares two optional `[String: Any]` render-payload dictionaries (nil == nil, nil != non-nil),
+    /// using `NSDictionary.isEqual` for the non-nil case (same approach as the data-layer types).
+    private static func jsonEqual(_ lhs: [String: Any]?, _ rhs: [String: Any]?) -> Bool {
+        switch (lhs, rhs) {
+        case (nil, nil): return true
+        case (let l?, let r?): return NSDictionary(dictionary: l).isEqual(to: r)
+        default: return false
+        }
+    }
+}
+
+/// Read-facing cross-module facade over the Visual Inbox data layer.
+///
+/// All accessors are `async` because the backing repository is an `actor`. The overlay observes
+/// state, reads the rendering inputs (messages + raw templates/theme JSON), and triggers
+/// mark-opened — but it never re-implements any data-layer policy.
+@_spi(VisualInbox)
+public protocol VisualInboxProvider: Sendable {
+    /// A continuous stream of coalesced overlay snapshots. Emits on subscribe (current state) and
+    /// then on every relevant data-layer change: the inbox enablement/visibility flip (via the
+    /// repository load-state stream) and inbox message-set / opened-state changes (via the in-app
+    /// store subscription). Emissions are de-duped, and reading a snapshot only reads cached state —
+    /// it never triggers a network fetch.
+    func observe() -> AsyncStream<VisualInboxSnapshot>
+    /// Ensures the data layer has fetched templates + branding (idempotent / fetch-if-missing),
+    /// transitioning `state` through `.loading` to a terminal `.visible`/`.hidden`.
+    func load() async
+
+    /// Current visibility/loading state.
+    func state() async -> VisualInboxState
+
+    /// Selected/sorted visual-inbox messages (cio_inbox prefix, priority/sentAt, expiry-dropped).
+    func messages() async -> [VisualInboxMessageSnapshot]
+
+    /// Count of selected messages the user has not yet opened — drives the unread badge.
+    func unopenedCount() async -> Int
+
+    /// Raw templates registry JSON (`{ name: [versions] }`), or nil if unavailable. The overlay
+    /// decodes this into Jist `[String: [JistTemplate]]`.
+    func templatesJSON() async -> [String: Any]?
+
+    /// Raw branding theme tokens JSON, or nil if unavailable. The overlay decodes this into Jist
+    /// `[String: JistValue]`.
+    func themeJSON() async -> [String: Any]?
+
+    /// Marks a message opened via the existing headless plumbing (no new mutation path). Looked up
+    /// by the snapshot id so the overlay never has to hold an internal `InboxMessage`.
+    /// - Returns: `true` if a matching message was still present in the store and the mark was
+    ///   issued; `false` if the message was gone (the mark was a no-op). Callers use this to avoid
+    ///   permanently deduping a mark that never applied.
+    @discardableResult
+    func markOpened(messageId: String) async -> Bool
+}
+
+// MARK: - Implementation
+
+/// Default `VisualInboxProvider` that adapts the internal `VisualInboxRepository` + headless
+/// `NotificationInbox` to the SPI value types. Constructed from the shared DI graph.
+final class VisualInboxProviderImpl: VisualInboxProvider, @unchecked Sendable {
+    private let repository: VisualInboxRepository
+    private let inbox: NotificationInbox
+    private let inAppMessageManager: InAppMessageManager
+
+    /// De-dupe guard for `observe()` emissions. Guarded by `lastSnapshotLock` because the two merge
+    /// child tasks can recompute concurrently.
+    private var lastEmittedSnapshot: VisualInboxSnapshot?
+    private let lastSnapshotLock = NSLock()
+
+    init(
+        repository: VisualInboxRepository,
+        inbox: NotificationInbox,
+        inAppMessageManager: InAppMessageManager
+    ) {
+        self.repository = repository
+        self.inbox = inbox
+        self.inAppMessageManager = inAppMessageManager
+    }
+
+    func load() async {
+        await repository.enableAndLoad()
+    }
+
+    func observe() -> AsyncStream<VisualInboxSnapshot> {
+        AsyncStream { continuation in
+            // Merge two trigger sources — repository.loadStateChanges() (enablement/visibility flips)
+            // and the in-app store's inboxMessages (message-set / opened-state changes) — each
+            // re-reading the current cached state to emit a coalesced, de-duped snapshot. No fetch.
+            let driver = Task { [repository, weak self] in
+                let loadStateChanges = await repository.loadStateChanges()
+                // Bridge store subscription callbacks into this task via a local continuation.
+                // (`makeStream()` is iOS 17+, so capture the continuation from the builder instead to
+                // stay within the SDK's iOS-13-compatible source floor.)
+                var storeContinuation: AsyncStream<Void>.Continuation!
+                let storeTicks = AsyncStream<Void> { storeContinuation = $0 }
+                let subscriber = InAppMessageStoreSubscriber { _ in
+                    storeContinuation.yield(())
+                }
+                let subscriptionTask = self?.inAppMessageManager.subscribe(
+                    keyPath: \.inboxMessages,
+                    subscriber: subscriber
+                )
+
+                // One child task per source forwards into the recompute pump (cancellation-safe).
+                await withTaskGroup(of: Void.self) { group in
+                    group.addTask {
+                        for await _ in loadStateChanges {
+                            await self?.emitSnapshot(into: continuation)
+                        }
+                    }
+                    group.addTask {
+                        for await _ in storeTicks {
+                            await self?.emitSnapshot(into: continuation)
+                        }
+                    }
+                    await group.waitForAll()
+                }
+
+                withExtendedLifetime(subscriber) {
+                    // Explicitly unsubscribe (not just cancel the subscribe Task) so the store stops
+                    // notifying this subscriber once the overlay's observe() shuts down.
+                    _ = self?.inAppMessageManager.unsubscribe(subscriber: subscriber)
+                    subscriptionTask?.cancel()
+                }
+                storeContinuation.finish()
+            }
+
+            continuation.onTermination = { @Sendable _ in
+                driver.cancel()
+            }
+        }
+    }
+
+    /// Last emitted snapshot, used to de-dupe. Accessed only from the single `observe()` driver
+    /// task's child tasks; serialized by the `lastSnapshotLock` since those run concurrently.
+    private func emitSnapshot(into continuation: AsyncStream<VisualInboxSnapshot>.Continuation) async {
+        let snapshot = await currentSnapshot()
+        lastSnapshotLock.lock()
+        let changed = lastEmittedSnapshot == nil || lastEmittedSnapshot != snapshot
+        if changed { lastEmittedSnapshot = snapshot }
+        lastSnapshotLock.unlock()
+        guard changed else { return }
+        continuation.yield(snapshot)
+    }
+
+    /// Reads the current cached overlay state into one coalesced snapshot. Cache-only (no network).
+    ///
+    /// The message list is read ONCE (a single `repository.jistMessages()` read) and both the
+    /// snapshot messages and `unopenedCount` are derived from that same array. Reading the list and
+    /// the count via separate reads could observe a store change in between and produce a badge that
+    /// disagrees with the list it's shown next to; deriving both from one read keeps them consistent.
+    private func currentSnapshot() async -> VisualInboxSnapshot {
+        async let state = self.state()
+        async let jistMessages = repository.jistMessages()
+        async let templates = templatesJSON()
+        async let theme = themeJSON()
+
+        let resolvedMessages = await jistMessages
+        let snapshotMessages = resolvedMessages.map {
+            VisualInboxMessageSnapshot(
+                id: $0.queueId,
+                type: $0.type,
+                properties: $0.properties,
+                opened: $0.opened,
+                sentAt: $0.sentAt
+            )
+        }
+        let unopened = resolvedMessages.filter { !$0.opened }.count
+
+        return await VisualInboxSnapshot(
+            state: state,
+            messages: snapshotMessages,
+            unopenedCount: unopened,
+            templatesJSON: templates,
+            themeJSON: theme
+        )
+    }
+
+    func state() async -> VisualInboxState {
+        await repository.loadState.asSPIState
+    }
+
+    func messages() async -> [VisualInboxMessageSnapshot] {
+        await repository.jistMessages().map {
+            VisualInboxMessageSnapshot(
+                id: $0.queueId,
+                type: $0.type,
+                properties: $0.properties,
+                opened: $0.opened,
+                sentAt: $0.sentAt
+            )
+        }
+    }
+
+    func unopenedCount() async -> Int {
+        await repository.jistMessages().filter { !$0.opened }.count
+    }
+
+    func templatesJSON() async -> [String: Any]? {
+        await repository.templatesRegistry()?.raw
+    }
+
+    func themeJSON() async -> [String: Any]? {
+        await repository.branding()?.theme
+    }
+
+    @discardableResult
+    func markOpened(messageId: String) async -> Bool {
+        // Resolve the full InboxMessage from current state so we reuse the existing headless
+        // markOpened plumbing (which dispatches the .updateOpened action). No new mutation path.
+        let state = await inAppMessageManager.state
+        guard let message = state.inboxMessages.first(where: { $0.queueId == messageId }) else {
+            // Message no longer in the store → nothing to mark. Report no-op so the caller doesn't
+            // permanently dedupe a mark that never applied.
+            return false
+        }
+        inbox.markMessageOpened(message: message)
+        return true
+    }
+}
+
+private extension VisualInboxLoadState {
+    /// Maps the internal load state to the SPI value type.
+    var asSPIState: VisualInboxState {
+        switch self {
+        case .idle: return .idle
+        case .loading: return .loading
+        case .visible(let count): return .visible(messageCount: count)
+        case .hidden(let reason): return .hidden(reason: reason)
+        }
+    }
+}
+
+// MARK: - DI entry point
+
+@_spi(VisualInbox)
+public extension DIGraphShared {
+    /// The cross-module Visual Inbox provider, resolved from the shared graph. Used by the overlay
+    /// UI module; not registered in the generated graph because the SPI value types are not part of
+    /// the AutoMockable/Sourcery surface.
+    var visualInboxProvider: VisualInboxProvider {
+        VisualInboxProviderImpl(
+            repository: visualInboxRepository,
+            inbox: notificationInbox,
+            inAppMessageManager: inAppMessageManager
+        )
+    }
+}

--- a/Sources/MessagingInbox/NotificationInboxOverlay.swift
+++ b/Sources/MessagingInbox/NotificationInboxOverlay.swift
@@ -1,0 +1,262 @@
+import CioInternalCommon
+@_spi(VisualInbox) import CioMessagingInApp
+import Foundation
+#if canImport(SwiftUI)
+import Jist
+import SwiftUI
+
+/// A SwiftUI overlay that renders the Visual Notification Inbox on top of your app.
+///
+/// Mount it anywhere in your hierarchy (typically pinned to a corner via a `ZStack`). It renders a
+/// floating bell button with an unread-count badge plus a slide-out panel that lists inbox messages,
+/// each rendered natively via **Jist** from the server-provided templates + branding theme.
+///
+/// ## Usage
+/// ```swift
+/// ZStack { MyDashboard(); NotificationInboxOverlay() }
+/// ```
+@available(iOS 13.0, *)
+public struct NotificationInboxOverlay: View {
+    @StateObject private var model: VisualInboxModel
+
+    /// True when the slide-out panel is visible.
+    @State private var isPanelOpen: Bool = false
+
+    /// Vertical inset that keeps the slide-out panel clear of the floating button.
+    private let panelBottomInset: CGFloat = 88
+
+    /// Creates an inbox overlay backed by the SDK's shared Visual Inbox data layer.
+    public init() {
+        _model = StateObject(wrappedValue: VisualInboxModel())
+    }
+
+    /// Creates an inbox overlay backed by the supplied model. Used by tests/previews to inject a fake.
+    init(model: VisualInboxModel) {
+        _model = StateObject(wrappedValue: model)
+    }
+
+    public var body: some View {
+        ZStack(alignment: .bottomTrailing) {
+            // Scrim (item 10): captures touches behind the panel so taps don't pass through to the
+            // host app. Tapping the scrim closes the panel. Only present while open AND chrome is
+            // shown — a hidden inbox hides all chrome, including an open panel/scrim.
+            if isPanelOpen, showsChrome {
+                Color.black.opacity(0.2)
+                    .ignoresSafeAreaCompat()
+                    .contentShape(Rectangle())
+                    .onTapGesture { setPanel(open: false) }
+                    .transition(.opacity)
+            }
+
+            // The slide-out panel sits above the scrim but behind the floating button.
+            if isPanelOpen, showsChrome {
+                panel
+                    .transition(.move(edge: .trailing).combined(with: .opacity))
+            }
+
+            // Bell is shown unless the inbox is hidden (item 11: hidden → no chrome).
+            if showsChrome {
+                floatingButton
+            }
+        }
+        // Fill the host so bottom-trailing alignment pins the button to the bottom-right corner.
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+        .onAppear { model.start() }
+        .onDisappear { model.stop() }
+        // If the inbox transitions to hidden while the panel is open, close it so it doesn't linger
+        // (and doesn't silently reappear if the inbox becomes visible again).
+        .onChange(of: showsChrome) { visible in
+            if !visible, isPanelOpen { isPanelOpen = false }
+        }
+    }
+
+    // MARK: - Derived UI state
+
+    /// Whether any chrome (bell/panel) should be shown. Hidden state shows nothing.
+    private var showsChrome: Bool {
+        switch model.state {
+        case .hidden: return false
+        case .idle, .loading, .visible: return true
+        }
+    }
+
+    private func setPanel(open: Bool) {
+        withAnimation(.easeInOut(duration: 0.3)) {
+            isPanelOpen = open
+        }
+        // Auto-mark-opened (item 8): when the panel becomes visible, mark the visible messages
+        // opened (deduped inside the model so a message is never marked twice).
+        if open {
+            model.markVisibleMessagesOpened()
+        }
+    }
+
+    // MARK: - Floating button + badge (item 6)
+
+    private var floatingButton: some View {
+        Button(action: { setPanel(open: !isPanelOpen) }, label: {
+            ZStack(alignment: .topTrailing) {
+                // Default bundled SF Symbol bell (branding SVG bell is deferred).
+                Image(systemName: "bell.fill")
+                    .foregroundColor(.white)
+                    .frame(width: 56, height: 56)
+                    .background(Color.accentColor)
+                    .clipShape(Circle())
+                    .shadow(radius: 4)
+
+                if model.unopenedCount > 0 {
+                    Text("\(model.unopenedCount)")
+                        .font(.caption)
+                        .foregroundColor(.white)
+                        .padding(5)
+                        .background(Color.red)
+                        .clipShape(Circle())
+                        .offset(x: 4, y: -4)
+                }
+            }
+        })
+        .padding(16)
+        // `.accessibility(label:)` is the iOS 13-safe form; `.accessibilityLabel` is iOS 14+.
+        .accessibility(label: Text(model.unopenedCount > 0 ? "Notifications, \(model.unopenedCount) unread" : "Notifications"))
+    }
+
+    // MARK: - Slide-out panel (items 6, 7, 11)
+
+    private var panel: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text("Inbox")
+                    .font(.headline)
+
+                Spacer()
+
+                Button(action: { setPanel(open: false) }, label: {
+                    Image(systemName: "xmark")
+                        .foregroundColor(.secondary)
+                })
+                .accessibility(label: Text("Close inbox"))
+            }
+            .padding()
+
+            Divider()
+
+            content
+        }
+        .frame(maxWidth: 480, maxHeight: .infinity, alignment: .top)
+        .background(Color(.systemBackground))
+        .cornerRadius(12)
+        .shadow(radius: 8)
+        .padding(.horizontal, 16)
+        .padding(.top, 16)
+        .padding(.bottom, panelBottomInset)
+    }
+
+    /// Panel body driven by load state (item 11): spinner while loading, empty placeholder when
+    /// visible-but-empty, otherwise the Jist-rendered list.
+    @ViewBuilder
+    private var content: some View {
+        if model.messages.isEmpty, case .visible = model.state {
+            // Visible with no messages → genuine "caught up" empty state.
+            VStack {
+                Spacer()
+                Text("You're all caught up")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if model.messages.isEmpty {
+            // idle/loading (pre-first-snapshot or fetch in progress) → spinner, not the empty copy.
+            VStack {
+                Spacer()
+                ProgressView()
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            messageList
+        }
+    }
+
+    private var messageList: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(model.messages) { message in
+                    VisualInboxMessageRow(
+                        message: message,
+                        data: model.decodedData[message.id] ?? [:],
+                        templates: model.templates,
+                        theme: model.theme
+                    )
+                    Divider()
+                }
+            }
+        }
+    }
+}
+
+/// Cross-version `ignoresSafeArea` helper (the modern modifier is iOS 14+; `edgesIgnoringSafeArea`
+/// covers iOS 13).
+@available(iOS 13.0, *)
+private extension View {
+    @ViewBuilder
+    func ignoresSafeAreaCompat() -> some View {
+        if #available(iOS 14.0, *) {
+            ignoresSafeArea()
+        } else {
+            edgesIgnoringSafeArea(.all)
+        }
+    }
+}
+
+/// A single inbox message rendered via Jist (item 7).
+///
+/// Jist (`JistView`) requires iOS 15+. On iOS 13/14 we fall back to a minimal text row so the panel
+/// stays usable below the Jist floor.
+@available(iOS 13.0, *)
+struct VisualInboxMessageRow: View {
+    let message: VisualInboxMessageSnapshot
+    /// The message's `properties` already decoded into Jist data by `VisualInboxModel` (decoded once
+    /// per refresh, not per render).
+    let data: [String: JistValue]
+    let templates: [String: [JistTemplate]]
+    let theme: [String: JistValue]
+
+    var body: some View {
+        Group {
+            if #available(iOS 15.0, *) {
+                JistView(
+                    name: message.type,
+                    templates: templates,
+                    data: data,
+                    theme: theme,
+                    mode: .auto,
+                    formatDate: nil,
+                    // swiftlint:disable:next todo
+                    // TODO: action mapping is deferred (scope items 12/13). For now actions are a
+                    // no-op hook — wire to trackMessageClicked / deep-link handling later.
+                    onAction: { _ in }
+                )
+            } else {
+                fallbackRow
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .contentShape(Rectangle())
+    }
+
+    /// Minimal pre-iOS-15 row (below the Jist floor).
+    private var fallbackRow: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(message.type)
+                .font(.subheadline)
+                .fontWeight(message.opened ? .regular : .semibold)
+            Text(message.id)
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+    }
+}
+#endif

--- a/Sources/MessagingInbox/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/MessagingInbox/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+	This module renders the visual inbox UI on top of the headless inbox API. It does not itself
+	collect data or call any required-reason APIs — message collection and storage live in the
+	MessagingInApp / DataPipeline modules, which declare those in their own manifests. Both arrays
+	are intentionally empty here.
+	Docs: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files
+	-->
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+	</array>
+
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+	</array>
+
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/Sources/MessagingInbox/VisualInboxJistDecoder.swift
+++ b/Sources/MessagingInbox/VisualInboxJistDecoder.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Jist
+
+/// Decodes the Visual Inbox data layer's raw JSON inputs into the concrete types `JistView`
+/// expects: a versioned templates registry, per-message `[String: JistValue]` data, and a
+/// `[String: JistValue]` theme.
+///
+/// The data layer hands the overlay loosely-typed Foundation values (`[String: Any]`) on purpose so
+/// the network/data layer stays Jist-agnostic. This is the single place that bridges those into
+/// Jist's input types. Decoding is best-effort and never throws: a malformed/unknown entry is
+/// skipped rather than failing the whole render (mirrors the Jist Example fixture loaders).
+enum VisualInboxJistDecoder {
+    private static let decoder = JSONDecoder()
+
+    /// Decodes the raw templates registry (`{ "<name>": [ <versionObject>, ... ] }`) into
+    /// `[String: [JistTemplate]]`. `$schema` and any non-array / non-decodable entries are skipped.
+    static func decodeTemplates(_ raw: [String: Any]?) -> [String: [JistTemplate]] {
+        guard let raw = raw else { return [:] }
+        var result: [String: [JistTemplate]] = [:]
+        for (name, value) in raw {
+            guard let versions = value as? [Any] else { continue }
+            var templates: [JistTemplate] = []
+            for version in versions {
+                guard JSONSerialization.isValidJSONObject(version),
+                      let data = try? JSONSerialization.data(withJSONObject: version),
+                      let template = try? decoder.decode(JistTemplate.self, from: data) else { continue }
+                templates.append(template)
+            }
+            if !templates.isEmpty {
+                result[name] = templates
+            }
+        }
+        return result
+    }
+
+    /// Decodes a message's typed `properties` (`[String: Any]`) into `[String: JistValue]` for the
+    /// renderer's `data` argument. Returns an empty dictionary if the payload can't be encoded.
+    static func decodeData(_ properties: [String: Any]) -> [String: JistValue] {
+        guard JSONSerialization.isValidJSONObject(properties),
+              let data = try? JSONSerialization.data(withJSONObject: properties),
+              let decoded = try? decoder.decode([String: JistValue].self, from: data) else {
+            return [:]
+        }
+        return decoded
+    }
+
+    /// Decodes the branding theme tokens (`[String: Any]`) into `[String: JistValue]` for the
+    /// renderer's `theme` argument. Returns an empty dictionary if unavailable/undecodable.
+    static func decodeTheme(_ raw: [String: Any]?) -> [String: JistValue] {
+        guard let raw = raw,
+              JSONSerialization.isValidJSONObject(raw),
+              let data = try? JSONSerialization.data(withJSONObject: raw),
+              let decoded = try? decoder.decode([String: JistValue].self, from: data) else {
+            return [:]
+        }
+        return decoded
+    }
+}

--- a/Sources/MessagingInbox/VisualInboxModel.swift
+++ b/Sources/MessagingInbox/VisualInboxModel.swift
@@ -1,0 +1,174 @@
+import CioInternalCommon
+@_spi(VisualInbox) import CioMessagingInApp
+import Foundation
+#if canImport(SwiftUI)
+import Jist
+import SwiftUI
+
+/// Observable state holder that drives ``NotificationInboxOverlay``.
+///
+/// All SDK interaction goes through the `@_spi(VisualInbox)` ``VisualInboxProvider`` facade (the
+/// overlay never touches the headless public `NotificationInbox` API). The model owns:
+///  - the published render state (``VisualInboxState``) for loading/visible/hidden chrome (item 11),
+///  - the selected messages + unopened count read-only API (item 9), and
+///  - the auto-mark-opened dedupe guard (item 8).
+///
+/// Thread safety: `@MainActor` so all `@Published` mutations happen on the main thread; the
+/// provider calls are `async` and hop back to the main actor before publishing.
+@available(iOS 13.0, *)
+@MainActor
+final class VisualInboxModel: ObservableObject {
+    /// Current visibility/loading state from the data layer. Drives which chrome is shown.
+    @Published private(set) var state: VisualInboxState = .idle
+
+    /// Selected/sorted messages to render. Read-only to the view (item 9).
+    @Published private(set) var messages: [VisualInboxMessageSnapshot] = []
+
+    /// Number of unopened messages — drives the unread badge (item 9).
+    @Published private(set) var unopenedCount: Int = 0
+
+    /// Templates registry decoded into Jist types, refreshed alongside `messages`. Decoded once per
+    /// refresh (not per row) so the Jist render path stays cheap.
+    @Published private(set) var templates: [String: [JistTemplate]] = [:]
+
+    /// Branding theme decoded into Jist types, refreshed alongside `messages`.
+    @Published private(set) var theme: [String: JistValue] = [:]
+
+    /// Each message's `properties` decoded into Jist render data, keyed by message id. Decoded ONCE
+    /// per `messages` refresh (here, not per render) so the row body just reads the prepared value
+    /// instead of re-decoding `[String: Any]` on every recompose.
+    @Published private(set) var decodedData: [String: [String: JistValue]] = [:]
+
+    private let provider: VisualInboxProvider
+
+    /// Backing task for the load + refresh cycle; cancelled when the view disappears.
+    private var refreshTask: Task<Void, Never>?
+
+    /// Backing task for the continuous `observe()` subscription; cancelled when the view disappears.
+    /// This is what makes the overlay REACTIVE: it republishes whenever the data layer's
+    /// enablement/visibility/messages/opened-state change, with no recompose or navigation.
+    private var observeTask: Task<Void, Never>?
+
+    /// In-flight / already-done guard for auto-mark-opened (item 8). A message id present here has
+    /// either been marked or is being marked, so it is never marked twice.
+    private var markedOpenedIds: Set<String> = []
+
+    init(provider: VisualInboxProvider) {
+        self.provider = provider
+    }
+
+    /// Convenience initializer using the shared DI graph's Visual Inbox provider.
+    convenience init() {
+        self.init(provider: DIGraphShared.shared.visualInboxProvider)
+    }
+
+    deinit {
+        refreshTask?.cancel()
+        observeTask?.cancel()
+    }
+
+    // MARK: - Lifecycle
+
+    /// Kicks off the data-layer load AND subscribes to the continuous `observe()` stream so the
+    /// overlay stays reactive. Safe to call repeatedly; an in-flight load/subscription is reused.
+    ///
+    /// The one-shot `load()` still runs (it triggers the fetch-if-missing on the data layer and gives
+    /// an immediate first paint), but continuous updates are driven by the subscription below — so
+    /// when enablement flips true ~3s after launch (or messages / opened-state change), the published
+    /// state updates automatically and the bell appears with no recompose.
+    func start() {
+        if refreshTask == nil {
+            refreshTask = Task { [weak self] in
+                guard let self = self else { return }
+                await self.provider.load()
+                if Task.isCancelled { return }
+                await self.refresh()
+            }
+        }
+        if observeTask == nil {
+            observeTask = Task { [weak self] in
+                guard let self = self else { return }
+                for await snapshot in self.provider.observe() {
+                    if Task.isCancelled { return }
+                    self.apply(snapshot: snapshot)
+                }
+            }
+        }
+    }
+
+    /// Cancels the load/refresh cycle and the continuous subscription.
+    func stop() {
+        refreshTask?.cancel()
+        refreshTask = nil
+        observeTask?.cancel()
+        observeTask = nil
+    }
+
+    /// Pulls the latest state + messages + unopened count from the data layer onto the main actor.
+    /// Retained for the one-shot path (initial paint / after mark-opened); continuous updates come
+    /// through `apply(snapshot:)` via the `observe()` subscription.
+    func refresh() async {
+        let newState = await provider.state()
+        let newMessages = await provider.messages()
+        // Derive the badge from the same messages array (rather than a separate provider read) so the
+        // count can never disagree with the list if the store changes mid-refresh.
+        let newUnopened = newMessages.filter { !$0.opened }.count
+        let newTemplates = VisualInboxJistDecoder.decodeTemplates(await provider.templatesJSON())
+        let newTheme = VisualInboxJistDecoder.decodeTheme(await provider.themeJSON())
+        if Task.isCancelled { return }
+        state = newState
+        messages = newMessages
+        unopenedCount = newUnopened
+        templates = newTemplates
+        theme = newTheme
+        decodedData = Self.decodeData(for: newMessages)
+    }
+
+    /// Publishes a coalesced snapshot from the `observe()` stream. Runs on the main actor (the model
+    /// is `@MainActor`), so the SwiftUI view re-renders automatically.
+    func apply(snapshot: VisualInboxSnapshot) {
+        state = snapshot.state
+        messages = snapshot.messages
+        unopenedCount = snapshot.unopenedCount
+        templates = VisualInboxJistDecoder.decodeTemplates(snapshot.templatesJSON)
+        theme = VisualInboxJistDecoder.decodeTheme(snapshot.themeJSON)
+        decodedData = Self.decodeData(for: snapshot.messages)
+    }
+
+    /// Decodes each message's `properties` into Jist render data once, keyed by message id.
+    private static func decodeData(for messages: [VisualInboxMessageSnapshot]) -> [String: [String: JistValue]] {
+        var result: [String: [String: JistValue]] = [:]
+        for message in messages {
+            result[message.id] = VisualInboxJistDecoder.decodeData(message.properties)
+        }
+        return result
+    }
+
+    // MARK: - Auto mark-opened (item 8)
+
+    /// Marks every currently-visible message opened, exactly once each. Called when the panel opens
+    /// (and re-callable as new messages scroll into view). The `markedOpenedIds` guard dedupes so a
+    /// message is never marked repeatedly across panel open/close cycles or refreshes.
+    func markVisibleMessagesOpened() {
+        let toMark = messages.filter { !$0.opened && !markedOpenedIds.contains($0.id) }
+        guard !toMark.isEmpty else { return }
+        // Reserve ids synchronously (on the main actor) so a re-entrant call can't double-fire the
+        // same mark while the async marks are in flight.
+        for message in toMark {
+            markedOpenedIds.insert(message.id)
+        }
+        Task { [weak self, provider] in
+            for message in toMark {
+                // If the message has since left the store the mark no-ops (returns false). Release
+                // the reservation in that case so the id stays RETRYABLE instead of being deduped
+                // forever on a mark that never applied. A mark that did apply stays reserved.
+                let didMark = await provider.markOpened(messageId: message.id)
+                if !didMark {
+                    self?.markedOpenedIds.remove(message.id)
+                }
+            }
+            await self?.refresh()
+        }
+    }
+}
+#endif

--- a/Tests/MessagingInbox/MessagingInboxTargetTests.swift
+++ b/Tests/MessagingInbox/MessagingInboxTargetTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+
+/// Placeholder so the `MessagingInboxTests` target retains at least one source file and keeps
+/// building. The visual-inbox unit tests live in the dedicated `inbox-tests` PR (split out of
+/// #1111/#1113 to keep those PRs review-focused).
+final class MessagingInboxTargetTests: XCTestCase {
+    func test_targetBuilds() {
+        XCTAssertTrue(true)
+    }
+}

--- a/api-docs/CioMessagingInApp.api
+++ b/api-docs/CioMessagingInApp.api
@@ -182,3 +182,33 @@ public final class CioMessagingInApp.Subscription {
 	public fun init(sink: @escaping (@escaping (State?, State) -> Unit) -> Unit);
 	public fun func skipRepeats(_ isRepeat: @escaping (_ oldState: State, _ newState: State) -> Boolean) -> Subscription<State>;
 }
+public final class CioMessagingInApp.VisualInboxMessageSnapshot {
+	public final val id: String;
+	public final val type: String;
+	public final val properties: Map<String, Any>;
+	public final val opened: Boolean;
+	public final val sentAt: Date;
+	public fun init(id: String, type: String, properties: List<String: Any>, opened: Boolean, sentAt: Date);
+}
+public interface CioMessagingInApp.VisualInboxProvider {
+	public fun func observe() -> AsyncStream<VisualInboxSnapshot>;
+	public fun func load() async;
+	public fun func state() async -> VisualInboxState;
+	public fun func messages() async -> List<VisualInboxMessageSnapshot>;
+	public fun func unopenedCount() async -> Int;
+	public fun func templatesJSON() async -> List<String: Any>?;
+	public fun func themeJSON() async -> List<String: Any>?;
+	public fun func markOpened(messageId: String) async -> Boolean;
+}
+public final class CioMessagingInApp.VisualInboxSnapshot {
+	public final val state: VisualInboxState;
+	public final val messages: List<VisualInboxMessageSnapshot>;
+	public final val unopenedCount: Int;
+	public final val templatesJSON: Map<String, Any>?;
+	public final val themeJSON: Map<String, Any>?;
+	public fun init(state: VisualInboxState, messages: List<VisualInboxMessageSnapshot>, unopenedCount: Int, templatesJSON: List<String: Any>?, themeJSON: List<String: Any>?);
+	public fun func == (lhs: VisualInboxSnapshot, rhs: VisualInboxSnapshot) -> Boolean;
+}
+public enum CioMessagingInApp.VisualInboxState {
+	public var isVisible: Boolean;
+}


### PR DESCRIPTION
Visual Notification Inbox **overlay UI** stacked on the data-layer PR: floating bell + unread badge + slide-out panel, each message rendered via **Jist** (type→template, typed properties→data, templates+theme), auto-mark-opened with in-flight dedupe, read-only get-messages + unopened-count, touch-capturing overlay, and empty/loading states. Consumes the internal `VisualInbox` (headless `NotificationInbox` left intact).

Scope: items 6–11. **Deferred to follow-up:** items 12–18 (click/action mapping, performAction host API, marking-read web parity, no-template fallback, chrome theming + dark, date format) and the branding `floatingIcon.svg` bell (uses default bell for now).

Interim: **Jist referenced locally** (TODO: switch to published artifact). iOS only: package floor temporarily raised 13→15 for the Jist dependency (Jist render `@available(iOS 15)`-gated + 13/14 fallback; revert at Jist M0). Android: jist compiled in-tree + desugaring/minSdk override (TODO: published artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New customer-facing UI module and SPI surface over inbox state/mutations, plus a breaking SPM iOS 15 floor and unpinned Jist git dependency until follow-up work lands.
> 
> **Overview**
> Adds a new **`MessagingInbox`** (`CioMessagingInbox`) SwiftPM product and CocoaPods spec, shipping **`NotificationInboxOverlay`** — a SwiftUI bell, unread badge, scrim, and slide-out panel that renders inbox rows via **Jist** from server templates and branding.
> 
> The overlay talks to the headless inbox only through a new **`@_spi(VisualInbox)`** bridge in MessagingInApp: **`VisualInboxProvider`** with coalesced **`VisualInboxSnapshot`** emissions, **`observe()`** merging repository **`loadStateChanges()`** and in-app store updates (de-duped), plus **`markOpened`** via existing **`NotificationInbox`** plumbing. **`VisualInboxRepository`** now notifies observers when **`loadState`** changes.
> 
> **SPM** adds a **`jist`** dependency (branch `main`, TODO pin) and temporarily raises the **package iOS minimum to 15**; Jist rendering is **`@available(iOS 15, *)`** with a simple fallback row on 13/14. The **APN UIKit sample** deployment target moves **13 → 15** to match. Jist actions, branded bell, and CocoaPods Jist dependency are explicitly deferred; inbox tests are a placeholder pending a follow-up PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9510806e5acdfeffec64b50da94eec5110a3dc31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->