### PR TITLE
chore(geofence): sync geofences without sending location

### DIFF
--- a/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
@@ -16,6 +16,7 @@ struct GeofenceApiConfig: Decodable {
     let remoteFetchRefreshExpiryTime: Double?
     /// Wire format is milliseconds; converted to seconds in `toDomain`.
     let duplicateEventsExpiryTime: Double?
+    let maxMonitoringDistance: Double?
     let ios: GeofenceApiPlatformConfig?
 }
 
@@ -50,27 +51,54 @@ extension GeofenceApiResponse {
 }
 
 extension GeofenceApiConfig {
-    /// Per-field sanitization: non-positive numerics fall back to constants; `ios.maxBusinessGeofences`
-    /// out of 0…19 falls back. `0` is preserved as a valid server-side kill switch.
+    /// Coerces raw server values into sane bounds so a misconfigured backend can't push monitoring
+    /// into a pathological state: non-positive values fall back; positive out-of-range radii/expiries
+    /// clamp; `ios.maxBusinessGeofences` out of 0…19 falls back (`0` is a valid kill switch).
     func toDomain() -> GeofenceConfig {
-        GeofenceConfig(
-            localRefreshTriggerRadius: positive(localRefreshTriggerRadius)
-                ?? GeofenceConstants.movementTriggerRadius,
+        let localRefresh = positive(localRefreshTriggerRadius)
+            .map { $0.clamped(to: GeofenceConstants.minLocalRefreshRadius ... GeofenceConstants.maxLocalRefreshRadius) }
+            ?? GeofenceConstants.movementTriggerRadius
+        // null → default cap (the field isn't sent today, and an unbounded default would register
+        // far-away geofences a device can't reach soon); explicit `0` → no cap; a value below the
+        // trigger radius (incl. negatives) would create a dead-zone — a geofence inside the trigger
+        // but beyond the cap never gets re-ranked — so fall back to the default cap; else use it.
+        let cap: Double
+        switch maxMonitoringDistance {
+        case .none:
+            cap = GeofenceConstants.defaultMaxMonitoringDistance
+        case .some(let value) where value == 0:
+            cap = GeofenceConstants.noMonitoringDistanceCap
+        case .some(let value) where value < localRefresh:
+            cap = GeofenceConstants.defaultMaxMonitoringDistance
+        case .some(let value):
+            cap = value
+        }
+        return GeofenceConfig(
+            localRefreshTriggerRadius: localRefresh,
             remoteFetchRefreshTriggerRadius: positive(remoteFetchRefreshTriggerRadius)
                 ?? GeofenceConstants.serverFetchDistance,
-            remoteFetchRefreshExpiry: positive(remoteFetchRefreshExpiryTime).map { $0 / 1000 }
+            remoteFetchRefreshExpiry: positive(remoteFetchRefreshExpiryTime)
+                .map { ($0 / 1000).clamped(to: GeofenceConstants.minRemoteFetchRefreshExpiry ... GeofenceConstants.maxRemoteFetchRefreshExpiry) }
                 ?? GeofenceConstants.staleSyncInterval,
-            duplicateEventsExpiry: positive(duplicateEventsExpiryTime).map { $0 / 1000 }
+            duplicateEventsExpiry: positive(duplicateEventsExpiryTime)
+                .map { ($0 / 1000).clamped(to: GeofenceConstants.minDuplicateEventsExpiry ... GeofenceConstants.maxDuplicateEventsExpiry) }
                 ?? GeofenceConstants.eventCooldownInterval,
             maxBusinessGeofences: (ios?.maxBusinessGeofences).flatMap { value in
                 (0 ... GeofenceConstants.maxMonitoredGeofences).contains(value) ? value : nil
-            } ?? GeofenceConstants.maxMonitoredGeofences
+            } ?? GeofenceConstants.maxMonitoredGeofences,
+            maxMonitoringDistance: cap
         )
     }
 
     private func positive(_ value: Double?) -> Double? {
         guard let value, value > 0 else { return nil }
         return value
+    }
+}
+
+private extension Comparable {
+    func clamped(to range: ClosedRange<Self>) -> Self {
+        min(max(self, range.lowerBound), range.upperBound)
     }
 }
 

--- a/Sources/LocationGeofence/Api/GeofenceApiService.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiService.swift
@@ -11,11 +11,10 @@ enum GeofenceApiError: Error, Equatable {
     case decoding
 }
 
