### PR TITLE
chore(geofence): adopt OS-persisted regions, harden API decoding, and event payload

### DIFF
--- a/Sources/Common/Communication/CombinedCacheEventBusHandler.swift
+++ b/Sources/Common/Communication/CombinedCacheEventBusHandler.swift
@@ -88,8 +88,9 @@ public class CombinedCacheEventBusHandler: EventBusHandler {
     /// Posts `event` and returns only after all current observers have been invoked.
     ///
     /// The event is always added to the in-memory cache. If no observers exist at
-    /// post time, the event is also written to persistent storage so that a future
-    /// observer can receive it via replay.
+    /// post time, a persistent event is also written to storage so a future observer
+    /// can receive it via replay. Transient events (`isPersistent == false`) are never
+    /// written to disk — they are only useful in the moment.
     public func postEventAndWait<E: EventRepresentable>(_ event: E) async {
         logger.debug("CombinedCacheEventBusHandler: Posting event \(event)")
         let observers = await bus.post(event)
@@ -97,7 +98,7 @@ public class CombinedCacheEventBusHandler: EventBusHandler {
         for observer in observers {
             observer(event)
         }
-        if observers.isEmpty {
+        if observers.isEmpty, event.isPersistent {
             logger.debug("CombinedCacheEventBusHandler: No observers, persisting event \(event)")
             do {
                 try await eventStorage.store(event: event)

--- a/Sources/Common/Communication/Event.swift
+++ b/Sources/Common/Communication/Event.swift
@@ -163,18 +163,20 @@ public struct TrackInAppMetricEvent: EventRepresentable {
     }
 }
 
-public struct TrackGeofenceMetricEvent: EventRepresentable {
+public struct TrackGeofenceMetricEvent: EventRepresentable, GeofenceMetric {
     public let storageId: String
     public let params: [String: String]
     public let geofenceId: String
     public let transition: GeofenceTransition
     public let timestamp: Date
+    public let name: String?
 
     public init(
         storageId: String = UUID().uuidString,
         geofenceId: String,
         transition: GeofenceTransition,
         timestamp: Date = Date(),
+        name: String?,
         params: [String: String] = [:]
     ) {
         self.storageId = storageId
@@ -182,6 +184,7 @@ public struct TrackGeofenceMetricEvent: EventRepresentable {
         self.geofenceId = geofenceId
         self.transition = transition
         self.timestamp = timestamp
+        self.name = name
     }
 }
 

--- a/Sources/Common/Service/BackgroundDeliveryHttpClient.swift
+++ b/Sources/Common/Service/BackgroundDeliveryHttpClient.swift
@@ -14,7 +14,7 @@ public enum BackgroundDeliveryHttpError: Error, Equatable {
 /// One CDP `/track` request for a background-delivery caller. Bundles the request-body fields
 /// into one value so the client signature stays stable as the payload grows.
 public struct BackgroundTrackRequest {
-    /// `track` event name (e.g. `"Geofence Entered"`).
+    /// CDP `track` event name.
     public let eventName: String
     /// Identified user id. Caller must validate non-empty before sending.
     public let userId: String

--- a/Sources/Common/Type/GeofenceMetric.swift
+++ b/Sources/Common/Type/GeofenceMetric.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// A geofence transition carrying the fields needed to build its `/track` analytics payload.
+///
+/// Both delivery paths conform — `PendingGeofenceMetric` (direct-HTTP) and
+/// `TrackGeofenceMetricEvent` (EventBus → DataPipeline) — so the property shape is defined once.
+public protocol GeofenceMetric {
+    var geofenceId: String { get }
+    var transition: GeofenceTransition { get }
+    var timestamp: Date { get }
+    /// The geofence's name, or `nil` when unavailable.
+    var name: String? { get }
+}
+
+public extension GeofenceMetric {
+    /// `/track` event properties. `geofence_name` is included only when a name is available.
+    var trackEventProperties: [String: Any] {
+        var properties: [String: Any] = [
+            "geofence_id": geofenceId,
+            "transition_type": transition.rawValue,
+            "timestamp": Int(timestamp.timeIntervalSince1970)
+        ]
+        if let name {
+            properties["geofence_name"] = name
+        }
+        return properties
+    }
+}

--- a/Sources/Common/Type/GeofenceTransition.swift
+++ b/Sources/Common/Type/GeofenceTransition.swift
@@ -12,12 +12,11 @@ public enum GeofenceTransition: String, Codable, Sendable {
 }
 
 public extension GeofenceTransition {
-    /// Analytics event name for this transition. Matches the Android SDK's
-    /// `"Geofence Entered"` / `"Geofence Exited"`.
+    /// Analytics event name for this transition.
     var trackEventName: String {
         switch self {
-        case .enter: return "CIO Geofence Entered"
-        case .exit: return "CIO Geofence Exited"
+        case .enter: return "geofence_entered"
+        case .exit: return "geofence_exited"
         }
     }
 }

--- a/Sources/DataPipeline/DataPipelineImplementation+GeofenceObserver.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation+GeofenceObserver.swift
@@ -10,12 +10,7 @@ extension DataPipelineImplementation {
     /// `metric.timestamp` so a flush replayed hours after capture still attributes
     /// the transition to when it happened, not when it was sent.
     func processGeofenceMetricEvent(_ metric: TrackGeofenceMetricEvent) {
-        let properties: [String: Any] = [
-            "geofence_id": metric.geofenceId,
-            "transition_type": metric.transition.rawValue,
-            "timestamp": Int(metric.timestamp.timeIntervalSince1970)
-        ]
-        var trackEvent = TrackEvent(event: metric.transition.trackEventName, properties: try? JSON(properties))
+        var trackEvent = TrackEvent(event: metric.transition.trackEventName, properties: try? JSON(metric.trackEventProperties))
         trackEvent.timestamp = metric.timestamp.string(format: .iso8601WithMilliseconds)
         analytics.process(event: trackEvent)
     }

--- a/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
@@ -21,7 +21,7 @@ struct GeofenceApiConfig: Decodable {
 }
 
 struct GeofenceApiPlatformConfig: Decodable {
-    let maxBusinessGeofences: Int?
+    let maxBusinessGeofence: Int?
 }
 
 struct GeofenceApiRegion: Decodable {
@@ -32,8 +32,33 @@ struct GeofenceApiRegion: Decodable {
     let radius: Double
     let externalId: String?
     let transitionTypes: [String]?
-    /// Wire format is seconds since epoch.
+    /// Wire format is milliseconds since epoch.
     let lastUpdated: Double?
+}
+
+extension GeofenceApiRegion {
+    private enum CodingKeys: String, CodingKey {
+        case id, name, latitude, longitude, radius, externalId, transitionTypes, lastUpdated
+    }
+
+    /// The backend sends `id` as a JSON number; mocked/legacy payloads used strings. Accept either
+    /// and normalize to `String` — the value is used verbatim as the OS region identifier, which is
+    /// string-typed. Declared in an extension so the memberwise init stays available to tests.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let stringId = try? container.decode(String.self, forKey: .id) {
+            self.id = stringId
+        } else {
+            self.id = try String(container.decode(Int.self, forKey: .id))
+        }
+        self.name = try container.decodeIfPresent(String.self, forKey: .name)
+        self.latitude = try container.decode(Double.self, forKey: .latitude)
+        self.longitude = try container.decode(Double.self, forKey: .longitude)
+        self.radius = try container.decode(Double.self, forKey: .radius)
+        self.externalId = try container.decodeIfPresent(String.self, forKey: .externalId)
+        self.transitionTypes = try container.decodeIfPresent([String].self, forKey: .transitionTypes)
+        self.lastUpdated = try container.decodeIfPresent(Double.self, forKey: .lastUpdated)
+    }
 }
 
 // MARK: - Domain mapping
@@ -53,7 +78,7 @@ extension GeofenceApiResponse {
 extension GeofenceApiConfig {
     /// Coerces raw server values into sane bounds so a misconfigured backend can't push monitoring
     /// into a pathological state: non-positive values fall back; positive out-of-range radii/expiries
-    /// clamp; `ios.maxBusinessGeofences` out of 0…19 falls back (`0` is a valid kill switch).
+    /// clamp; `ios.maxBusinessGeofence` out of 0…19 falls back (`0` is a valid kill switch).
     func toDomain() -> GeofenceConfig {
         let localRefresh = positive(localRefreshTriggerRadius)
             .map { $0.clamped(to: GeofenceConstants.minLocalRefreshRadius ... GeofenceConstants.maxLocalRefreshRadius) }
@@ -83,7 +108,7 @@ extension GeofenceApiConfig {
             duplicateEventsExpiry: positive(duplicateEventsExpiryTime)
                 .map { ($0 / 1000).clamped(to: GeofenceConstants.minDuplicateEventsExpiry ... GeofenceConstants.maxDuplicateEventsExpiry) }
                 ?? GeofenceConstants.eventCooldownInterval,
-            maxBusinessGeofences: (ios?.maxBusinessGeofences).flatMap { value in
+            maxBusinessGeofences: (ios?.maxBusinessGeofence).flatMap { value in
                 (0 ... GeofenceConstants.maxMonitoredGeofences).contains(value) ? value : nil
             } ?? GeofenceConstants.maxMonitoredGeofences,
             maxMonitoringDistance: cap
@@ -114,7 +139,7 @@ extension GeofenceApiRegion {
             radius: radius,
             name: name ?? "",
             transitionTypes: Self.resolveTransitionTypes(transitionTypes),
-            lastUpdated: lastUpdated.map { Date(timeIntervalSince1970: $0) } ?? Date(timeIntervalSince1970: 0)
+            lastUpdated: lastUpdated.map { Date(timeIntervalSince1970: $0 / 1000) } ?? Date(timeIntervalSince1970: 0)
         )
     }
 

--- a/Sources/LocationGeofence/Event/GeofenceDeliveryTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceDeliveryTracker.swift
@@ -33,17 +33,11 @@ final class GeofenceDeliveryTrackerImpl: GeofenceDeliveryTracker {
             return onComplete(.failure(.invalidRequest))
         }
 
-        let properties: [String: Any] = [
-            "geofence_id": metric.geofenceId,
-            "transition_type": metric.transition.rawValue,
-            "timestamp": Int(metric.timestamp.timeIntervalSince1970)
-        ]
-
         httpClient.sendTrackEvent(
             BackgroundTrackRequest(
                 eventName: metric.transition.trackEventName,
                 userId: userId,
-                properties: properties,
+                properties: metric.trackEventProperties,
                 timestamp: metric.timestamp
             ),
             completion: onComplete

--- a/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
@@ -74,11 +74,16 @@ final class GeofenceEventTracker: @unchecked Sendable {
         // is identified at capture time; `deliver` routes nil-stamped rows to EventBus.
         let liveUserId = contextStore.currentUserId
         let stampedUserId: String? = (liveUserId?.isEmpty == false) ? liveUserId : nil
+        // Resolve the geofence name now and carry it on the metric; nil when unavailable so the
+        // event omits `geofence_name` rather than sending an empty value.
+        let cachedName = await storage.getCachedGeofences().first { $0.id == geofenceId }?.name
+        let geofenceName = (cachedName?.isEmpty == false) ? cachedName : nil
         let metric = PendingGeofenceMetric(
             geofenceId: geofenceId,
             transition: transition,
             timestamp: now,
-            userId: stampedUserId
+            userId: stampedUserId,
+            name: geofenceName
         )
         _ = await pendingStore.append(metric)
 
@@ -139,7 +144,8 @@ final class GeofenceEventTracker: @unchecked Sendable {
         eventBusHandler.postEvent(TrackGeofenceMetricEvent(
             geofenceId: metric.geofenceId,
             transition: metric.transition,
-            timestamp: metric.timestamp
+            timestamp: metric.timestamp,
+            name: metric.name
         ))
         logger.geofenceEventTracked(geofenceId: metric.geofenceId, transition: metric.transition)
     }

--- a/Sources/LocationGeofence/GeofenceBootstrap.swift
+++ b/Sources/LocationGeofence/GeofenceBootstrap.swift
@@ -21,27 +21,50 @@ enum GeofenceBootstrap {
         let restoreAnchor = await di.geofenceStorage.getLastRegistrationCenter() ?? lastSync?.location
         let userId = di.backgroundDeliveryContextStore.currentUserId
 
+        // The set we expect to still own: the business geofences registered last session plus the
+        // movement trigger registered alongside them. Empty on first launch or after the OS cleared
+        // everything. Compared against the OS-retained set below to decide adopt vs re-register.
+        let lastRegisteredBusinessIds = await di.geofenceStorage.getRegisteredBusinessIds()
+        let expectedOwnedRegions = lastRegisteredBusinessIds.isEmpty
+            ? Set<String>()
+            : lastRegisteredBusinessIds.union([GeofenceConstants.movementTriggerIdentifier])
+
         // Phase 2: synchronous on the main actor. No `await` between handler-bind and
-        // `startMonitoring`, so `ownedRegionIdentifiers` is populated before any new
-        // delegate call can land.
+        // `adoptExistingRegions` / `startMonitoring`, so `ownedRegionIdentifiers` is populated
+        // before any new delegate call can land.
         let monitor = di.geofenceMonitor
         let tracker = di.geofenceEventTracker
         let coordinator = di.geofenceSyncCoordinator
         GeofenceMonitorBinder.bind(monitor: monitor, tracker: tracker, coordinator: coordinator)
-        let registration = coordinator.applyCachedRegistration(
-            cachedRegions: cachedRegions,
-            anchor: restoreAnchor,
-            config: cachedConfig,
-            userId: userId
-        )
-        // Persist what was registered as the ranking-staleness reference. The await is safe here:
-        // applyCachedRegistration already ran startMonitoring synchronously, so the cold-wake
-        // no-await window has closed and a queued transition can't land in an empty filter.
-        if let registration {
-            await di.geofenceStorage.recordRegistration(
-                center: registration.center,
-                businessIds: registration.businessIds
+
+        // iOS persists `monitoredRegions` across process launch and device reboot. Adopt only when the
+        // OS still holds the COMPLETE set we registered last session — re-claim it instead of
+        // re-registering from `restoreAnchor`, which ranks from a possibly-stale anchor and would
+        // overwrite the good registration center with a wrong nearest-set. A partial overlap (some
+        // regions dropped, e.g. a monitoring failure or only the trigger surviving) falls through to
+        // re-register so the missing business geofences come back rather than staying unmonitored
+        // until the next refresh.
+        if !expectedOwnedRegions.isEmpty, expectedOwnedRegions.isSubset(of: monitor.osMonitoredRegionIdentifiers) {
+            monitor.adoptExistingRegions(matching: expectedOwnedRegions)
+        } else {
+            // First launch after install, the OS dropped our regions (e.g. permission revoked then
+            // re-granted, which clears `monitoredRegions`), or a partial drop. Register fresh from cache.
+            let registration = coordinator.applyCachedRegistration(
+                cachedRegions: cachedRegions,
+                anchor: restoreAnchor,
+                config: cachedConfig,
+                userId: userId
             )
+            // Persist what was registered as the ranking-staleness reference. The await is safe
+            // here: applyCachedRegistration already ran startMonitoring synchronously, so the
+            // cold-wake no-await window has closed and a queued transition can't land in an empty
+            // filter.
+            if let registration {
+                await di.geofenceStorage.recordRegistration(
+                    center: registration.center,
+                    businessIds: registration.businessIds
+                )
+            }
         }
 
         // Self-heal mid-process permission changes (Settings toggle, late prompt response).

--- a/Sources/LocationGeofence/GeofenceModuleState.swift
+++ b/Sources/LocationGeofence/GeofenceModuleState.swift
@@ -4,18 +4,15 @@ import Foundation
 
 /// Holds the Geofence module's runtime state and performs one-time setup.
 ///
-/// Lives for the process lifetime via `shared` so the foreground observer token and the
-/// first-run rearm gate outlive `GeofenceModule.initialize()` — the SDK does not retain the
-/// module facade once initialization returns.
+/// Lives for the process lifetime via `shared` so the first-run rearm gate outlives
+/// `GeofenceModule.initialize()` — the SDK does not retain the module facade once
+/// initialization returns.
 final class GeofenceModuleState {
     static let shared = GeofenceModuleState()
 
-    private let lifecycleNotifying: AppLifecycleNotifying
     /// Resolved lazily at each use so the live `LocationServices` is read even when the geofence
     /// module initializes before `LocationModule` (registration order is not guaranteed).
     private let locationServicesProvider: () -> LocationServices
-    /// Retains the foreground observer registered for geofence refresh.
-    private var foregroundToken: AppLifecycleObserverToken?
     /// True when a refresh skipped because no cached location was available. Re-armed
     /// (CAS true→false) on the next location fix so the first GPS update still drives the
     /// initial geofence registration.
@@ -25,15 +22,13 @@ final class GeofenceModuleState {
 
     /// Internal init lets tests build instances independent of `.shared`.
     init(
-        lifecycleNotifying: AppLifecycleNotifying = RealAppLifecycleNotifying(),
         locationServicesProvider: @escaping () -> LocationServices = { CustomerIO.location }
     ) {
-        self.lifecycleNotifying = lifecycleNotifying
         self.locationServicesProvider = locationServicesProvider
     }
 
-    /// Wires the geofence module: event subscriptions, cold-wake pending-flush, foreground
-    /// refresh, first-run rearm, and OS monitor bootstrap. Idempotent across repeat calls.
+    /// Wires the geofence module: event subscriptions, cold-wake pending-flush, first-run
+    /// rearm, and OS monitor bootstrap. Idempotent across repeat calls.
     func setup(di: DIGraphShared) {
         lock.lock()
         defer { lock.unlock() }
@@ -42,12 +37,6 @@ final class GeofenceModuleState {
 
         registerEventSubscriptions(di: di)
         Task { await di.geofenceEventTracker.flushPending() }
-        // Foreground geofence refresh is intentionally mode-independent — geofence monitoring
-        // runs even when location tracking is disabled. Skips silently with no cached anchor;
-        // movement EXIT drives the first registration in that case.
-        foregroundToken = lifecycleNotifying.addDidBecomeActiveObserver { [weak self] in
-            self?.refreshGeofencesIfPossible(di: di)
-        }
         Task { @MainActor in
             await GeofenceBootstrap.wireMonitor(di: di)
         }
@@ -63,27 +52,32 @@ final class GeofenceModuleState {
                 _ = await di.geofenceSyncCoordinator.reset()
             }
         }
-        // Rearm first-run refresh on the first fresh fix after an identify/foreground skip.
+        // Rearm first-run refresh on the first fresh fix after an identify skipped for no anchor.
         di.eventBusHandler.addObserver(LocationAcquiredEvent.self) { [weak self] event in
             self?.rearmFirstRunRefreshIfArmed(location: event.location, di: di)
         }
     }
 
-    /// Shared by the identify and foreground triggers. Reads the SDK's last known location
-    /// through the public Location API; arms the first-run rearm when none is available so
-    /// the next fix fires `refresh` once.
+    /// Invoked on identify. Picks the anchor to refresh from, arming the first-run rearm when no
+    /// anchor is available so the next fix fires `refresh` once.
     private func refreshGeofencesIfPossible(di: DIGraphShared) {
-        // Arm synchronously before the async cache read so a concurrent `LocationAcquiredEvent`
-        // can't slip between spawning the Task and the flag write and miss the arm. Cleared
-        // below once a cached location is found.
+        // Arm synchronously before the async reads so a concurrent `LocationAcquiredEvent` can't
+        // slip between spawning the Task and the flag write and miss the arm. Cleared below once
+        // an anchor is found.
         lastSkippedForNoLocation.wrappedValue = true
         Task { @MainActor [weak self] in
             guard let self else { return }
-            guard let location = await self.locationServicesProvider().getLastKnownLocation() else { return }
+            // Prefer the last registration center (walked by movement EXITs) over the Location
+            // cache. Movement never updates that cache, so on relaunch it is stale — anchoring a
+            // refresh there ranks from a far-away old fix and clobbers the good registration with
+            // an empty set. Fall back to the cache only before anything is registered (first run).
+            let registrationCenter = await di.geofenceStorage.getLastRegistrationCenter()
+            let cached = await self.locationServicesProvider().getLastKnownLocation()
+            guard let anchor = registrationCenter ?? cached else { return }
             self.lastSkippedForNoLocation.wrappedValue = false
             _ = await di.geofenceSyncCoordinator.refresh(
-                latitude: location.latitude,
-                longitude: location.longitude
+                latitude: anchor.latitude,
+                longitude: anchor.longitude
             )
         }
     }

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -88,4 +88,8 @@ extension Logger {
     func geofenceFirstRunRearm() {
         debug("First-run refresh re-armed by new location fix", geofenceTag)
     }
+
+    func geofenceRegionsAdopted(count: Int) {
+        debug("Adopted \(count) OS-persisted region(s) on launch; skipping re-registration", geofenceTag)
+    }
 }

--- a/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
@@ -43,6 +43,17 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
         ownedRegionIdentifiers
     }
 
+    var osMonitoredRegionIdentifiers: Set<String> {
+        Set(manager.monitoredRegions.map(\.identifier))
+    }
+
+    func adoptExistingRegions(matching identifiers: Set<String>) {
+        let adopted = identifiers.intersection(osMonitoredRegionIdentifiers)
+        guard !adopted.isEmpty else { return }
+        ownedRegionIdentifiers.formUnion(adopted)
+        logger.geofenceRegionsAdopted(count: adopted.count)
+    }
+
     func setOnTransition(_ handler: GeofenceTransitionHandler?) {
         onTransition = handler
     }

--- a/Sources/LocationGeofence/Monitor/GeofenceRegionMonitoring.swift
+++ b/Sources/LocationGeofence/Monitor/GeofenceRegionMonitoring.swift
@@ -50,4 +50,14 @@ protocol GeofenceRegionMonitoring: AnyObject, Sendable {
 
     /// Returns the set of region identifiers currently being monitored by this monitor.
     var monitoredRegionIdentifiers: Set<String> { get }
+
+    /// Region identifiers the OS still actively monitors app-wide (`CLLocationManager.monitoredRegions`).
+    /// These persist across process launch and device reboot, so on a fresh process this is populated
+    /// even though `monitoredRegionIdentifiers` (the in-memory ownership filter) starts empty.
+    var osMonitoredRegionIdentifiers: Set<String> { get }
+
+    /// Re-claims the OS-persisted regions whose identifiers are in `identifiers` as owned by this
+    /// monitor, without re-registering them. Restores transition recognition on a fresh process
+    /// where the OS kept monitoring but the in-memory ownership set was lost.
+    func adoptExistingRegions(matching identifiers: Set<String>)
 }

--- a/Sources/LocationGeofence/Storage/PendingGeofenceMetric.swift
+++ b/Sources/LocationGeofence/Storage/PendingGeofenceMetric.swift
@@ -3,12 +3,15 @@ import Foundation
 
 /// A geofence transition queued for delivery (direct-HTTP when stamped with a
 /// userId, EventBus → DataPipeline anonymous when not).
-struct PendingGeofenceMetric: Codable, Equatable, Sendable {
+struct PendingGeofenceMetric: Codable, Equatable, Sendable, GeofenceMetric {
     let geofenceId: String
     let transition: GeofenceTransition
     let timestamp: Date
     /// The userId identified at capture time, or `nil` if none was identified.
     let userId: String?
+    /// The geofence's name, resolved at capture time, or `nil` when unavailable. Travels with the
+    /// metric so a delayed flush still has it even after the geofence leaves the cache.
+    let name: String?
 
     /// Composite key over `(geofenceId, transition, timestamp_sec)` used for
     /// storage-layer dedup. Matches Android's `PendingGeofenceDelivery.key`.
@@ -23,12 +26,14 @@ struct PendingGeofenceMetric: Codable, Equatable, Sendable {
         geofenceId: String,
         transition: GeofenceTransition,
         timestamp: Date,
-        userId: String?
+        userId: String?,
+        name: String?
     ) {
         self.geofenceId = geofenceId
         self.transition = transition
         self.timestamp = timestamp
         self.userId = userId
+        self.name = name
     }
 
     enum CodingKeys: String, CodingKey {
@@ -36,5 +41,6 @@ struct PendingGeofenceMetric: Codable, Equatable, Sendable {
         case transition
         case timestamp
         case userId = "user_id"
+        case name = "geofence_name"
     }
 }

--- a/Tests/Common/Communication/CombinedCacheEventBusHandlerTests.swift
+++ b/Tests/Common/Communication/CombinedCacheEventBusHandlerTests.swift
@@ -27,6 +27,17 @@ class CombinedCacheEventBusHandlerTest: UnitTest {
         XCTAssertEqual(mockEventStorage.storeCallsCount, 1)
     }
 
+    func test_postEventAndWait_givenNoObserversAndTransientEvent_expectEventNotStored() async {
+        let handler = makeHandler()
+
+        // LocationAcquiredEvent is transient (isPersistent == false).
+        await handler.postEventAndWait(LocationAcquiredEvent(location: LocationData(latitude: 0, longitude: 0)))
+
+        // Even with no observers it must not be written to disk, so location-only apps
+        // don't accumulate undrained event files.
+        XCTAssertEqual(mockEventStorage.storeCallsCount, 0)
+    }
+
     func test_postEventAndWait_givenNoObservers_expectNoStoreErrorPropagated() async {
         mockEventStorage.storeThrowableError = NSError(domain: "test", code: 1)
         let handler = makeHandler()

--- a/Tests/Common/Service/BackgroundDeliveryHttpClientTests.swift
+++ b/Tests/Common/Service/BackgroundDeliveryHttpClientTests.swift
@@ -41,7 +41,7 @@ struct BackgroundDeliveryHttpClientTests {
         await withCheckedContinuation { continuation in
             client.sendTrackEvent(
                 BackgroundTrackRequest(
-                    eventName: "CIO Geofence Entered",
+                    eventName: "geofence_entered",
                     userId: "user_42",
                     properties: ["geofence_id": "geo_1", "transition_type": "enter"],
                     timestamp: Date(timeIntervalSince1970: 1700000000)
@@ -56,7 +56,7 @@ struct BackgroundDeliveryHttpClientTests {
         #expect(params?.headers?["Content-Type"] == "application/json; charset=utf-8")
 
         let body = params?.body.flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] }
-        #expect(body?["event"] as? String == "CIO Geofence Entered")
+        #expect(body?["event"] as? String == "geofence_entered")
         #expect(body?["userId"] as? String == "user_42")
         #expect(body?["timestamp"] as? String == "2023-11-14T22:13:20.000Z")
         let properties = body?["properties"] as? [String: Any]

--- a/Tests/DataPipeline/DataPipelineEventBustTests.swift
+++ b/Tests/DataPipeline/DataPipelineEventBustTests.swift
@@ -68,7 +68,8 @@ class DataPipelineEventBustTests: IntegrationTest {
             TrackGeofenceMetricEvent(
                 geofenceId: givenGeofenceId,
                 transition: .enter,
-                timestamp: capturedAt
+                timestamp: capturedAt,
+                name: "HQ"
             )
         )
 
@@ -78,11 +79,12 @@ class DataPipelineEventBustTests: IntegrationTest {
         }
 
         XCTAssertEqual(trackEvent.type, "track")
-        XCTAssertEqual(trackEvent.event, "CIO Geofence Entered")
+        XCTAssertEqual(trackEvent.event, "geofence_entered")
         let properties = trackEvent.properties?.dictionaryValue ?? [:]
         XCTAssertEqual(properties["geofence_id"] as? String, givenGeofenceId)
         XCTAssertEqual(properties["transition_type"] as? String, "enter")
         XCTAssertEqual(properties["timestamp"] as? Int, Int(capturedAt.timeIntervalSince1970))
+        XCTAssertEqual(properties["geofence_name"] as? String, "HQ")
         XCTAssertNil(properties["latitude"])
         XCTAssertNil(properties["longitude"])
         XCTAssertEqual(trackEvent.timestamp, capturedAt.string(format: .iso8601WithMilliseconds))
@@ -96,7 +98,8 @@ class DataPipelineEventBustTests: IntegrationTest {
             TrackGeofenceMetricEvent(
                 geofenceId: givenGeofenceId,
                 transition: .exit,
-                timestamp: capturedAt
+                timestamp: capturedAt,
+                name: nil
             )
         )
 
@@ -105,11 +108,13 @@ class DataPipelineEventBustTests: IntegrationTest {
             return
         }
 
-        XCTAssertEqual(trackEvent.event, "CIO Geofence Exited")
+        XCTAssertEqual(trackEvent.event, "geofence_exited")
         let properties = trackEvent.properties?.dictionaryValue ?? [:]
         XCTAssertEqual(properties["geofence_id"] as? String, givenGeofenceId)
         XCTAssertEqual(properties["transition_type"] as? String, "exit")
         XCTAssertEqual(properties["timestamp"] as? Int, Int(capturedAt.timeIntervalSince1970))
+        // No name on the event → property omitted entirely.
+        XCTAssertNil(properties["geofence_name"])
         XCTAssertNil(properties["latitude"])
         XCTAssertNil(properties["longitude"])
         XCTAssertEqual(trackEvent.timestamp, capturedAt.string(format: .iso8601WithMilliseconds))

--- a/Tests/LocationGeofence/Geofence/Api/GeofenceApiResponseTests.swift
+++ b/Tests/LocationGeofence/Geofence/Api/GeofenceApiResponseTests.swift
@@ -54,7 +54,7 @@ struct GeofenceApiResponseTests {
     @Test
     func toDomainConfig_givenIosMaxBusinessGeofencesZero_expectKillSwitchPreserved() throws {
         let json = """
-        {"config":{"ios":{"max_business_geofences":0}},"geofences":[]}
+        {"config":{"ios":{"max_business_geofence":0}},"geofences":[]}
         """
         let response = try decode(json)
         #expect(response.toDomainConfig()?.maxBusinessGeofences == 0)
@@ -63,7 +63,7 @@ struct GeofenceApiResponseTests {
     @Test
     func toDomainConfig_givenIosMaxBusinessGeofencesOutOfRange_expectFallback() throws {
         let json = """
-        {"config":{"ios":{"max_business_geofences":25}},"geofences":[]}
+        {"config":{"ios":{"max_business_geofence":25}},"geofences":[]}
         """
         let response = try decode(json)
         #expect(response.toDomainConfig()?.maxBusinessGeofences == GeofenceConstants.maxMonitoredGeofences)
@@ -73,7 +73,7 @@ struct GeofenceApiResponseTests {
     func toDomainConfig_givenIosMaxBusinessGeofencesAtUpperBound_expectPreserved() throws {
         // 19 is the inclusive upper bound (movement trigger consumes the 20th OS slot).
         let json = """
-        {"config":{"ios":{"max_business_geofences":19}},"geofences":[]}
+        {"config":{"ios":{"max_business_geofence":19}},"geofences":[]}
         """
         let response = try decode(json)
         #expect(response.toDomainConfig()?.maxBusinessGeofences == 19)
@@ -82,7 +82,7 @@ struct GeofenceApiResponseTests {
     @Test
     func toDomainConfig_givenIosMaxBusinessGeofencesNegative_expectFallback() throws {
         let json = """
-        {"config":{"ios":{"max_business_geofences":-1}},"geofences":[]}
+        {"config":{"ios":{"max_business_geofence":-1}},"geofences":[]}
         """
         let response = try decode(json)
         #expect(response.toDomainConfig()?.maxBusinessGeofences == GeofenceConstants.maxMonitoredGeofences)
@@ -168,6 +168,25 @@ struct GeofenceApiResponseTests {
     // MARK: - Region mapping
 
     @Test
+    func toDomainRegions_givenNumericId_expectDecodedAsString() throws {
+        // The backend sends `id` as a JSON number; it must decode and normalize to a String.
+        let json = """
+        {"geofences":[{"id":4,"latitude":1,"longitude":2,"radius":100}]}
+        """
+        let response = try decode(json)
+        #expect(response.toDomainRegions().first?.id == "4")
+    }
+
+    @Test
+    func toDomainRegions_givenStringId_expectDecodedUnchanged() throws {
+        let json = """
+        {"geofences":[{"id":"g1","latitude":1,"longitude":2,"radius":100}]}
+        """
+        let response = try decode(json)
+        #expect(response.toDomainRegions().first?.id == "g1")
+    }
+
+    @Test
     func toDomainRegions_givenMinimalRegion_expectDefaults() throws {
         let json = """
         {"geofences":[{"id":"g1","latitude":1,"longitude":2,"radius":100}]}
@@ -209,9 +228,10 @@ struct GeofenceApiResponseTests {
     }
 
     @Test
-    func toDomainRegions_givenLastUpdatedSeconds_expectDate() throws {
+    func toDomainRegions_givenLastUpdatedMillis_expectConvertedToSeconds() throws {
+        // Wire value is epoch milliseconds; the domain `Date` is seconds.
         let json = """
-        {"geofences":[{"id":"g1","latitude":1,"longitude":2,"radius":100,"last_updated":1700000000}]}
+        {"geofences":[{"id":"g1","latitude":1,"longitude":2,"radius":100,"last_updated":1700000000000}]}
         """
         let response = try decode(json)
         #expect(response.toDomainRegions().first?.lastUpdated == Date(timeIntervalSince1970: 1700000000))

--- a/Tests/LocationGeofence/Geofence/Api/GeofenceApiServiceTests.swift
+++ b/Tests/LocationGeofence/Geofence/Api/GeofenceApiServiceTests.swift
@@ -153,7 +153,7 @@ struct GeofenceApiServiceTests {
             "remote_fetch_refresh_trigger_radius": 4000,
             "remote_fetch_refresh_expiry_time": 43200000,
             "duplicate_events_expiry_time": 1800000,
-            "ios": { "max_business_geofences": 10 }
+            "ios": { "max_business_geofence": 10 }
           },
           "geofences": [
             {

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -96,7 +96,7 @@ struct GeofenceSyncCoordinatorTests {
                 remoteFetchRefreshExpiryTime: config.remoteFetchRefreshExpiry * 1000,
                 duplicateEventsExpiryTime: config.duplicateEventsExpiry * 1000,
                 maxMonitoringDistance: config.maxMonitoringDistance,
-                ios: GeofenceApiPlatformConfig(maxBusinessGeofences: config.maxBusinessGeofences)
+                ios: GeofenceApiPlatformConfig(maxBusinessGeofence: config.maxBusinessGeofences)
             )
         }
         return GeofenceApiResponse(config: apiConfig, geofences: apiRegions)

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceDeliveryTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceDeliveryTrackerTests.swift
@@ -17,13 +17,15 @@ struct GeofenceDeliveryTrackerTests {
     private func makeMetric(
         geofenceId: String = "geo_1",
         transition: GeofenceTransition = .enter,
-        timestamp: Date = Date(timeIntervalSince1970: 1700000000)
+        timestamp: Date = Date(timeIntervalSince1970: 1700000000),
+        name: String? = nil
     ) -> PendingGeofenceMetric {
         PendingGeofenceMetric(
             geofenceId: geofenceId,
             transition: transition,
             timestamp: timestamp,
-            userId: nil
+            userId: nil,
+            name: name
         )
     }
 
@@ -41,7 +43,7 @@ struct GeofenceDeliveryTrackerTests {
         }
 
         let args = httpClient.sendTrackEventReceivedArguments
-        #expect(args?.request.eventName == "CIO Geofence Entered")
+        #expect(args?.request.eventName == "geofence_entered")
         #expect(args?.request.userId == "user_42")
         #expect(args?.request.timestamp == Date(timeIntervalSince1970: 1700000000))
         let properties = args?.request.properties ?? [:]
@@ -50,6 +52,23 @@ struct GeofenceDeliveryTrackerTests {
         #expect(properties["timestamp"] as? Int == 1700000000)
         #expect(properties["latitude"] == nil)
         #expect(properties["longitude"] == nil)
+        // No name on the metric → property omitted entirely (not sent empty/null).
+        #expect(properties["geofence_name"] == nil)
+    }
+
+    @Test
+    func trackMetric_givenName_expectGeofenceNameProperty() async {
+        let (tracker, httpClient) = makeTracker()
+        httpClient.sendTrackEventClosure = { _, completion in completion(.success(())) }
+
+        await withCheckedContinuation { continuation in
+            tracker.trackMetric(metric: makeMetric(name: "HQ"), userId: "user_42") { _ in
+                continuation.resume()
+            }
+        }
+
+        let properties = httpClient.sendTrackEventReceivedArguments?.request.properties ?? [:]
+        #expect(properties["geofence_name"] as? String == "HQ")
     }
 
     @Test
@@ -63,7 +82,7 @@ struct GeofenceDeliveryTrackerTests {
             }
         }
 
-        #expect(httpClient.sendTrackEventReceivedArguments?.request.eventName == "CIO Geofence Exited")
+        #expect(httpClient.sendTrackEventReceivedArguments?.request.eventName == "geofence_exited")
     }
 
     // MARK: - Guard clauses

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -420,7 +420,8 @@ struct GeofenceEventTrackerTests {
         _ = await pending.append(PendingGeofenceMetric(
             geofenceId: "geo_1", transition: .enter,
             timestamp: Date(timeIntervalSince1970: 1),
-            userId: "user_A"
+            userId: "user_A",
+            name: nil
         ))
         let delivery = GeofenceDeliveryTrackerMock()
         delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
@@ -445,7 +446,8 @@ struct GeofenceEventTrackerTests {
         _ = await pending.append(PendingGeofenceMetric(
             geofenceId: "geo_1", transition: .enter,
             timestamp: Date(timeIntervalSince1970: 1),
-            userId: "user_A"
+            userId: "user_A",
+            name: nil
         ))
         let delivery = GeofenceDeliveryTrackerMock()
         delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
@@ -471,7 +473,8 @@ struct GeofenceEventTrackerTests {
         _ = await pending.append(PendingGeofenceMetric(
             geofenceId: "geo_1", transition: .enter,
             timestamp: capturedAt,
-            userId: nil
+            userId: nil,
+            name: nil
         ))
         let delivery = GeofenceDeliveryTrackerMock()
         let bus = EventBusHandlerMock()
@@ -493,5 +496,80 @@ struct GeofenceEventTrackerTests {
         let posted = postedGeofenceEvents(from: bus)
         #expect(posted.count == 1)
         #expect(posted.first?.timestamp == capturedAt)
+    }
+
+    // MARK: - Geofence name resolution
+
+    private func seedGeofence(_ storage: GeofenceStorage, id: String, name: String) async {
+        await storage.setCachedGeofences([
+            Geofence(
+                id: id, latitude: 1, longitude: 2, radius: 100,
+                name: name, transitionTypes: [.enter], lastUpdated: Date(timeIntervalSince1970: 0)
+            )
+        ])
+    }
+
+    @Test
+    func trackTransition_givenCachedGeofenceWithName_expectMetricCarriesName() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        await seedGeofence(storage, id: "geo_1", name: "HQ")
+        let pending = makePendingStore(directory: dir)
+        let delivery = GeofenceDeliveryTrackerMock()
+        // Fail the send so the row survives on disk for inspection.
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.failure(.http(statusCode: 503))) }
+        let tracker = makeTracker(
+            storage: storage,
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_42")
+        )
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+
+        #expect(await pending.loadAll().first?.name == "HQ")
+    }
+
+    @Test
+    func trackTransition_givenGeofenceNotCached_expectNilName() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pending = makePendingStore(directory: dir)
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.failure(.http(statusCode: 503))) }
+        let tracker = makeTracker(
+            storage: makeStorage(directory: dir),
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_42")
+        )
+
+        await tracker.trackTransition(geofenceId: "geo_unknown", transition: .enter)
+
+        #expect(await pending.loadAll().first?.name == nil)
+    }
+
+    @Test
+    func trackTransition_givenCachedGeofenceWithEmptyName_expectNilName() async {
+        // The API maps an absent name to "". Empty must resolve to nil so the event omits
+        // `geofence_name` rather than sending an empty string.
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        await seedGeofence(storage, id: "geo_1", name: "")
+        let pending = makePendingStore(directory: dir)
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.failure(.http(statusCode: 503))) }
+        let tracker = makeTracker(
+            storage: storage,
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_42")
+        )
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+
+        #expect(await pending.loadAll().first?.name == nil)
     }
 }

--- a/Tests/LocationGeofence/Geofence/GeofenceBootstrapTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceBootstrapTests.swift
@@ -210,6 +210,102 @@ struct GeofenceBootstrapTests {
         #expect(await storage.getLastRegistrationCenter() == nil)
     }
 
+    // MARK: - Adopt OS-persisted regions
+
+    @Test
+    func wireMonitor_givenOsStillMonitorsOurRegions_expectAdoptedWithoutReregistering() async {
+        // Relaunch: the OS kept the regions we registered last session. Re-claim them instead of
+        // re-registering, and leave the persisted registration center untouched.
+        let di = DIGraphShared.shared
+        let storage = GeofenceStorage(
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        await storage.setCachedGeofences([
+            Geofence(
+                id: "g1",
+                latitude: 1,
+                longitude: 2,
+                radius: 100,
+                name: "g1",
+                transitionTypes: [.enter],
+                lastUpdated: Date(timeIntervalSince1970: 0)
+            )
+        ])
+        await storage.recordRegistration(center: LocationData(latitude: 10, longitude: 20), businessIds: ["g1"])
+        di.override(value: storage, forType: GeofenceStorage.self)
+        let monitor = MockGeofenceRegionMonitor()
+        monitor.osMonitoredRegions = ["g1", GeofenceConstants.movementTriggerIdentifier]
+        di.override(value: monitor as GeofenceRegionMonitoring, forType: GeofenceRegionMonitoring.self)
+        let coordinator = GeofenceSyncCoordinatorMock()
+        di.override(value: coordinator as GeofenceSyncCoordinator, forType: GeofenceSyncCoordinator.self)
+        defer { di.reset() }
+
+        await GeofenceBootstrap.wireMonitor(di: di)
+
+        #expect(monitor.adoptExistingRegionsCallsCount == 1)
+        #expect(monitor.adoptedIdentifiers == ["g1", GeofenceConstants.movementTriggerIdentifier])
+        #expect(coordinator.applyCachedRegistrationCallsCount == 0)
+        #expect(await storage.getLastRegistrationCenter() == LocationData(latitude: 10, longitude: 20))
+    }
+
+    @Test
+    func wireMonitor_givenOsAlsoMonitorsHostAppRegions_expectOnlyOwnRegionsAdopted() async {
+        // CLLocationManager.monitoredRegions is app-wide. Adoption must claim only the SDK's own
+        // regions (cached geofences + movement trigger), never the host app's.
+        let di = DIGraphShared.shared
+        let storage = GeofenceStorage(
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        await storage.setCachedGeofences([
+            Geofence(
+                id: "g1",
+                latitude: 1,
+                longitude: 2,
+                radius: 100,
+                name: "g1",
+                transitionTypes: [.enter],
+                lastUpdated: Date(timeIntervalSince1970: 0)
+            )
+        ])
+        await storage.recordRegistration(center: LocationData(latitude: 10, longitude: 20), businessIds: ["g1"])
+        di.override(value: storage, forType: GeofenceStorage.self)
+        let monitor = MockGeofenceRegionMonitor()
+        monitor.osMonitoredRegions = ["g1", GeofenceConstants.movementTriggerIdentifier, "host.app.region"]
+        di.override(value: monitor as GeofenceRegionMonitoring, forType: GeofenceRegionMonitoring.self)
+        let coordinator = GeofenceSyncCoordinatorMock()
+        di.override(value: coordinator as GeofenceSyncCoordinator, forType: GeofenceSyncCoordinator.self)
+        defer { di.reset() }
+
+        await GeofenceBootstrap.wireMonitor(di: di)
+
+        #expect(monitor.adoptedIdentifiers == ["g1", GeofenceConstants.movementTriggerIdentifier])
+        #expect(coordinator.applyCachedRegistrationCallsCount == 0)
+    }
+
+    @Test
+    func wireMonitor_givenOsRetainedOnlyASubset_expectReregisterNotPartialAdopt() async {
+        // Partial drop: last session registered g1 + g2, but the OS now holds only g1 + the trigger
+        // (g2 dropped — a monitoring failure, or only some survived). Adopting the subset would leave
+        // g2 unmonitored, so fall through and re-register from cache instead.
+        let di = DIGraphShared.shared
+        let storage = GeofenceStorage(
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        await storage.recordRegistration(center: LocationData(latitude: 10, longitude: 20), businessIds: ["g1", "g2"])
+        di.override(value: storage, forType: GeofenceStorage.self)
+        let monitor = MockGeofenceRegionMonitor()
+        monitor.osMonitoredRegions = ["g1", GeofenceConstants.movementTriggerIdentifier]
+        di.override(value: monitor as GeofenceRegionMonitoring, forType: GeofenceRegionMonitoring.self)
+        let coordinator = GeofenceSyncCoordinatorMock()
+        di.override(value: coordinator as GeofenceSyncCoordinator, forType: GeofenceSyncCoordinator.self)
+        defer { di.reset() }
+
+        await GeofenceBootstrap.wireMonitor(di: di)
+
+        #expect(monitor.adoptExistingRegionsCallsCount == 0)
+        #expect(coordinator.applyCachedRegistrationCallsCount == 1)
+    }
+
     @Test
     func geofenceSyncCoordinator_givenRepeatedResolution_expectSameInstance() {
         let di = DIGraphShared.shared

--- a/Tests/LocationGeofence/Geofence/Storage/PendingGeofenceMetricStoreTests.swift
+++ b/Tests/LocationGeofence/Geofence/Storage/PendingGeofenceMetricStoreTests.swift
@@ -19,7 +19,8 @@ struct PendingGeofenceMetricStoreTests {
             geofenceId: geofenceId,
             transition: transition,
             timestamp: Date(timeIntervalSince1970: 1700000000),
-            userId: nil
+            userId: nil,
+            name: nil
         )
     }
 
@@ -260,7 +261,8 @@ struct PendingGeofenceMetricStoreTests {
                                 geofenceId: "geo_\(i)_\(j)",
                                 transition: .enter,
                                 timestamp: Date(),
-                                userId: nil
+                                userId: nil,
+                                name: nil
                             ))
                         case 1:
                             _ = await store.loadAll()

--- a/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
+++ b/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
@@ -29,8 +29,25 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
     private(set) var operationLog: [MockMonitorOperation] = []
     private var activeIdentifiers: Set<String> = []
 
+    /// Seedable OS-persisted set — tests set this to model regions the OS still monitors on a
+    /// fresh process (where `activeIdentifiers`, the in-memory ownership filter, starts empty).
+    var osMonitoredRegions: Set<String> = []
+    private(set) var adoptExistingRegionsCallsCount = 0
+    private(set) var adoptedIdentifiers: Set<String> = []
+
     var monitoredRegionIdentifiers: Set<String> {
         activeIdentifiers
+    }
+
+    var osMonitoredRegionIdentifiers: Set<String> {
+        osMonitoredRegions
+    }
+
+    func adoptExistingRegions(matching identifiers: Set<String>) {
+        adoptExistingRegionsCallsCount += 1
+        let adopted = identifiers.intersection(osMonitoredRegions)
+        adoptedIdentifiers.formUnion(adopted)
+        activeIdentifiers.formUnion(adopted)
     }
 
     func setOnTransition(_ handler: GeofenceTransitionHandler?) {

--- a/Tests/LocationGeofence/GeofenceModuleSetupTests.swift
+++ b/Tests/LocationGeofence/GeofenceModuleSetupTests.swift
@@ -11,8 +11,9 @@ import Testing
 /// full module `initialize()` path (which spins up `CLLocationManager`, lifecycle observers,
 /// and other side effects).
 ///
-/// Each test owns the EventBus, coordinator spy, monitor mock, storage, and a stub
-/// `LocationServices`. `.serialized` because tests share `DIGraphShared.shared` overrides.
+/// Each test owns a private `DIGraphShared` instance (EventBus, coordinator spy, monitor mock,
+/// storage, stub `LocationServices`), so a fire-and-forget refresh `Task` can never resolve a
+/// dependency another suite swapped on the shared graph. `.serialized` to keep ordering stable.
 @Suite("GeofenceModuleState.setup", .serialized)
 struct GeofenceModuleSetupTests {
     @Test
@@ -75,6 +76,35 @@ struct GeofenceModuleSetupTests {
         #expect(received?.1 == 56.78)
         #expect(f.spyCoordinator.refreshCallsCount == 1)
     }
+
+    @Test
+    @MainActor
+    func setup_givenProfileIdentifiedEventWithRegistrationCenter_expectRefreshAnchoredThereNotCache() async throws {
+        // A movement-walked registration center exists. It must win over the Location cache, which
+        // movement never updates and is stale on relaunch — anchoring there would clobber the good
+        // registration with a far-away ranking.
+        let f = Fixture(cachedLocation: LocationData(latitude: 12.34, longitude: 56.78))
+        defer { f.cleanup() }
+
+        await f.di.geofenceStorage.recordRegistration(center: LocationData(latitude: 10, longitude: 20), businessIds: ["g1"])
+
+        let (refreshSignal, refreshContinuation) = AsyncStream<(Double, Double)>.makeStream()
+        f.spyCoordinator.refreshClosure = { lat, lon in
+            refreshContinuation.yield((lat, lon))
+            return .success(())
+        }
+
+        f.wire()
+
+        let deliver = try #require(f.bus.observers[ProfileIdentifiedEvent.key], "ProfileIdentifiedEvent observer must be registered")
+        deliver(ProfileIdentifiedEvent(identifier: "u1"))
+
+        var iter = refreshSignal.makeAsyncIterator()
+        let received = await iter.next()
+
+        #expect(received?.0 == 10)
+        #expect(received?.1 == 20)
+    }
 }
 
 /// Per-test setup: overrides the DI shared singleton with capturing/mocking deps and builds
@@ -89,7 +119,7 @@ private struct Fixture {
     let state: GeofenceModuleState
 
     init(cachedLocation: LocationData? = nil) {
-        self.di = DIGraphShared.shared
+        self.di = DIGraphShared()
 
         self.bus = CapturingEventBusHandler()
         di.override(value: bus as EventBusHandler, forType: EventBusHandler.self)
@@ -106,7 +136,6 @@ private struct Fixture {
 
         let stubServices = StubLocationServices(cachedLocation: cachedLocation)
         self.state = GeofenceModuleState(
-            lifecycleNotifying: NoOpAppLifecycleNotifying(),
             locationServicesProvider: { stubServices }
         )
     }
@@ -134,21 +163,6 @@ private final class StubLocationServices: LocationServices, @unchecked Sendable 
     func getLastKnownLocation() async -> LocationData? {
         cachedLocation
     }
-}
-
-/// No-op lifecycle notifier so the foreground observer never fires during tests.
-private final class NoOpAppLifecycleNotifying: AppLifecycleNotifying {
-    func addDidBecomeActiveObserver(using block: @escaping () -> Void) -> AppLifecycleObserverToken {
-        NoOpToken()
-    }
-
-    func addDidEnterBackgroundObserver(using block: @escaping () -> Void) -> AppLifecycleObserverToken {
-        NoOpToken()
-    }
-}
-
-private final class NoOpToken: AppLifecycleObserverToken {
-    func remove() {}
 }
 
 /// Captures registered observers so tests can deliver events synchronously without spinning

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -294,6 +294,12 @@ public interface CioInternalCommon.FileStorage {
 }
 public enum CioInternalCommon.FileType {
 }
+public interface CioInternalCommon.GeofenceMetric {
+	public var geofenceId: String;
+	public var transition: GeofenceTransition;
+	public var timestamp: Date;
+	public var name: String?;
+}
 public enum CioInternalCommon.GeofenceTransition {
 }
 public interface CioInternalCommon.GlobalDataStore {
@@ -595,7 +601,8 @@ public final class CioInternalCommon.TrackGeofenceMetricEvent {
 	public final val geofenceId: String;
 	public final val transition: GeofenceTransition;
 	public final val timestamp: Date;
-	public fun init(storageId: String = UUID().uuidString, geofenceId: String, transition: GeofenceTransition, timestamp: Date = Date(), params: List<String: String> = List<:>);
+	public final val name: String?;
+	public fun init(storageId: String = UUID().uuidString, geofenceId: String, transition: GeofenceTransition, timestamp: Date = Date(), name: String?, params: List<String: String> = List<:>);
 }
 public final class CioInternalCommon.TrackInAppMetricEvent {
 	public final val storageId: String;


### PR DESCRIPTION
## What

Fixes found during on-device geofence validation, layered on top of the `origin/main` merge into the feature branch. One squashed commit.

### Adopt OS-persisted regions on launch
iOS keeps `CLLocationManager.monitoredRegions` across process launch and device reboot. On launch the SDK now re-claims the regions it already owns instead of re-registering from a cached anchor. The old path anchored off the Location cache — which movement never updates, so it goes stale on relaunch — and could clobber a good registration, leaving **zero business geofences** monitored. Refresh now anchors off `registrationCenter ?? cache`, and the redundant foreground re-arm trigger was removed.

### Harden geofences API decoding
- Accept region `id` as a JSON number or string. The backend sends a number; the DTO required `String`, so the whole response failed to decode and no geofences loaded.
- Use the singular wire key `ios.max_business_geofence` (the DTO used the plural key, so the server cap was silently ignored).
- Treat region `last_updated` as epoch **milliseconds**.

### Event payload
- Don't persist transient events (`isPersistent == false`, e.g. `LocationAcquiredEvent`) to disk when unobserved — they stay in the in-memory cache only.
- Transition event names are `geofence_entered` / `geofence_exited`.
- `geofence_name` is included in the `/track` payload only when a name is available. Both delivery paths (direct-HTTP and EventBus → DataPipeline) build the payload in one place via the `GeofenceMetric.trackEventProperties` extension.

## Testing
Full SDK test suite green. New coverage: region adoption (relaunch re-claim + host-app isolation), numeric/string `id`, the singular config key, millis units, the transient-event persistence guard, and `geofence_name` present/absent/empty + name resolution. On-device journey validated (fetch → register → movement re-rank → enter/exit + cooldown dedup).

## Stack
Base: `feature/geofence-on-device` (already contains the `origin/main` merge). Squash-merges into the feature branch; no other open PRs in the chain.

MBL-1761

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes geofence registration on relaunch, nearby API decoding, and CDP event names/properties—any mismatch with backend dashboards or partial OS region state could affect monitoring or analytics attribution.
> 
> **Overview**
> On-device geofence fixes: **relaunch monitoring**, **API decoding**, and **analytics/event-bus behavior**.
> 
> **Launch / registration:** On cold start, if the OS still monitors the **full** set from last session (business geofences + movement trigger), the SDK **adopts** those regions instead of re-registering from a stale anchor—which could wipe monitoring. Partial OS drops still trigger a fresh register from cache. Identify-time refresh now prefers **last registration center** over the Location cache; the **foreground** lifecycle refresh hook was removed.
> 
> **Geofences API:** Region `id` decodes as **number or string**; config uses **`ios.max_business_geofence`**; `last_updated` is treated as **epoch milliseconds**.
> 
> **Events & analytics:** Unobserved posts only hit disk when `isPersistent` is true (e.g. `LocationAcquiredEvent` stays in-memory). Transition tracks use **`geofence_entered` / `geofence_exited`**; optional **`geofence_name`** is resolved at capture and built once via **`GeofenceMetric.trackEventProperties`** for HTTP and DataPipeline paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f934fec2a5b0ff8ec8950dc9f3e4b9b4ced856c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->