### PR TITLE
feat(inbox): demo Visual Inbox in APN-UIKit sample (overlay + granular + listener)

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
@@ -4,6 +4,7 @@ import CioLocation
 import CioMessagingInApp
 import CioMessagingPush
 import CioMessagingPushAPN
+import os
 import UIKit
 
 @main
@@ -12,6 +13,7 @@ class AppDelegateWithCioIntegration: CioAppDelegateWrapper<AppDelegate> {}
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var storage = DIGraphShared.shared.storage
     var deepLinkHandler = DIGraphShared.shared.deepLinksHandlerUtil
+    private let inboxEventListener = SampleInboxEventListener()
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
@@ -76,6 +78,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 region: settings.inApp.region.toCIORegion()
             ).build())
             .setEventListener(self)
+
+        // Visual Notification Inbox action listener. Observational here (logs each callback and
+        // returns `false` so the SDK runs its default action handling). A host that wants to
+        // intercept an action returns `true` from `inboxMessageActionTaken`.
+        MessagingInApp.shared.setInboxEventListener(inboxEventListener)
     }
 
     // Handle Universal Link deep link from the Customer.io SDK. This function will get called if a push notification
@@ -170,5 +177,37 @@ extension AppDelegate: InAppEventListener {
             "action-value": actionValue,
             "action-name": actionName
         ])
+    }
+}
+
+/// Sample listener for Visual Notification Inbox events. Observational: it logs each callback and
+/// returns `false` from `inboxMessageActionTaken` so the SDK still applies its default action
+/// handling (e.g. opening an http(s) url). Return `true` instead to fully handle the action and
+/// suppress the SDK's default behavior.
+class SampleInboxEventListener: InboxEventListener {
+    private static let log = OSLog(subsystem: "io.customer.ios-sample.apn-uikit", category: "CIO-Inbox")
+
+    func inboxMessageActionTaken(message: InboxMessage, actionValue: String, actionName: String) -> Bool {
+        os_log(
+            "[CIO-Inbox] sample listener: actionTaken queueId=%{public}@ name=%{public}@ value=%{public}@",
+            log: Self.log,
+            type: .info,
+            message.queueId,
+            actionName,
+            actionValue
+        )
+        return false
+    }
+
+    func inboxMessageShown(message: InboxMessage) {
+        os_log("[CIO-Inbox] sample listener: shown queueId=%{public}@", log: Self.log, type: .info, message.queueId)
+    }
+
+    func inboxMessageOpened(message: InboxMessage) {
+        os_log("[CIO-Inbox] sample listener: opened queueId=%{public}@", log: Self.log, type: .info, message.queueId)
+    }
+
+    func inboxMessageDismissed(message: InboxMessage) {
+        os_log("[CIO-Inbox] sample listener: dismissed queueId=%{public}@", log: Self.log, type: .info, message.queueId)
     }
 }

