### PR TITLE
chore(geofence): report authorization tier on every monitor wiring pass

### DIFF
--- a/CustomerIOLocationGeofence.podspec
+++ b/CustomerIOLocationGeofence.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "CustomerIOLocationGeofence"
-  spec.version      = "4.5.0" # Don't modify this line - it's automatically updated
+  spec.version      = "4.5.3" # Don't modify this line - it's automatically updated
   spec.summary      = "Official Customer.io SDK for iOS - Location Geofence Module"
   spec.homepage     = "https://github.com/customerio/customerio-ios"
   spec.documentation_url = 'https://customer.io/docs/sdk/ios/'

--- a/Sources/LocationGeofence/GeofenceBootstrap.swift
+++ b/Sources/LocationGeofence/GeofenceBootstrap.swift
@@ -67,6 +67,10 @@ enum GeofenceBootstrap {
             }
         }
 
+        // The adopt path above skips `startMonitoring` (the other tier-log site), so without this
+        // a relaunch that re-claims OS-persisted regions would report nothing about delivery readiness.
+        monitor.reportPermissionTier()
+
         // Self-heal mid-process permission changes (Settings toggle, late prompt response).
         // The handler replaces any prior one — no stacking when both foreground init and
         // cold-wake bootstrap run in the same process.

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -35,6 +35,13 @@ extension Logger {
         )
     }
 
