### PR TITLE
chore(geofence): declare geofence data use in privacy manifest

### DIFF
--- a/Sources/LocationGeofence/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/LocationGeofence/Resources/PrivacyInfo.xcprivacy
@@ -2,28 +2,40 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<!--
-	Docs for this section: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests
-	This section describes what information this module collects about the app user.
-
-	NOTE: the data-use declaration is intentionally left empty for now. The geofence module
-	collects precise location (linked to the identified profile) and sends it to Customer.io;
-	the NSPrivacyCollectedDataTypes entry below must be completed, after privacy review, before
-	this module is released.
-
-	The SDK does NOT request location permissions - host apps are responsible for:
-	- Adding NSLocationWhenInUseUsageDescription / NSLocationAlwaysAndWhenInUseUsageDescription to their Info.plist
-	- Requesting permissions from users at appropriate times
-	-->
+	<!-- Geofence transitions are sent via /track with the user id; the device's
+	     coordinates are never sent, so no location data type is declared. -->
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeProductInteraction</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/> <!-- anonymous profiles make person-linkage optional -->
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+				<string>NSPrivacyCollectedDataTypePurposeProductPersonalization</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeUserID</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+				<string>NSPrivacyCollectedDataTypePurposeProductPersonalization</string>
+			</array>
+		</dict>
 	</array>
 
-	<!--
-	Docs: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api
-	Documents if this module uses certain system calls and why.
-	CoreLocation is not a "required reason" API, so nothing is declared here.
-	-->
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 	</array>


### PR DESCRIPTION
The `CioLocationGeofence` privacy manifest had an empty placeholder (and a stale comment claiming it collects precise location). Now that geofence events and the sync fetch send **no coordinates**, this declares the actual data use.

**`NSPrivacyCollectedDataTypes`:**

| Data type | Linked | Tracking | Purposes |
|---|---|---|---|
| `ProductInteraction` | false | false | AppFunctionality, Analytics, ProductPersonalization |
| `UserID` | false | false | AppFunctionality, Analytics, ProductPersonalization |

- **No location type** — the module reports a `Geofence Transition` event (`transition` + `geofenceId` + optional `geofenceName`) tied to the user, but never sends the device's coordinates.
- `Linked = false` matches DataPipeline/MessagingInApp, which declare the same data over the same `/track` pipeline (anonymous profiles make person-linkage optional).
- `NSPrivacyTracking = false`; no required-reason APIs (CoreLocation isn't one).

Purposes align with the other CIO modules. Plist lints clean; module builds.

https://linear.app/customerio/issue/MBL-1761/ios-execute-geofencing-validation-and-lifecycle-testing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Privacy manifest and comment-only updates with no runtime or API behavior changes.
> 
> **Overview**
> Fills in **`CioLocationGeofence`**’s Apple privacy manifest after the empty placeholder and removes the outdated note that the module collects precise location.
> 
> **`NSPrivacyCollectedDataTypes`** now declares **ProductInteraction** and **UserID** (both not linked, not used for tracking, with AppFunctionality / Analytics / ProductPersonalization purposes), matching **DataPipeline** and **MessagingInApp**. Inline comments document that geofence entry/exit is reported as a **Geofence Transition** event (transition, geofence id, optional name) for the identified user, with **no location data type** because coordinates are not sent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83c01c743c483e6f8fd5180655838aaec66b8dc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->