### PR TITLE
fix(inbox): spring panel animation + dismiss-resurrection guard

### DIFF
--- a/Sources/MessagingInApp/State/InAppMessageReducer.swift
+++ b/Sources/MessagingInApp/State/InAppMessageReducer.swift
@@ -57,9 +57,14 @@ private func reducer(action: InAppMessageAction, state: InAppMessageState) -> In
         //  2. Prune any tombstone whose id is NOT in the incoming list — the server has caught up, so
         //     the tombstone is no longer needed (and a later, genuinely-new message reusing the id
         //     wouldn't be wrongly suppressed).
+        //  Only a NON-EMPTY poll is authoritative enough to prune (step 2): an empty/transient
+        //  response carries no "server forgot this id" signal, so keep all tombstones then —
+        //  otherwise a later poll re-echoing a dismissed id would resurrect it.
         let incomingIds = Set(messages.map(\.queueId))
         let filteredMessages = messages.filter { !state.deletedInboxMessageIds.contains($0.queueId) }
-        let prunedTombstones = state.deletedInboxMessageIds.intersection(incomingIds)
+        let prunedTombstones = incomingIds.isEmpty
+            ? state.deletedInboxMessageIds
+            : state.deletedInboxMessageIds.intersection(incomingIds)
         return state.copy(inboxMessages: filteredMessages, deletedInboxMessageIds: prunedTombstones)
 
     case .embedMessages(let messages):

--- a/Sources/MessagingInApp/State/InAppMessageReducer.swift
+++ b/Sources/MessagingInApp/State/InAppMessageReducer.swift
@@ -48,8 +48,19 @@ private func reducer(action: InAppMessageAction, state: InAppMessageState) -> In
         return state.copy(messagesInQueue: Set(messages))
 
     case .processInboxMessages(let messages):
-        // Already deduplicated/sorted by middleware
-        return state.copy(inboxMessages: messages)
+        // Already deduplicated/sorted by middleware.
+        //
+        // Dismiss-resurrection guard: a poll's `/queue` response can still contain a message the user
+        // just deleted (eventual consistency / cached queue). Replacing the whole list with the server
+        // response would resurrect that row and keep the overlay chrome visible. So:
+        //  1. Filter incoming to exclude any tombstoned id (don't resurrect a deleted message).
+        //  2. Prune any tombstone whose id is NOT in the incoming list — the server has caught up, so
+        //     the tombstone is no longer needed (and a later, genuinely-new message reusing the id
+        //     wouldn't be wrongly suppressed).
+        let incomingIds = Set(messages.map(\.queueId))
+        let filteredMessages = messages.filter { !state.deletedInboxMessageIds.contains($0.queueId) }
+        let prunedTombstones = state.deletedInboxMessageIds.intersection(incomingIds)
+        return state.copy(inboxMessages: filteredMessages, deletedInboxMessageIds: prunedTombstones)
 
     case .embedMessages(let messages):
         var newEmbeddedMessages = state.embeddedMessagesState
@@ -135,11 +146,13 @@ private func reducer(action: InAppMessageAction, state: InAppMessageState) -> In
             return state.copy(inboxMessages: updatedMessages)
 
         case .deleteMessage(let message):
-            // Remove deleted message from state
+            // Remove deleted message from the current list AND tombstone its id so a stale poll
+            // response (eventual consistency) can't resurrect it on the next `processInboxMessages`.
             let updatedMessages = state.inboxMessages.filter { inboxMessage in
                 inboxMessage.queueId != message.queueId
             }
-            return state.copy(inboxMessages: updatedMessages)
+            let updatedTombstones = state.deletedInboxMessageIds.union([message.queueId])
+            return state.copy(inboxMessages: updatedMessages, deletedInboxMessageIds: updatedTombstones)
 
         case .trackClicked:
             // No state update needed for tracking clicks

