### PR TITLE
chore(inbox): web-parity interaction (mount overlay, dismiss, relative dates, no-template skip)

### DIFF
--- a/Apps/APN-UIKit/APN UIKit.xcodeproj/project.pbxproj
+++ b/Apps/APN-UIKit/APN UIKit.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		30DB021B873DE5D52C01151C /* InboxViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6271087BB2D1D2EED90C6A75 /* InboxViewController.swift */; };
+		AA0100000000000000000001 /* InboxOverlayWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0100000000000000000002 /* InboxOverlayWindow.swift */; };
 		30F117082D63531A00DB1E11 /* SampleAppsCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 30F117072D63531A00DB1E11 /* SampleAppsCommon */; };
 		30F1170A2D6356BA00DB1E11 /* SampleAppsCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 30F117092D6356BA00DB1E11 /* SampleAppsCommon */; };
 		4650330629F68FEB001B6552 /* NotificationServiceExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 465032FF29F68FEB001B6552 /* NotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -111,6 +112,7 @@
 		46D5D99329E459D800EAF40B /* APN UIKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "APN UIKitTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		46D5D99D29E459D800EAF40B /* APN UIKitUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "APN UIKitUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6271087BB2D1D2EED90C6A75 /* InboxViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxViewController.swift; sourceTree = "<group>"; };
+		AA0100000000000000000002 /* InboxOverlayWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxOverlayWindow.swift; sourceTree = "<group>"; };
 		669B9F6E2D8B2D430087CC20 /* AutoDependencyInjection.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoDependencyInjection.generated.swift; sourceTree = "<group>"; };
 		669B9F702D8B2D430087CC20 /* AutoMockable.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoMockable.generated.swift; sourceTree = "<group>"; };
 		669B9F712D8B2D430087CC20 /* DIDependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DIDependencies.swift; sourceTree = "<group>"; };
@@ -354,6 +356,7 @@
 				669B9F982D8B2D430087CC20 /* DeepLinkViewController.swift */,
 				669B9F992D8B2D430087CC20 /* InlineInAppMessageUikitViewController.swift */,
 				6271087BB2D1D2EED90C6A75 /* InboxViewController.swift */,
+				AA0100000000000000000002 /* InboxOverlayWindow.swift */,
 				669B9F9A2D8B2D430087CC20 /* LoginViewController.swift */,
 			);
 			path = View;
@@ -645,6 +648,7 @@
 				669B9FC92D8B2D430087CC20 /* DeepLinkViewController.swift in Sources */,
 				669B9FCA2D8B2D430087CC20 /* InlineInAppMessageUikitViewController.swift in Sources */,
 				30DB021B873DE5D52C01151C /* InboxViewController.swift in Sources */,
+				AA0100000000000000000001 /* InboxOverlayWindow.swift in Sources */,
 				669B9FCB2D8B2D430087CC20 /* LoginViewController.swift in Sources */,
 				669B9FCC2D8B2D430087CC20 /* AppDelegate.swift in Sources */,
 				669B9FCD2D8B2D430087CC20 /* BuildEnvironment.swift in Sources */,

--- a/Apps/APN-UIKit/APN UIKit/SceneDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/SceneDelegate.swift
@@ -14,6 +14,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         window = UIWindow(windowScene: windowScene)
         setVisibleWindow()