-/// Fetches nearby geofences + workspace config from the CDP API.
+/// Fetches geofences + workspace config from the CDP API.
 protocol GeofenceApiService: AutoMockable, Sendable {
-    func fetchGeofences(
-        latitude: Double,
-        longitude: Double,
+    /// Fetch-all: returns the full (capped) set with no location sent.
+    func fetchAllGeofences(
         completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void
     )
 }
@@ -45,9 +44,14 @@ final class GeofenceApiServiceImpl: GeofenceApiService, @unchecked Sendable {
         self.logger = logger
     }
 
-    func fetchGeofences(
-        latitude: Double,
-        longitude: Double,
+    func fetchAllGeofences(
+        completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void
+    ) {
+        request(queryItems: [], completion: completion)
+    }
+
+    private func request(
+        queryItems: [URLQueryItem],
         completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void
     ) {
         guard let apiHost = contextStore.currentApiHost, !apiHost.isEmpty else {
@@ -56,7 +60,7 @@ final class GeofenceApiServiceImpl: GeofenceApiService, @unchecked Sendable {
         guard let cdpApiKey = contextStore.currentCdpApiKey, !cdpApiKey.isEmpty else {
             return completion(.failure(.missingCdpApiKey))
         }
-        guard let url = Self.composeUrl(apiHost: apiHost, latitude: latitude, longitude: longitude) else {
+        guard let url = Self.composeUrl(apiHost: apiHost, queryItems: queryItems) else {
             return completion(.failure(.invalidRequest))
         }
 
@@ -90,14 +94,11 @@ final class GeofenceApiServiceImpl: GeofenceApiService, @unchecked Sendable {
         }
     }
 
-    /// Composes `https://{apiHost}/geofences/nearby?latitude=…&longitude=…`.
-    /// URLComponents handles percent-encoding for the query values.
-    static func composeUrl(apiHost: String, latitude: Double, longitude: Double) -> URL? {
+    /// Composes `https://{apiHost}/geofences/nearby` with the given query items (empty for
+    /// fetch-all). URLComponents handles percent-encoding for the query values.
+    static func composeUrl(apiHost: String, queryItems: [URLQueryItem]) -> URL? {
         var components = URLComponents(string: BackgroundDeliveryHttp.absoluteHost(apiHost) + endpointPath)
-        components?.queryItems = [
-            URLQueryItem(name: "latitude", value: "\(latitude)"),
-            URLQueryItem(name: "longitude", value: "\(longitude)")
-        ]
+        components?.queryItems = queryItems.isEmpty ? nil : queryItems
         return components?.url
     }
 }

--- a/Sources/LocationGeofence/Coordinator/GeofenceDistanceFilter.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceDistanceFilter.swift
@@ -5,11 +5,16 @@ import Foundation
 /// to cap business-geofence registrations at the OS-allowed count (iOS allows 20 total
 /// monitored regions; one slot is reserved for the movement-trigger geofence).
 struct GeofenceDistanceFilter: Sendable {
-    /// Ties broken by ascending `id` for deterministic ordering. Returns empty when `limit <= 0`.
-    func nearest(_ regions: [Geofence], to location: LocationData, limit: Int) -> [Geofence] {
+    /// Ties broken by ascending `id` for deterministic ordering. Distances are rounded to whole
+    /// meters before comparison: `CLLocation.distance` can return sub-meter-varying values for
+    /// identical inputs, which would otherwise defeat the id tiebreak and make the order of
+    /// equidistant regions nondeterministic. Regions farther than `maxDistance` are excluded
+    /// (`GeofenceConstants.noMonitoringDistanceCap` for no cap). Returns empty when `limit <= 0`.
+    func nearest(_ regions: [Geofence], to location: LocationData, limit: Int, maxDistance: Double) -> [Geofence] {
         guard limit > 0, !regions.isEmpty else { return [] }
         return regions
-            .map { ($0, $0.distanceTo(location)) }
+            .map { ($0, $0.distanceTo(location).rounded()) }
+            .filter { $0.1 <= maxDistance }
             .sorted { lhs, rhs in
                 if lhs.1 != rhs.1 { return lhs.1 < rhs.1 }
                 return lhs.0.id < rhs.0.id

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+RefreshDecision.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+RefreshDecision.swift
@@ -1,0 +1,48 @@
+import CioInternalCommon
+import CoreLocation
+import Foundation
+
+/// The `refresh` decision table, split out to keep the coordinator's core flow readable.
+/// Methods are `internal` (not `private`) only because they live in a separate file from their
+/// callers; they remain coordinator implementation detail.
+extension GeofenceSyncCoordinatorImpl {
+    /// Decision table for an identify / app-launch refresh, independent of what triggered it:
+    /// re-fetch when the cache is stale in time, re-rank locally when the ranking is stale or the
+    /// cache is unregistered, else skip.
+    func refreshAction(location: LocationData, config: GeofenceConfig) async -> RefreshAction {
+        let lastSync = await storage.getLastSync()
+        // Measured from the last registration; nil (never set) → 0 → treated as within radius.
+        let distanceFromLastRegistration = (await storage.getLastRegistrationCenter()).map { distance(from: $0, to: location) } ?? 0
+
+        if isStaleInTime(lastSync: lastSync, config: config) { return .remote }
+        // Device left the trigger radius since the nearest-set was last ranked — re-rank locally,
+        // no network. This is the EXIT the live movement trigger fires on; refresh() catches one
+        // missed while the app was dead (no boundary crossing to wake it).
+        if distanceFromLastRegistration >= config.localRefreshTriggerRadius { return .local }
+        if await hasUnregisteredCache() { return .local }
+        return .skip
+    }
+
+    /// Cache aged out of its freshness window (or was never fetched).
+    func isStaleInTime(lastSync: LastSyncRecord?, config: GeofenceConfig) -> Bool {
+        guard let lastSync else { return true }
+        return dateUtil.now.timeIntervalSince(lastSync.timestamp) >= config.remoteFetchRefreshExpiry
+    }
+
+    /// Cache holds regions but nothing is registered with the OS (e.g. regs lost on sign-out) →
+    /// re-register. A missing registration center is the "nothing registered" signal: it's set
+    /// whenever the movement trigger registers and cleared on sign-out. A distance-capped set has
+    /// no business regions but still registers the trigger (center set), so it's not "lost" — gating
+    /// on the center too avoids a redundant re-rank on every refresh for a fully-capped workspace.
+    func hasUnregisteredCache() async -> Bool {
+        guard !(await storage.getCachedGeofences()).isEmpty else { return false }
+        let noBusinessRegistered = await storage.getRegisteredBusinessIds().isEmpty
+        let noRegistrationCenter = await storage.getLastRegistrationCenter() == nil
+        return noBusinessRegistered && noRegistrationCenter
+    }
+
+    func distance(from: LocationData, to: LocationData) -> Double {
+        CLLocation(latitude: from.latitude, longitude: from.longitude)
+            .distance(from: CLLocation(latitude: to.latitude, longitude: to.longitude))
+    }
+}

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
@@ -11,23 +11,26 @@ enum GeofenceSyncError: Error, Equatable {
 
 /// Which branch `handleMovement` took for the current EXIT.
 enum HandleMovementTier: String, Sendable {
-    /// Re-rank cached regions for the new location; no API call.
+    /// Re-rank cached regions for the new location; no API call. The only `fetchAll` movement path.
     case localRerank
-    /// Anchor moved beyond `remoteFetchRefreshTriggerRadius` (or absent) — refetch from server.
+    /// Refetch from the server — when no anchor exists yet (first EXIT after install / clearAll /
+    /// sign-out).
     case remoteRefresh
 }
 
 /// Sync pipeline for the on-device geofence cache. Entry points:
 ///
-/// - `refresh(latitude:longitude:)` — fetch from the server, distance-filter, register,
-///   persist. Gated on identified user, in-flight dedup, and freshness.
-/// - `handleMovement(latitude:longitude:)` — movement-trigger EXIT entry. Two-tier:
-///   re-rank cache when within `remoteFetchRefreshTriggerRadius` of the API anchor,
-///   otherwise refetch from the server. Shares the same dedup gate as `refresh`.
+/// - `refresh(latitude:longitude:)` — identify / app-launch entry. Routes through `refreshAction`:
+///   re-fetch when stale, re-rank locally when the ranking is stale or the cache is unregistered,
+///   else skip. Gated on identified user and in-flight dedup.
+/// - `handleMovement(latitude:longitude:)` — movement-trigger EXIT entry. Re-ranks the cached set
+///   for the new location; bootstraps from the server only when there's no anchor. Shares the same
+///   dedup gate as `refresh`.
 /// - `applyCachedRegistration(...)` — synchronously register from caller-fetched state,
 ///   used by cold-wake / boot / auth-change paths. Synchronous on the main actor so
 ///   `ownedRegionIdentifiers` is populated before the next yield — otherwise the OS may
-///   deliver a queued cold-wake transition into an empty filter set.
+///   deliver a queued cold-wake transition into an empty filter set. Returns what it
+///   registered so the caller can persist it once the no-await window has closed.
 /// - `reset()` — sign-out cleanup. Stops OS-side monitoring and clears user-scoped store
 ///   state (cooldowns, last-sync). Preserves the workspace cache.
 protocol GeofenceSyncCoordinator: AutoMockable, AnyObject, Sendable {
@@ -40,7 +43,7 @@ protocol GeofenceSyncCoordinator: AutoMockable, AnyObject, Sendable {
         anchor: LocationData?,
         config: GeofenceConfig?,
         userId: String?
-    )
+    ) -> GeofenceRegistration?
 }
 
 /// `@unchecked Sendable`: stored `Logger` and `DateUtil` are existentials of protocols
@@ -48,12 +51,17 @@ protocol GeofenceSyncCoordinator: AutoMockable, AnyObject, Sendable {
 /// the only mutable state is the `Synchronized<Bool>` dedup gate.
 final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sendable {
     private let apiService: GeofenceApiService
-    private let storage: GeofenceSyncStorage
     private let monitor: GeofenceRegionMonitoring
     private let contextStore: BackgroundDeliveryContextStore
     private let distanceFilter: GeofenceDistanceFilter
-    private let dateUtil: DateUtil
     private let logger: Logger
+    // Internal (not private) so the `+RefreshDecision` extension in its own file can read them;
+    // all are immutable injected deps.
+    let storage: GeofenceSyncStorage
+    let dateUtil: DateUtil
+    /// Defaults to `GeofenceSyncMode.active` (the shipped mode); injectable as the seam for a
+    /// future location-bound mode (see `GeofenceSyncMode`).
+    let syncMode: GeofenceSyncMode
     private let refreshInProgress = Synchronized<Bool>(false)
 
     init(
@@ -63,7 +71,8 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         contextStore: BackgroundDeliveryContextStore,
         distanceFilter: GeofenceDistanceFilter = GeofenceDistanceFilter(),
         dateUtil: DateUtil,
-        logger: Logger
+        logger: Logger,
+        syncMode: GeofenceSyncMode = .active
     ) {
         self.apiService = apiService
         self.storage = storage
@@ -72,6 +81,7 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         self.distanceFilter = distanceFilter
         self.dateUtil = dateUtil
         self.logger = logger
+        self.syncMode = syncMode
     }
 
     func refresh(latitude: Double, longitude: Double) async -> Result<Void, GeofenceSyncError> {
@@ -87,26 +97,28 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         }
 
         let cachedConfig = await storage.getCachedConfig()
-        if let lastSync = await storage.getLastSync() {
-            // Time-fresh alone isn't enough: if the app was killed while the user
-            // travelled far, no movement EXIT fired to update the cache.
-            let effectiveConfig = cachedConfig ?? .fallback
-            let timeSinceLastSync = dateUtil.now.timeIntervalSince(lastSync.timestamp)
-            let distanceFromAnchor = CLLocation(latitude: lastSync.location.latitude, longitude: lastSync.location.longitude)
-                .distance(from: CLLocation(latitude: latitude, longitude: longitude))
-            if timeSinceLastSync < effectiveConfig.remoteFetchRefreshExpiry,
-               distanceFromAnchor < effectiveConfig.remoteFetchRefreshTriggerRadius {
-                logger.geofenceSyncSkippedFresh()
-                return .success(())
-            }
+        let effectiveConfig = cachedConfig ?? .fallback
+        let location = LocationData(latitude: latitude, longitude: longitude)
+        switch await refreshAction(location: location, config: effectiveConfig) {
+        case .remote:
+            return await performRemoteRefresh(
+                expectedUserId: userId,
+                latitude: latitude,
+                longitude: longitude,
+                cachedConfig: cachedConfig
+            )
+        case .local:
+            let cachedRegions = await storage.getCachedGeofences()
+            return await performLocalRefresh(
+                latitude: latitude,
+                longitude: longitude,
+                config: effectiveConfig,
+                cachedRegions: cachedRegions
+            )
+        case .skip:
+            logger.geofenceSyncSkippedFresh()
+            return .success(())
         }
-
-        return await performRemoteRefresh(
-            expectedUserId: userId,
-            latitude: latitude,
-            longitude: longitude,
-            cachedConfig: cachedConfig
-        )
     }
 
     func handleMovement(latitude: Double, longitude: Double) async -> Result<Void, GeofenceSyncError> {
@@ -124,15 +136,10 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         let cachedConfig = await storage.getCachedConfig()
         let anchor = await storage.getLastSync()?.location
         let effectiveConfig = cachedConfig ?? .fallback
-        // No anchor → no Tier A reference; fall through to remote.
-        let needsRemoteFetch: Bool = {
-            guard let anchor else { return true }
-            let distance = CLLocation(latitude: anchor.latitude, longitude: anchor.longitude)
-                .distance(from: CLLocation(latitude: latitude, longitude: longitude))
-            return distance >= effectiveConfig.remoteFetchRefreshTriggerRadius
-        }()
-
-        if needsRemoteFetch {
+        // No anchor (first EXIT after install / clearAll / sign-out) bootstraps from the server.
+        // Otherwise re-rank the cached set locally: fetchAll holds the complete workspace, so
+        // movement never re-fetches.
+        if anchor == nil {
             logger.geofenceMovementTrigger(tier: .remoteRefresh)
             return await performRemoteRefresh(
                 expectedUserId: userId,
@@ -179,35 +186,40 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         anchor: LocationData?,
         config: GeofenceConfig?,
         userId: String?
-    ) {
+    ) -> GeofenceRegistration? {
         guard let userId, !userId.isEmpty else {
             logger.geofenceSyncSkipped(reason: "no identified user")
-            return
+            return nil
         }
         guard !cachedRegions.isEmpty else {
             logger.geofenceSyncSkipped(reason: "no cached regions to restore")
-            return
+            return nil
         }
         // Need an anchor to distance-filter and to center the movement trigger. Skipping
         // when absent is safer than re-using an arbitrary location.
         guard let anchor else {
             logger.geofenceSyncSkipped(reason: "no last-sync anchor to restore from")
-            return
+            return nil
         }
         guard acquireGate() else {
             logger.geofenceSyncSkipped(reason: "restore already in progress")
-            return
+            return nil
         }
         defer { releaseGate() }
 
         let effectiveConfig = config ?? .fallback
-        let nearest = distanceFilter.nearest(cachedRegions, to: anchor, limit: effectiveConfig.maxBusinessGeofences)
+        let nearest = distanceFilter.nearest(cachedRegions, to: anchor, limit: effectiveConfig.maxBusinessGeofences, maxDistance: effectiveConfig.maxMonitoringDistance)
         registerWithOsSync(
             businessRegions: nearest,
             movementTriggerLocation: anchor,
-            movementTriggerRadius: effectiveConfig.localRefreshTriggerRadius
+            movementTriggerRadius: effectiveConfig.localRefreshTriggerRadius,
+            registerMovementTrigger: effectiveConfig.maxBusinessGeofences > 0 && !cachedRegions.isEmpty
         )
         logger.geofenceSyncCompleted(registeredCount: nearest.count)
+        // Return the registration so the caller persists it (async, after the no-await window) as
+        // the ranking-staleness reference — otherwise a later fresh refresh measures from a stale
+        // anchor and may skip while the OS holds the wrong nearest-set.
+        return GeofenceRegistration(center: anchor, businessIds: Set(nearest.map(\.id)))
     }
 
     /// Returns false when another call already holds the gate; the caller short-circuits.
@@ -232,7 +244,7 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         longitude: Double,
         cachedConfig: GeofenceConfig?
     ) async -> Result<Void, GeofenceSyncError> {
-        let fetchResult = await awaitApiFetch(latitude: latitude, longitude: longitude)
+        let fetchResult = await awaitApiFetch()
         let response: GeofenceApiResponse
         switch fetchResult {
         case .success(let value):
@@ -254,12 +266,13 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         let regions = response.toDomainRegions()
         let effectiveConfig = parsedConfig ?? cachedConfig ?? .fallback
         let anchor = LocationData(latitude: latitude, longitude: longitude)
-        let nearest = distanceFilter.nearest(regions, to: anchor, limit: effectiveConfig.maxBusinessGeofences)
+        let nearest = distanceFilter.nearest(regions, to: anchor, limit: effectiveConfig.maxBusinessGeofences, maxDistance: effectiveConfig.maxMonitoringDistance)
         await MainActor.run {
             registerWithOsSync(
                 businessRegions: nearest,
                 movementTriggerLocation: anchor,
-                movementTriggerRadius: effectiveConfig.localRefreshTriggerRadius
+                movementTriggerRadius: effectiveConfig.localRefreshTriggerRadius,
+                registerMovementTrigger: effectiveConfig.maxBusinessGeofences > 0 && !regions.isEmpty
             )
         }
 
@@ -270,13 +283,15 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
             await storage.setCachedConfig(parsedConfig)
         }
         await storage.recordSync(timestamp: dateUtil.now, location: anchor)
+        await storage.recordRegistration(center: anchor, businessIds: Set(nearest.map(\.id)))
         logger.geofenceSyncCompleted(registeredCount: nearest.count)
         return .success(())
     }
 
-    /// Re-rank cached regions for the new location and re-register with the OS. No API call,
-    /// no cache or `lastSync` writes — the API anchor is what `handleMovement` compared
-    /// against, so leaving it intact preserves the next Tier B threshold.
+    /// Re-rank cached regions for the new location and re-register with the OS. No API call and no
+    /// `lastSync` write — the API-fetch anchor is what the re-fetch decision compares against, so
+    /// leaving it intact preserves the next threshold. Records the registration anchor so the
+    /// ranking-staleness reference follows the device after a local re-rank.
     private func performLocalRefresh(
         latitude: Double,
         longitude: Double,
@@ -284,25 +299,32 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         cachedRegions: [Geofence]
     ) async -> Result<Void, GeofenceSyncError> {
         let anchor = LocationData(latitude: latitude, longitude: longitude)
-        let nearest = distanceFilter.nearest(cachedRegions, to: anchor, limit: config.maxBusinessGeofences)
+        let nearest = distanceFilter.nearest(cachedRegions, to: anchor, limit: config.maxBusinessGeofences, maxDistance: config.maxMonitoringDistance)
         await MainActor.run {
             registerWithOsSync(
                 businessRegions: nearest,
                 movementTriggerLocation: anchor,
-                movementTriggerRadius: config.localRefreshTriggerRadius
+                movementTriggerRadius: config.localRefreshTriggerRadius,
+                registerMovementTrigger: config.maxBusinessGeofences > 0 && !cachedRegions.isEmpty
             )
         }
+        await storage.recordRegistration(center: anchor, businessIds: Set(nearest.map(\.id)))
         logger.geofenceSyncCompleted(registeredCount: nearest.count)
         return .success(())
     }
+}
 
-    private func awaitApiFetch(
-        latitude: Double,
-        longitude: Double
-    ) async -> Result<GeofenceApiResponse, GeofenceApiError> {
+// MARK: - OS registration & fetch plumbing
+
+private extension GeofenceSyncCoordinatorImpl {
+    /// `fetchAll` sends no location — the precise location that drives on-device ranking and the
+    /// anchor never leaves the coordinator. Kept as a `switch` so a future location-bound mode
+    /// (see `GeofenceSyncMode`) slots in here.
+    func awaitApiFetch() async -> Result<GeofenceApiResponse, GeofenceApiError> {
         await withCheckedContinuation { continuation in
-            apiService.fetchGeofences(latitude: latitude, longitude: longitude) { result in
-                continuation.resume(returning: result)
+            switch syncMode {
+            case .fetchAll:
+                apiService.fetchAllGeofences { continuation.resume(returning: $0) }
             }
         }
     }
@@ -311,10 +333,11 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
     /// `@MainActor`-isolated so a same-actor caller (e.g. `applyCachedRegistration`)
     /// can register without yielding — see the protocol doc for why that matters.
     @MainActor
-    private func registerWithOsSync(
+    func registerWithOsSync(
         businessRegions: [Geofence],
         movementTriggerLocation: LocationData,
-        movementTriggerRadius: Double
+        movementTriggerRadius: Double,
+        registerMovementTrigger: Bool
     ) {
         monitor.stopMonitoringAll()
         for region in businessRegions {
@@ -325,9 +348,11 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
                 transitionTypes: region.transitionTypes
             )
         }
-        // With no business regions, a movement trigger would just refetch and get the
-        // same empty result — leave it off until the next identify / foreground refresh.
-        guard !businessRegions.isEmpty else { return }
+        // Keep the movement trigger whenever the workspace has registrable geofences — even if the
+        // distance cap left the current business set empty, exiting the trigger re-ranks and can
+        // bring a now-closer geofence into range. Skipped only when there's nothing to register
+        // toward (no geofences, or registration kill-switched).
+        guard registerMovementTrigger else { return }
         monitor.startMonitoring(
             identifier: GeofenceConstants.movementTriggerIdentifier,
             center: movementTriggerLocation,

--- a/Sources/LocationGeofence/GeofenceBootstrap.swift
+++ b/Sources/LocationGeofence/GeofenceBootstrap.swift
@@ -15,6 +15,10 @@ enum GeofenceBootstrap {
         let cachedRegions = await di.geofenceStorage.getCachedGeofences()
         let cachedConfig = await di.geofenceStorage.getCachedConfig()
         let lastSync = await di.geofenceStorage.getLastSync()
+        // Prefer the last registration center over the fetch anchor: a local re-rank moves the
+        // registration center but leaves lastSync at the fetch point, so restoring from lastSync
+        // would revert the OS to the older nearest-set. Falls back to lastSync before any re-rank.
+        let restoreAnchor = await di.geofenceStorage.getLastRegistrationCenter() ?? lastSync?.location
         let userId = di.backgroundDeliveryContextStore.currentUserId
 
         // Phase 2: synchronous on the main actor. No `await` between handler-bind and
@@ -24,12 +28,21 @@ enum GeofenceBootstrap {
         let tracker = di.geofenceEventTracker
         let coordinator = di.geofenceSyncCoordinator
         GeofenceMonitorBinder.bind(monitor: monitor, tracker: tracker, coordinator: coordinator)
-        coordinator.applyCachedRegistration(
+        let registration = coordinator.applyCachedRegistration(
             cachedRegions: cachedRegions,
-            anchor: lastSync?.location,
+            anchor: restoreAnchor,
             config: cachedConfig,
             userId: userId
         )
+        // Persist what was registered as the ranking-staleness reference. The await is safe here:
+        // applyCachedRegistration already ran startMonitoring synchronously, so the cold-wake
+        // no-await window has closed and a queued transition can't land in an empty filter.
+        if let registration {
+            await di.geofenceStorage.recordRegistration(
+                center: registration.center,
+                businessIds: registration.businessIds
+            )
+        }
 
         // Self-heal mid-process permission changes (Settings toggle, late prompt response).
         // The handler replaces any prior one — no stacking when both foreground init and

--- a/Sources/LocationGeofence/GeofenceConstants.swift
+++ b/Sources/LocationGeofence/GeofenceConstants.swift
@@ -9,15 +9,40 @@ enum GeofenceConstants {
     /// iOS allows 20 total monitored regions; 1 is reserved for the movement trigger.
     static let maxMonitoredGeofences = 19
 
-    /// Radius of the Movement Trigger Geofence in meters.
-    static let movementTriggerRadius: Double = 1000
+    /// Fallback for `localRefreshTriggerRadius` (meters) — the movement-trigger geofence radius and
+    /// the ranking-staleness threshold. Server config overrides it.
+    static let movementTriggerRadius: Double = 3000
 
-    /// Distance from last server sync (in meters) that triggers a new server fetch.
-    static let serverFetchDistance: Double = 3000
+    /// Fallback for `remoteFetchRefreshTriggerRadius` (meters). Currently unread — `fetchAll` never
+    /// re-fetches on movement — but kept (server still sends it) and reserved for a future
+    /// location-bound sync mode. See `GeofenceSyncMode`.
+    static let serverFetchDistance: Double = 20000
+
+    /// Default `maxMonitoringDistance` (meters) applied when the server omits the field — which it
+    /// does today. A finite cap (not "unlimited") so a device far from a workspace's geofences (e.g.
+    /// in the US with geofences in Europe) doesn't burn OS slots on regions it can't reach soon;
+    /// local re-rank re-adds them as the device approaches. The server can send an explicit `0` to
+    /// disable the cap (mapped to `noMonitoringDistanceCap`).
+    static let defaultMaxMonitoringDistance: Double = 1000000 // 1000 km
+
+    /// Sentinel for "no distance cap" — every candidate registers regardless of distance. Used when
+    /// the server explicitly sends `0`.
+    static let noMonitoringDistanceCap: Double = .greatestFiniteMagnitude
 
     /// Cooldown interval (in seconds) for suppressing duplicate enter/exit events for the same geofence.
     static let eventCooldownInterval: TimeInterval = 1 * 60 * 60
 
     /// Staleness interval (in seconds) after which a server sync is considered stale.
     static let staleSyncInterval: TimeInterval = 24 * 60 * 60
+
+    // Sane bounds the SDK coerces server config into, so a misconfigured backend can't push
+    // monitoring into a pathological state: a positive out-of-range value clamps to the nearest
+    // bound; a non-positive value falls back. (`maxMonitoringDistance` needs no upper bound — a
+    // huge value just means "no cap" — and is separately disabled when below the trigger radius.)
+    static let minLocalRefreshRadius: Double = 100
+    static let maxLocalRefreshRadius: Double = 5000
+    static let minRemoteFetchRefreshExpiry: TimeInterval = 60 // 1 minute
+    static let maxRemoteFetchRefreshExpiry: TimeInterval = 7 * 24 * 60 * 60 // 7 days
+    static let minDuplicateEventsExpiry: TimeInterval = 60 // 1 minute
+    static let maxDuplicateEventsExpiry: TimeInterval = 24 * 60 * 60 // 24 hours
 }

--- a/Sources/LocationGeofence/GeofenceSyncMode.swift
+++ b/Sources/LocationGeofence/GeofenceSyncMode.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// The kind of refresh a signal calls for, decided independently of what triggered it.
+///
+/// - `remote` — fetch a fresh set from the API.
+/// - `local`  — re-rank / re-register the cached set on-device, no network.
+/// - `skip`   — cache is current; do nothing.
+enum RefreshAction: Equatable {
+    case remote
+    case local
+    case skip
+}
+
+/// How the SDK fetches a user's geofences.
+///
+/// `fetchAll` is the only mode: the backend returns the full (capped) set and the SDK never sends
+/// device location to fetch. This is a deliberate privacy posture — there is intentionally no code
+/// path that transmits location off-device.
+///
+/// To re-introduce a location-bound mode later (needs backend support; a deliberate SDK release,
+/// never a runtime or server-pushed toggle that could silently start sending location): add a case
+/// here, restore the coordinate coarsener + `GeofenceApiService.fetchNearbyGeofences`, branch on it
+/// in `GeofenceSyncCoordinator.awaitApiFetch`, and re-add the movement re-fetch rule (compare
+/// distance-from-last-fetch against `GeofenceConfig.remoteFetchRefreshTriggerRadius`) in the refresh
+/// and `handleMovement` decisions.
+enum GeofenceSyncMode: Equatable {
+    case fetchAll
+
+    /// The mode the SDK ships with. Compile-time only — see the type doc.
+    static let active: GeofenceSyncMode = .fetchAll
+}

--- a/Sources/LocationGeofence/Model/GeofenceConfig.swift
+++ b/Sources/LocationGeofence/Model/GeofenceConfig.swift
@@ -12,7 +12,7 @@ import Foundation
 /// for the SDK-built movement-trigger geofence. `0` is a valid server-side kill switch —
 /// disables business region registration for the account without uninstalling the SDK.
 struct GeofenceConfig: Codable, Equatable, Sendable {
-    /// Movement-trigger geofence radius in meters. Default 1000m.
+    /// Movement-trigger geofence radius in meters. Default 3000m.
     let localRefreshTriggerRadius: Double
     /// Distance in meters from the last server sync that triggers a fresh server fetch. Currently
     /// unread (`fetchAll` never re-fetches on movement); reserved for a future location-bound sync

--- a/Sources/LocationGeofence/Model/GeofenceConfig.swift
+++ b/Sources/LocationGeofence/Model/GeofenceConfig.swift
@@ -14,7 +14,9 @@ import Foundation
 struct GeofenceConfig: Codable, Equatable, Sendable {
     /// Movement-trigger geofence radius in meters. Default 1000m.
     let localRefreshTriggerRadius: Double
-    /// Distance in meters from the last server sync that triggers a fresh server fetch.
+    /// Distance in meters from the last server sync that triggers a fresh server fetch. Currently
+    /// unread (`fetchAll` never re-fetches on movement); reserved for a future location-bound sync
+    /// mode and still decoded because the server sends it. See `GeofenceSyncMode`.
     let remoteFetchRefreshTriggerRadius: Double
     /// Freshness window for cached sync. A successful sync within this interval suppresses
     /// redundant API calls from identify / app-launch triggers.
@@ -24,6 +26,12 @@ struct GeofenceConfig: Codable, Equatable, Sendable {
     /// Maximum number of business geofences to monitor. Always 0…19 on iOS (movement
     /// trigger consumes the 20th OS slot).
     let maxBusinessGeofences: Int
+    /// Maximum distance in meters from the device at which a geofence is registered with the OS.
+    /// Geofences beyond it are skipped and re-added by a later re-rank as the device moves closer;
+    /// `GeofenceConstants.noMonitoringDistanceCap` means no cap. The server value and `fallback`
+    /// apply `GeofenceConstants.defaultMaxMonitoringDistance` when the server omits it (see
+    /// `GeofenceApiConfig.toDomain`).
+    let maxMonitoringDistance: Double
 }
 
 extension GeofenceConfig {
@@ -34,6 +42,7 @@ extension GeofenceConfig {
         remoteFetchRefreshTriggerRadius: GeofenceConstants.serverFetchDistance,
         remoteFetchRefreshExpiry: GeofenceConstants.staleSyncInterval,
         duplicateEventsExpiry: GeofenceConstants.eventCooldownInterval,
-        maxBusinessGeofences: GeofenceConstants.maxMonitoredGeofences
+        maxBusinessGeofences: GeofenceConstants.maxMonitoredGeofences,
+        maxMonitoringDistance: GeofenceConstants.defaultMaxMonitoringDistance
     )
 }

--- a/Sources/LocationGeofence/Model/GeofenceRegistration.swift
+++ b/Sources/LocationGeofence/Model/GeofenceRegistration.swift
@@ -1,0 +1,10 @@
+import CioInternalCommon
+import Foundation
+
+/// What `applyCachedRegistration` registered with the OS, returned so the caller can persist it
+/// as the ranking-staleness reference. `nil` when registration was skipped (no user, no regions,
+/// no anchor, or another sync in flight).
+struct GeofenceRegistration: Equatable, Sendable {
+    let center: LocationData
+    let businessIds: Set<String>
+}

--- a/Sources/LocationGeofence/Storage/GeofenceStorage.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage.swift
@@ -93,6 +93,8 @@ actor GeofenceStorage {
         state.eventCooldowns = nil
         state.lastServerSyncTimestamp = nil
         state.lastServerSyncLocation = nil
+        state.movementTriggerCenter = nil
+        state.monitoredGeofenceIds = nil
         saveToDisk(state)
     }
 
@@ -141,6 +143,33 @@ actor GeofenceStorage {
         var state = loadFromDisk() ?? GeofenceState()
         state.lastServerSyncTimestamp = timestamp
         state.lastServerSyncLocation = location
+        saveToDisk(state)
+    }
+
+    // MARK: - Last Registration
+
+    /// Center of the most recent OS registration (the movement-trigger center). The sync
+    /// decision measures distance from here to detect a stale ranking — the device moved
+    /// beyond the trigger radius while the app was dead, so the registered nearest-set is
+    /// no longer the closest geofences and needs a local re-rank.
+    func getLastRegistrationCenter() -> LocationData? {
+        loadFromDisk()?.movementTriggerCenter
+    }
+
+    /// Business geofence IDs registered with the OS at the last registration. Lets the sync
+    /// decision spot a cache that holds regions while nothing is registered (e.g. regs lost
+    /// on sign-out) and re-register instead of skipping.
+    func getRegisteredBusinessIds() -> Set<String> {
+        loadFromDisk()?.monitoredGeofenceIds ?? []
+    }
+
+    /// Records the registration anchor + business IDs in one load-modify-save. Updated on every
+    /// registration, including a local re-rank, so the ranking-staleness reference follows the
+    /// device. Distinct from `recordSync` (the API-fetch anchor), which a local re-rank leaves intact.
+    func recordRegistration(center: LocationData, businessIds: Set<String>) {
+        var state = loadFromDisk() ?? GeofenceState()
+        state.movementTriggerCenter = center
+        state.monitoredGeofenceIds = businessIds
         saveToDisk(state)
     }
 

--- a/Sources/LocationGeofence/Storage/GeofenceSyncStorage.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceSyncStorage.swift
@@ -8,9 +8,12 @@ protocol GeofenceSyncStorage: Sendable {
     func getCachedConfig() async -> GeofenceConfig?
     func getCachedGeofences() async -> [Geofence]
     func getLastSync() async -> LastSyncRecord?
+    func getLastRegistrationCenter() async -> LocationData?
+    func getRegisteredBusinessIds() async -> Set<String>
     func setCachedGeofences(_ regions: [Geofence]) async
     func setCachedConfig(_ config: GeofenceConfig) async
     func recordSync(timestamp: Date, location: LocationData) async
+    func recordRegistration(center: LocationData, businessIds: Set<String>) async
     func clearUserScopedState() async
 }
 

--- a/Sources/LocationGeofence/autogenerated/AutoMockable.generated.swift
+++ b/Sources/LocationGeofence/autogenerated/AutoMockable.generated.swift
@@ -95,38 +95,38 @@ class GeofenceApiServiceMock: GeofenceApiService, Mock {
     init() {}
 
     public func resetMock() {
-        fetchGeofencesCallsCount = 0
-        fetchGeofencesReceivedArguments = nil
-        fetchGeofencesReceivedInvocations = []
+        fetchAllGeofencesCallsCount = 0
+        fetchAllGeofencesReceivedArguments = nil
+        fetchAllGeofencesReceivedInvocations = []
 
         mockCalled = false // do last as resetting properties above can make this true
     }
 
-    // MARK: - fetchGeofences
+    // MARK: - fetchAllGeofences
 
     /// Number of times the function was called.
-    @Atomic private(set) var fetchGeofencesCallsCount = 0
+    @Atomic private(set) var fetchAllGeofencesCallsCount = 0
     /// `true` if the function was ever called.
-    var fetchGeofencesCalled: Bool {
-        fetchGeofencesCallsCount > 0
+    var fetchAllGeofencesCalled: Bool {
+        fetchAllGeofencesCallsCount > 0
     }
 
     /// The arguments from the *last* time the function was called.
-    @Atomic private(set) var fetchGeofencesReceivedArguments: (latitude: Double, longitude: Double, completion: (Result<GeofenceApiResponse, GeofenceApiError>) -> Void)?
+    @Atomic private(set) var fetchAllGeofencesReceivedArguments: ((Result<GeofenceApiResponse, GeofenceApiError>) -> Void)?
     /// Arguments from *all* of the times that the function was called.
-    @Atomic private(set) var fetchGeofencesReceivedInvocations: [(latitude: Double, longitude: Double, completion: (Result<GeofenceApiResponse, GeofenceApiError>) -> Void)] = []
+    @Atomic private(set) var fetchAllGeofencesReceivedInvocations: [(Result<GeofenceApiResponse, GeofenceApiError>) -> Void] = []
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    var fetchGeofencesClosure: ((Double, Double, @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void) -> Void)?
+    var fetchAllGeofencesClosure: ((@escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void) -> Void)?
 
-    /// Mocked function for `fetchGeofences(latitude: Double, longitude: Double, completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
-    func fetchGeofences(latitude: Double, longitude: Double, completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void) {
+    /// Mocked function for `fetchAllGeofences(completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
+    func fetchAllGeofences(completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void) {
         mockCalled = true
-        fetchGeofencesCallsCount += 1
-        fetchGeofencesReceivedArguments = (latitude: latitude, longitude: longitude, completion: completion)
-        fetchGeofencesReceivedInvocations.append((latitude: latitude, longitude: longitude, completion: completion))
-        fetchGeofencesClosure?(latitude, longitude, completion)
+        fetchAllGeofencesCallsCount += 1
+        fetchAllGeofencesReceivedArguments = completion
+        fetchAllGeofencesReceivedInvocations.append(completion)
+        fetchAllGeofencesClosure?(completion)
     }
 }
 
@@ -313,19 +313,23 @@ class GeofenceSyncCoordinatorMock: GeofenceSyncCoordinator, Mock {
     @Atomic private(set) var applyCachedRegistrationReceivedArguments: (cachedRegions: [Geofence], anchor: LocationData?, config: GeofenceConfig?, userId: String?)?
     /// Arguments from *all* of the times that the function was called.
     @Atomic private(set) var applyCachedRegistrationReceivedInvocations: [(cachedRegions: [Geofence], anchor: LocationData?, config: GeofenceConfig?, userId: String?)] = []
+    /// Value to return from the mocked function.
+    var applyCachedRegistrationReturnValue: GeofenceRegistration?
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     The closure has first priority to return a value for the mocked function. If the closure returns `nil`,
+     then the mock will attempt to return the value for `applyCachedRegistrationReturnValue`
      */
-    var applyCachedRegistrationClosure: (([Geofence], LocationData?, GeofenceConfig?, String?) -> Void)?
+    var applyCachedRegistrationClosure: (([Geofence], LocationData?, GeofenceConfig?, String?) -> GeofenceRegistration?)?
 
     /// Mocked function for `applyCachedRegistration(cachedRegions: [Geofence], anchor: LocationData?, config: GeofenceConfig?, userId: String?)`. Your opportunity to return a mocked value and check result of mock in test code.
     @MainActor
-    func applyCachedRegistration(cachedRegions: [Geofence], anchor: LocationData?, config: GeofenceConfig?, userId: String?) {
+    func applyCachedRegistration(cachedRegions: [Geofence], anchor: LocationData?, config: GeofenceConfig?, userId: String?) -> GeofenceRegistration? {
         mockCalled = true
         applyCachedRegistrationCallsCount += 1
         applyCachedRegistrationReceivedArguments = (cachedRegions: cachedRegions, anchor: anchor, config: config, userId: userId)
         applyCachedRegistrationReceivedInvocations.append((cachedRegions: cachedRegions, anchor: anchor, config: config, userId: userId))
-        applyCachedRegistrationClosure?(cachedRegions, anchor, config, userId)
+        return applyCachedRegistrationClosure.map { $0(cachedRegions, anchor, config, userId) } ?? applyCachedRegistrationReturnValue
     }
 }
 

--- a/Tests/LocationGeofence/Geofence/Api/GeofenceApiResponseTests.swift
+++ b/Tests/LocationGeofence/Geofence/Api/GeofenceApiResponseTests.swift
@@ -105,6 +105,66 @@ struct GeofenceApiResponseTests {
         #expect(config?.duplicateEventsExpiry == 60)
     }
 
+    @Test
+    func toDomainConfig_givenLocalRefreshRadiusBelowMin_expectClampedToMin() throws {
+        let response = try decode("{\"config\":{\"local_refresh_trigger_radius\":10},\"geofences\":[]}")
+        #expect(response.toDomainConfig()?.localRefreshTriggerRadius == GeofenceConstants.minLocalRefreshRadius)
+    }
+
+    @Test
+    func toDomainConfig_givenLocalRefreshRadiusAboveMax_expectClampedToMax() throws {
+        let response = try decode("{\"config\":{\"local_refresh_trigger_radius\":99999},\"geofences\":[]}")
+        #expect(response.toDomainConfig()?.localRefreshTriggerRadius == GeofenceConstants.maxLocalRefreshRadius)
+    }
+
+    @Test
+    func toDomainConfig_givenExpiriesOutOfRange_expectClamped() throws {
+        // 1s (below the 1-min min) and 48h (above the 24h max), both in ms.
+        let json = """
+        {"config":{"remote_fetch_refresh_expiry_time":1000,"duplicate_events_expiry_time":172800000},"geofences":[]}
+        """
+        let response = try decode(json)
+        let config = response.toDomainConfig()
+        #expect(config?.remoteFetchRefreshExpiry == GeofenceConstants.minRemoteFetchRefreshExpiry)
+        #expect(config?.duplicateEventsExpiry == GeofenceConstants.maxDuplicateEventsExpiry)
+    }
+
+    @Test
+    func toDomainConfig_givenMaxMonitoringDistanceAbsent_expectDefaultCap() throws {
+        // The server omits the field today — apply the default cap, not "unlimited".
+        let response = try decode("{\"config\":{\"local_refresh_trigger_radius\":3000},\"geofences\":[]}")
+        #expect(response.toDomainConfig()?.maxMonitoringDistance == GeofenceConstants.defaultMaxMonitoringDistance)
+    }
+
+    @Test
+    func toDomainConfig_givenMaxMonitoringDistanceZero_expectNoCap() throws {
+        // An explicit 0 is the server's way to turn the cap off.
+        let json = """
+        {"config":{"local_refresh_trigger_radius":3000,"max_monitoring_distance":0},"geofences":[]}
+        """
+        let response = try decode(json)
+        #expect(response.toDomainConfig()?.maxMonitoringDistance == GeofenceConstants.noMonitoringDistanceCap)
+    }
+
+    @Test
+    func toDomainConfig_givenMaxMonitoringDistanceBelowTriggerRadius_expectDefaultCap() throws {
+        // A cap below the trigger radius would create a dead-zone → falls back to the default cap.
+        let json = """
+        {"config":{"local_refresh_trigger_radius":3000,"max_monitoring_distance":1000},"geofences":[]}
+        """
+        let response = try decode(json)
+        #expect(response.toDomainConfig()?.maxMonitoringDistance == GeofenceConstants.defaultMaxMonitoringDistance)
+    }
+
+    @Test
+    func toDomainConfig_givenMaxMonitoringDistanceAboveTriggerRadius_expectPreserved() throws {
+        let json = """
+        {"config":{"local_refresh_trigger_radius":3000,"max_monitoring_distance":10000},"geofences":[]}
+        """
+        let response = try decode(json)
+        #expect(response.toDomainConfig()?.maxMonitoringDistance == 10000)
+    }
+
     // MARK: - Region mapping
 
     @Test

--- a/Tests/LocationGeofence/Geofence/Api/GeofenceApiServiceTests.swift
+++ b/Tests/LocationGeofence/Geofence/Api/GeofenceApiServiceTests.swift
@@ -34,19 +34,20 @@ struct GeofenceApiServiceTests {
     // MARK: - Request shaping
 
     @Test
-    func fetchGeofences_givenStoreState_expectGetRequestWithQueryAndAuth() async {
+    func fetchAllGeofences_givenStoreState_expectGetRequestWithNoQueryAndAuth() async {
         let (service, runner) = makeService(store: makeStore())
         runner.requestClosure = { _, _, onComplete in
             onComplete("{\"geofences\":[]}".data(using: .utf8), makeOkResponse(), nil)
         }
 
         await withCheckedContinuation { continuation in
-            service.fetchGeofences(latitude: 37.7749, longitude: -122.4194) { _ in continuation.resume() }
+            service.fetchAllGeofences { _ in continuation.resume() }
         }
 
         let params = runner.requestReceivedArguments?.params
         #expect(params?.method == "GET")
-        #expect(params?.url.absoluteString == "https://cdp.customer.io/v1/geofences/nearby?latitude=37.7749&longitude=-122.4194")
+        // Fetch-all sends no location — the URL carries no query string at all.
+        #expect(params?.url.absoluteString == "https://cdp.customer.io/v1/geofences/nearby")
         #expect(params?.headers?["Authorization"] == "Basic c2tfdGVzdF9hYmM6")
         #expect(params?.headers?["Accept"] == "application/json")
         #expect(params?.body == nil)
@@ -60,7 +61,7 @@ struct GeofenceApiServiceTests {
         }
 
         await withCheckedContinuation { continuation in
-            service.fetchGeofences(latitude: 1.0, longitude: 2.0) { _ in continuation.resume() }
+            service.fetchAllGeofences { _ in continuation.resume() }
         }
 
         let urlString = runner.requestReceivedArguments?.params.url.absoluteString
@@ -75,7 +76,7 @@ struct GeofenceApiServiceTests {
         let (service, _) = makeService(store: makeStore(host: nil))
 
         let result: Result<GeofenceApiResponse, GeofenceApiError> = await withCheckedContinuation { continuation in
-            service.fetchGeofences(latitude: 1.0, longitude: 2.0) { result in
+            service.fetchAllGeofences { result in
                 continuation.resume(returning: result)
             }
         }
@@ -88,7 +89,7 @@ struct GeofenceApiServiceTests {
         let (service, _) = makeService(store: makeStore(cdpApiKey: nil))
 
         let result: Result<GeofenceApiResponse, GeofenceApiError> = await withCheckedContinuation { continuation in
-            service.fetchGeofences(latitude: 1.0, longitude: 2.0) { result in
+            service.fetchAllGeofences { result in
                 continuation.resume(returning: result)
             }
         }
@@ -104,7 +105,7 @@ struct GeofenceApiServiceTests {
         runner.requestClosure = { _, _, onComplete in onComplete(nil, makeOkResponse(statusCode: 500), nil) }
 
         let result: Result<GeofenceApiResponse, GeofenceApiError> = await withCheckedContinuation { continuation in
-            service.fetchGeofences(latitude: 1.0, longitude: 2.0) { result in
+            service.fetchAllGeofences { result in
                 continuation.resume(returning: result)
             }
         }
@@ -118,7 +119,7 @@ struct GeofenceApiServiceTests {
         runner.requestClosure = { _, _, onComplete in onComplete(nil, nil, URLError(.notConnectedToInternet)) }
 
         let result: Result<GeofenceApiResponse, GeofenceApiError> = await withCheckedContinuation { continuation in
-            service.fetchGeofences(latitude: 1.0, longitude: 2.0) { result in
+            service.fetchAllGeofences { result in
                 continuation.resume(returning: result)
             }
         }
@@ -132,7 +133,7 @@ struct GeofenceApiServiceTests {
         runner.requestClosure = { _, _, onComplete in onComplete("not json".data(using: .utf8), makeOkResponse(), nil) }
 
         let result: Result<GeofenceApiResponse, GeofenceApiError> = await withCheckedContinuation { continuation in
-            service.fetchGeofences(latitude: 1.0, longitude: 2.0) { result in
+            service.fetchAllGeofences { result in
                 continuation.resume(returning: result)
             }
         }
@@ -170,7 +171,7 @@ struct GeofenceApiServiceTests {
         runner.requestClosure = { _, _, onComplete in onComplete(json.data(using: .utf8), makeOkResponse(), nil) }
 
         let result: Result<GeofenceApiResponse, GeofenceApiError> = await withCheckedContinuation { continuation in
-            service.fetchGeofences(latitude: 1.0, longitude: 2.0) { result in
+            service.fetchAllGeofences { result in
                 continuation.resume(returning: result)
             }
         }

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceDistanceFilterTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceDistanceFilterTests.swift
@@ -22,19 +22,19 @@ struct GeofenceDistanceFilterTests {
 
     @Test
     func nearest_givenEmpty_expectEmpty() {
-        #expect(filter.nearest([], to: origin, limit: 5).isEmpty)
+        #expect(filter.nearest([], to: origin, limit: 5, maxDistance: GeofenceConstants.noMonitoringDistanceCap).isEmpty)
     }
 
     @Test
     func nearest_givenLimitZero_expectEmpty() {
         let regions = [makeRegion(id: "a", latitude: 0.1, longitude: 0.1)]
-        #expect(filter.nearest(regions, to: origin, limit: 0).isEmpty)
+        #expect(filter.nearest(regions, to: origin, limit: 0, maxDistance: GeofenceConstants.noMonitoringDistanceCap).isEmpty)
     }
 
     @Test
     func nearest_givenLimitNegative_expectEmpty() {
         let regions = [makeRegion(id: "a", latitude: 0.1, longitude: 0.1)]
-        #expect(filter.nearest(regions, to: origin, limit: -3).isEmpty)
+        #expect(filter.nearest(regions, to: origin, limit: -3, maxDistance: GeofenceConstants.noMonitoringDistanceCap).isEmpty)
     }
 
     @Test
@@ -43,7 +43,7 @@ struct GeofenceDistanceFilterTests {
             makeRegion(id: "a", latitude: 0.1, longitude: 0.1),
             makeRegion(id: "b", latitude: 0.2, longitude: 0.2)
         ]
-        let result = filter.nearest(regions, to: origin, limit: 10)
+        let result = filter.nearest(regions, to: origin, limit: 10, maxDistance: GeofenceConstants.noMonitoringDistanceCap)
         #expect(result.count == 2)
         #expect(Set(result.map(\.id)) == ["a", "b"])
     }
@@ -57,7 +57,7 @@ struct GeofenceDistanceFilterTests {
             makeRegion(id: "c", latitude: 0.5, longitude: 0),
             makeRegion(id: "d", latitude: 10.0, longitude: 0)
         ]
-        let result = filter.nearest(regions, to: origin, limit: 2)
+        let result = filter.nearest(regions, to: origin, limit: 2, maxDistance: GeofenceConstants.noMonitoringDistanceCap)
         #expect(result.map(\.id) == ["c", "b"])
     }
 
@@ -69,7 +69,28 @@ struct GeofenceDistanceFilterTests {
             makeRegion(id: "a", latitude: 0.1, longitude: 0),
             makeRegion(id: "m", latitude: 0.1, longitude: 0)
         ]
-        let result = filter.nearest(regions, to: origin, limit: 3)
+        let result = filter.nearest(regions, to: origin, limit: 3, maxDistance: GeofenceConstants.noMonitoringDistanceCap)
         #expect(result.map(\.id) == ["a", "m", "z"])
+    }
+
+    @Test
+    func nearest_givenMaxDistance_expectExcludesRegionsBeyondCap() {
+        let regions = [
+            makeRegion(id: "near", latitude: 0.01, longitude: 0), // ~1.1 km
+            makeRegion(id: "far", latitude: 1.0, longitude: 0) // ~111 km
+        ]
+        let result = filter.nearest(regions, to: origin, limit: 5, maxDistance: 5000) // 5 km cap
+        #expect(result.map(\.id) == ["near"])
+    }
+
+    @Test
+    func nearest_givenNoMaxDistance_expectAllIncluded() {
+        let regions = [
+            makeRegion(id: "near", latitude: 0.01, longitude: 0),
+            makeRegion(id: "far", latitude: 1.0, longitude: 0)
+        ]
+        // The no-cap sentinel includes every region regardless of distance.
+        let result = filter.nearest(regions, to: origin, limit: 5, maxDistance: GeofenceConstants.noMonitoringDistanceCap)
+        #expect(result.map(\.id) == ["near", "far"])
     }
 }

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -34,7 +34,8 @@ struct GeofenceSyncCoordinatorTests {
         storage: GeofenceSyncStorage,
         monitor: MockGeofenceRegionMonitor? = nil,
         contextStore: BackgroundDeliveryContextStore? = nil,
-        dateUtil: DateUtilStub = DateUtilStub()
+        dateUtil: DateUtilStub = DateUtilStub(),
+        syncMode: GeofenceSyncMode = .fetchAll
     ) -> Setup {
         let resolvedContextStore = contextStore ?? makeContextStore()
         let resolvedMonitor = monitor ?? MockGeofenceRegionMonitor()
@@ -44,7 +45,8 @@ struct GeofenceSyncCoordinatorTests {
             monitor: resolvedMonitor,
             contextStore: resolvedContextStore,
             dateUtil: dateUtil,
-            logger: LoggerMock()
+            logger: LoggerMock(),
+            syncMode: syncMode
         )
         return Setup(
             coordinator: coordinator,
@@ -91,6 +93,7 @@ struct GeofenceSyncCoordinatorTests {
                 // parse boundary's ms→s logic produces the same seconds.
                 remoteFetchRefreshExpiryTime: config.remoteFetchRefreshExpiry * 1000,
                 duplicateEventsExpiryTime: config.duplicateEventsExpiry * 1000,
+                maxMonitoringDistance: config.maxMonitoringDistance,
                 ios: GeofenceApiPlatformConfig(maxBusinessGeofences: config.maxBusinessGeofences)
             )
         }
@@ -107,7 +110,7 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
 
         #expect(result.errorOrNil == .noIdentifiedUser)
-        #expect(setup.api.fetchGeofencesCallsCount == 0)
+        #expect(setup.api.fetchAllGeofencesCallsCount == 0)
         #expect(setup.monitor.startedRegions.isEmpty)
     }
 
@@ -122,7 +125,8 @@ struct GeofenceSyncCoordinatorTests {
             remoteFetchRefreshTriggerRadius: 3000,
             remoteFetchRefreshExpiry: oneHour,
             duplicateEventsExpiry: 60,
-            maxBusinessGeofences: 10
+            maxBusinessGeofences: 10,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
         ))
         await storage.recordSync(
             timestamp: dateUtil.givenNow.addingTimeInterval(-100),
@@ -134,38 +138,126 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.refresh(latitude: 0, longitude: 0)
 
         #expect(result.isSuccess)
-        #expect(setup.api.fetchGeofencesCallsCount == 0)
+        #expect(setup.api.fetchAllGeofencesCallsCount == 0)
         #expect(setup.monitor.startedRegions.isEmpty)
     }
 
     @Test
-    func refresh_givenTimeFreshButFarFromAnchor_expectApiCalled() async {
+    func refresh_givenFetchAllTimeFreshAndFarFromFetchAnchor_expectSkipNoApiCall() async {
+        // Outrunning the fetch anchor does NOT force a re-fetch (the cached set is complete), and
+        // with no ranking staleness it skips.
         let storage = makeStorage()
         let dateUtil = DateUtilStub()
-        // Time-fresh (100s ago vs 1h expiry) but caller is well beyond the 3km trigger radius.
         let oneHour: TimeInterval = 60 * 60
         await storage.setCachedConfig(GeofenceConfig(
             localRefreshTriggerRadius: 1000,
             remoteFetchRefreshTriggerRadius: 3000,
             remoteFetchRefreshExpiry: oneHour,
             duplicateEventsExpiry: 60,
-            maxBusinessGeofences: 10
+            maxBusinessGeofences: 10,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
         ))
-        await storage.recordSync(
-            timestamp: dateUtil.givenNow.addingTimeInterval(-100),
-            location: LocationData(latitude: 0, longitude: 0)
-        )
-        let api = GeofenceApiServiceMock()
-        api.fetchGeofencesClosure = { _, _, completion in
-            completion(.success(makeApiResponse(regions: [])))
-        }
-        let setup = makeCoordinator(api: api, storage: storage, dateUtil: dateUtil)
+        // Fetch anchor is far (~248km), but the registration anchor is at the refresh location, so
+        // ranking is fresh — confirming fetchAll ignores fetch-anchor distance. Registered IDs
+        // non-empty → not an unregistered-cache case.
+        await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-100), location: LocationData(latitude: 0, longitude: 0))
+        await storage.recordRegistration(center: LocationData(latitude: 1.0, longitude: 2.0), businessIds: ["a"])
+        let setup = makeCoordinator(storage: storage, dateUtil: dateUtil, syncMode: .fetchAll)
 
-        // (1.0, 2.0) is ~248km from (0, 0) — way beyond 3km.
         let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
 
         #expect(result.isSuccess)
-        #expect(api.fetchGeofencesCallsCount == 1)
+        #expect(setup.api.fetchAllGeofencesCallsCount == 0)
+        // Genuinely skipped (not a local re-rank): no regions registered this call.
+        #expect(setup.monitor.startedRegions.isEmpty)
+    }
+
+    @Test
+    func refresh_givenTimeFreshButRankingStale_expectLocalRerankNoApiCall() async {
+        // Kill-then-travel: the app was dead so no movement EXIT fired, but the device is now beyond
+        // the trigger radius from the last registration. Re-rank the cached set locally — no fetch.
+        let storage = makeStorage()
+        let dateUtil = DateUtilStub()
+        let oneHour: TimeInterval = 60 * 60
+        await storage.setCachedConfig(GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 3000,
+            remoteFetchRefreshExpiry: oneHour,
+            duplicateEventsExpiry: 60,
+            maxBusinessGeofences: 10,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
+        ))
+        await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-100), location: LocationData(latitude: 0, longitude: 0))
+        await storage.recordRegistration(center: LocationData(latitude: 0, longitude: 0), businessIds: ["old"])
+        await storage.setCachedGeofences([makeRegion(id: "near", latitude: 1, longitude: 2)])
+        let setup = makeCoordinator(storage: storage, dateUtil: dateUtil, syncMode: .fetchAll)
+
+        // ~248km from the registration center — well beyond the 1km ranking radius.
+        let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
+
+        #expect(result.isSuccess)
+        #expect(setup.api.fetchAllGeofencesCallsCount == 0)
+        #expect(setup.monitor.startedRegions.contains { $0.identifier == "near" })
+    }
+
+    @Test
+    func refresh_givenTimeFreshAndRankingFreshButUnregisteredCache_expectLocalRerankNoApiCall() async {
+        // Cache holds regions but nothing is registered — no registration center (regs lost on
+        // sign-out / never restored) → re-register locally rather than skip, so the user isn't left
+        // with no monitored geofences until staleness.
+        let storage = makeStorage()
+        let dateUtil = DateUtilStub()
+        let oneHour: TimeInterval = 60 * 60
+        await storage.setCachedConfig(GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 3000,
+            remoteFetchRefreshExpiry: oneHour,
+            duplicateEventsExpiry: 60,
+            maxBusinessGeofences: 10,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
+        ))
+        await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-100), location: LocationData(latitude: 0, longitude: 0))
+        // No recordRegistration → no registration center → genuinely "nothing registered".
+        await storage.setCachedGeofences([makeRegion(id: "cached", latitude: 0, longitude: 0)])
+        let setup = makeCoordinator(storage: storage, dateUtil: dateUtil, syncMode: .fetchAll)
+
+        // Same location as anchor → time-fresh + ranking-fresh, but nothing is registered.
+        let result = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+
+        #expect(result.isSuccess)
+        #expect(setup.api.fetchAllGeofencesCallsCount == 0)
+        #expect(setup.monitor.startedRegions.contains { $0.identifier == "cached" })
+    }
+
+    @Test
+    func refresh_givenTimeFreshRankingFreshAndFullyCappedOut_expectSkipNoRerank() async {
+        // Every cached geofence is beyond maxMonitoringDistance, so the last registration registered
+        // the movement trigger only (center set, zero business IDs). That's not "regs lost" — a
+        // time/ranking-fresh refresh must skip, not re-rank on every launch.
+        let storage = makeStorage()
+        let dateUtil = DateUtilStub()
+        let oneHour: TimeInterval = 60 * 60
+        await storage.setCachedConfig(GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 3000,
+            remoteFetchRefreshExpiry: oneHour,
+            duplicateEventsExpiry: 60,
+            maxBusinessGeofences: 10,
+            maxMonitoringDistance: 5000
+        ))
+        await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-100), location: LocationData(latitude: 0, longitude: 0))
+        // Prior capped-out registration: trigger registered (center set), no business IDs.
+        await storage.recordRegistration(center: LocationData(latitude: 0, longitude: 0), businessIds: [])
+        await storage.setCachedGeofences([makeRegion(id: "far", latitude: 1, longitude: 2)]) // ~248 km, beyond the 5 km cap
+        let setup = makeCoordinator(storage: storage, dateUtil: dateUtil, syncMode: .fetchAll)
+
+        let result = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+
+        #expect(result.isSuccess)
+        #expect(setup.api.fetchAllGeofencesCallsCount == 0)
+        // Genuinely skipped: no re-rank, so no stop/start churn this call.
+        #expect(setup.monitor.startedRegions.isEmpty)
+        #expect(setup.monitor.stopAllCallCount == 0)
     }
 
     @Test
@@ -179,14 +271,15 @@ struct GeofenceSyncCoordinatorTests {
             remoteFetchRefreshTriggerRadius: 3000,
             remoteFetchRefreshExpiry: oneHour,
             duplicateEventsExpiry: 60,
-            maxBusinessGeofences: 10
+            maxBusinessGeofences: 10,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
         ))
         await storage.recordSync(
             timestamp: dateUtil.givenNow.addingTimeInterval(-2 * oneHour),
             location: LocationData(latitude: 0, longitude: 0)
         )
         let api = GeofenceApiServiceMock()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.success(makeApiResponse(regions: [])))
         }
         let setup = makeCoordinator(api: api, storage: storage, dateUtil: dateUtil)
@@ -194,7 +287,7 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.refresh(latitude: 0, longitude: 0)
 
         #expect(result.isSuccess)
-        #expect(api.fetchGeofencesCallsCount == 1)
+        #expect(api.fetchAllGeofencesCallsCount == 1)
     }
 
     @Test
@@ -211,7 +304,7 @@ struct GeofenceSyncCoordinatorTests {
         )
         let api = GeofenceApiServiceMock()
         let region = makeRegion(id: "g1", latitude: 1.0, longitude: 2.0)
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.success(makeApiResponse(regions: [region])))
         }
 
@@ -219,7 +312,7 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
 
         #expect(result.isSuccess)
-        #expect(api.fetchGeofencesCallsCount == 1)
+        #expect(api.fetchAllGeofencesCallsCount == 1)
         let cached = await storage.getCachedGeofences()
         #expect(cached.map(\.id) == ["g1"])
         let lastSync = await storage.getLastSync()
@@ -243,7 +336,7 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.refresh(latitude: 0, longitude: 0)
 
         #expect(result.isSuccess)
-        #expect(setup.api.fetchGeofencesCallsCount == 0)
+        #expect(setup.api.fetchAllGeofencesCallsCount == 0)
     }
 
     @Test
@@ -252,7 +345,7 @@ struct GeofenceSyncCoordinatorTests {
         // API is called regardless of cached-config state.
         let storage = makeStorage()
         let api = GeofenceApiServiceMock()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.success(makeApiResponse(regions: [])))
         }
         let setup = makeCoordinator(api: api, storage: storage)
@@ -260,7 +353,7 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
 
         #expect(result.isSuccess)
-        #expect(api.fetchGeofencesCallsCount == 1)
+        #expect(api.fetchAllGeofencesCallsCount == 1)
         #expect(await storage.getLastSync() != nil)
     }
 
@@ -274,7 +367,7 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
 
         #expect(result.errorOrNil == .noIdentifiedUser)
-        #expect(setup.api.fetchGeofencesCallsCount == 0)
+        #expect(setup.api.fetchAllGeofencesCallsCount == 0)
     }
 
     // MARK: - Fetch outcomes
@@ -283,7 +376,7 @@ struct GeofenceSyncCoordinatorTests {
     func refresh_givenApiTransportError_expectFailureAndNoCacheWritten() async {
         let storage = makeStorage()
         let api = GeofenceApiServiceMock()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.failure(.transport))
         }
 
@@ -306,11 +399,12 @@ struct GeofenceSyncCoordinatorTests {
             remoteFetchRefreshTriggerRadius: 1500,
             remoteFetchRefreshExpiry: 1800,
             duplicateEventsExpiry: 30,
-            maxBusinessGeofences: 5
+            maxBusinessGeofences: 5,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
         )
         await storage.setCachedConfig(priorConfig)
         let api = GeofenceApiServiceMock()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.success(makeApiResponse(regions: [])))
         }
 
@@ -329,10 +423,11 @@ struct GeofenceSyncCoordinatorTests {
             remoteFetchRefreshTriggerRadius: 2500,
             remoteFetchRefreshExpiry: 7200,
             duplicateEventsExpiry: 90,
-            maxBusinessGeofences: 8
+            maxBusinessGeofences: 8,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
         )
         let api = GeofenceApiServiceMock()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.success(makeApiResponse(regions: [], config: newConfig)))
         }
 
@@ -352,7 +447,8 @@ struct GeofenceSyncCoordinatorTests {
             remoteFetchRefreshTriggerRadius: 3000,
             remoteFetchRefreshExpiry: 86400,
             duplicateEventsExpiry: 60,
-            maxBusinessGeofences: 3
+            maxBusinessGeofences: 3,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
         )
         await storage.setCachedConfig(config)
 
@@ -361,7 +457,7 @@ struct GeofenceSyncCoordinatorTests {
             makeRegion(id: "g\(i)", latitude: Double(i) * 0.1, longitude: 0)
         }
         let api = GeofenceApiServiceMock()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.success(makeApiResponse(regions: regions)))
         }
 
@@ -384,12 +480,13 @@ struct GeofenceSyncCoordinatorTests {
             remoteFetchRefreshTriggerRadius: 3000,
             remoteFetchRefreshExpiry: 86400,
             duplicateEventsExpiry: 60,
-            maxBusinessGeofences: 10
+            maxBusinessGeofences: 10,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
         )
         await storage.setCachedConfig(config)
         let api = GeofenceApiServiceMock()
         let region = makeRegion(id: "g1", latitude: 37.7749, longitude: -122.4194)
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.success(makeApiResponse(regions: [region])))
         }
 
@@ -409,7 +506,7 @@ struct GeofenceSyncCoordinatorTests {
     func refresh_givenEmptyBusinessRegions_expectNoMovementTriggerRegistered() async {
         let storage = makeStorage()
         let api = GeofenceApiServiceMock()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.success(makeApiResponse(regions: [])))
         }
 
@@ -425,7 +522,7 @@ struct GeofenceSyncCoordinatorTests {
         let storage = makeStorage()
         let api = GeofenceApiServiceMock()
         let region = makeRegion(id: "g1", latitude: 1.0, longitude: 2.0)
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.success(makeApiResponse(regions: [region])))
         }
 
@@ -448,7 +545,7 @@ struct GeofenceSyncCoordinatorTests {
         let api = GeofenceApiServiceMock()
         let firstReachedApi = AsyncSignal()
         let allowFinish = AsyncSignal()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             Task {
                 await firstReachedApi.fire()
                 await allowFinish.wait()
@@ -467,7 +564,7 @@ struct GeofenceSyncCoordinatorTests {
 
         #expect(second.errorOrNil == .alreadyInProgress)
         #expect(firstResult.isSuccess)
-        #expect(api.fetchGeofencesCallsCount == 1)
+        #expect(api.fetchAllGeofencesCallsCount == 1)
     }
 
     // MARK: - Storage invariants
@@ -486,10 +583,11 @@ struct GeofenceSyncCoordinatorTests {
             remoteFetchRefreshTriggerRadius: 2500,
             remoteFetchRefreshExpiry: 7200,
             duplicateEventsExpiry: 90,
-            maxBusinessGeofences: 8
+            maxBusinessGeofences: 8,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
         )
         let region = makeRegion(id: "g1", latitude: 1.0, longitude: 2.0)
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.success(makeApiResponse(regions: [region], config: newConfig)))
         }
         let setup = makeCoordinator(api: api, storage: spy)
@@ -497,9 +595,37 @@ struct GeofenceSyncCoordinatorTests {
         _ = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
 
         let writes = await spy.operations.filter { op in
-            op == .setCachedGeofences || op == .setCachedConfig || op == .recordSync
+            op == .setCachedGeofences || op == .setCachedConfig || op == .recordSync || op == .recordRegistration
         }
-        #expect(writes == [.setCachedGeofences, .setCachedConfig, .recordSync])
+        #expect(writes == [.setCachedGeofences, .setCachedConfig, .recordSync, .recordRegistration])
+    }
+
+    @Test
+    func refresh_givenRemoteFetch_expectRegistrationCenterAndIdsPersisted() async {
+        // The remote path must persist the registration anchor + registered IDs — it's the
+        // ranking-staleness reference a later cold-boot refresh measures against. Without it,
+        // ranking staleness goes undetected after a kill-then-travel.
+        let storage = makeStorage()
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 3000,
+            remoteFetchRefreshExpiry: 86400,
+            duplicateEventsExpiry: 60,
+            maxBusinessGeofences: 2,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
+        )
+        // 3 regions; nearest 2 to the (0,0) fetch location are g0/g1.
+        let regions = (0 ..< 3).map { i in makeRegion(id: "g\(i)", latitude: Double(i) * 0.1, longitude: 0) }
+        let api = GeofenceApiServiceMock()
+        api.fetchAllGeofencesClosure = { completion in
+            completion(.success(makeApiResponse(regions: regions, config: config)))
+        }
+        let setup = makeCoordinator(api: api, storage: storage)
+
+        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+
+        #expect(await storage.getLastRegistrationCenter() == LocationData(latitude: 0, longitude: 0))
+        #expect(await storage.getRegisteredBusinessIds() == ["g0", "g1"])
     }
 
     @Test
@@ -510,11 +636,12 @@ struct GeofenceSyncCoordinatorTests {
             remoteFetchRefreshTriggerRadius: 1500,
             remoteFetchRefreshExpiry: 1800,
             duplicateEventsExpiry: 30,
-            maxBusinessGeofences: 5
+            maxBusinessGeofences: 5,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
         )
         await storage.setCachedConfig(priorConfig)
         let api = GeofenceApiServiceMock()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.failure(.transport))
         }
         let setup = makeCoordinator(api: api, storage: storage)
@@ -534,7 +661,7 @@ struct GeofenceSyncCoordinatorTests {
     func applyCachedRegistration_givenNoUserId_expectNoRegistration() {
         let setup = makeCoordinator(storage: makeStorage())
 
-        setup.coordinator.applyCachedRegistration(
+        _ = setup.coordinator.applyCachedRegistration(
             cachedRegions: [sampleRegion()],
             anchor: LocationData(latitude: 0, longitude: 0),
             config: .fallback,
@@ -548,7 +675,7 @@ struct GeofenceSyncCoordinatorTests {
     func applyCachedRegistration_givenEmptyRegions_expectNoRegistration() {
         let setup = makeCoordinator(storage: makeStorage())
 
-        setup.coordinator.applyCachedRegistration(
+        _ = setup.coordinator.applyCachedRegistration(
             cachedRegions: [],
             anchor: LocationData(latitude: 0, longitude: 0),
             config: .fallback,
@@ -564,7 +691,7 @@ struct GeofenceSyncCoordinatorTests {
         // sensibly — bail rather than re-using an arbitrary location.
         let setup = makeCoordinator(storage: makeStorage())
 
-        setup.coordinator.applyCachedRegistration(
+        _ = setup.coordinator.applyCachedRegistration(
             cachedRegions: [sampleRegion()],
             anchor: nil,
             config: .fallback,
@@ -581,7 +708,8 @@ struct GeofenceSyncCoordinatorTests {
             remoteFetchRefreshTriggerRadius: 3000,
             remoteFetchRefreshExpiry: 86400,
             duplicateEventsExpiry: 60,
-            maxBusinessGeofences: 3
+            maxBusinessGeofences: 3,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
         )
         let anchor = LocationData(latitude: 37.7749, longitude: -122.4194)
         // 5 regions; nearest 3 to the anchor are g0/g1/g2.
@@ -590,7 +718,7 @@ struct GeofenceSyncCoordinatorTests {
         }
         let setup = makeCoordinator(storage: makeStorage())
 
-        setup.coordinator.applyCachedRegistration(
+        _ = setup.coordinator.applyCachedRegistration(
             cachedRegions: regions,
             anchor: anchor,
             config: config,
@@ -614,11 +742,102 @@ struct GeofenceSyncCoordinatorTests {
     }
 
     @Test
+    func applyCachedRegistration_givenAllInputs_expectReturnsRegisteredCenterAndIds() {
+        // The caller persists this as the ranking-staleness reference, so the returned center/ids
+        // must match what was registered with the OS (the nearest set, capped at maxBusinessGeofences).
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 600,
+            remoteFetchRefreshTriggerRadius: 3000,
+            remoteFetchRefreshExpiry: 86400,
+            duplicateEventsExpiry: 60,
+            maxBusinessGeofences: 3,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
+        )
+        let anchor = LocationData(latitude: 37.7749, longitude: -122.4194)
+        let regions = (0 ..< 5).map { i in
+            makeRegion(id: "g\(i)", latitude: anchor.latitude + Double(i) * 0.01, longitude: anchor.longitude)
+        }
+        let setup = makeCoordinator(storage: makeStorage())
+
+        let registration = setup.coordinator.applyCachedRegistration(
+            cachedRegions: regions,
+            anchor: anchor,
+            config: config,
+            userId: "user-1"
+        )
+
+        #expect(registration?.center == anchor)
+        #expect(registration?.businessIds == ["g0", "g1", "g2"])
+    }
+
+    @Test
+    func applyCachedRegistration_givenSkipped_expectNilReturn() {
+        let setup = makeCoordinator(storage: makeStorage())
+
+        let registration = setup.coordinator.applyCachedRegistration(
+            cachedRegions: [sampleRegion()],
+            anchor: LocationData(latitude: 0, longitude: 0),
+            config: .fallback,
+            userId: nil
+        )
+
+        #expect(registration == nil)
+    }
+
+    @Test
+    func applyCachedRegistration_givenAllRegionsBeyondCap_expectMovementTriggerButNoBusinessRegions() {
+        // The distance cap excludes the only cached region; the movement trigger must still register
+        // so a later EXIT re-ranks and can bring a now-closer region into range.
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 600,
+            remoteFetchRefreshTriggerRadius: 3000,
+            remoteFetchRefreshExpiry: 86400,
+            duplicateEventsExpiry: 60,
+            maxBusinessGeofences: 10,
+            maxMonitoringDistance: 5000
+        )
+        let setup = makeCoordinator(storage: makeStorage())
+
+        let registration = setup.coordinator.applyCachedRegistration(
+            cachedRegions: [makeRegion(id: "far", latitude: 1, longitude: 2)], // ~248 km from anchor
+            anchor: LocationData(latitude: 0, longitude: 0),
+            config: config,
+            userId: "user-1"
+        )
+
+        #expect(setup.monitor.startedRegions.map(\.identifier) == [GeofenceConstants.movementTriggerIdentifier])
+        #expect(registration?.businessIds.isEmpty == true)
+    }
+
+    @Test
+    func applyCachedRegistration_givenKillSwitch_expectNoRegistrationIncludingTrigger() {
+        // maxBusinessGeofences == 0 disables registration entirely — not even the movement trigger.
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 600,
+            remoteFetchRefreshTriggerRadius: 3000,
+            remoteFetchRefreshExpiry: 86400,
+            duplicateEventsExpiry: 60,
+            maxBusinessGeofences: 0,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
+        )
+        let setup = makeCoordinator(storage: makeStorage())
+
+        _ = setup.coordinator.applyCachedRegistration(
+            cachedRegions: [makeRegion(id: "g1", latitude: 0, longitude: 0)],
+            anchor: LocationData(latitude: 0, longitude: 0),
+            config: config,
+            userId: "user-1"
+        )
+
+        #expect(setup.monitor.startedRegions.isEmpty)
+    }
+
+    @Test
     func applyCachedRegistration_givenNilConfig_expectFallbackUsed() {
         let anchor = LocationData(latitude: 0, longitude: 0)
         let setup = makeCoordinator(storage: makeStorage())
 
-        setup.coordinator.applyCachedRegistration(
+        _ = setup.coordinator.applyCachedRegistration(
             cachedRegions: [sampleRegion(offset: 0.1)],
             anchor: anchor,
             config: nil,
@@ -637,7 +856,7 @@ struct GeofenceSyncCoordinatorTests {
         let api = GeofenceApiServiceMock()
         let firstReachedApi = AsyncSignal()
         let allowFinish = AsyncSignal()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             Task {
                 await firstReachedApi.fire()
                 await allowFinish.wait()
@@ -651,7 +870,7 @@ struct GeofenceSyncCoordinatorTests {
         // Refresh holds the dedup gate. ApplyCachedRegistration must bail without touching
         // the monitor.
         let monitorCallsBefore = setup.monitor.startedRegions.count
-        setup.coordinator.applyCachedRegistration(
+        _ = setup.coordinator.applyCachedRegistration(
             cachedRegions: [sampleRegion()],
             anchor: LocationData(latitude: 0, longitude: 0),
             config: .fallback,
@@ -672,7 +891,7 @@ struct GeofenceSyncCoordinatorTests {
         let storage = makeStorage()
         let contextStore = makeContextStore(userId: nil)
         let api = GeofenceApiServiceMock()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.success(makeApiResponse(regions: [])))
         }
         let setup = makeCoordinator(api: api, storage: storage, contextStore: contextStore)
@@ -685,7 +904,7 @@ struct GeofenceSyncCoordinatorTests {
         let second = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
 
         #expect(second.isSuccess)
-        #expect(api.fetchGeofencesCallsCount == 1)
+        #expect(api.fetchAllGeofencesCallsCount == 1)
     }
 
     // MARK: - handleMovement
@@ -698,7 +917,7 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.handleMovement(latitude: 1.0, longitude: 2.0)
 
         #expect(result.errorOrNil == .noIdentifiedUser)
-        #expect(setup.api.fetchGeofencesCallsCount == 0)
+        #expect(setup.api.fetchAllGeofencesCallsCount == 0)
         #expect(setup.monitor.startedRegions.isEmpty)
     }
 
@@ -708,7 +927,7 @@ struct GeofenceSyncCoordinatorTests {
         // Matches Android's `anchor == null` branch.
         let storage = makeStorage()
         let api = GeofenceApiServiceMock()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             completion(.success(makeApiResponse(regions: [makeRegion(id: "g1", latitude: 0, longitude: 0)])))
         }
         let setup = makeCoordinator(api: api, storage: storage)
@@ -716,7 +935,7 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.handleMovement(latitude: 1.0, longitude: 2.0)
 
         #expect(result.isSuccess)
-        #expect(setup.api.fetchGeofencesCallsCount == 1)
+        #expect(setup.api.fetchAllGeofencesCallsCount == 1)
     }
 
     @Test
@@ -727,7 +946,8 @@ struct GeofenceSyncCoordinatorTests {
             remoteFetchRefreshTriggerRadius: 5000,
             remoteFetchRefreshExpiry: 3600,
             duplicateEventsExpiry: 3600,
-            maxBusinessGeofences: 10
+            maxBusinessGeofences: 10,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
         )
         await storage.setCachedConfig(config)
         // Anchor at (0, 0); cached regions arrayed nearby for re-rank verification.
@@ -739,44 +959,45 @@ struct GeofenceSyncCoordinatorTests {
         let api = GeofenceApiServiceMock()
         let setup = makeCoordinator(api: api, storage: storage)
 
-        // New position ~111 m from anchor — within 5 km Tier B threshold.
+        // New position ~111 m from anchor — re-ranks the cached set locally, no fetch.
         let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
 
         #expect(result.isSuccess)
-        #expect(setup.api.fetchGeofencesCallsCount == 0)
+        #expect(setup.api.fetchAllGeofencesCallsCount == 0)
         let businessRegistered = setup.monitor.startedRegions.filter { $0.identifier != GeofenceConstants.movementTriggerIdentifier }
         #expect(businessRegistered.map(\.identifier) == ["near", "far"])
     }
 
     @Test
-    func handleMovement_givenMovementBeyondThreshold_expectTierBRemoteFetch() async {
+    func handleMovement_givenFetchAllMovementBeyondThreshold_expectLocalRerankNoApiCall() async {
+        // fetchAll holds the complete set, so even a large move never re-fetches — it re-ranks the
+        // cached regions on-device. No code path sends location off-device.
         let storage = makeStorage()
         let config = GeofenceConfig(
             localRefreshTriggerRadius: 1000,
             remoteFetchRefreshTriggerRadius: 5000,
             remoteFetchRefreshExpiry: 3600,
             duplicateEventsExpiry: 3600,
-            maxBusinessGeofences: 10
+            maxBusinessGeofences: 10,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
         )
         await storage.setCachedConfig(config)
         await storage.recordSync(timestamp: Date(timeIntervalSince1970: 100), location: LocationData(latitude: 0, longitude: 0))
-        let api = GeofenceApiServiceMock()
-        api.fetchGeofencesClosure = { _, _, completion in
-            completion(.success(makeApiResponse(regions: [makeRegion(id: "fresh", latitude: 1, longitude: 1)])))
-        }
-        let setup = makeCoordinator(api: api, storage: storage)
+        await storage.setCachedGeofences([makeRegion(id: "cached", latitude: 1, longitude: 1)])
+        let setup = makeCoordinator(storage: storage, syncMode: .fetchAll)
 
-        // ~157 km from anchor — well beyond 5 km Tier B threshold.
+        // ~157 km from anchor — a large move that still re-ranks locally, never re-fetches.
         let result = await setup.coordinator.handleMovement(latitude: 1.0, longitude: 1.0)
 
         #expect(result.isSuccess)
-        #expect(setup.api.fetchGeofencesCallsCount == 1)
+        #expect(setup.api.fetchAllGeofencesCallsCount == 0)
+        #expect(setup.monitor.startedRegions.contains { $0.identifier == "cached" })
     }
 
     @Test
-    func handleMovement_givenTierA_expectLastSyncAndCacheNotMutated() async {
-        // Tier A re-uses the existing API anchor — must not overwrite it, otherwise the next
-        // Tier B threshold check would always pass relative to wherever the user just stood.
+    func handleMovement_givenLocalRerank_expectLastSyncAndCacheNotMutated() async {
+        // A local re-rank re-uses the existing API anchor — must not overwrite lastSync, or the
+        // time-staleness reference would drift to wherever the user just stood.
         let storage = makeStorage()
         let originalAnchor = LocationData(latitude: 0, longitude: 0)
         let originalTimestamp = Date(timeIntervalSince1970: 100)
@@ -785,7 +1006,8 @@ struct GeofenceSyncCoordinatorTests {
             remoteFetchRefreshTriggerRadius: 5000,
             remoteFetchRefreshExpiry: 3600,
             duplicateEventsExpiry: 3600,
-            maxBusinessGeofences: 10
+            maxBusinessGeofences: 10,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
         )
         await storage.setCachedConfig(config)
         await storage.recordSync(timestamp: originalTimestamp, location: originalAnchor)
@@ -800,16 +1022,42 @@ struct GeofenceSyncCoordinatorTests {
     }
 
     @Test
-    func handleMovement_givenTierA_expectMovementTriggerRecenteredAtNewLocation() async {
-        // The movement trigger's job is to fire when the user leaves the *current* zone.
-        // After Tier A, it must center on where the user just stood, not the API anchor.
+    func handleMovement_givenLocalRerank_expectRegistrationCenterAndIdsPersistedAtNewLocation() async {
+        // A local re-rank must advance the registration reference to the new location, so the next
+        // refresh's ranking-staleness check measures from where the device actually re-registered.
         let storage = makeStorage()
         let config = GeofenceConfig(
             localRefreshTriggerRadius: 1000,
             remoteFetchRefreshTriggerRadius: 5000,
             remoteFetchRefreshExpiry: 3600,
             duplicateEventsExpiry: 3600,
-            maxBusinessGeofences: 10
+            maxBusinessGeofences: 10,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
+        )
+        await storage.setCachedConfig(config)
+        await storage.recordSync(timestamp: Date(timeIntervalSince1970: 100), location: LocationData(latitude: 0, longitude: 0))
+        await storage.setCachedGeofences([makeRegion(id: "near", latitude: 0, longitude: 0.0005)])
+        let setup = makeCoordinator(storage: storage)
+
+        let newLocation = LocationData(latitude: 0, longitude: 0.001)
+        _ = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude)
+
+        #expect(await storage.getLastRegistrationCenter() == newLocation)
+        #expect(await storage.getRegisteredBusinessIds() == ["near"])
+    }
+
+    @Test
+    func handleMovement_givenLocalRerank_expectMovementTriggerRecenteredAtNewLocation() async {
+        // The movement trigger's job is to fire when the user leaves the *current* zone.
+        // After a local re-rank, it must center on where the user just stood, not the API anchor.
+        let storage = makeStorage()
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 5000,
+            remoteFetchRefreshExpiry: 3600,
+            duplicateEventsExpiry: 3600,
+            maxBusinessGeofences: 10,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
         )
         await storage.setCachedConfig(config)
         await storage.recordSync(timestamp: Date(timeIntervalSince1970: 100), location: LocationData(latitude: 0, longitude: 0))
@@ -833,7 +1081,7 @@ struct GeofenceSyncCoordinatorTests {
         let api = GeofenceApiServiceMock()
         let suspendUntil = AsyncSignal()
         let arrived = AsyncSignal()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             Task {
                 await arrived.fire()
                 await suspendUntil.wait()
@@ -902,7 +1150,7 @@ struct GeofenceSyncCoordinatorTests {
         let api = GeofenceApiServiceMock()
         let suspendUntil = AsyncSignal()
         let arrived = AsyncSignal()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             Task {
                 await arrived.fire()
                 await suspendUntil.wait()
@@ -929,7 +1177,7 @@ struct GeofenceSyncCoordinatorTests {
         let api = GeofenceApiServiceMock()
         let suspendUntil = AsyncSignal()
         let arrived = AsyncSignal()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             Task {
                 await arrived.fire()
                 await suspendUntil.wait()
@@ -961,7 +1209,7 @@ struct GeofenceSyncCoordinatorTests {
         let api = GeofenceApiServiceMock()
         let suspendUntil = AsyncSignal()
         let arrived = AsyncSignal()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             Task {
                 await arrived.fire()
                 await suspendUntil.wait()
@@ -988,11 +1236,11 @@ struct GeofenceSyncCoordinatorTests {
         // short-circuit a concurrent refresh. Pinned independently because a regression
         // that gave handleMovement its own gate would still pass the forward test.
         let storage = makeStorage()
-        // No cached config → handleMovement falls back to `.fallback`, no anchor → Tier B.
+        // No cached config → handleMovement falls back to `.fallback`; no anchor → remote bootstrap.
         let api = GeofenceApiServiceMock()
         let suspendUntil = AsyncSignal()
         let arrived = AsyncSignal()
-        api.fetchGeofencesClosure = { _, _, completion in
+        api.fetchAllGeofencesClosure = { completion in
             Task {
                 await arrived.fire()
                 await suspendUntil.wait()
@@ -1032,9 +1280,12 @@ private actor SpyGeofenceSyncStorage: GeofenceSyncStorage {
         case getCachedConfig
         case getCachedGeofences
         case getLastSync
+        case getLastRegistrationCenter
+        case getRegisteredBusinessIds
         case setCachedGeofences
         case setCachedConfig
         case recordSync
+        case recordRegistration
         case clearUserScopedState
     }
 
@@ -1060,6 +1311,16 @@ private actor SpyGeofenceSyncStorage: GeofenceSyncStorage {
         return await underlying.getLastSync()
     }
 
+    func getLastRegistrationCenter() async -> LocationData? {
+        operations.append(.getLastRegistrationCenter)
+        return await underlying.getLastRegistrationCenter()
+    }
+
+    func getRegisteredBusinessIds() async -> Set<String> {
+        operations.append(.getRegisteredBusinessIds)
+        return await underlying.getRegisteredBusinessIds()
+    }
+
     func setCachedGeofences(_ regions: [Geofence]) async {
         operations.append(.setCachedGeofences)
         await underlying.setCachedGeofences(regions)
@@ -1073,6 +1334,11 @@ private actor SpyGeofenceSyncStorage: GeofenceSyncStorage {
     func recordSync(timestamp: Date, location: LocationData) async {
         operations.append(.recordSync)
         await underlying.recordSync(timestamp: timestamp, location: location)
+    }
+
+    func recordRegistration(center: LocationData, businessIds: Set<String>) async {
+        operations.append(.recordRegistration)
+        await underlying.recordRegistration(center: center, businessIds: businessIds)
     }
 
     func clearUserScopedState() async {

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -219,7 +219,8 @@ struct GeofenceEventTrackerTests {
             remoteFetchRefreshTriggerRadius: 3000,
             remoteFetchRefreshExpiry: 24 * 60 * 60,
             duplicateEventsExpiry: serverCooldown,
-            maxBusinessGeofences: 19
+            maxBusinessGeofences: 19,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
         ))
         let pending = makePendingStore(directory: dir)
         let delivery = GeofenceDeliveryTrackerMock()

--- a/Tests/LocationGeofence/Geofence/GeofenceBootstrapTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceBootstrapTests.swift
@@ -118,6 +118,97 @@ struct GeofenceBootstrapTests {
     }
 
     @Test
+    func wireMonitor_givenRegistrationCenterAndLastSync_expectAnchorFromRegistrationCenter() async {
+        // A local re-rank moved the registration center past the fetch anchor. Restore must use
+        // the registration center so cold boot reproduces the last-monitored set, not the older one.
+        let di = DIGraphShared.shared
+        let storage = GeofenceStorage(
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        await storage.recordSync(timestamp: Date(), location: LocationData(latitude: 0, longitude: 0))
+        await storage.recordRegistration(center: LocationData(latitude: 10, longitude: 20), businessIds: ["g1"])
+        di.override(value: storage, forType: GeofenceStorage.self)
+        let monitor = MockGeofenceRegionMonitor()
+        di.override(value: monitor as GeofenceRegionMonitoring, forType: GeofenceRegionMonitoring.self)
+        let coordinator = GeofenceSyncCoordinatorMock()
+        di.override(value: coordinator as GeofenceSyncCoordinator, forType: GeofenceSyncCoordinator.self)
+        defer { di.reset() }
+
+        await GeofenceBootstrap.wireMonitor(di: di)
+
+        let anchor = coordinator.applyCachedRegistrationReceivedArguments?.anchor
+        #expect(anchor?.latitude == 10)
+        #expect(anchor?.longitude == 20)
+    }
+
+    @Test
+    func wireMonitor_givenNoRegistrationCenter_expectAnchorFromLastSync() async {
+        // First restore after a remote fetch (no local re-rank yet): fall back to the fetch anchor.
+        let di = DIGraphShared.shared
+        let storage = GeofenceStorage(
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        await storage.recordSync(timestamp: Date(), location: LocationData(latitude: 5, longitude: 6))
+        di.override(value: storage, forType: GeofenceStorage.self)
+        let monitor = MockGeofenceRegionMonitor()
+        di.override(value: monitor as GeofenceRegionMonitoring, forType: GeofenceRegionMonitoring.self)
+        let coordinator = GeofenceSyncCoordinatorMock()
+        di.override(value: coordinator as GeofenceSyncCoordinator, forType: GeofenceSyncCoordinator.self)
+        defer { di.reset() }
+
+        await GeofenceBootstrap.wireMonitor(di: di)
+
+        let anchor = coordinator.applyCachedRegistrationReceivedArguments?.anchor
+        #expect(anchor?.latitude == 5)
+        #expect(anchor?.longitude == 6)
+    }
+
+    @Test
+    func wireMonitor_givenCoordinatorReturnsRegistration_expectPersistedAsReference() async {
+        // The registration applyCachedRegistration reports is persisted as the ranking-staleness
+        // reference so a later refresh measures distance from the actually-registered set.
+        let di = DIGraphShared.shared
+        let storage = GeofenceStorage(
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        di.override(value: storage, forType: GeofenceStorage.self)
+        let monitor = MockGeofenceRegionMonitor()
+        di.override(value: monitor as GeofenceRegionMonitoring, forType: GeofenceRegionMonitoring.self)
+        let coordinator = GeofenceSyncCoordinatorMock()
+        coordinator.applyCachedRegistrationReturnValue = GeofenceRegistration(
+            center: LocationData(latitude: 12, longitude: 34),
+            businessIds: ["g1"]
+        )
+        di.override(value: coordinator as GeofenceSyncCoordinator, forType: GeofenceSyncCoordinator.self)
+        defer { di.reset() }
+
+        await GeofenceBootstrap.wireMonitor(di: di)
+
+        let persisted = await storage.getLastRegistrationCenter()
+        #expect(persisted == LocationData(latitude: 12, longitude: 34))
+        #expect(await storage.getRegisteredBusinessIds() == ["g1"])
+    }
+
+    @Test
+    func wireMonitor_givenCoordinatorReturnsNil_expectNoRegistrationPersisted() async {
+        let di = DIGraphShared.shared
+        let storage = GeofenceStorage(
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        di.override(value: storage, forType: GeofenceStorage.self)
+        let monitor = MockGeofenceRegionMonitor()
+        di.override(value: monitor as GeofenceRegionMonitoring, forType: GeofenceRegionMonitoring.self)
+        let coordinator = GeofenceSyncCoordinatorMock()
+        coordinator.applyCachedRegistrationReturnValue = nil
+        di.override(value: coordinator as GeofenceSyncCoordinator, forType: GeofenceSyncCoordinator.self)
+        defer { di.reset() }
+
+        await GeofenceBootstrap.wireMonitor(di: di)
+
+        #expect(await storage.getLastRegistrationCenter() == nil)
+    }
+
+    @Test
     func geofenceSyncCoordinator_givenRepeatedResolution_expectSameInstance() {
         let di = DIGraphShared.shared
         let first = di.geofenceSyncCoordinator as? GeofenceSyncCoordinatorImpl

--- a/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
@@ -260,7 +260,8 @@ struct GeofenceStorageTests {
             remoteFetchRefreshTriggerRadius: 4000,
             remoteFetchRefreshExpiry: 12 * 60 * 60,
             duplicateEventsExpiry: 30 * 60,
-            maxBusinessGeofences: 10
+            maxBusinessGeofences: 10,
+            maxMonitoringDistance: 50000
         )
         await storage.setCachedConfig(config)
         let cached = await storage.getCachedConfig()
@@ -309,7 +310,8 @@ struct GeofenceStorageTests {
             remoteFetchRefreshTriggerRadius: 2000,
             remoteFetchRefreshExpiry: 60,
             duplicateEventsExpiry: 30,
-            maxBusinessGeofences: 5
+            maxBusinessGeofences: 5,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
         )
         await storage.setCachedConfig(updated)
         let cached = await storage.getCachedConfig()
@@ -453,7 +455,20 @@ struct GeofenceStorageTests {
     // MARK: - Concurrent safety
 
     @Test
-    func clearUserScopedState_expectCooldownsAndLastSyncCleared_workspaceCachePreserved() async {
+    func recordRegistration_thenGet_expectRoundTrip() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let center = LocationData(latitude: 37.7749, longitude: -122.4194)
+
+        await storage.recordRegistration(center: center, businessIds: ["g1", "g2"])
+
+        #expect(await storage.getLastRegistrationCenter() == center)
+        #expect(await storage.getRegisteredBusinessIds() == ["g1", "g2"])
+    }
+
+    @Test
+    func clearUserScopedState_expectCooldownsLastSyncAndRegistrationCleared_workspaceCachePreserved() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let storage = makeStorage(directory: dir)
@@ -463,6 +478,7 @@ struct GeofenceStorageTests {
         ])
         await storage.setCachedConfig(.fallback)
         await storage.recordSync(timestamp: Date(timeIntervalSince1970: 100), location: LocationData(latitude: 1, longitude: 2))
+        await storage.recordRegistration(center: LocationData(latitude: 1, longitude: 2), businessIds: ["g1"])
 
         await storage.clearUserScopedState()
 
@@ -472,6 +488,10 @@ struct GeofenceStorageTests {
         let config = await storage.getCachedConfig()
         #expect(cooldowns.isEmpty)
         #expect(lastSync == nil)
+        // Registration is user-scoped — cleared so the next user re-registers from their own refresh.
+        #expect(await storage.getLastRegistrationCenter() == nil)
+        #expect(await storage.getRegisteredBusinessIds().isEmpty)
+        // Workspace cache is shared across users — preserved.
         #expect(regions.map(\.id) == ["g1"])
         #expect(config != nil)
     }


### PR DESCRIPTION
## What

Geofence sync no longer transmits device location. The backend returns the full
(capped) workspace set and the SDK sends no coordinates to fetch it; remote fetch
is time/staleness-based and a movement trigger only re-ranks the cached set
on-device.

The location-based "nearby" fetch path (and its coordinate coarsener) is removed
entirely rather than gated, so there is no code path that sends device location
off-device. `GeofenceSyncMode` is kept as a single-case enum so a location-bound
mode can be reintroduced deliberately later (backend support + a deliberate SDK
release, never a runtime/server toggle).

## Also in this PR

- **`maxMonitoringDistance` cap** — candidates farther than this from the device
  aren't registered with the OS; a local re-rank re-adds them as the device
  approaches. absent → a finite default cap (the server omits it today; an
  unbounded default would register geofences a device can't reach soon, e.g. a US
  device registering Europe regions); explicit server `0` → no cap; a value below
  the trigger radius (a dead-zone) → default cap; else used as-is.
- **Movement trigger kept when geofences exist but none are in range now** so an
  EXIT re-ranks them in as the device approaches. Only a truly empty set (no
  geofences, or `maxBusinessGeofences == 0`) registers nothing.
- **Cold-boot ranking-reference fix** — restore now re-centers from the last
  registration center, not the older fetch anchor, and persists what it
  registered so a later refresh can detect a stale ranking (kill-then-travel).
- **Deterministic nearest-region ordering** — distances are rounded to whole
  meters before the id tiebreak; `CLLocation.distance` varies sub-meter for
  identical inputs, which made equidistant ordering (and a test) flaky.
- **Config hardening** — positive out-of-range radii/expiries clamp to sane
  bounds; non-positive values fall back per field.

Mirrors the Android implementation.

## Testing

175 LocationGeofence unit tests, including the refresh decision table, the
distance cap, movement-trigger gating, cold-boot anchor selection +
registration-reference persistence, and the dedup gate.

[MBL-1843](https://linear.app/customerio/issue/MBL-1843/use-coarse-location-for-nearby-geofence-fetch-requests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core geofence sync, OS monitoring, and refresh gating; incorrect ranking or registration persistence could miss geofences or over-fetch, though behavior is heavily unit-tested.
> 
> **Overview**
> Geofence sync no longer sends device coordinates to the CDP API: fetches use **`fetchAllGeofences`** (no query params) and **`GeofenceSyncMode.fetchAll`** is the only shipped path, with movement handling limited to on-device re-ranking except when there is no prior fetch anchor.
> 
> **Refresh and movement behavior** is reworked around a **`refreshAction`** table (time-stale → remote fetch; ranking-stale from **last registration center** or “cache but nothing registered” → local re-rank; else skip). Movement EXIT no longer re-fetches based on distance from the last sync anchor.
> 
> Adds **`maxMonitoringDistance`** (decode + defaults/clamps) so OS registration skips far-away regions; the movement trigger can still register when the workspace has geofences but none are in range. Persists **`recordRegistration`** (center + business IDs) separately from **`lastSync`**, and cold boot restores from the registration center and writes back what was registered.
> 
> Config mapping **clamps** local refresh radius and expiry fields; nearest-region selection **rounds distances to whole meters** for stable ordering. Extensive LocationGeofence test updates cover the new decision table and API shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 579eca9fae7e6b2415dfa563ba1c88352df09525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->