### PR TITLE
chore(geofence): add a unique id to each geofence transition event

### DIFF
--- a/Sources/Common/Communication/Event.swift
+++ b/Sources/Common/Communication/Event.swift
@@ -170,6 +170,7 @@ public struct TrackGeofenceMetricEvent: EventRepresentable, GeofenceMetric {
     public let transition: GeofenceTransition
     public let timestamp: Date
     public let name: String?
+    public let transitionId: String
 
     public init(
         storageId: String = UUID().uuidString,
@@ -177,6 +178,7 @@ public struct TrackGeofenceMetricEvent: EventRepresentable, GeofenceMetric {
         transition: GeofenceTransition,
         timestamp: Date = Date(),
         name: String?,
+        transitionId: String,
         params: [String: String] = [:]
     ) {
         self.storageId = storageId
@@ -185,6 +187,7 @@ public struct TrackGeofenceMetricEvent: EventRepresentable, GeofenceMetric {
         self.transition = transition
         self.timestamp = timestamp
         self.name = name
+        self.transitionId = transitionId
     }
 }
 

--- a/Sources/Common/Type/GeofenceMetric.swift
+++ b/Sources/Common/Type/GeofenceMetric.swift
@@ -10,6 +10,8 @@ public protocol GeofenceMetric {
     var timestamp: Date { get }
     /// The geofence's name, or `nil` when unavailable.
     var name: String? { get }
+    /// Uniquely identifies this transition; stable across delivery retries.
+    var transitionId: String { get }
 }
 
 public extension GeofenceMetric {
@@ -18,11 +20,13 @@ public extension GeofenceMetric {
     var trackEventName: String { "Geofence Transition" }
 
     /// `/track` event properties. `geofenceName` is included only when a name is available.
-    /// `timestamp` is not a property — it is set on the event envelope by each delivery path.
+    /// `transitionId` uniquely identifies the transition and stays stable across delivery retries.
+    /// `timestamp` is not a property — it is set on the event envelope by each path.
     var trackEventProperties: [String: Any] {
         var properties: [String: Any] = [
             "transition": transition.rawValue,
-            "geofenceId": geofenceId
+            "geofenceId": geofenceId,
+            "transitionId": transitionId
         ]
         if let name {
             properties["geofenceName"] = name

--- a/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
@@ -83,7 +83,8 @@ final class GeofenceEventTracker: @unchecked Sendable {
             transition: transition,
             timestamp: now,
             userId: stampedUserId,
-            name: geofenceName
+            name: geofenceName,
+            transitionId: UUID().uuidString
         )
         _ = await pendingStore.append(metric)
 
@@ -145,7 +146,8 @@ final class GeofenceEventTracker: @unchecked Sendable {
             geofenceId: metric.geofenceId,
             transition: metric.transition,
             timestamp: metric.timestamp,
-            name: metric.name
+            name: metric.name,
+            transitionId: metric.transitionId
         ))
         logger.geofenceEventTracked(geofenceId: metric.geofenceId, transition: metric.transition)
     }

--- a/Sources/LocationGeofence/Storage/PendingGeofenceMetric.swift
+++ b/Sources/LocationGeofence/Storage/PendingGeofenceMetric.swift
@@ -12,6 +12,7 @@ struct PendingGeofenceMetric: Codable, Equatable, Sendable, GeofenceMetric {
     /// The geofence's name, resolved at capture time, or `nil` when unavailable. Travels with the
     /// metric so a delayed flush still has it even after the geofence leaves the cache.
     let name: String?
+    let transitionId: String
 
     /// Composite key over `(geofenceId, transition, timestamp_sec)` used for
     /// storage-layer dedup. Matches Android's `PendingGeofenceDelivery.key`.
@@ -27,13 +28,15 @@ struct PendingGeofenceMetric: Codable, Equatable, Sendable, GeofenceMetric {
         transition: GeofenceTransition,
         timestamp: Date,
         userId: String?,
-        name: String?
+        name: String?,
+        transitionId: String
     ) {
         self.geofenceId = geofenceId
         self.transition = transition
         self.timestamp = timestamp
         self.userId = userId
         self.name = name
+        self.transitionId = transitionId
     }
 
     enum CodingKeys: String, CodingKey {
@@ -42,5 +45,6 @@ struct PendingGeofenceMetric: Codable, Equatable, Sendable, GeofenceMetric {
         case timestamp
         case userId = "user_id"
         case name = "geofence_name"
+        case transitionId = "transition_id"
     }
 }

--- a/Tests/DataPipeline/DataPipelineEventBustTests.swift
+++ b/Tests/DataPipeline/DataPipelineEventBustTests.swift
@@ -69,7 +69,8 @@ class DataPipelineEventBustTests: IntegrationTest {
                 geofenceId: givenGeofenceId,
                 transition: .enter,
                 timestamp: capturedAt,
-                name: "HQ"
+                name: "HQ",
+                transitionId: "txn_enter_1"
             )
         )
 
@@ -89,6 +90,8 @@ class DataPipelineEventBustTests: IntegrationTest {
         XCTAssertNil(properties["latitude"])
         XCTAssertNil(properties["longitude"])
         XCTAssertEqual(trackEvent.timestamp, capturedAt.string(format: .iso8601WithMilliseconds))
+        // EventBus path carries the transitionId through to the analytics payload.
+        XCTAssertEqual(properties["transitionId"] as? String, "txn_enter_1")
     }
 
     func testSubscribeToJourneyEvents_DataPipelineHandlesTrackGeofenceMetricEvent_exit() async {
@@ -100,7 +103,8 @@ class DataPipelineEventBustTests: IntegrationTest {
                 geofenceId: givenGeofenceId,
                 transition: .exit,
                 timestamp: capturedAt,
-                name: nil
+                name: nil,
+                transitionId: "txn_exit_1"
             )
         )
 

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceDeliveryTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceDeliveryTrackerTests.swift
@@ -18,14 +18,16 @@ struct GeofenceDeliveryTrackerTests {
         geofenceId: String = "geo_1",
         transition: GeofenceTransition = .enter,
         timestamp: Date = Date(timeIntervalSince1970: 1700000000),
-        name: String? = nil
+        name: String? = nil,
+        transitionId: String = "txn_abc"
     ) -> PendingGeofenceMetric {
         PendingGeofenceMetric(
             geofenceId: geofenceId,
             transition: transition,
             timestamp: timestamp,
             userId: nil,
-            name: name
+            name: name,
+            transitionId: transitionId
         )
     }
 
@@ -55,6 +57,8 @@ struct GeofenceDeliveryTrackerTests {
         #expect(properties["longitude"] == nil)
         // No name on the metric → property omitted entirely (not sent empty/null).
         #expect(properties["geofenceName"] == nil)
+        // transitionId carried through verbatim from the persisted row.
+        #expect(properties["transitionId"] as? String == "txn_abc")
     }
 
     @Test

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -100,6 +100,29 @@ struct GeofenceEventTrackerTests {
     }
 
     @Test
+    func trackTransition_givenDeliveryFailsThenFlush_expectSameTransitionIdReused() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pending = makePendingStore(directory: dir)
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.failure(.transport)) }
+        let tracker = makeTracker(
+            storage: makeStorage(directory: dir),
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_42")
+        )
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter) // attempt 1 fails → row persists
+        await tracker.flushPending() // attempt 2 replays the persisted row
+
+        let metrics = delivery.trackMetricReceivedInvocations.map(\.metric)
+        #expect(metrics.count == 2)
+        #expect(metrics.first?.transitionId.isEmpty == false) // minted at capture
+        #expect(metrics[0].transitionId == metrics[1].transitionId) // reloaded from disk, reused verbatim
+    }
+
+    @Test
     func trackTransition_givenNoUserId_expectEventBusAndQueueDrained() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