--- a/Sources/MessagingInApp/State/InAppMessageState.swift
+++ b/Sources/MessagingInApp/State/InAppMessageState.swift
@@ -18,6 +18,13 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
     let messagesInQueue: Set<Message>
     let inboxMessages: [InboxMessage] // Array allows all-properties equality to work
     let shownMessageQueueIds: Set<String>
+    /// Client-side tombstones for inbox messages the user has deleted this session. A delete removes
+    /// the message locally AND on the server, but a subsequent poll's `/queue` response can still
+    /// contain the just-deleted message (eventual consistency / cached queue) — replaying it would
+    /// resurrect the row and keep the overlay chrome visible. We therefore exclude tombstoned ids from
+    /// any incoming `processInboxMessages`, and prune a tombstone once the server response no longer
+    /// contains it (the delete has propagated). Internal-only: not part of equality / public API.
+    let deletedInboxMessageIds: Set<String>
 
     init(
         siteId: String = "",
@@ -32,7 +39,8 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
         embeddedMessagesState: EmbeddedMessagesState = EmbeddedMessagesState(),
         messagesInQueue: Set<Message> = [],
         inboxMessages: [InboxMessage] = [],
-        shownMessageQueueIds: Set<String> = []
+        shownMessageQueueIds: Set<String> = [],
+        deletedInboxMessageIds: Set<String> = []
     ) {
         self.siteId = siteId
         self.dataCenter = dataCenter
@@ -47,6 +55,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
         self.messagesInQueue = messagesInQueue
         self.inboxMessages = inboxMessages
         self.shownMessageQueueIds = shownMessageQueueIds
+        self.deletedInboxMessageIds = deletedInboxMessageIds
     }
 
     /// Copies the current state and replaces the given properties with the new values.
@@ -61,7 +70,8 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
         embeddedMessagesState: EmbeddedMessagesState? = nil,
         messagesInQueue: Set<Message>? = nil,
         inboxMessages: [InboxMessage]? = nil,
-        shownMessageQueueIds: Set<String>? = nil
+        shownMessageQueueIds: Set<String>? = nil,
+        deletedInboxMessageIds: Set<String>? = nil
     ) -> InAppMessageState {
         InAppMessageState(
             siteId: siteId,
@@ -76,7 +86,8 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
             embeddedMessagesState: embeddedMessagesState ?? self.embeddedMessagesState,
             messagesInQueue: messagesInQueue ?? self.messagesInQueue,
             inboxMessages: inboxMessages ?? self.inboxMessages,
-            shownMessageQueueIds: shownMessageQueueIds ?? self.shownMessageQueueIds
+            shownMessageQueueIds: shownMessageQueueIds ?? self.shownMessageQueueIds,
+            deletedInboxMessageIds: deletedInboxMessageIds ?? self.deletedInboxMessageIds
         )
     }
 