--- a/Apps/APN-UIKit/APN UIKit/View/DashboardViewController.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/DashboardViewController.swift
@@ -241,6 +241,13 @@ class DashboardViewController: BaseViewController {
 /// click-through. While it's closed, only the floating bell's bottom-trailing corner stays
 /// interactive — and only if the overlay actually drew the bell there — so touches elsewhere (and an
 /// empty corner when the inbox is hidden) fall through to the dashboard.
+///
+/// NOTE: this is a **sample-grade** hand-rolled hit-test for embedding a SwiftUI overlay in a UIKit
+/// host, with inherent edge cases — e.g. touch capture is held for `closeSettleDelay` so taps don't
+/// leak through the fading scrim, which can briefly (~0.45s) block the dashboard if the inbox hides
+/// *instantly* (rather than via a panel close). In a SwiftUI app, mount `NotificationInboxOverlay`
+/// directly in a `ZStack` (see the CocoaPods-FCM sample) — SwiftUI handles touch passthrough
+/// natively and none of this container is needed.
 private final class InboxOverlayPassthroughView: UIView {
     /// `true` while the panel is presented or still animating closed; the container then captures the
     /// full screen. Driven indirectly via `setPanelPresented(_:)`.

--- a/Apps/APN-UIKit/APN UIKit/View/DashboardViewController.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/DashboardViewController.swift
@@ -257,9 +257,15 @@ private final class InboxOverlayPassthroughView: UIView {
         if capturesAllTouches {
             return super.hitTest(point, with: event)
         }
-        // Panel closed: only the bell's corner is interactive; pass everything else through.
+        // Panel closed: only the bell's corner is interactive; pass everything else through. The
+        // overlay pins the bell to SwiftUI's bottom-TRAILING corner — the right in LTR, the left in
+        // RTL — so anchor the zone to the trailing edge per the resolved layout direction (otherwise
+        // the bell is untappable in RTL and the wrong corner intercepts touches).
+        let originX = effectiveUserInterfaceLayoutDirection == .rightToLeft
+            ? bounds.minX
+            : bounds.maxX - bellZoneSize
         let bellZone = CGRect(
-            x: bounds.maxX - bellZoneSize,
+            x: originX,
             y: bounds.maxY - bellZoneSize,
             width: bellZoneSize,
             height: bellZoneSize

--- a/Apps/APN-UIKit/APN UIKit/View/DashboardViewController.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/DashboardViewController.swift
@@ -40,37 +40,42 @@ class DashboardViewController: BaseViewController {
         setEmailAndDeviceToken()
         configureVersionLabel()
         addAccessibilityIdentifiersForAppium()
-        addVisualInboxBell()
+        addVisualInboxOverlay()
     }
 
-    /// Demonstrates the recommended Visual Notification Inbox integration: place the SDK's public
-    /// `NotificationInboxBell` directly in your screen (here, pinned bottom-trailing on the dashboard)
-    /// and present `NotificationInboxView` when tapped — no app-wide passthrough overlay window needed.
-    /// The bell hides itself when there is nothing to show.
-    private func addVisualInboxBell() {
+    /// Demonstrates the drop-in Visual Notification Inbox integration: mount the SDK's public
+    /// `NotificationInboxOverlay` (floating bell + slide-out panel + dismiss scrim) on top of the
+    /// screen. Because the overlay is SwiftUI and this is a UIKit host, it's hosted in a full-screen
+    /// passthrough view: while the panel is closed, taps outside the bell fall through to the
+    /// dashboard; while it's open, the overlay captures them (so the scrim blocks click-through).
+    /// `onPanelPresentationChange` drives that capture toggle. The bell hides itself when there is
+    /// nothing to show.
+    private func addVisualInboxOverlay() {
         guard #available(iOS 15.0, *) else { return }
-        let bell = NotificationInboxBell(onTap: { [weak self] in self?.presentVisualInbox() })
-        let host = UIHostingController(rootView: bell)
+        let passthrough = InboxOverlayPassthroughView()
+        passthrough.backgroundColor = .clear
+        let overlay = NotificationInboxOverlay(onPanelPresentationChange: { [weak passthrough] isOpen in
+            // Capture full-screen touches only while the panel is presented; pass through otherwise.
+            passthrough?.capturesAllTouches = isOpen
+        })
+        let host = UIHostingController(rootView: overlay)
         host.view.backgroundColor = .clear
         addChild(host)
-        view.addSubview(host.view)
+        passthrough.addSubview(host.view)
         host.view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(passthrough)
+        passthrough.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            host.view.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16),
-            host.view.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -16),
-            host.view.widthAnchor.constraint(equalToConstant: 72),
-            host.view.heightAnchor.constraint(equalToConstant: 72)
+            passthrough.topAnchor.constraint(equalTo: view.topAnchor),
+            passthrough.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            passthrough.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            passthrough.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            host.view.topAnchor.constraint(equalTo: passthrough.topAnchor),
+            host.view.leadingAnchor.constraint(equalTo: passthrough.leadingAnchor),
+            host.view.trailingAnchor.constraint(equalTo: passthrough.trailingAnchor),
+            host.view.bottomAnchor.constraint(equalTo: passthrough.bottomAnchor)
         ])
         host.didMove(toParent: self)
-    }
-
-    /// Presents the embeddable `NotificationInboxView` (the Jist-rendered message list) in a sheet.
-    @available(iOS 15.0, *)
-    private func presentVisualInbox() {
-        let host = UIHostingController(rootView: NotificationInboxView())
-        host.title = "Notifications"
-        let nav = UINavigationController(rootViewController: host)
-        present(nav, animated: true)
     }
 
     func configureDashboardRouter() {
@@ -225,5 +230,41 @@ class DashboardViewController: BaseViewController {
 
     @IBAction func openLocationTest(_ sender: UIButton) {
         dashboardRouter?.routeToLocationTest()
+    }
+}
+
+/// Full-screen container that hosts the SwiftUI `NotificationInboxOverlay` in a UIKit screen.
+///
+/// While the inbox panel is closed (`capturesAllTouches == false`) only the floating bell's
+/// bottom-trailing corner stays interactive; touches anywhere else fall through to the views behind
+/// it, so the dashboard stays usable. While the panel is open the overlay's scrim must block
+/// click-through, so the host flips `capturesAllTouches` to `true` via `onPanelPresentationChange`
+/// and the container captures the full screen.
+///
+/// We gate the closed state on an explicit corner zone rather than SwiftUI's "no hit on empty space"
+/// behavior: once the hosting view has laid out the full-screen scrim/panel, it no longer reports
+/// empty regions as passthrough, which would otherwise leave the whole screen capturing touches
+/// after the panel is opened once.
+private final class InboxOverlayPassthroughView: UIView {
+    /// Set from `NotificationInboxOverlay`'s `onPanelPresentationChange`: `true` while the panel is open.
+    var capturesAllTouches = false
+
+    /// Size of the bottom-trailing square kept interactive while the panel is closed — large enough to
+    /// cover the overlay's floating bell (56pt) + its 16pt padding + unread badge overhang.
+    private let bellZoneSize: CGFloat = 160
+
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        if capturesAllTouches {
+            return super.hitTest(point, with: event)
+        }
+        // Panel closed: only the bell's corner is interactive; pass everything else through.
+        let bellZone = CGRect(
+            x: bounds.maxX - bellZoneSize,
+            y: bounds.maxY - bellZoneSize,
+            width: bellZoneSize,
+            height: bellZoneSize
+        )
+        guard bellZone.contains(point) else { return nil }
+        return super.hitTest(point, with: event)
     }
 }

--- a/Apps/APN-UIKit/APN UIKit/View/DashboardViewController.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/DashboardViewController.swift
@@ -55,8 +55,10 @@ class DashboardViewController: BaseViewController {
         let passthrough = InboxOverlayPassthroughView()
         passthrough.backgroundColor = .clear
         let overlay = NotificationInboxOverlay(onPanelPresentationChange: { [weak passthrough] isOpen in
-            // Capture full-screen touches only while the panel is presented; pass through otherwise.
-            passthrough?.capturesAllTouches = isOpen
+            // Capture full-screen touches while the panel is presented; pass through otherwise. The
+            // view keeps capturing briefly after `isOpen` flips false so taps don't leak to the
+            // dashboard through the still-fading scrim.
+            passthrough?.setPanelPresented(isOpen)
         })
         let host = UIHostingController(rootView: overlay)
         host.view.backgroundColor = .clear
@@ -235,42 +237,57 @@ class DashboardViewController: BaseViewController {
 
 /// Full-screen container that hosts the SwiftUI `NotificationInboxOverlay` in a UIKit screen.
 ///
-/// While the inbox panel is closed (`capturesAllTouches == false`) only the floating bell's
-/// bottom-trailing corner stays interactive; touches anywhere else fall through to the views behind
-/// it, so the dashboard stays usable. While the panel is open the overlay's scrim must block
-/// click-through, so the host flips `capturesAllTouches` to `true` via `onPanelPresentationChange`
-/// and the container captures the full screen.
-///
-/// We gate the closed state on an explicit corner zone rather than SwiftUI's "no hit on empty space"
-/// behavior: once the hosting view has laid out the full-screen scrim/panel, it no longer reports
-/// empty regions as passthrough, which would otherwise leave the whole screen capturing touches
-/// after the panel is opened once.
+/// While the panel is presented the container captures the full screen so the overlay's scrim blocks
+/// click-through. While it's closed, only the floating bell's bottom-trailing corner stays
+/// interactive — and only if the overlay actually drew the bell there — so touches elsewhere (and an
+/// empty corner when the inbox is hidden) fall through to the dashboard.
 private final class InboxOverlayPassthroughView: UIView {
-    /// Set from `NotificationInboxOverlay`'s `onPanelPresentationChange`: `true` while the panel is open.
-    var capturesAllTouches = false
+    /// `true` while the panel is presented or still animating closed; the container then captures the
+    /// full screen. Driven indirectly via `setPanelPresented(_:)`.
+    private var capturesAllTouches = false
+
+    /// Pending "stop capturing" work, scheduled when the panel closes and cancelled if it reopens.
+    private var endCaptureWorkItem: DispatchWorkItem?
+
+    /// Roughly the panel's close-animation settle time. Capture is held this long after the panel
+    /// reports closed so taps don't leak to the dashboard through the still-fading scrim.
+    private let closeSettleDelay: TimeInterval = 0.45
 
     /// Size of the bottom-trailing square kept interactive while the panel is closed — large enough to
     /// cover the overlay's floating bell (56pt) + its 16pt padding + unread badge overhang.
     private let bellZoneSize: CGFloat = 160
 
+    /// Driven by `NotificationInboxOverlay.onPanelPresentationChange`: capture turns on immediately on
+    /// open, and turns off only after `closeSettleDelay` on close (a reopen within the window cancels
+    /// the pending turn-off), so the fading scrim keeps blocking taps during the close animation.
+    func setPanelPresented(_ presented: Bool) {
+        endCaptureWorkItem?.cancel()
+        endCaptureWorkItem = nil
+        if presented {
+            capturesAllTouches = true
+        } else {
+            let work = DispatchWorkItem { [weak self] in self?.capturesAllTouches = false }
+            endCaptureWorkItem = work
+            DispatchQueue.main.asyncAfter(deadline: .now() + closeSettleDelay, execute: work)
+        }
+    }
+
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         if capturesAllTouches {
             return super.hitTest(point, with: event)
         }
-        // Panel closed: only the bell's corner is interactive; pass everything else through. The
-        // overlay pins the bell to SwiftUI's bottom-TRAILING corner — the right in LTR, the left in
-        // RTL — so anchor the zone to the trailing edge per the resolved layout direction (otherwise
-        // the bell is untappable in RTL and the wrong corner intercepts touches).
+        // Panel closed: only the bell's corner is interactive. The overlay pins the bell to SwiftUI's
+        // bottom-TRAILING corner — right in LTR, left in RTL — so anchor the zone to the trailing edge
+        // per the resolved layout direction.
         let originX = effectiveUserInterfaceLayoutDirection == .rightToLeft
             ? bounds.minX
             : bounds.maxX - bellZoneSize
-        let bellZone = CGRect(
-            x: originX,
-            y: bounds.maxY - bellZoneSize,
-            width: bellZoneSize,
-            height: bellZoneSize
-        )
+        let bellZone = CGRect(x: originX, y: bounds.maxY - bellZoneSize, width: bellZoneSize, height: bellZoneSize)
         guard bellZone.contains(point) else { return nil }
-        return super.hitTest(point, with: event)
+        // Within the corner, capture only if the overlay actually drew content there (the bell). When
+        // the inbox is hidden no bell is drawn, so `super.hitTest` resolves to this container — pass
+        // through (return nil) to keep the dashboard usable under an empty corner.
+        let hit = super.hitTest(point, with: event)
+        return hit === self ? nil : hit
     }
 }

--- a/Apps/APN-UIKit/APN UIKit/View/InboxViewController.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/InboxViewController.swift
@@ -1,4 +1,6 @@
 import CioMessagingInApp
+import CioMessagingInbox
+import SwiftUI
 import UIKit
 
 // MARK: - InboxMessageCell
@@ -175,6 +177,51 @@ class InboxViewController: BaseViewController, UITableViewDelegate, UITableViewD
         setupUI()
         // Observer will provide initial messages when registered
         setupObserver()
+        addVisualInboxBell()
+    }
+
+    /// Demonstrates the granular Visual Inbox UI (alongside this screen's headless `addChangeListener`
+    /// table): place the SDK's public `NotificationInboxBell` wherever you like — here pinned
+    /// bottom-trailing — and present the embeddable `NotificationInboxView` (the Jist-rendered list)
+    /// when it's tapped. The bell hides itself when there is nothing to show.
+    private func addVisualInboxBell() {
+        guard #available(iOS 15.0, *) else { return }
+        let bell = NotificationInboxBell(onTap: { [weak self] in self?.presentVisualInboxList() })
+        let host = UIHostingController(rootView: bell)
+        host.view.backgroundColor = .clear
+        addChild(host)
+        view.addSubview(host.view)
+        host.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            host.view.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16),
+            host.view.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -16),
+            host.view.widthAnchor.constraint(equalToConstant: 72),
+            host.view.heightAnchor.constraint(equalToConstant: 72)
+        ])
+        host.didMove(toParent: self)
+    }
+
+    /// Presents the embeddable `NotificationInboxView` in a dismissible sheet (Done button + grabber).
+    @available(iOS 15.0, *)
+    private func presentVisualInboxList() {
+        let host = UIHostingController(rootView: NotificationInboxView())
+        host.title = "Visual Inbox"
+        host.navigationItem.rightBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .done,
+            target: self,
+            action: #selector(dismissVisualInboxList)
+        )
+        let nav = UINavigationController(rootViewController: host)
+        nav.modalPresentationStyle = .pageSheet
+        if let sheet = nav.sheetPresentationController {
+            sheet.detents = [.medium(), .large()]
+            sheet.prefersGrabberVisible = true
+        }
+        present(nav, animated: true)
+    }
+
+    @objc private func dismissVisualInboxList() {
+        dismiss(animated: true)
     }
 
     deinit {

--- a/Apps/APN-UIKit/APN UIKit/View/InboxViewController.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/InboxViewController.swift
@@ -180,10 +180,8 @@ class InboxViewController: BaseViewController, UITableViewDelegate, UITableViewD
         addVisualInboxBell()
     }
 