@@ -421,7 +444,8 @@ struct GeofenceEventTrackerTests {
             geofenceId: "geo_1", transition: .enter,
             timestamp: Date(timeIntervalSince1970: 1),
             userId: "user_A",
-            name: nil
+            name: nil,
+            transitionId: "txn_a"
         ))
         let delivery = GeofenceDeliveryTrackerMock()
         delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
@@ -447,7 +471,8 @@ struct GeofenceEventTrackerTests {
             geofenceId: "geo_1", transition: .enter,
             timestamp: Date(timeIntervalSince1970: 1),
             userId: "user_A",
-            name: nil
+            name: nil,
+            transitionId: "txn_a"
         ))
         let delivery = GeofenceDeliveryTrackerMock()
         delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
@@ -474,7 +499,8 @@ struct GeofenceEventTrackerTests {
             geofenceId: "geo_1", transition: .enter,
             timestamp: capturedAt,
             userId: nil,
-            name: nil
+            name: nil,
+            transitionId: "txn_a"
         ))
         let delivery = GeofenceDeliveryTrackerMock()
         let bus = EventBusHandlerMock()

--- a/Tests/LocationGeofence/Geofence/Storage/PendingGeofenceMetricStoreTests.swift
+++ b/Tests/LocationGeofence/Geofence/Storage/PendingGeofenceMetricStoreTests.swift
@@ -14,13 +14,18 @@ struct PendingGeofenceMetricStoreTests {
         PendingGeofenceMetricStore(fileManager: .default, directoryURL: directory)
     }
 