+
+        // Mount the Visual Notification Inbox overlay (floating bell + panel) app-wide in its own
+        // passthrough window so it persists across root-VC swaps (login/logout) and navigation.
+        if #available(iOS 15.0, *) {
+            InboxOverlayWindow.install(in: windowScene)
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Apps/APN-UIKit/APN UIKit/View/InboxOverlayWindow.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/InboxOverlayWindow.swift
@@ -62,9 +62,12 @@ private final class PassthroughWindow: UIWindow {
         let buttonSize: CGFloat = 56
         let padding: CGFloat = 16
         let slop: CGFloat = 12
+        // The unread badge is drawn offset beyond the bell's top-trailing corner, so extend the hit
+        // area up and toward the trailing edge so taps on the badge hit the overlay too (not the app).
+        let badgeAllowance: CGFloat = 20
         let left = bounds.maxX - safeAreaInsets.right - padding - buttonSize - slop
-        let top = bounds.maxY - safeAreaInsets.bottom - padding - buttonSize - slop
-        return CGRect(x: left, y: top, width: buttonSize + slop * 2, height: buttonSize + slop * 2)
+        let top = bounds.maxY - safeAreaInsets.bottom - padding - buttonSize - slop - badgeAllowance
+        return CGRect(x: left, y: top, width: buttonSize + slop * 2 + badgeAllowance, height: buttonSize + slop * 2 + badgeAllowance)
     }
 
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {

--- a/Apps/APN-UIKit/APN UIKit/View/InboxOverlayWindow.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/InboxOverlayWindow.swift
@@ -1,0 +1,79 @@
+import CioMessagingInbox
+import SwiftUI
+import UIKit
+
+/// Hosts the Visual Notification Inbox overlay (`NotificationInboxOverlay`, a SwiftUI view) in a
+/// dedicated, passthrough `UIWindow` so the floating bell + slide-out panel appear app-wide on top of
+/// the existing UIKit UI — regardless of which view controller is on screen.
+///
+/// Why a separate window (not a child of the root VC): the app swaps its root view controller on
+/// login/logout, and pushes navigation controllers. A persistent overlay window survives those
+/// swaps and always stays above the app content. The window is set just below the system alert level
+/// so it floats over normal app windows but never above system alerts.
+@available(iOS 15.0, *)
+@MainActor
+enum InboxOverlayWindow {
+    private static var window: PassthroughWindow?
+
+    /// Creates (once) and shows the overlay window for the given scene.
+    static func install(in windowScene: UIWindowScene) {
+        guard window == nil else { return }
+
+        let overlayWindow = PassthroughWindow(windowScene: windowScene)
+        // The overlay tells the window when the panel opens/closes so the window can switch between
+        // full-screen capture (panel open) and bell-only capture (panel closed). See PassthroughWindow.
+        let hosting = UIHostingController(
+            rootView: NotificationInboxOverlay(
+                onPanelPresentationChange: { [weak overlayWindow] open in
+                    overlayWindow?.isPanelOpen = open
+                }
+            )
+        )
+        // Clear background so the app shows through everywhere the overlay isn't drawing.
+        hosting.view.backgroundColor = .clear
+
+        overlayWindow.rootViewController = hosting
+        overlayWindow.backgroundColor = .clear
+        // Float above app content but below system alerts.
+        overlayWindow.windowLevel = .alert - 1
+        overlayWindow.isHidden = false
+        window = overlayWindow
+    }
+}
+
+/// Passthrough overlay window.
+///
+/// SwiftUI routes the bell/scrim tap gestures *through* the hosting controller's root view (it does
+/// not create a distinct child `UIView` per control), so the naive "pass through unless the hit is a
+/// non-root subview" approach would starve the bell of touches. Instead we decide by panel state +
+/// geometry, and return the hit view (even when it is the hosting root) so SwiftUI receives the touch:
+///  - **panel open** → capture ALL touches; the SwiftUI scrim blocks click-through and a tap on it
+///    closes the panel.
+///  - **panel closed** → capture only the floating bell's region (bottom-trailing); every other touch
+///    falls through to the app window beneath, keeping the rest of the app usable.
+@available(iOS 15.0, *)
+private final class PassthroughWindow: UIWindow {
+    /// Set by the overlay via `onPanelPresentationChange`. When true, the panel/scrim is on screen.
+    var isPanelOpen = false
+
+    /// Approximate hit area of the floating bell — a 56pt button with 16pt padding pinned to the
+    /// bottom-trailing safe-area corner (matches `NotificationInboxOverlay`'s layout), plus slop.
+    private func bellHitRect() -> CGRect {
+        let buttonSize: CGFloat = 56
+        let padding: CGFloat = 16
+        let slop: CGFloat = 12
+        let left = bounds.maxX - safeAreaInsets.right - padding - buttonSize - slop
+        let top = bounds.maxY - safeAreaInsets.bottom - padding - buttonSize - slop
+        return CGRect(x: left, y: top, width: buttonSize + slop * 2, height: buttonSize + slop * 2)
+    }
+
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let hit = super.hitTest(point, with: event)
+        if isPanelOpen {
+            // Panel visible: capture everything so the scrim blocks click-through to the app.
+            return hit
+        }
+        // Panel closed: only the bell is interactive; everything else passes through to the app.
+        return bellHitRect().contains(point) ? hit : nil
+    }
+}

--- a/Apps/Common/Package.swift
+++ b/Apps/Common/Package.swift
@@ -23,6 +23,8 @@ let package = Package(
                 .product(name: "DataPipelines", package: "customerio-ios"),
                 .product(name: "MessagingPushAPN", package: "customerio-ios"),
                 .product(name: "MessagingInApp", package: "customerio-ios"),
+                // Visual Notification Inbox overlay (`CioMessagingInbox`) so sample apps can mount it.
+                .product(name: "MessagingInbox", package: "customerio-ios"),
                 .product(name: "Location", package: "customerio-ios")
             ],
             path: "Source"

--- a/Sources/MessagingInApp/Inbox/Data/VisualInboxSPI.swift
+++ b/Sources/MessagingInApp/Inbox/Data/VisualInboxSPI.swift
@@ -157,6 +157,16 @@ public protocol VisualInboxProvider: Sendable {
     ///   permanently deduping a mark that never applied.
     @discardableResult
     func markOpened(messageId: String) async -> Bool
+
+    /// Dismisses (removes) a message via the existing headless `markMessageDeleted` plumbing (no new
+    /// mutation path). Looked up by the snapshot id so the overlay never has to hold an internal
+    /// `InboxMessage`. Web parity: tapping a message dismisses it; dismissing the last message empties
+    /// the list and drives the inbox to `.hidden` (panel auto-closes, bell hides).
+    /// - Returns: `true` if a matching message was still present in the store and the delete was
+    ///   issued; `false` if the message was gone (the dismiss was a no-op). Callers use this to avoid
+    ///   permanently deduping a dismiss that never applied.
+    @discardableResult
+    func dismiss(messageId: String) async -> Bool
 }
 
 // MARK: - Implementation
