### PR TITLE
chore(geofence): single Geofence Transition event with camelCase payload

### DIFF
--- a/Sources/Common/Type/GeofenceMetric.swift
+++ b/Sources/Common/Type/GeofenceMetric.swift
@@ -13,15 +13,19 @@ public protocol GeofenceMetric {
 }
 
 public extension GeofenceMetric {
-    /// `/track` event properties. `geofence_name` is included only when a name is available.
+    /// `/track` event name. The same name for every transition; the direction is the
+    /// `transition` property.
+    var trackEventName: String { "Geofence Transition" }
+
+    /// `/track` event properties. `geofenceName` is included only when a name is available.
+    /// `timestamp` is not a property — it is set on the event envelope by each delivery path.
     var trackEventProperties: [String: Any] {
         var properties: [String: Any] = [
-            "geofence_id": geofenceId,
-            "transition_type": transition.rawValue,
-            "timestamp": Int(timestamp.timeIntervalSince1970)
+            "transition": transition.rawValue,
+            "geofenceId": geofenceId
         ]
         if let name {
-            properties["geofence_name"] = name
+            properties["geofenceName"] = name
         }
         return properties
     }

--- a/Sources/Common/Type/GeofenceTransition.swift
+++ b/Sources/Common/Type/GeofenceTransition.swift
@@ -10,13 +10,3 @@ public enum GeofenceTransition: String, Codable, Sendable {
     case enter
     case exit
 }
-
-public extension GeofenceTransition {
-    /// Analytics event name for this transition.
-    var trackEventName: String {
-        switch self {
-        case .enter: return "geofence_entered"
-        case .exit: return "geofence_exited"
-        }
-    }
-}

--- a/Sources/DataPipeline/DataPipelineImplementation+GeofenceObserver.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation+GeofenceObserver.swift
@@ -10,7 +10,7 @@ extension DataPipelineImplementation {
     /// `metric.timestamp` so a flush replayed hours after capture still attributes
     /// the transition to when it happened, not when it was sent.
     func processGeofenceMetricEvent(_ metric: TrackGeofenceMetricEvent) {
-        var trackEvent = TrackEvent(event: metric.transition.trackEventName, properties: try? JSON(metric.trackEventProperties))
+        var trackEvent = TrackEvent(event: metric.trackEventName, properties: try? JSON(metric.trackEventProperties))
         trackEvent.timestamp = metric.timestamp.string(format: .iso8601WithMilliseconds)
         analytics.process(event: trackEvent)
     }

--- a/Sources/LocationGeofence/Event/GeofenceDeliveryTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceDeliveryTracker.swift
@@ -35,7 +35,7 @@ final class GeofenceDeliveryTrackerImpl: GeofenceDeliveryTracker {
 
         httpClient.sendTrackEvent(
             BackgroundTrackRequest(
-                eventName: metric.transition.trackEventName,
+                eventName: metric.trackEventName,
                 userId: userId,
                 properties: metric.trackEventProperties,
                 timestamp: metric.timestamp

--- a/Tests/Common/Service/BackgroundDeliveryHttpClientTests.swift
+++ b/Tests/Common/Service/BackgroundDeliveryHttpClientTests.swift
@@ -41,9 +41,9 @@ struct BackgroundDeliveryHttpClientTests {
         await withCheckedContinuation { continuation in
             client.sendTrackEvent(
                 BackgroundTrackRequest(
-                    eventName: "geofence_entered",
+                    eventName: "Geofence Transition",
                     userId: "user_42",
-                    properties: ["geofence_id": "geo_1", "transition_type": "enter"],
+                    properties: ["geofenceId": "geo_1", "transition": "enter"],
                     timestamp: Date(timeIntervalSince1970: 1700000000)
                 )
             ) { _ in continuation.resume() }
@@ -56,12 +56,12 @@ struct BackgroundDeliveryHttpClientTests {
         #expect(params?.headers?["Content-Type"] == "application/json; charset=utf-8")
 
         let body = params?.body.flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] }
-        #expect(body?["event"] as? String == "geofence_entered")
+        #expect(body?["event"] as? String == "Geofence Transition")
         #expect(body?["userId"] as? String == "user_42")
         #expect(body?["timestamp"] as? String == "2023-11-14T22:13:20.000Z")
         let properties = body?["properties"] as? [String: Any]
-        #expect(properties?["geofence_id"] as? String == "geo_1")
-        #expect(properties?["transition_type"] as? String == "enter")
+        #expect(properties?["geofenceId"] as? String == "geo_1")
+        #expect(properties?["transition"] as? String == "enter")
     }
 
     @Test

--- a/Tests/DataPipeline/DataPipelineEventBustTests.swift
+++ b/Tests/DataPipeline/DataPipelineEventBustTests.swift
@@ -79,12 +79,13 @@ class DataPipelineEventBustTests: IntegrationTest {
         }
 
         XCTAssertEqual(trackEvent.type, "track")
-        XCTAssertEqual(trackEvent.event, "geofence_entered")
+        XCTAssertEqual(trackEvent.event, "Geofence Transition")
         let properties = trackEvent.properties?.dictionaryValue ?? [:]
-        XCTAssertEqual(properties["geofence_id"] as? String, givenGeofenceId)
-        XCTAssertEqual(properties["transition_type"] as? String, "enter")
-        XCTAssertEqual(properties["timestamp"] as? Int, Int(capturedAt.timeIntervalSince1970))
-        XCTAssertEqual(properties["geofence_name"] as? String, "HQ")
+        XCTAssertEqual(properties["geofenceId"] as? String, givenGeofenceId)
+        XCTAssertEqual(properties["transition"] as? String, "enter")
+        XCTAssertEqual(properties["geofenceName"] as? String, "HQ")
+        // timestamp lives on the event envelope, not in properties.
+        XCTAssertNil(properties["timestamp"])
         XCTAssertNil(properties["latitude"])
         XCTAssertNil(properties["longitude"])
         XCTAssertEqual(trackEvent.timestamp, capturedAt.string(format: .iso8601WithMilliseconds))
@@ -108,13 +109,14 @@ class DataPipelineEventBustTests: IntegrationTest {
             return
         }
 
-        XCTAssertEqual(trackEvent.event, "geofence_exited")
+        XCTAssertEqual(trackEvent.event, "Geofence Transition")
         let properties = trackEvent.properties?.dictionaryValue ?? [:]
-        XCTAssertEqual(properties["geofence_id"] as? String, givenGeofenceId)
-        XCTAssertEqual(properties["transition_type"] as? String, "exit")
-        XCTAssertEqual(properties["timestamp"] as? Int, Int(capturedAt.timeIntervalSince1970))
+        XCTAssertEqual(properties["geofenceId"] as? String, givenGeofenceId)
+        XCTAssertEqual(properties["transition"] as? String, "exit")
         // No name on the event → property omitted entirely.
-        XCTAssertNil(properties["geofence_name"])
+        XCTAssertNil(properties["geofenceName"])
+        // timestamp lives on the event envelope, not in properties.
+        XCTAssertNil(properties["timestamp"])
         XCTAssertNil(properties["latitude"])
         XCTAssertNil(properties["longitude"])
         XCTAssertEqual(trackEvent.timestamp, capturedAt.string(format: .iso8601WithMilliseconds))

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceDeliveryTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceDeliveryTrackerTests.swift
@@ -32,7 +32,7 @@ struct GeofenceDeliveryTrackerTests {
     // MARK: - Argument shaping
 
     @Test
-    func trackMetric_givenEnterTransition_expectAndroidWireFormat() async {
+    func trackMetric_givenEnterTransition_expectTransitionEventPayload() async {
         let (tracker, httpClient) = makeTracker()
         httpClient.sendTrackEventClosure = { _, completion in completion(.success(())) }
 
@@ -43,17 +43,18 @@ struct GeofenceDeliveryTrackerTests {
         }
 
         let args = httpClient.sendTrackEventReceivedArguments
-        #expect(args?.request.eventName == "geofence_entered")
+        #expect(args?.request.eventName == "Geofence Transition")
         #expect(args?.request.userId == "user_42")
+        // timestamp rides on the request envelope, not in properties.
         #expect(args?.request.timestamp == Date(timeIntervalSince1970: 1700000000))
         let properties = args?.request.properties ?? [:]
-        #expect(properties["geofence_id"] as? String == "geo_1")
-        #expect(properties["transition_type"] as? String == "enter")
-        #expect(properties["timestamp"] as? Int == 1700000000)
+        #expect(properties["geofenceId"] as? String == "geo_1")
+        #expect(properties["transition"] as? String == "enter")
+        #expect(properties["timestamp"] == nil)
         #expect(properties["latitude"] == nil)
         #expect(properties["longitude"] == nil)
         // No name on the metric → property omitted entirely (not sent empty/null).
-        #expect(properties["geofence_name"] == nil)
+        #expect(properties["geofenceName"] == nil)
     }
 
     @Test
@@ -68,11 +69,11 @@ struct GeofenceDeliveryTrackerTests {
         }
 
         let properties = httpClient.sendTrackEventReceivedArguments?.request.properties ?? [:]
-        #expect(properties["geofence_name"] as? String == "HQ")
+        #expect(properties["geofenceName"] as? String == "HQ")
     }
 
     @Test
-    func trackMetric_givenExitTransition_expectExitedEventName() async {
+    func trackMetric_givenExitTransition_expectSameEventNameAndExitProperty() async {
         let (tracker, httpClient) = makeTracker()
         httpClient.sendTrackEventClosure = { _, completion in completion(.success(())) }
 
@@ -82,7 +83,9 @@ struct GeofenceDeliveryTrackerTests {
             }
         }
 
-        #expect(httpClient.sendTrackEventReceivedArguments?.request.eventName == "geofence_exited")
+        let args = httpClient.sendTrackEventReceivedArguments
+        #expect(args?.request.eventName == "Geofence Transition")
+        #expect(args?.request.properties["transition"] as? String == "exit")
     }
 
     // MARK: - Guard clauses

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -553,7 +553,7 @@ struct GeofenceEventTrackerTests {
     @Test
     func trackTransition_givenCachedGeofenceWithEmptyName_expectNilName() async {
         // The API maps an absent name to "". Empty must resolve to nil so the event omits
-        // `geofence_name` rather than sending an empty string.
+        // `geofenceName` rather than sending an empty string.
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let storage = makeStorage(directory: dir)


### PR DESCRIPTION
All geofence transitions now track under a single event name, **`Geofence Transition`**, with the direction in the `transition` property instead of per-transition event names.

**Payload**
```
event: "Geofence Transition"
properties: { "transition": "enter" | "exit", "geofenceId": "...", "geofenceName": "..." }
```

- Properties are camelCase: `transition`, `geofenceId`, `geofenceName`.
- `geofenceName` is omitted when no name is available (not sent empty/null).
- `timestamp` is no longer a property — both delivery paths already stamp it on the event envelope (HTTP top-level `timestamp`, EventBus `TrackEvent.timestamp`), so attribution of a delayed flush is unchanged.
- Removed the now-unused per-transition `GeofenceTransition.trackEventName`.
- On-disk pending-metric keys are unchanged (internal persistence, not wire).

Android is implementing the same payload in parallel.

> [!NOTE]
> The `CocoaPods-FCM` check will fail here until #1120 merges — it carries the `CustomerIOLocationGeofence` podspec version fix (`4.5.0 → 4.5.3`) that this branch (off the feature tip) doesn't yet have. Unrelated to this change.

https://linear.app/customerio/issue/MBL-1876/update-geofence-events-payload-in-mobile-sdks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change to analytics event names and property keys; journeys and dashboards keyed on the old format need updates, though delivery logic and on-disk pending keys are unchanged.
> 
> **Overview**
> Geofence analytics now use one **`Geofence Transition`** track event for both enter and exit; direction is **`transition`** (`enter` / `exit`) instead of separate `geofence_entered` / `geofence_exited` names.
> 
> **`GeofenceMetric`** centralizes **`trackEventName`** and reshapes **`trackEventProperties`** to camelCase (`geofenceId`, `geofenceName`, `transition`). **`timestamp`** is dropped from properties; HTTP and EventBus paths still set it on the event envelope. Per-transition **`GeofenceTransition.trackEventName`** is removed.
> 
> **DataPipeline** and **direct HTTP** delivery both read **`metric.trackEventName`** / **`metric.trackEventProperties`**. Tests assert the new wire shape and that properties no longer include **`timestamp`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74d60272979d5b4c0a40694bcb434e47dea28148. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->