-    private func makeMetric(geofenceId: String = "geo_1", transition: GeofenceTransition = .enter) -> PendingGeofenceMetric {
+    private func makeMetric(
+        geofenceId: String = "geo_1",
+        transition: GeofenceTransition = .enter,
+        transitionId: String = "txn_store"
+    ) -> PendingGeofenceMetric {
         PendingGeofenceMetric(
             geofenceId: geofenceId,
             transition: transition,
             timestamp: Date(timeIntervalSince1970: 1700000000),
             userId: nil,
-            name: nil
+            name: nil,
+            transitionId: transitionId
         )
     }
 
@@ -262,7 +267,8 @@ struct PendingGeofenceMetricStoreTests {
                                 transition: .enter,
                                 timestamp: Date(),
                                 userId: nil,
-                                name: nil
+                                name: nil,
+                                transitionId: "txn_\(i)_\(j)"
                             ))
                         case 1:
                             _ = await store.loadAll()

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -299,6 +299,7 @@ public interface CioInternalCommon.GeofenceMetric {
 	public var transition: GeofenceTransition;
 	public var timestamp: Date;
 	public var name: String?;
+	public var transitionId: String;
 }
 public enum CioInternalCommon.GeofenceTransition {
 }
@@ -602,7 +603,8 @@ public final class CioInternalCommon.TrackGeofenceMetricEvent {
 	public final val transition: GeofenceTransition;
 	public final val timestamp: Date;
 	public final val name: String?;
-	public fun init(storageId: String = UUID().uuidString, geofenceId: String, transition: GeofenceTransition, timestamp: Date = Date(), name: String?, params: List<String: String> = List<:>);
+	public final val transitionId: String;
+	public fun init(storageId: String = UUID().uuidString, geofenceId: String, transition: GeofenceTransition, timestamp: Date = Date(), name: String?, transitionId: String, params: List<String: String> = List<:>);
 }
 public final class CioInternalCommon.TrackInAppMetricEvent {
 	public final val storageId: String;


### PR DESCRIPTION
Adds a `transitionId` to every geofence transition so a single transition can be recognized across delivery attempts.

`transitionId` is a UUID, minted once when the transition is captured, persisted on the queued row, and reused verbatim on every delivery attempt. It's emitted in `properties` on both delivery paths — direct-HTTP and EventBus → DataPipeline — via the shared `GeofenceMetric.trackEventProperties`, so the same value rides along regardless of how the transition is sent.

Non-optional `String`: the id matters on every transition and the feature hasn't shipped, so there's no nullable/legacy state to carry.

Follow-up to #1127 (which restored at-least-once delivery): a retried transition can now be reconciled by its id.

## Changes
- `GeofenceMetric`: protocol gains `transitionId`; included in `trackEventProperties`.
- `PendingGeofenceMetric`: persisted field (`transition_id` JSON key).
- `TrackGeofenceMetricEvent`: carries `transitionId` through the EventBus path.
- `GeofenceEventTracker`: mints the UUID at capture, reuses it on each flush.

## Tests
- Direct-HTTP and EventBus paths both emit `transitionId` in properties.
- New: a transition that fails then replays from disk reuses the same id verbatim (also exercises the persisted round-trip).

## Notes
- api-docs regenerated for the additive `transitionId` on the public `TrackGeofenceMetricEvent` / `GeofenceMetric`.

https://linear.app/customerio/issue/MBL-1761

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive analytics field and required initializer parameter on unreleased geofence APIs; no auth or delivery semantics change beyond stable id on retries.
> 
> **Overview**
> Adds a **`transitionId`** (UUID minted at capture) so the same geofence transition can be recognized across **at-least-once delivery retries**.
> 
> The id is stored on **`PendingGeofenceMetric`** (`transition_id` on disk), threaded through **`TrackGeofenceMetricEvent`**, and included in **`GeofenceMetric.trackEventProperties`** so both **direct HTTP** and **EventBus → DataPipeline** emit the same `transitionId` in track properties. **`GeofenceEventTracker`** generates the UUID once in `trackTransition` and reuses it on flush/replay.
> 
> Tests cover property emission on both paths and a new case that failed delivery then **`flushPending`** keeps the same id. Public **api-docs** are updated for the additive API surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f59159a0b0dc78c25bb4ef3b7c4d9e372405c0da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->