+    func geofenceBackgroundDeliveryAvailable(currentStatus: CLAuthorizationStatus) {
+        info(
+            "Geofence background delivery active: Always authorization granted (current status: \(currentStatus.rawValue)).",
+            geofenceTag
+        )
+    }
+
     // MARK: - Event Tracking
 
     func geofenceEventTracked(geofenceId: String, transition: GeofenceTransition) {

--- a/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
@@ -28,8 +28,7 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
     private let logger: Logger
     private var onTransition: GeofenceTransitionHandler?
     private var onAuthorizationChanged: GeofenceAuthorizationChangedHandler?
-    private var hasLoggedBlocked = false
-    private var hasLoggedForegroundOnly = false
+    private var lastLoggedPermissionTier: PermissionTier?
     private var ownedRegionIdentifiers: Set<String> = []
 
     init(logger: Logger) {
@@ -63,22 +62,8 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
     }
 
     func startMonitoring(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) {
-        let status = currentAuthorizationStatus()
-        switch Self.permissionTier(for: status) {
-        case .blocked:
-            if !hasLoggedBlocked {
-                hasLoggedBlocked = true
-                logger.geofencePermissionUnavailable(currentStatus: status)
-            }
-            return
-        case .foregroundOnly:
-            if !hasLoggedForegroundOnly {
-                hasLoggedForegroundOnly = true
-                logger.geofenceBackgroundDeliveryUnavailable(currentStatus: status)
-            }
-        case .backgroundDelivery:
-            break
-        }
+        reportPermissionTier()
+        guard Self.permissionTier(for: currentAuthorizationStatus()) != .blocked else { return }
 
         let coordinate = CLLocationCoordinate2D(latitude: center.latitude, longitude: center.longitude)
         guard CLLocationCoordinate2DIsValid(coordinate) else {
@@ -155,6 +140,21 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
             return .blocked
         @unknown default:
             return .blocked
+        }
+    }
+
+    func reportPermissionTier() {
+        let status = currentAuthorizationStatus()
+        let tier = Self.permissionTier(for: status)
+        guard tier != lastLoggedPermissionTier else { return }
+        lastLoggedPermissionTier = tier
+        switch tier {
+        case .blocked:
+            logger.geofencePermissionUnavailable(currentStatus: status)
+        case .foregroundOnly:
+            logger.geofenceBackgroundDeliveryUnavailable(currentStatus: status)
+        case .backgroundDelivery:
+            logger.geofenceBackgroundDeliveryAvailable(currentStatus: status)
         }
     }
 

--- a/Sources/LocationGeofence/Monitor/GeofenceRegionMonitoring.swift
+++ b/Sources/LocationGeofence/Monitor/GeofenceRegionMonitoring.swift
@@ -60,4 +60,8 @@ protocol GeofenceRegionMonitoring: AnyObject, Sendable {
     /// monitor, without re-registering them. Restores transition recognition on a fresh process
     /// where the OS kept monitoring but the in-memory ownership set was lost.
     func adoptExistingRegions(matching identifiers: Set<String>)
+
+    /// Logs the current authorization tier (background delivery / foreground only / blocked),
+    /// deduped so it emits only when the tier changes since the last report.
+    func reportPermissionTier()
 }

--- a/Tests/LocationGeofence/Geofence/GeofenceBootstrapTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceBootstrapTests.swift
@@ -87,6 +87,7 @@ struct GeofenceBootstrapTests {
         #expect(coordinator.applyCachedRegistrationCallsCount == 1)
         #expect(monitor.setOnAuthorizationChangedCallsCount == 1)
         #expect(monitor.onAuthorizationChanged != nil)
+        #expect(monitor.reportPermissionTierCallsCount == 1)
     }
 
     @Test
@@ -246,6 +247,8 @@ struct GeofenceBootstrapTests {
         #expect(monitor.adoptedIdentifiers == ["g1", GeofenceConstants.movementTriggerIdentifier])
         #expect(coordinator.applyCachedRegistrationCallsCount == 0)
         #expect(await storage.getLastRegistrationCenter() == LocationData(latitude: 10, longitude: 20))
+        // Adopt skips startMonitoring, so wireMonitor itself must report the tier.
+        #expect(monitor.reportPermissionTierCallsCount == 1)
     }
 
     @Test

--- a/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
+++ b/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
@@ -34,6 +34,7 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
     var osMonitoredRegions: Set<String> = []
     private(set) var adoptExistingRegionsCallsCount = 0
     private(set) var adoptedIdentifiers: Set<String> = []
+    private(set) var reportPermissionTierCallsCount = 0
 
     var monitoredRegionIdentifiers: Set<String> {
         activeIdentifiers
@@ -48,6 +49,10 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
         let adopted = identifiers.intersection(osMonitoredRegions)
         adoptedIdentifiers.formUnion(adopted)
         activeIdentifiers.formUnion(adopted)
+    }
+
+    func reportPermissionTier() {
+        reportPermissionTierCallsCount += 1
     }
 
     func setOnTransition(_ handler: GeofenceTransitionHandler?) {


### PR DESCRIPTION
On a relaunch/reboot the SDK re-claims OS-persisted regions via the **adopt** path, which skips `startMonitoring` — the only place the authorization tier was logged. So a relaunch reported nothing about whether background delivery was actually available, even at `Always`.

`wireMonitor` now reports the tier directly (covers both adopt and register paths), and a new positive log confirms background delivery is active:

```
[CIO] [Geofence] Geofence background delivery active: Always authorization granted (current status: 3).
```

Also replaces the two one-shot flags (`hasLoggedBlocked` / `hasLoggedForegroundOnly`) with a single `lastLoggedPermissionTier` that dedupes by tier and re-logs on a real tier change (e.g. a `WhenInUse → Always` upgrade), which the one-shot flags silently swallowed.

Verified on-device: relaunch with `Always` now logs `current status: 3` on the adopt path. All logs are `info` level (suppressed at the default `.error`).

### Also: CocoaPods-FCM CI fix
`CustomerIOLocationGeofence.podspec` was stuck at `4.5.0` while every other podspec (incl. `CustomerIOLocation`) is `4.5.3`. Because it pins `CustomerIOLocation = <own version>`, `pod install` couldn't resolve and the CocoaPods-FCM sample archived a stale Pods project (referencing Common files the main merge removed). Bumping it to `4.5.3` aligns the versions and unblocks that build. Pre-existing feature-branch drift, unrelated to the logging change.

https://linear.app/customerio/issue/MBL-1761/ios-execute-geofencing-validation-and-lifecycle-testing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and logging deduplication only; no change to region registration, adoption, or transition handling behavior beyond when logs fire.
> 
> **Overview**
> **Geofence permission tier is now logged whenever the monitor is wired**, not only when `startMonitoring` runs. `GeofenceBootstrap.wireMonitor` calls `reportPermissionTier()` after adopt or register so a relaunch that **re-claims OS-persisted regions** (adopt skips `startMonitoring`) still emits whether background delivery is available.
> 
> **Logging is centralized and tier-aware:** `CoreLocationGeofenceMonitor` exposes `reportPermissionTier()` (on the `GeofenceRegionMonitoring` protocol), replaces one-shot `hasLoggedBlocked` / `hasLoggedForegroundOnly` flags with **`lastLoggedPermissionTier`**, and only logs when the tier **changes**—so upgrades like When-In-Use → Always are logged again. A new **info** log confirms **Always** / background delivery is active; blocked and foreground-only messages are unchanged in meaning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c117854c5469f72f1c352368068dd73976c37b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
