### PR TITLE
ci: Updated to Danger version 12

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -16,7 +16,10 @@ jobs:
     name: Danger 
     steps:
       - uses: actions/checkout@v4
-      - name: Run danger 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Run danger
         run: npx danger@12 ci --dangerfile dangerfile.js
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -17,6 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run danger 
-        run: npx danger@11 ci --dangerfile dangerfile.js
+        run: npx danger@12 ci --dangerfile dangerfile.js
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,6 +1,5 @@
 // File that Danger runs to catch potential errors during PR reviews: https://danger.systems/js/
-import {message, danger, warn} from "danger"
-import {readFileSync} from "fs"
+const {message, danger, warn} = require("danger")
 
 // Warn about possible breaking changes being introduced in a pull request. 
 // Breaking changes should be documented when making a pull request. This is a reminder. 


### PR DESCRIPTION
MBL-1911: danger@11 bundles node-fetch v2, and the Gunzip decompression in node-fetch v2 has a known incompatibility with newer Node.js stream behavior. ubuntu-latest runners periodically bump their default Node.js version, and it appears they've moved to a version where ERR_STREAM_PREMATURE_CLOSE surfaces consistently in node-fetch v2's response handling. The dangerfile itself is fine — the crash happens before any of its code runs.

Complete each step to get your pull request merged in. [Learn more about the workflow this project uses](https://github.com/customerio/customerio-ios/blob/develop/docs/dev-notes/GIT-WORKFLOW.md). 
- [ ] [Assign members of your team](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) to review the pull request. 
- [ ] Wait for pull request status checks to complete. If there are problems, fix them until you see that [all status checks are passing](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fsymfony.com%2Fdoc%2F4.3%2F_images%2Fdocs-pull-request-symfonycloud.png&f=1&nofb=1). 
- [ ] Wait until the pull request has been reviewed *and approved* by a teammate
- [ ] After code reviews are approved and you determine this PR is ready to merge, select *Squash and Merge* button on this screen, leave the title and description to the default values, then merge the PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes to the Danger job and dangerfile module style; no SDK runtime or release behavior is affected.
> 
> **Overview**
> Fixes PR review **Danger** runs failing on newer **ubuntu-latest** Node versions by moving off **danger@11** (which pulls in **node-fetch v2** and can hit `ERR_STREAM_PREMATURE_CLOSE` before the dangerfile runs).
> 
> The **PR review** workflow now pins **Node 18** via `actions/setup-node@v4` and runs **`npx danger@12`**. **`dangerfile.js`** is updated to **`require("danger")`** instead of ESM `import`, and the unused **`fs`/`readFileSync`** import is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3058d59c4b3c87c7b833b9ff146f105113e8aaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->