@@ -321,6 +331,22 @@ final class VisualInboxProviderImpl: VisualInboxProvider, @unchecked Sendable {
             return false
         }
         inbox.markMessageOpened(message: message)
+        return true
+    }
+
+    @discardableResult
+    func dismiss(messageId: String) async -> Bool {
+        // Resolve the full InboxMessage from current state so we reuse the existing headless
+        // markMessageDeleted plumbing (which dispatches the .deleteMessage action). No new mutation
+        // path. The store change then flows through observe() → the message leaves the selection →
+        // computeLoadState empties → .hidden when it was the last message.
+        let state = await inAppMessageManager.state
+        guard let message = state.inboxMessages.first(where: { $0.queueId == messageId }) else {
+            // Message no longer in the store → nothing to delete. Report no-op so the caller doesn't
+            // permanently dedupe a dismiss that never applied.
+            return false
+        }
+        inbox.markMessageDeleted(message: message)
         return true
     }
 }

--- a/Sources/MessagingInbox/NotificationInboxOverlay.swift
+++ b/Sources/MessagingInbox/NotificationInboxOverlay.swift
@@ -25,14 +25,22 @@ public struct NotificationInboxOverlay: View {
     /// Vertical inset that keeps the slide-out panel clear of the floating button.
     private let panelBottomInset: CGFloat = 88
 
+    /// Called whenever the slide-out panel opens (`true`) or closes (`false`). Hosts that mount the
+    /// overlay in a passthrough window use this to capture touches full-screen while the panel is
+    /// open (so the scrim blocks click-through) and pass through when it's closed.
+    private let onPanelPresentationChange: ((Bool) -> Void)?
+
     /// Creates an inbox overlay backed by the SDK's shared Visual Inbox data layer.
-    public init() {
+    /// - Parameter onPanelPresentationChange: optional callback invoked when the panel opens/closes.
+    public init(onPanelPresentationChange: ((Bool) -> Void)? = nil) {
         _model = StateObject(wrappedValue: VisualInboxModel())
+        self.onPanelPresentationChange = onPanelPresentationChange
     }
 
     /// Creates an inbox overlay backed by the supplied model. Used by tests/previews to inject a fake.
-    init(model: VisualInboxModel) {
+    init(model: VisualInboxModel, onPanelPresentationChange: ((Bool) -> Void)? = nil) {
         _model = StateObject(wrappedValue: model)
+        self.onPanelPresentationChange = onPanelPresentationChange
     }
 
     public var body: some View {
@@ -41,7 +49,8 @@ public struct NotificationInboxOverlay: View {
             // host app. Tapping the scrim closes the panel. Only present while open AND chrome is
             // shown — a hidden inbox hides all chrome, including an open panel/scrim.
             if isPanelOpen, showsChrome {
-                Color.black.opacity(0.2)
+                // Scrim opacity 0.32 for cross-platform parity (Android uses the same value).
+                Color.black.opacity(0.32)
                     .ignoresSafeAreaCompat()
                     .contentShape(Rectangle())
                     .onTapGesture { setPanel(open: false) }
@@ -67,6 +76,11 @@ public struct NotificationInboxOverlay: View {
         // (and doesn't silently reappear if the inbox becomes visible again).
         .onChange(of: showsChrome) { visible in
             if !visible, isPanelOpen { isPanelOpen = false }
+        }
+        // Notify the host of panel open/close so a passthrough-window mount can toggle full-screen
+        // touch capture (panel open → scrim blocks click-through; closed → pass through).
+        .onChange(of: isPanelOpen) { open in
+            onPanelPresentationChange?(open)
         }
     }
 
@@ -123,23 +137,9 @@ public struct NotificationInboxOverlay: View {
     // MARK: - Slide-out panel (items 6, 7, 11)
 
     private var panel: some View {
+        // No header (title / close button) — matches web. The panel closes via the scrim tap or by
+        // tapping the bell again.
         VStack(alignment: .leading, spacing: 0) {
-            HStack {
-                Text("Inbox")
-                    .font(.headline)
-
-                Spacer()
-
-                Button(action: { setPanel(open: false) }, label: {
-                    Image(systemName: "xmark")
-                        .foregroundColor(.secondary)
-                })
-                .accessibility(label: Text("Close inbox"))
-            }
-            .padding()
-
-            Divider()
-
             content
         }
         .frame(maxWidth: 480, maxHeight: .infinity, alignment: .top)
@@ -155,7 +155,7 @@ public struct NotificationInboxOverlay: View {
     /// visible-but-empty, otherwise the Jist-rendered list.
     @ViewBuilder
     private var content: some View {
-        if model.messages.isEmpty, case .visible = model.state {
+        if model.renderableMessages.isEmpty, case .visible = model.state {
             // Visible with no messages → genuine "caught up" empty state.
             VStack {
                 Spacer()
@@ -165,7 +165,7 @@ public struct NotificationInboxOverlay: View {
                 Spacer()
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else if model.messages.isEmpty {
+        } else if model.renderableMessages.isEmpty {
             // idle/loading (pre-first-snapshot or fetch in progress) → spinner, not the empty copy.
             VStack {
                 Spacer()
@@ -181,12 +181,17 @@ public struct NotificationInboxOverlay: View {
     private var messageList: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                ForEach(model.messages) { message in
+                // No-template messages are skipped (item 4): `renderableMessages` drops any message
+                // whose `type` has no matching decoded template (logged once by the model).
+                ForEach(model.renderableMessages) { message in
                     VisualInboxMessageRow(
                         message: message,
                         data: model.decodedData[message.id] ?? [:],
                         templates: model.templates,
-                        theme: model.theme
+                        theme: model.theme,
+                        // Web parity (item 1): tapping a message dismisses it. The row resolves the
+                        // Jist action to a dismiss and calls back here; the model removes it.
+                        onDismiss: { model.dismiss(messageId: message.id) }
                     )
                     Divider()
                 }
@@ -221,6 +226,8 @@ struct VisualInboxMessageRow: View {
     let data: [String: JistValue]
     let templates: [String: [JistTemplate]]
     let theme: [String: JistValue]
+    /// Called when the message's Jist action resolves to a dismiss (item 1).
+    let onDismiss: () -> Void
 
     var body: some View {
         Group {
@@ -230,12 +237,12 @@ struct VisualInboxMessageRow: View {
                     templates: templates,
                     data: data,
                     theme: theme,
+                    // Dark-mode parity (item 5): `.auto` follows the system color scheme.
                     mode: .auto,
-                    formatDate: nil,
-                    // swiftlint:disable:next todo
-                    // TODO: action mapping is deferred (scope items 12/13). For now actions are a
-                    // no-op hook — wire to trackMessageClicked / deep-link handling later.
-                    onAction: { _ in }
+                    // Relative dates (item 3): Jist passes an ISO-8601 string; we return web-aligned
+                    // relative time ("just now", "2h ago", "3d ago").
+                    formatDate: { iso, _ in Self.relativeDate(from: iso) },
+                    onAction: handleAction
                 )
             } else {
                 fallbackRow
@@ -257,6 +264,63 @@ struct VisualInboxMessageRow: View {
                 .font(.caption)
                 .foregroundColor(.secondary)
         }
+    }
+
+    // MARK: - Jist action handling (item 1)
+
+    /// Maps a Jist `onAction` event to host behavior. Web parity: a "dismiss" action removes the
+    /// message. Any other action (real url / other behavior) is a deferred no-op for now.
+    ///
+    /// The live inbox templates emit the action as `name == "messageAction"` with the message's
+    /// `properties.messageAction = { behavior: "dismiss" }`, so the dismiss signal we match is
+    /// `data.behavior == "dismiss"`. We also accept the Jist-demo sentinels (`name == "dismiss"` or
+    /// `data.url == "#dismiss"`) as a fallback.
+    private func handleAction(_ event: JistActionEvent) {
+        let behavior = event.data?.objectValue?["behavior"]?.stringValue
+        let url = event.data?.objectValue?["url"]?.stringValue
+        if behavior == "dismiss" || event.name == "dismiss" || url == "#dismiss" {
+            onDismiss()
+            return
+        }
+        // Real-url / deeplink navigation + host action callback are deferred (#12 / #13). Log so the
+        // action is observable instead of silently dropped.
+        // swiftlint:disable:next todo
+        // TODO(#12/#13): map real-url actions to navigation / a host action callback.
+        DIGraphShared.shared.logger.debug("[CIO-Inbox] unhandled inbox action name=\(event.name) behavior=\(behavior ?? "<none>") url=\(url ?? "<none>") (real-url nav deferred)")
+    }
+
+    // MARK: - Relative dates (item 3)
+
+    private static let isoParser: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    /// Fallback parser for ISO-8601 strings WITHOUT fractional seconds (the primary parser is strict
+    /// about its option set, so a no-millisecond timestamp needs this variant).
+    private static let isoParserNoFraction: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    /// System-localized relative-time formatter (the platform equivalent of web's
+    /// `Intl.RelativeTimeFormat`): produces translated output ("2 hours ago", "yesterday", …) in the
+    /// device locale, so the inbox is i18n-ready without us hand-rolling/translating strings.
+    private static let relativeFormatter: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        return formatter
+    }()
+
+    /// Localized relative time from an ISO-8601 timestamp (translation-ready via the OS). Falls back
+    /// to the raw string if it can't be parsed (so a row never renders worse than before).
+    static func relativeDate(from iso: String, now: Date = Date()) -> String {
+        guard let date = isoParser.date(from: iso) ?? isoParserNoFraction.date(from: iso) else {
+            return iso
+        }
+        return relativeFormatter.localizedString(for: date, relativeTo: now)
     }
 }
 #endif

--- a/Sources/MessagingInbox/NotificationInboxOverlay.swift
+++ b/Sources/MessagingInbox/NotificationInboxOverlay.swift
@@ -100,8 +100,15 @@ public struct NotificationInboxOverlay: View {
     /// Whether any chrome (bell/panel) should be shown. Hidden state shows nothing.
     private var showsChrome: Bool {
         switch model.state {
-        case .hidden: return false
-        case .idle, .loading, .visible: return true
+        case .hidden:
+            return false
+        case .idle, .loading:
+            return true
+        case .visible:
+            // Visible but every message lacks a Jist template → nothing can render (each is logged +
+            // skipped by the model). Show no chrome rather than a bell over a blank/“caught up” panel;
+            // it reappears if a renderable message arrives.
+            return !model.renderableMessages.isEmpty
         }
     }
 

--- a/Sources/MessagingInbox/NotificationInboxOverlay.swift
+++ b/Sources/MessagingInbox/NotificationInboxOverlay.swift
@@ -76,12 +76,23 @@ public struct NotificationInboxOverlay: View {
         // (and doesn't silently reappear if the inbox becomes visible again).
         .onChange(of: showsChrome) { visible in
             if !visible, isPanelOpen { isPanelOpen = false }
+            // Re-notify when chrome visibility flips: if the inbox goes hidden while the panel flag is
+            // still settling, the host must stop full-screen capture so touches aren't swallowed with
+            // nothing on screen.
+            notifyPanelPresentation()
         }
-        // Notify the host of panel open/close so a passthrough-window mount can toggle full-screen
-        // touch capture (panel open → scrim blocks click-through; closed → pass through).
-        .onChange(of: isPanelOpen) { open in
-            onPanelPresentationChange?(open)
+        // Notify the host of panel presentation so a passthrough-window mount can toggle full-screen
+        // touch capture (presented → scrim blocks click-through; not → pass through).
+        .onChange(of: isPanelOpen) { _ in
+            notifyPanelPresentation()
         }
+    }
+
+    /// The panel is "presented" (host should capture full-screen touches) only when it is open AND the
+    /// inbox chrome is shown. Keying the host callback off BOTH prevents leaving touch capture on after
+    /// the inbox goes `.hidden` while `isPanelOpen` is still true.
+    private func notifyPanelPresentation() {
+        onPanelPresentationChange?(isPanelOpen && showsChrome)
     }
 
     // MARK: - Derived UI state
@@ -155,8 +166,10 @@ public struct NotificationInboxOverlay: View {
     /// visible-but-empty, otherwise the Jist-rendered list.
     @ViewBuilder
     private var content: some View {
-        if model.renderableMessages.isEmpty, case .visible = model.state {
-            // Visible with no messages → genuine "caught up" empty state.
+        if model.messages.isEmpty, case .visible = model.state {
+            // Genuinely caught up: visible with NO messages at all. Keyed off the full message list
+            // (not `renderableMessages`) so messages that merely lack a template don't read as
+            // "caught up" — those still exist, they just can't render.
             VStack {
                 Spacer()
                 Text("You're all caught up")
@@ -165,7 +178,7 @@ public struct NotificationInboxOverlay: View {
                 Spacer()
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else if model.renderableMessages.isEmpty {
+        } else if model.messages.isEmpty {
             // idle/loading (pre-first-snapshot or fetch in progress) → spinner, not the empty copy.
             VStack {
                 Spacer()
@@ -174,6 +187,8 @@ public struct NotificationInboxOverlay: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
+            // Messages exist → render the renderable ones. If every message lacks a template the list
+            // is blank (each is logged + skipped); we deliberately do NOT claim "caught up" here.
             messageList
         }
     }

--- a/Sources/MessagingInbox/VisualInboxModel.swift
+++ b/Sources/MessagingInbox/VisualInboxModel.swift
@@ -41,6 +41,23 @@ final class VisualInboxModel: ObservableObject {
 
     private let provider: VisualInboxProvider
 
+    /// SDK logger for [CIO-Inbox] diagnostics (e.g. the no-template skip in item 4).
+    private let logger: Logger = DIGraphShared.shared.logger
+
+    /// Ids already logged as "no matching template" so the skip warning is emitted once per message
+    /// rather than on every refresh/recompose.
+    private var loggedMissingTemplateIds: Set<String> = []
+
+    /// Messages that have a matching decoded template and are therefore renderable via Jist.
+    ///
+    /// No-template fallback (item 4): a message whose `type` is not in the decoded templates registry
+    /// is skipped (not rendered as a blank row) and logged once as a [CIO-Inbox] error. We can't skip
+    /// in pre-iOS-15 fallback rows (no templates there), so the skip only applies when Jist renders.
+    var renderableMessages: [VisualInboxMessageSnapshot] {
+        guard #available(iOS 15.0, *) else { return messages }
+        return messages.filter { templates[$0.type] != nil }
+    }
+
     /// Backing task for the load + refresh cycle; cancelled when the view disappears.
     private var refreshTask: Task<Void, Never>?
 
@@ -52,6 +69,10 @@ final class VisualInboxModel: ObservableObject {
     /// In-flight / already-done guard for auto-mark-opened (item 8). A message id present here has
     /// either been marked or is being marked, so it is never marked twice.
     private var markedOpenedIds: Set<String> = []
+
+    /// In-flight guard for dismiss (web parity: tap → dismiss). A message id present here has a
+    /// dismiss in flight, so a rapid double-tap / re-entrant `onAction` can't double-fire the delete.
+    private var dismissingIds: Set<String> = []
 
     init(provider: VisualInboxProvider) {
         self.provider = provider
@@ -122,6 +143,7 @@ final class VisualInboxModel: ObservableObject {
         templates = newTemplates
         theme = newTheme
         decodedData = Self.decodeData(for: newMessages)
+        logMissingTemplates()
     }
 
     /// Publishes a coalesced snapshot from the `observe()` stream. Runs on the main actor (the model
@@ -133,6 +155,18 @@ final class VisualInboxModel: ObservableObject {
         templates = VisualInboxJistDecoder.decodeTemplates(snapshot.templatesJSON)
         theme = VisualInboxJistDecoder.decodeTheme(snapshot.themeJSON)
         decodedData = Self.decodeData(for: snapshot.messages)
+        logMissingTemplates()
+    }
+
+    /// Emits a one-time [CIO-Inbox] error for each message whose `type` has no matching decoded
+    /// template (item 4). These messages are skipped by `renderableMessages` so they never render as
+    /// a blank row. Logged once per id to avoid per-refresh spam.
+    private func logMissingTemplates() {
+        guard #available(iOS 15.0, *) else { return }
+        for message in messages where templates[message.type] == nil && !loggedMissingTemplateIds.contains(message.id) {
+            loggedMissingTemplateIds.insert(message.id)
+            logger.error("[CIO-Inbox] skipping message \(message.id): no template for type \"\(message.type)\" in registry")
+        }
     }
 
     /// Decodes each message's `properties` into Jist render data once, keyed by message id.
@@ -166,6 +200,27 @@ final class VisualInboxModel: ObservableObject {
                 if !didMark {
                     self?.markedOpenedIds.remove(message.id)
                 }
+            }
+            await self?.refresh()
+        }
+    }
+
+    // MARK: - Dismiss (web parity: tap → dismiss)
+
+    /// Dismisses (removes) a message, mirroring web behavior where tapping a message removes it from
+    /// the list. Dismissing the last message empties the list, which drives the data layer to
+    /// `.hidden` — the panel auto-closes and the bell hides (item 2).
+    ///
+    /// The `dismissingIds` guard dedupes so a rapid double-tap / re-entrant `onAction` for the same
+    /// message can't dispatch the delete twice. If the dismiss no-ops (message already gone) the
+    /// reservation is released so the id stays retryable.
+    func dismiss(messageId: String) {
+        guard !dismissingIds.contains(messageId) else { return }
+        dismissingIds.insert(messageId)
+        Task { [weak self, provider] in
+            let didDismiss = await provider.dismiss(messageId: messageId)
+            if !didDismiss {
+                self?.dismissingIds.remove(messageId)
             }
             await self?.refresh()
         }

--- a/Sources/MessagingInbox/VisualInboxModel.swift
+++ b/Sources/MessagingInbox/VisualInboxModel.swift
@@ -184,7 +184,10 @@ final class VisualInboxModel: ObservableObject {
     /// (and re-callable as new messages scroll into view). The `markedOpenedIds` guard dedupes so a
     /// message is never marked repeatedly across panel open/close cycles or refreshes.
     func markVisibleMessagesOpened() {
-        let toMark = messages.filter { !$0.opened && !markedOpenedIds.contains($0.id) }
+        // Only mark messages the user can actually see: `renderableMessages` (those with a template).
+        // Messages skipped for a missing template are never shown in the list, so they must not be
+        // marked opened.
+        let toMark = renderableMessages.filter { !$0.opened && !markedOpenedIds.contains($0.id) }
         guard !toMark.isEmpty else { return }
         // Reserve ids synchronously (on the main actor) so a re-entrant call can't double-fire the
         // same mark while the async marks are in flight.

--- a/Tests/MessagingInbox/VisualInboxModelTests.swift
+++ b/Tests/MessagingInbox/VisualInboxModelTests.swift
@@ -54,6 +54,8 @@ final class VisualInboxModelTests: XCTestCase {
             makeSnapshot(id: "b", opened: false),
             makeSnapshot(id: "c", opened: true) // already opened — never marked
         ]
+        // Messages must be renderable (have a template) to be marked opened.
+        provider.stubTemplates = ["test": [["version": "1", "root": ["type": "placeholder"]]]]
         let model = VisualInboxModel(provider: provider)
         await model.refresh()
 
@@ -71,6 +73,7 @@ final class VisualInboxModelTests: XCTestCase {
     func test_markVisibleMessagesOpened_whenMarkNoOps_thenIdStaysRetryable() async {
         let provider = FakeVisualInboxProvider()
         provider.stubMessages = [makeSnapshot(id: "a", opened: false)]
+        provider.stubTemplates = ["test": [["version": "1", "root": ["type": "placeholder"]]]]
         // First round: "a" is gone from the store, so the mark no-ops.
         provider.missingMessageIds = ["a"]
         let model = VisualInboxModel(provider: provider)
@@ -93,6 +96,7 @@ final class VisualInboxModelTests: XCTestCase {
     func test_markVisibleMessagesOpened_whenAllOpened_thenNothingMarked() async {
         let provider = FakeVisualInboxProvider()
         provider.stubMessages = [makeSnapshot(id: "a", opened: true)]
+        provider.stubTemplates = ["test": [["version": "1", "root": ["type": "placeholder"]]]]
         let model = VisualInboxModel(provider: provider)
         await model.refresh()
 

--- a/Tests/MessagingInbox/VisualInboxModelTests.swift
+++ b/Tests/MessagingInbox/VisualInboxModelTests.swift
@@ -103,6 +103,92 @@ final class VisualInboxModelTests: XCTestCase {
         XCTAssertTrue(provider.markedOpenedIds.isEmpty)
     }
 
+    // MARK: - dismiss (web parity: tap → dismiss)
+
+    func test_dismiss_whenCalled_thenProviderDismissesMessage() async {
+        let provider = FakeVisualInboxProvider()
+        provider.stubMessages = [makeSnapshot(id: "a", opened: false)]
+        let model = VisualInboxModel(provider: provider)
+        await model.refresh()
+
+        model.dismiss(messageId: "a")
+        await provider.waitForDismisses(expected: 1)
+
+        XCTAssertEqual(provider.dismissedIds, ["a"])
+    }
+
+    func test_dismiss_whenCalledTwiceWhileInFlight_thenDismissedOnce() async {
+        let provider = FakeVisualInboxProvider()
+        provider.stubMessages = [makeSnapshot(id: "a", opened: false)]
+        let model = VisualInboxModel(provider: provider)
+        await model.refresh()
+
+        // Two synchronous calls before the first dismiss Task finishes: the in-flight guard dedupes.
+        model.dismiss(messageId: "a")
+        model.dismiss(messageId: "a")
+        await provider.waitForDismisses(expected: 1)
+        try? await Task.sleep(nanoseconds: 20000000) // 20ms — give any (incorrect) second dismiss a chance.
+
+        XCTAssertEqual(provider.dismissedIds, ["a"])
+    }
+
+    /// A dismiss that NO-OPs (message already gone → `dismiss` returns false) must NOT permanently
+    /// dedupe the id; a later dismiss with the message present must re-issue.
+    func test_dismiss_whenDismissNoOps_thenIdStaysRetryable() async {
+        let provider = FakeVisualInboxProvider()
+        provider.stubMessages = [makeSnapshot(id: "a", opened: false)]
+        provider.missingMessageIds = ["a"]
+        let model = VisualInboxModel(provider: provider)
+        await model.refresh()
+
+        model.dismiss(messageId: "a")
+        await provider.waitForDismisses(expected: 1)
+
+        provider.missingMessageIds = []
+        model.dismiss(messageId: "a")
+        await provider.waitForDismisses(expected: 2)
+
+        XCTAssertEqual(provider.dismissedIds, ["a", "a"])
+    }
+
+    // MARK: - relative dates (item 3)
+
+    func test_relativeDate_whenValid_thenLocalizedRelativeString() {
+        // Uses the OS's RelativeDateTimeFormatter (localized), so we don't assert exact wording —
+        // just that a past timestamp yields a non-empty string distinct from the raw ISO input.
+        let now = Date(timeIntervalSince1970: 1000000)
+        let iso = ISO8601DateFormatter().string(from: now.addingTimeInterval(-7200))
+        let result = VisualInboxMessageRow.relativeDate(from: iso, now: now)
+        XCTAssertFalse(result.isEmpty)
+        XCTAssertNotEqual(result, iso)
+    }
+
+    func test_relativeDate_whenUnparseable_thenReturnsRawString() {
+        XCTAssertEqual(VisualInboxMessageRow.relativeDate(from: "not-a-date"), "not-a-date")
+    }
+
+    // MARK: - no-template skip (item 4)
+
+    func test_renderableMessages_whenTypeHasNoTemplate_thenSkipped() async {
+        let provider = FakeVisualInboxProvider()
+        provider.stubMessages = [
+            VisualInboxMessageSnapshot(id: "a", type: "known", properties: [:], opened: false, sentAt: Date()),
+            VisualInboxMessageSnapshot(id: "b", type: "unknown", properties: [:], opened: false, sentAt: Date())
+        ]
+        // Only "known" has a decoded template version in the registry. The root node uses an
+        // unrecognized type so it decodes to JistNode.unknown (a valid, minimal template).
+        provider.stubTemplates = ["known": [["version": "1", "root": ["type": "placeholder"]]]]
+        let model = VisualInboxModel(provider: provider)
+        await model.refresh()
+
+        if #available(iOS 15.0, *) {
+            XCTAssertEqual(model.renderableMessages.map(\.id), ["a"])
+        } else {
+            // Below the Jist floor the fallback row renders every message (no template lookup).
+            XCTAssertEqual(model.renderableMessages.map(\.id), ["a", "b"])
+        }
+    }
+
     // MARK: - reactive observe() subscription (the bug fix)
 
     /// The bug: at launch the data layer is `.hidden` (enablement header not yet returned). When
@@ -207,9 +293,12 @@ private final class FakeVisualInboxProvider: VisualInboxProvider, @unchecked Sen
     private(set) var markedOpenedIds: [String] = []
     private let lock = NSLock()
 
-    /// Ids that `markOpened` should report as a NO-OP (message no longer in the store → returns
-    /// false). Empty by default, so every mark "applies". Used by the failed-mark-retry test.
+    /// Ids that `markOpened` / `dismiss` should report as a NO-OP (message no longer in the store →
+    /// returns false). Empty by default, so every mark "applies". Used by the failed-mark-retry test.
     var missingMessageIds: Set<String> = []
+
+    /// Ids passed to `dismiss`, in order, for the dismiss/onAction tests.
+    private(set) var dismissedIds: [String] = []
 
     /// Snapshot emitted to `observe()` subscribers on subscribe.
     var initialSnapshot: VisualInboxSnapshot?
@@ -297,6 +386,26 @@ private final class FakeVisualInboxProvider: VisualInboxProvider, @unchecked Sen
         }
         lock.unlock()
         return didMark
+    }
+
+    @discardableResult
+    func dismiss(messageId: String) async -> Bool {
+        lock.lock()
+        dismissedIds.append(messageId)
+        let didDismiss = !missingMessageIds.contains(messageId)
+        lock.unlock()
+        return didDismiss
+    }
+
+    /// Waits until the model's detached dismiss Task records at least `expected` dismisses.
+    func waitForDismisses(expected: Int) async {
+        for _ in 0 ..< 200 {
+            lock.lock()
+            let count = dismissedIds.count
+            lock.unlock()
+            if count >= expected { return }
+            try? await Task.sleep(nanoseconds: 1000000) // 1ms
+        }
     }
 
     /// Waits until the model's detached mark Task reaches the expected number of marks (or a budget

--- a/api-docs/CioMessagingInApp.api
+++ b/api-docs/CioMessagingInApp.api
@@ -199,6 +199,7 @@ public interface CioMessagingInApp.VisualInboxProvider {
 	public fun func templatesJSON() async -> List<String: Any>?;
 	public fun func themeJSON() async -> List<String: Any>?;
 	public fun func markOpened(messageId: String) async -> Boolean;
+	public fun func dismiss(messageId: String) async -> Boolean;
 }
 public final class CioMessagingInApp.VisualInboxSnapshot {
 	public final val state: VisualInboxState;


### PR DESCRIPTION
Wires up web-parity inbox interaction on iOS: mounts the overlay app-wide in the APN-UIKit sample, adds tap-to-dismiss, relative dates, no-template skip, dark-mode `.auto`, and scrim parity (0.32).

Deferred (clean TODOs left): real-url/deeplink navigation (#12), host action callback API (#13), full chrome theming from `branding.patterns.inbox` (#17), and the custom/SVG bell asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds SPI `dismiss` and changes overlay UX (message deletion on tap, chrome visibility, touch passthrough); mutations reuse existing headless delete/mark paths but affect integrators and inbox state.
> 
> **Overview**
> Brings the Visual Notification Inbox overlay closer to **web behavior** in the SDK and demonstrates it in the **APN UIKit** sample.
> 
> **SDK (`NotificationInboxOverlay` / `VisualInboxModel`)** adds **tap-to-dismiss** (Jist actions → `VisualInboxProvider.dismiss` → existing `markMessageDeleted`), **localized relative dates**, **dark mode** via Jist `.auto`, **scrim at 0.32**, and **no-template messages** skipped (with one-time logging) while hiding chrome when nothing is renderable. The panel **drops the Inbox header/close button**; closing uses scrim or bell. An optional **`onPanelPresentationChange`** callback lets hosts toggle full-screen touch capture when the panel is open. **Auto mark-opened** only applies to renderable rows.
> 
> **SPI** extends `VisualInboxProvider` with **`dismiss(messageId:)`** (documented in `CioMessagingInApp.api`).
> 
> **Sample app** mounts the overlay in a dedicated **passthrough `UIWindow`** (`InboxOverlayWindow`) from `SceneDelegate` so the bell survives login/logout root swaps; bell-only hit testing when closed, full capture when open. **SampleAppsCommon** links **MessagingInbox**.
> 
> **Tests** cover dismiss dedupe/retry, relative dates, and `renderableMessages` filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 251f078e2bb7c93dc453a919e6d035cd11396a8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->