--- a/Sources/MessagingInbox/NotificationInboxOverlay.swift
+++ b/Sources/MessagingInbox/NotificationInboxOverlay.swift
@@ -104,7 +104,10 @@ public struct NotificationInboxOverlay: View {
     }
 
     private func setPanel(open: Bool) {
-        withAnimation(.easeInOut(duration: 0.3)) {
+        // Spring (no fixed duration) chosen to approximate Compose's default slide+fade enter/exit
+        // springs on Android: smooth, slightly springy, no bounce. `dampingFraction: 0.85` keeps it
+        // critically-ish damped (no overshoot) while `response: 0.35` keeps it snappy.
+        withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
             isPanelOpen = open
         }
         // Auto-mark-opened (item 8): when the panel becomes visible, mark the visible messages

--- a/Sources/MessagingInbox/NotificationInboxOverlay.swift
+++ b/Sources/MessagingInbox/NotificationInboxOverlay.swift
@@ -104,10 +104,10 @@ public struct NotificationInboxOverlay: View {
     }
 
     private func setPanel(open: Bool) {
-        // Spring (no fixed duration) chosen to approximate Compose's default slide+fade enter/exit
-        // springs on Android: smooth, slightly springy, no bounce. `dampingFraction: 0.85` keeps it
-        // critically-ish damped (no overshoot) while `response: 0.35` keeps it snappy.
-        withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+        // Slide the panel with a spring — iOS's natural idiom for fluid, interruptible UI motion
+        // (the same feel as sheets and navigation). No fixed duration; lightly damped so the panel
+        // settles quickly and smoothly without overshoot.
+        withAnimation(.spring(response: 0.4, dampingFraction: 0.9)) {
             isPanelOpen = open
         }
         // Auto-mark-opened (item 8): when the panel becomes visible, mark the visible messages

--- a/Sources/MessagingInbox/VisualInboxModel.swift
+++ b/Sources/MessagingInbox/VisualInboxModel.swift
@@ -275,12 +275,14 @@ final class VisualInboxModel: ObservableObject {
         guard !dismissingIds.contains(messageId) else { return }
         dismissingIds.insert(messageId)
         Task { [weak self, provider] in
-            _ = await provider.dismiss(messageId: messageId)
-            // Always release the reservation once the dismiss completes — on success too, not only on
-            // a no-op. The data layer now tombstones the id so a stale poll can't resurrect the row;
-            // but if a row WITH the same id ever legitimately reappears (e.g. after the tombstone is
-            // pruned), it must remain dismissible rather than be permanently swallowed by this guard.
-            self?.dismissingIds.remove(messageId)
+            let didDismiss = await provider.dismiss(messageId: messageId)
+            // Release the reservation only on a no-op (message already gone) so the id stays
+            // retryable. On success keep it reserved: the data-layer tombstone prevents the row from
+            // resurrecting, and a second in-flight dismiss for the same id must not re-run the delete
+            // plumbing (duplicate network call + host `inboxMessageDismissed`).
+            if !didDismiss {
+                self?.dismissingIds.remove(messageId)
+            }
             await self?.refresh()
         }
     }

--- a/Sources/MessagingInbox/VisualInboxModel.swift
+++ b/Sources/MessagingInbox/VisualInboxModel.swift
@@ -275,10 +275,12 @@ final class VisualInboxModel: ObservableObject {
         guard !dismissingIds.contains(messageId) else { return }
         dismissingIds.insert(messageId)
         Task { [weak self, provider] in
-            let didDismiss = await provider.dismiss(messageId: messageId)
-            if !didDismiss {
-                self?.dismissingIds.remove(messageId)
-            }
+            _ = await provider.dismiss(messageId: messageId)
+            // Always release the reservation once the dismiss completes — on success too, not only on
+            // a no-op. The data layer now tombstones the id so a stale poll can't resurrect the row;
+            // but if a row WITH the same id ever legitimately reappears (e.g. after the tombstone is
+            // pruned), it must remain dismissible rather than be permanently swallowed by this guard.
+            self?.dismissingIds.remove(messageId)
             await self?.refresh()
         }
     }

--- a/Tests/MessagingInApp/State/InAppMessageStateTests.swift
+++ b/Tests/MessagingInApp/State/InAppMessageStateTests.swift
@@ -1905,6 +1905,25 @@ class InAppMessageStateTests: IntegrationTest {
         XCTAssertFalse(state.deletedInboxMessageIds.contains("doomed-1"), "tombstone pruned once server stops returning the id")
     }
 
+    func test_deleteThenEmptyPoll_givenTransientEmptyResponse_expectTombstoneRetained() async throws {
+        await inAppMessageManager.dispatchAsync(action: .initialize(siteId: .random, dataCenter: .random, environment: .production))
+        await inAppMessageManager.dispatchAsync(action: .setUserIdentifier(user: .random))
+
+        let doomed = makeInboxMessage(queueId: "doomed-1")
+        await inAppMessageManager.dispatchAsync(action: .processInboxMessages(messages: [doomed]))
+        _ = await inAppMessageManager.waitForState { $0.inboxMessages.map(\.queueId) == ["doomed-1"] }
+
+        await inAppMessageManager.dispatchAsync(action: .inboxAction(action: .deleteMessage(message: doomed)))
+        var state = await inAppMessageManager.waitForState { $0.deletedInboxMessageIds.contains("doomed-1") }
+        XCTAssertTrue(state.deletedInboxMessageIds.contains("doomed-1"))
+
+        // An empty/transient poll is NOT authoritative — it must not prune the tombstone, otherwise a
+        // later poll re-echoing the id would resurrect the dismissed message.
+        await inAppMessageManager.dispatchAsync(action: .processInboxMessages(messages: []))
+        state = await inAppMessageManager.state
+        XCTAssertTrue(state.deletedInboxMessageIds.contains("doomed-1"), "empty poll must retain tombstones")
+    }
+
     func test_resetState_expectInboxTombstonesCleared() async throws {
         await inAppMessageManager.dispatchAsync(action: .initialize(siteId: .random, dataCenter: .random, environment: .production))
         await inAppMessageManager.dispatchAsync(action: .setUserIdentifier(user: .random))

--- a/Tests/MessagingInApp/State/InAppMessageStateTests.swift
+++ b/Tests/MessagingInApp/State/InAppMessageStateTests.swift
@@ -1842,6 +1842,85 @@ class InAppMessageStateTests: IntegrationTest {
         let finalState = await inAppMessageManager.state
         XCTAssertTrue(finalState.inboxMessages.isEmpty)
     }
+
+    // MARK: - Inbox dismiss-resurrection (tombstone) tests
+
+    private func makeInboxMessage(queueId: String, sentAt: Date = Date()) -> InboxMessage {
+        InboxMessage(
+            queueId: queueId,
+            deliveryId: "delivery-\(queueId)",
+            expiry: nil,
+            sentAt: sentAt,
+            topics: [],
+            type: "welcome",
+            opened: false,
+            priority: nil,
+            properties: [:]
+        )
+    }
+
+    func test_deleteThenReprocess_givenServerStillReturnsDeletedMessage_expectMessageStaysGone() async throws {
+        await inAppMessageManager.dispatchAsync(action: .initialize(siteId: .random, dataCenter: .random, environment: .production))
+        await inAppMessageManager.dispatchAsync(action: .setUserIdentifier(user: .random))
+
+        let keep = makeInboxMessage(queueId: "keep-1")
+        let doomed = makeInboxMessage(queueId: "doomed-1")
+
+        // Seed the inbox with both messages.
+        await inAppMessageManager.dispatchAsync(action: .processInboxMessages(messages: [keep, doomed]))
+        var state = await inAppMessageManager.waitForState { Set($0.inboxMessages.map(\.queueId)) == ["keep-1", "doomed-1"] }
+        XCTAssertEqual(Set(state.inboxMessages.map(\.queueId)), ["keep-1", "doomed-1"])
+
+        // User deletes one message: it's removed from the list AND tombstoned.
+        await inAppMessageManager.dispatchAsync(action: .inboxAction(action: .deleteMessage(message: doomed)))
+        state = await inAppMessageManager.waitForState { $0.inboxMessages.map(\.queueId) == ["keep-1"] }
+        XCTAssertEqual(state.inboxMessages.map(\.queueId), ["keep-1"])
+        XCTAssertTrue(state.deletedInboxMessageIds.contains("doomed-1"), "deleted id should be tombstoned")
+
+        // A stale poll (eventual consistency) still returns the deleted message.
+        await inAppMessageManager.dispatchAsync(action: .processInboxMessages(messages: [keep, doomed]))
+        state = await inAppMessageManager.state
+        XCTAssertEqual(state.inboxMessages.map(\.queueId), ["keep-1"], "tombstoned message must not resurrect")
+        XCTAssertTrue(state.deletedInboxMessageIds.contains("doomed-1"), "tombstone retained while server still returns the id")
+    }
+
+    func test_deleteThenReprocess_givenServerNoLongerReturnsDeletedMessage_expectTombstonePruned() async throws {
+        await inAppMessageManager.dispatchAsync(action: .initialize(siteId: .random, dataCenter: .random, environment: .production))
+        await inAppMessageManager.dispatchAsync(action: .setUserIdentifier(user: .random))
+
+        let keep = makeInboxMessage(queueId: "keep-1")
+        let doomed = makeInboxMessage(queueId: "doomed-1")
+
+        await inAppMessageManager.dispatchAsync(action: .processInboxMessages(messages: [keep, doomed]))
+        _ = await inAppMessageManager.waitForState { Set($0.inboxMessages.map(\.queueId)) == ["keep-1", "doomed-1"] }
+
+        await inAppMessageManager.dispatchAsync(action: .inboxAction(action: .deleteMessage(message: doomed)))
+        var state = await inAppMessageManager.waitForState { $0.deletedInboxMessageIds.contains("doomed-1") }
+        XCTAssertTrue(state.deletedInboxMessageIds.contains("doomed-1"))
+
+        // The server has caught up: the next poll no longer contains the deleted id.
+        await inAppMessageManager.dispatchAsync(action: .processInboxMessages(messages: [keep]))
+        state = await inAppMessageManager.state
+        XCTAssertEqual(state.inboxMessages.map(\.queueId), ["keep-1"])
+        XCTAssertFalse(state.deletedInboxMessageIds.contains("doomed-1"), "tombstone pruned once server stops returning the id")
+    }
+
+    func test_resetState_expectInboxTombstonesCleared() async throws {
+        await inAppMessageManager.dispatchAsync(action: .initialize(siteId: .random, dataCenter: .random, environment: .production))
+        await inAppMessageManager.dispatchAsync(action: .setUserIdentifier(user: .random))
+
+        let doomed = makeInboxMessage(queueId: "doomed-1")
+        await inAppMessageManager.dispatchAsync(action: .processInboxMessages(messages: [doomed]))
+        _ = await inAppMessageManager.waitForState { $0.inboxMessages.map(\.queueId) == ["doomed-1"] }
+
+        await inAppMessageManager.dispatchAsync(action: .inboxAction(action: .deleteMessage(message: doomed)))
+        var state = await inAppMessageManager.waitForState { $0.deletedInboxMessageIds.contains("doomed-1") }
+        XCTAssertTrue(state.deletedInboxMessageIds.contains("doomed-1"))
+
+        await inAppMessageManager.dispatchAsync(action: .resetState)
+        state = await inAppMessageManager.state
+        XCTAssertTrue(state.deletedInboxMessageIds.isEmpty, "resetState clears inbox tombstones")
+    }
 }
 
 extension InAppMessageManager {


### PR DESCRIPTION
Spring-based overlay panel animation (parity with Android slide+fade motion) and a client-side tombstone that prevents a deleted inbox message from reappearing via a stale poll response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inbox list merge/delete behavior on every poll; logic is nuanced (empty vs non-empty prune) but covered by new tests and scoped to visual inbox state.
> 
> **Overview**
> Fixes deleted inbox rows **reappearing** after a stale `/queue` poll by tracking session **tombstones** (`deletedInboxMessageIds`): deletes record the id, `processInboxMessages` drops tombstoned messages from the server payload, and prunes tombstones only when a **non-empty** poll no longer includes that id (empty polls do not prune).
> 
> **Visual inbox** updates: overlay panel open/close uses a **spring** animation instead of fixed `easeInOut`, and successful dismisses keep the `dismissingIds` guard so double-taps cannot fire duplicate delete/network/host callbacks while tombstones hold.
> 
> Adds integration tests for resurrection, pruning, empty-poll retention, and `resetState` clearing tombstones.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 821a5aca68a4cb9d88b927bfbb483d88a3fb1ff5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->