-    /// Demonstrates the granular Visual Inbox UI (alongside this screen's headless `addChangeListener`
-    /// table): place the SDK's public `NotificationInboxBell` wherever you like — here pinned
-    /// bottom-trailing — and present the embeddable `NotificationInboxView` (the Jist-rendered list)
-    /// when it's tapped. The bell hides itself when there is nothing to show.
+    /// Demonstrates the granular Visual Inbox UI alongside this screen's headless `addChangeListener`
+    /// table: place `NotificationInboxBell` (here bottom-trailing) and present `NotificationInboxView`.
     private func addVisualInboxBell() {
         guard #available(iOS 15.0, *) else { return }
         let bell = NotificationInboxBell(onTap: { [weak self] in self?.presentVisualInboxList() })
@@ -206,11 +204,7 @@ class InboxViewController: BaseViewController, UITableViewDelegate, UITableViewD
     private func presentVisualInboxList() {
         let host = UIHostingController(rootView: NotificationInboxView())
         host.title = "Visual Inbox"
-        host.navigationItem.rightBarButtonItem = UIBarButtonItem(
-            barButtonSystemItem: .done,
-            target: self,
-            action: #selector(dismissVisualInboxList)
-        )
+        host.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissVisualInboxList))
         let nav = UINavigationController(rootViewController: host)
         nav.modalPresentationStyle = .pageSheet
         if let sheet = nav.sheetPresentationController {


### PR DESCRIPTION
Demonstrates the Visual Notification Inbox in the APN-UIKit sample: the dashboard mounts the drop-in overlay (with UIKit touch passthrough), the inbox screen keeps the headless list and adds the granular bell + embeddable list, and the app registers a log-only inbox event listener.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the APN-UIKit sample app (demo UI and logging); no SDK or production app behavior is modified.
> 
> **Overview**
> Extends the **APN-UIKit** sample to show three Visual Notification Inbox integration patterns: drop-in overlay on the dashboard, granular bell + list on the headless inbox screen, and an observational `InboxEventListener`.
> 
> On **startup**, the app registers `SampleInboxEventListener` via `MessagingInApp.shared.setInboxEventListener`, logging inbox lifecycle/action callbacks and returning `false` from `inboxMessageActionTaken` so the SDK keeps default URL handling.
> 
> The **dashboard** no longer pins `NotificationInboxBell` and presents `NotificationInboxView` in a nav sheet. It now hosts full-screen `NotificationInboxOverlay` inside a custom `InboxOverlayPassthroughView` that toggles touch capture from `onPanelPresentationChange` (full screen while open / during close settle; bell corner only when closed, with RTL-aware hit testing).
> 
> The **Inbox** screen keeps its UITableView + change listener demo and adds `NotificationInboxBell` plus a page-sheet presentation of `NotificationInboxView` (Done + grabber).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31c5956341196f92563a43b23146da949caa351b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->