### PR TITLE
feat(in-app): add dark mode support for in-app messages

### DIFF
--- a/Sources/MessagingInApp/Config/MessagingInAppConfigBuilder.swift
+++ b/Sources/MessagingInApp/Config/MessagingInAppConfigBuilder.swift
@@ -18,6 +18,7 @@ public class MessagingInAppConfigBuilder {
     // configuration options for MessagingInAppConfigOptions
     private let siteId: String
     private let region: Region
+    private var colorScheme: ColorScheme = .auto
 
     /// Initializes new `MessagingInAppConfigBuilder` with required configuration options.
     /// - Parameters:
@@ -28,11 +29,18 @@ public class MessagingInAppConfigBuilder {
         self.region = region
     }
 
+    @discardableResult
+    public func setColorScheme(_ colorScheme: ColorScheme) -> MessagingInAppConfigBuilder {
+        self.colorScheme = colorScheme
+        return self
+    }
+
     /// Builds and returns `MessagingInAppConfigOptions` instance from the configured properties.
     public func build() -> MessagingInAppConfigOptions {
         MessagingInAppConfigOptions(
             siteId: siteId,
-            region: region
+            region: region,
+            colorScheme: colorScheme
         )
     }
 }
@@ -74,6 +82,16 @@ public extension MessagingInAppConfigBuilder {
         let regionStr = sdkConfig[Keys.region.rawValue] as? String ?? ""
         let region = Region.getRegion(from: regionStr)
 
-        return MessagingInAppConfigBuilder(siteId: siteId, region: region).build()
+        let builder = MessagingInAppConfigBuilder(siteId: siteId, region: region)
+
+        if let colorSchemeStr = config["colorScheme"] as? String {
+            switch colorSchemeStr {
+            case "light": builder.setColorScheme(.light)
+            case "dark": builder.setColorScheme(.dark)
+            default: builder.setColorScheme(.auto)
+            }
+        }
+
+        return builder.build()
     }
 }

--- a/Sources/MessagingInApp/Config/MessagingInAppConfigOptions.swift
+++ b/Sources/MessagingInApp/Config/MessagingInAppConfigOptions.swift
@@ -6,4 +6,5 @@ import CioInternalCommon
 public struct MessagingInAppConfigOptions {
     public let siteId: String
     public let region: Region
+    public let colorScheme: ColorScheme
 }

--- a/Sources/MessagingInApp/Gist/EngineWeb/EngineWeb.swift
+++ b/Sources/MessagingInApp/Gist/EngineWeb/EngineWeb.swift
@@ -17,6 +17,7 @@ protocol EngineWebInstance: AutoMockable {
     var delegate: EngineWebDelegate? { get set }
     var view: UIView { get }
     func cleanEngineWeb()
+    func updateColorScheme(_ scheme: String)
 }
 
 public class EngineWeb: NSObject, EngineWebInstance {
@@ -89,6 +90,17 @@ public class EngineWeb: NSObject, EngineWebInstance {
         } else {
             logger.logWithModuleTag("Invalid URL: \(messageUrl)", level: .error)
             delegate?.error()
+        }
+    }
+
+    public func updateColorScheme(_ scheme: String) {
+        do {
+            let jsonData = try JSONEncoder().encode(["action": "updateColorScheme", "colorScheme": scheme])
+            guard let jsonString = String(data: jsonData, encoding: .utf8) else { return }
+            let js = "window.postMessage(\(jsonString), '*');"
+            webView.evaluateJavaScript(js, completionHandler: nil)
+        } catch {
+            logger.logWithModuleTag("Failed to encode color scheme update: \(error)", level: .error)
         }
     }
 

--- a/Sources/MessagingInApp/Gist/EngineWeb/EngineWeb.swift
+++ b/Sources/MessagingInApp/Gist/EngineWeb/EngineWeb.swift
@@ -35,7 +35,8 @@ public class EngineWeb: NSObject, EngineWebInstance {
         webView
     }
 
-    private let currentConfiguration: EngineWebConfiguration
+    private var currentConfiguration: EngineWebConfiguration
+    private let colorSchemeMode: ColorScheme
 
     public private(set) var currentRoute: String {
         get { _currentRoute }
@@ -46,6 +47,7 @@ public class EngineWeb: NSObject, EngineWebInstance {
     init(configuration: EngineWebConfiguration, state: InAppMessageState, message: Message) {
         self.currentMessage = message
         self.currentConfiguration = configuration
+        self.colorSchemeMode = state.colorScheme
 
         super.init()
 
@@ -171,6 +173,15 @@ extension EngineWeb: WKScriptMessageHandler {
 // swiftlint:enable cyclomatic_complexity
 extension EngineWeb: WKNavigationDelegate {
     public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        currentConfiguration = EngineWebConfiguration(
+            siteId: currentConfiguration.siteId,
+            dataCenter: currentConfiguration.dataCenter,
+            instanceId: currentConfiguration.instanceId,
+            endpoint: currentConfiguration.endpoint,
+            messageId: currentConfiguration.messageId,
+            properties: currentConfiguration.properties,
+            colorScheme: colorSchemeMode.resolve(with: webView.traitCollection)
+        )
         injectConfiguration(currentConfiguration)
     }
 

--- a/Sources/MessagingInApp/Gist/EngineWeb/EngineWeb.swift
+++ b/Sources/MessagingInApp/Gist/EngineWeb/EngineWeb.swift
@@ -96,6 +96,8 @@ public class EngineWeb: NSObject, EngineWebInstance {
     }
 
     public func updateColorScheme(_ scheme: String) {
+        applyInterfaceStyle(scheme)
+
         do {
             let jsonData = try JSONEncoder().encode(["action": "updateColorScheme", "colorScheme": scheme])
             guard let jsonString = String(data: jsonData, encoding: .utf8) else { return }
@@ -103,6 +105,17 @@ public class EngineWeb: NSObject, EngineWebInstance {
             webView.evaluateJavaScript(js, completionHandler: nil)
         } catch {
             logger.logWithModuleTag("Failed to encode color scheme update: \(error)", level: .error)
+        }
+    }
+
+    private func applyInterfaceStyle(_ scheme: String) {
+        switch scheme {
+        case "dark":
+            webView.overrideUserInterfaceStyle = .dark
+        case "light":
+            webView.overrideUserInterfaceStyle = .light
+        default:
+            webView.overrideUserInterfaceStyle = .unspecified
         }
     }
 
@@ -173,6 +186,8 @@ extension EngineWeb: WKScriptMessageHandler {
 // swiftlint:enable cyclomatic_complexity
 extension EngineWeb: WKNavigationDelegate {
     public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        let resolvedScheme = colorSchemeMode.resolve(with: webView.traitCollection)
+        applyInterfaceStyle(resolvedScheme)
         currentConfiguration = EngineWebConfiguration(
             siteId: currentConfiguration.siteId,
             dataCenter: currentConfiguration.dataCenter,

--- a/Sources/MessagingInApp/Gist/EngineWeb/EngineWeb.swift
+++ b/Sources/MessagingInApp/Gist/EngineWeb/EngineWeb.swift
@@ -195,7 +195,7 @@ extension EngineWeb: WKNavigationDelegate {
             endpoint: currentConfiguration.endpoint,
             messageId: currentConfiguration.messageId,
             properties: currentConfiguration.properties,
-            colorScheme: colorSchemeMode.resolve(with: webView.traitCollection)
+            colorScheme: resolvedScheme
         )
         injectConfiguration(currentConfiguration)
     }

--- a/Sources/MessagingInApp/Gist/EngineWeb/EngineWebConfiguration.swift
+++ b/Sources/MessagingInApp/Gist/EngineWeb/EngineWebConfiguration.swift
@@ -8,6 +8,7 @@ struct EngineWebConfiguration: Encodable {
     let messageId: String
     let livePreview: Bool = false
     let properties: [String: AnyEncodable?]?
+    let colorScheme: String?
 
     init(
         siteId: String,
@@ -15,7 +16,8 @@ struct EngineWebConfiguration: Encodable {
         instanceId: String,
         endpoint: String,
         messageId: String,
-        properties: [String: AnyEncodable?]?
+        properties: [String: AnyEncodable?]?,
+        colorScheme: String? = nil
     ) {
         self.siteId = siteId
         self.dataCenter = dataCenter
@@ -23,5 +25,6 @@ struct EngineWebConfiguration: Encodable {
         self.endpoint = endpoint
         self.messageId = messageId
         self.properties = properties
+        self.colorScheme = colorScheme
     }
 }

--- a/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
@@ -23,6 +23,8 @@ open class BaseMessageManager {
     var engine: EngineWebInstance!
     var gistView: GistView!
     var deeplinkUtil: DeepLinkUtil
+    private var lastResolvedColorScheme: String?
+    private var colorSchemeSubscriber: InAppMessageStoreSubscriber?
 
     // MARK: - Initializers
 
@@ -47,13 +49,15 @@ open class BaseMessageManager {
         self.deeplinkUtil = diGraph.deepLinkUtil
 
         // Create engine
+        let resolvedColorScheme = state.colorScheme.resolve(with: UITraitCollection.current)
         let engineWebConfiguration = EngineWebConfiguration(
             siteId: state.siteId,
             dataCenter: state.dataCenter,
             instanceId: message.instanceId,
             endpoint: state.environment.networkSettings.engineAPI,
             messageId: message.messageId,
-            properties: message.properties.mapValues { AnyEncodable($0) }
+            properties: message.properties.mapValues { AnyEncodable($0) },
+            colorScheme: resolvedColorScheme
         )
         self.engine = engineWebProvider.getEngineWebInstance(
             configuration: engineWebConfiguration,
@@ -64,12 +68,54 @@ open class BaseMessageManager {
 
         // Create GistView
         self.gistView = GistView(message: currentMessage, engineView: engine.view)
+        self.lastResolvedColorScheme = resolvedColorScheme
 
         // Set delegate and subscribe
         engine.delegate = self
+
+        // Subscribe to runtime colorScheme changes
+        subscribeToColorSchemeChanges()
+
+        // Handle system trait collection changes (dark mode toggle)
+        gistView.onTraitCollectionChange = { [weak self] traitCollection in
+            self?.handleTraitCollectionChange(traitCollection)
+        }
+    }
+
+    private func subscribeToColorSchemeChanges() {
+        colorSchemeSubscriber = {
+            let subscriber = InAppMessageStoreSubscriber { [weak self] state in
+                guard let self else { return }
+                let resolved = state.colorScheme.resolve(with: UITraitCollection.current)
+                if resolved != self.lastResolvedColorScheme {
+                    self.lastResolvedColorScheme = resolved
+                    self.threadUtil.runMain {
+                        self.engine.updateColorScheme(resolved)
+                    }
+                }
+            }
+            self.inAppMessageManager.subscribe(keyPath: \.colorScheme, subscriber: subscriber)
+            return subscriber
+        }()
+    }
+
+    private func handleTraitCollectionChange(_ traitCollection: UITraitCollection) {
+        inAppMessageManager.fetchState { [weak self] state in
+            guard let self else { return }
+            let resolved = state.colorScheme.resolve(with: traitCollection)
+            if resolved != self.lastResolvedColorScheme {
+                self.lastResolvedColorScheme = resolved
+                self.threadUtil.runMain {
+                    self.engine.updateColorScheme(resolved)
+                }
+            }
+        }
     }
 
     deinit {
+        if let subscriber = colorSchemeSubscriber {
+            inAppMessageManager.unsubscribe(subscriber: subscriber)
+        }
         removeEngineWebView()
     }
 

--- a/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
@@ -49,7 +49,7 @@ open class BaseMessageManager {
         self.deeplinkUtil = diGraph.deepLinkUtil
 
         // Create engine
-        let resolvedColorScheme = state.colorScheme.resolve(with: UITraitCollection.current)
+        let resolvedColorScheme = MessagingInAppImplementation.currentColorScheme.resolve(with: UITraitCollection.current)
         let engineWebConfiguration = EngineWebConfiguration(
             siteId: state.siteId,
             dataCenter: state.dataCenter,
@@ -100,14 +100,11 @@ open class BaseMessageManager {
     }
 
     private func handleTraitCollectionChange(_ traitCollection: UITraitCollection) {
-        inAppMessageManager.fetchState { [weak self] state in
-            guard let self else { return }
-            let resolved = state.colorScheme.resolve(with: traitCollection)
-            if resolved != self.lastResolvedColorScheme {
-                self.lastResolvedColorScheme = resolved
-                self.threadUtil.runMain {
-                    self.engine.updateColorScheme(resolved)
-                }
+        let resolved = MessagingInAppImplementation.currentColorScheme.resolve(with: traitCollection)
+        if resolved != lastResolvedColorScheme {
+            lastResolvedColorScheme = resolved
+            threadUtil.runMain { [weak self] in
+                self?.engine.updateColorScheme(resolved)
             }
         }
     }

--- a/Sources/MessagingInApp/Gist/Managers/ModalMessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/ModalMessageManager.swift
@@ -20,11 +20,12 @@ public class ModalMessageManager: BaseMessageManager {
         inAppMessageStoreSubscriber = {
             let subscriber = InAppMessageStoreSubscriber { [self] state in
                 let messageState = state.modalMessageState
+                let colorScheme = state.colorScheme
                 switch messageState {
                 case .displayed:
                     threadUtil.runMain {
                         // Subclasses (Modal or Inline) can show differently
-                        self.onMessageDisplayed()
+                        self.onMessageDisplayed(colorScheme: colorScheme)
                     }
                 case .dismissed, .initial:
                     threadUtil.runMain {
@@ -41,7 +42,7 @@ public class ModalMessageManager: BaseMessageManager {
     }
 
     // Show the modal when the message is displayed
-    func onMessageDisplayed() {
+    func onMessageDisplayed(colorScheme: ColorScheme = .auto) {
         guard isMessageLoaded else {
             logger.logWithModuleTag(
                 "Message not loaded yet. Skipping loadModalMessage for \(currentMessage.describeForLogs).",
@@ -62,7 +63,8 @@ public class ModalMessageManager: BaseMessageManager {
         modalViewManager = ModalViewManager(
             gistView: gistView,
             position: gistProperties.position,
-            overlayColor: gistProperties.overlayColor
+            overlayColor: gistProperties.overlayColor,
+            colorScheme: colorScheme
         )
         // Show the modal with an optional completion
         modalViewManager?.showModalView { [weak self] in

--- a/Sources/MessagingInApp/Gist/Managers/ModalMessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/ModalMessageManager.swift
@@ -100,7 +100,7 @@ public class ModalMessageManager: BaseMessageManager {
 
     private func subscribeToColorSchemeChanges() {
         colorSchemeSubscriber = {
-            let subscriber = InAppMessageStoreSubscriber { [weak self] state in
+            let subscriber = InAppMessageStoreSubscriber { [weak self] _ in
                 guard let self else { return }
                 let colorScheme = MessagingInAppImplementation.currentColorScheme
                 self.threadUtil.runMain {

--- a/Sources/MessagingInApp/Gist/Managers/ModalMessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/ModalMessageManager.swift
@@ -5,9 +5,12 @@ import UIKit
 public class ModalMessageManager: BaseMessageManager {
     private var modalViewManager: ModalViewManager?
     var inAppMessageStoreSubscriber: InAppMessageStoreSubscriber?
+    private var colorSchemeSubscriber: InAppMessageStoreSubscriber?
+
     override init(state: InAppMessageState, message: Message) {
         super.init(state: state, message: message)
         subscribeToInAppMessageState()
+        subscribeToColorSchemeChanges()
     }
 
     deinit {
@@ -20,9 +23,9 @@ public class ModalMessageManager: BaseMessageManager {
         inAppMessageStoreSubscriber = {
             let subscriber = InAppMessageStoreSubscriber { [self] state in
                 let messageState = state.modalMessageState
-                let colorScheme = state.colorScheme
                 switch messageState {
                 case .displayed:
+                    let colorScheme = MessagingInAppImplementation.currentColorScheme
                     threadUtil.runMain {
                         // Subclasses (Modal or Inline) can show differently
                         self.onMessageDisplayed(colorScheme: colorScheme)
@@ -95,11 +98,30 @@ public class ModalMessageManager: BaseMessageManager {
         modalViewManager.dismissModalView(completionHandler: dismissalHandler)
     }
 
+    private func subscribeToColorSchemeChanges() {
+        colorSchemeSubscriber = {
+            let subscriber = InAppMessageStoreSubscriber { [weak self] state in
+                guard let self else { return }
+                let colorScheme = MessagingInAppImplementation.currentColorScheme
+                self.threadUtil.runMain {
+                    self.modalViewManager?.updateColorScheme(colorScheme)
+                }
+            }
+            self.inAppMessageManager.subscribe(keyPath: \.colorScheme, subscriber: subscriber)
+            return subscriber
+        }()
+    }
+
     open func unsubscribeFromInAppMessageState() {
-        guard let subscriber = inAppMessageStoreSubscriber else { return }
-        logger.logWithModuleTag("Unsubscribing BaseMessageManager from InAppMessageState", level: .debug)
-        inAppMessageManager.unsubscribe(subscriber: subscriber)
-        inAppMessageStoreSubscriber = nil
+        if let subscriber = inAppMessageStoreSubscriber {
+            logger.logWithModuleTag("Unsubscribing BaseMessageManager from InAppMessageState", level: .debug)
+            inAppMessageManager.unsubscribe(subscriber: subscriber)
+            inAppMessageStoreSubscriber = nil
+        }
+        if let subscriber = colorSchemeSubscriber {
+            inAppMessageManager.unsubscribe(subscriber: subscriber)
+            colorSchemeSubscriber = nil
+        }
     }
 
     private func finishDismissal(messageState: ModalMessageState) {

--- a/Sources/MessagingInApp/Gist/Managers/ModalViewManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/ModalViewManager.swift
@@ -11,19 +11,21 @@ class ModalViewManager {
     var viewController: GistModalViewController!
     var position: MessagePosition
     var overlayColor: String?
+    let colorScheme: ColorScheme
 
-    init(gistView: GistView, position: MessagePosition, overlayColor: String?) {
+    init(gistView: GistView, position: MessagePosition, overlayColor: String?, colorScheme: ColorScheme = .auto) {
         self.viewController = GistModalViewController()
         viewController.gistView = gistView
         viewController.setup(position: position)
         self.position = position
         self.overlayColor = overlayColor
+        self.colorScheme = colorScheme
     }
 
     func showModalView(completionHandler: @escaping () -> Void) {
         viewController.view.isHidden = true
         window = getUIWindow()
-        inheritAppInterfaceStyle()
+        applyColorSchemeToWindow()
         window?.rootViewController = viewController
         window?.isHidden = false
         var finalPosition: CGFloat = 0
@@ -82,6 +84,17 @@ class ModalViewManager {
         window?.isHidden = true
         viewController.removeFromParent()
         window = nil
+    }
+
+    private func applyColorSchemeToWindow() {
+        switch colorScheme {
+        case .light:
+            window?.overrideUserInterfaceStyle = .light
+        case .dark:
+            window?.overrideUserInterfaceStyle = .dark
+        case .auto:
+            inheritAppInterfaceStyle()
+        }
     }
 
     private func inheritAppInterfaceStyle() {

--- a/Sources/MessagingInApp/Gist/Managers/ModalViewManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/ModalViewManager.swift
@@ -105,7 +105,7 @@ class ModalViewManager {
     private func inheritAppInterfaceStyle() {
         guard let appWindow = UIApplication.shared.connectedScenes
             .compactMap({ $0 as? UIWindowScene })
-            .flatMap({ $0.windows })
+            .flatMap(\.windows)
             .first(where: { $0 !== self.window }) else { return }
 
         if appWindow.overrideUserInterfaceStyle != .unspecified {

--- a/Sources/MessagingInApp/Gist/Managers/ModalViewManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/ModalViewManager.swift
@@ -98,6 +98,7 @@ class ModalViewManager {
         case .dark:
             window?.overrideUserInterfaceStyle = .dark
         case .auto:
+            window?.overrideUserInterfaceStyle = .unspecified
             inheritAppInterfaceStyle()
         }
     }

--- a/Sources/MessagingInApp/Gist/Managers/ModalViewManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/ModalViewManager.swift
@@ -23,6 +23,7 @@ class ModalViewManager {
     func showModalView(completionHandler: @escaping () -> Void) {
         viewController.view.isHidden = true
         window = getUIWindow()
+        inheritAppInterfaceStyle()
         window?.rootViewController = viewController
         window?.isHidden = false
         var finalPosition: CGFloat = 0
@@ -81,6 +82,19 @@ class ModalViewManager {
         window?.isHidden = true
         viewController.removeFromParent()
         window = nil
+    }
+
+    private func inheritAppInterfaceStyle() {
+        guard let appWindow = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .flatMap({ $0.windows })
+            .first(where: { $0 !== self.window }) else { return }
+
+        if appWindow.overrideUserInterfaceStyle != .unspecified {
+            window?.overrideUserInterfaceStyle = appWindow.overrideUserInterfaceStyle
+        } else if let rootVC = appWindow.rootViewController, rootVC.overrideUserInterfaceStyle != .unspecified {
+            window?.overrideUserInterfaceStyle = rootVC.overrideUserInterfaceStyle
+        }
     }
 
     private func getUIWindow() -> UIWindow {

--- a/Sources/MessagingInApp/Gist/Managers/ModalViewManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/ModalViewManager.swift
@@ -11,7 +11,7 @@ class ModalViewManager {
     var viewController: GistModalViewController!
     var position: MessagePosition
     var overlayColor: String?
-    let colorScheme: ColorScheme
+    var colorScheme: ColorScheme
 
     init(gistView: GistView, position: MessagePosition, overlayColor: String?, colorScheme: ColorScheme = .auto) {
         self.viewController = GistModalViewController()
@@ -84,6 +84,11 @@ class ModalViewManager {
         window?.isHidden = true
         viewController.removeFromParent()
         window = nil
+    }
+
+    func updateColorScheme(_ newColorScheme: ColorScheme) {
+        colorScheme = newColorScheme
+        applyColorSchemeToWindow()
     }
 
     private func applyColorSchemeToWindow() {

--- a/Sources/MessagingInApp/Gist/Views/GistView.swift
+++ b/Sources/MessagingInApp/Gist/Views/GistView.swift
@@ -16,6 +16,7 @@ public protocol GistViewLifecycleDelegate: AnyObject {
 public class GistView: UIView {
     public weak var delegate: GistViewDelegate?
     public weak var lifecycleDelegate: GistViewLifecycleDelegate?
+    var onTraitCollectionChange: ((UITraitCollection) -> Void)?
     var message: Message?
 
     convenience init(message: Message, engineView: UIView) {
@@ -23,6 +24,13 @@ public class GistView: UIView {
         self.message = message
         addSubview(engineView)
         engineView.autoresizingMask = [.flexibleWidth, .flexibleHeight, .flexibleBottomMargin, .flexibleRightMargin]
+    }
+
+    override public func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
+            onTraitCollectionChange?(traitCollection)
+        }
     }
 
     override public func removeFromSuperview() {

--- a/Sources/MessagingInApp/MessagingInApp.swift
+++ b/Sources/MessagingInApp/MessagingInApp.swift
@@ -9,6 +9,8 @@ public protocol MessagingInAppInstance: AutoMockable {
     func setEventListener(_ eventListener: InAppEventListener?)
 
     func dismissMessage()
+
+    func setColorScheme(_ colorScheme: ColorScheme)
 }
 
 public class MessagingInApp: ModuleTopLevelObject<MessagingInAppInstance>, MessagingInAppInstance {
@@ -83,5 +85,9 @@ public class MessagingInApp: ModuleTopLevelObject<MessagingInAppInstance>, Messa
     // Dismiss in-app message
     public func dismissMessage() {
         implementation?.dismissMessage()
+    }
+
+    public func setColorScheme(_ colorScheme: ColorScheme) {
+        implementation?.setColorScheme(colorScheme)
     }
 }

--- a/Sources/MessagingInApp/MessagingInAppImplementation.swift
+++ b/Sources/MessagingInApp/MessagingInAppImplementation.swift
@@ -27,7 +27,8 @@ class MessagingInAppImplementation: MessagingInAppInstance {
         inAppMessageManager.dispatch(action: .initialize(
             siteId: moduleConfig.siteId,
             dataCenter: moduleConfig.region.rawValue,
-            environment: GistEnvironment.production
+            environment: GistEnvironment.production,
+            colorScheme: moduleConfig.colorScheme
         )) {
             self.subscribeToEventBus()
         }
@@ -72,5 +73,9 @@ class MessagingInAppImplementation: MessagingInAppInstance {
     // Dismiss in-app message
     func dismissMessage() {
         gist.dismissMessage()
+    }
+
+    func setColorScheme(_ colorScheme: ColorScheme) {
+        inAppMessageManager.dispatch(action: .setColorScheme(colorScheme: colorScheme))
     }
 }

--- a/Sources/MessagingInApp/MessagingInAppImplementation.swift
+++ b/Sources/MessagingInApp/MessagingInAppImplementation.swift
@@ -2,6 +2,8 @@ import CioInternalCommon
 import Foundation
 
 class MessagingInAppImplementation: MessagingInAppInstance {
+    @Atomic static var currentColorScheme: ColorScheme = .auto
+
     private let moduleConfig: MessagingInAppConfigOptions
 
     private let logger: Logger
@@ -20,6 +22,7 @@ class MessagingInAppImplementation: MessagingInAppInstance {
         self.eventBusHandler = diGraph.eventBusHandler
         self.notificationInbox = diGraph.notificationInbox
 
+        Self.currentColorScheme = moduleConfig.colorScheme
         subscribeToInAppMessageState()
     }
 
@@ -76,6 +79,7 @@ class MessagingInAppImplementation: MessagingInAppInstance {
     }
 
     func setColorScheme(_ colorScheme: ColorScheme) {
+        Self.currentColorScheme = colorScheme
         inAppMessageManager.dispatch(action: .setColorScheme(colorScheme: colorScheme))
     }
 }

--- a/Sources/MessagingInApp/MessagingInAppImplementation.swift
+++ b/Sources/MessagingInApp/MessagingInAppImplementation.swift
@@ -2,6 +2,10 @@ import CioInternalCommon
 import Foundation
 
 class MessagingInAppImplementation: MessagingInAppInstance {
+    // Synchronous storage for color scheme to avoid a race condition where
+    // setColorScheme() dispatches to the async store but a message displays
+    // before the store processes it. The store dispatch keeps state consistent
+    // for subscribers; this static provides the immediate value for rendering.
     @Atomic static var currentColorScheme: ColorScheme = .auto
 
     private let moduleConfig: MessagingInAppConfigOptions

--- a/Sources/MessagingInApp/State/InAppMessageAction.swift
+++ b/Sources/MessagingInApp/State/InAppMessageAction.swift
@@ -3,7 +3,8 @@ import Foundation
 /// Represents an action that can be dispatched to InAppMessage store.
 /// It acts like a sealed class, so that only the cases defined here can be used with InAppMessage store.
 enum InAppMessageAction: Equatable {
-    case initialize(siteId: String, dataCenter: String, environment: GistEnvironment)
+    case initialize(siteId: String, dataCenter: String, environment: GistEnvironment, colorScheme: ColorScheme = .auto)
+    case setColorScheme(colorScheme: ColorScheme)
     case setPollingInterval(interval: Double)
     case setSseEnabled(enabled: Bool)
     case setUserIdentifier(user: String)
@@ -51,8 +52,11 @@ enum InAppMessageAction: Equatable {
     // swiftlint:disable cyclomatic_complexity
     static func == (lhs: InAppMessageAction, rhs: InAppMessageAction) -> Bool {
         switch (lhs, rhs) {
-        case (.initialize(let lhsSiteId, let lhsDataCenter, let lhsEnvironment), .initialize(let rhsSiteId, let rhsDataCenter, let rhsEnvironment)):
-            return lhsSiteId == rhsSiteId && lhsDataCenter == rhsDataCenter && lhsEnvironment == rhsEnvironment
+        case (.initialize(let lhsSiteId, let lhsDataCenter, let lhsEnvironment, let lhsColorScheme), .initialize(let rhsSiteId, let rhsDataCenter, let rhsEnvironment, let rhsColorScheme)):
+            return lhsSiteId == rhsSiteId && lhsDataCenter == rhsDataCenter && lhsEnvironment == rhsEnvironment && lhsColorScheme == rhsColorScheme
+
+        case (.setColorScheme(let lhsColorScheme), .setColorScheme(let rhsColorScheme)):
+            return lhsColorScheme == rhsColorScheme
 
         case (.setPollingInterval(let lhsInterval), .setPollingInterval(let rhsInterval)):
             return lhsInterval == rhsInterval

--- a/Sources/MessagingInApp/State/InAppMessageMiddleware.swift
+++ b/Sources/MessagingInApp/State/InAppMessageMiddleware.swift
@@ -28,6 +28,7 @@ func userAuthenticationMiddleware() -> InAppMessageMiddleware {
         // Block actions that require valid userId or anonymousId unless at least one is set.
         switch action {
         case .initialize,
+             .setColorScheme,
              .setUserIdentifier,
              .setAnonymousIdentifier,
              .setPageRoute,

--- a/Sources/MessagingInApp/State/InAppMessageReducer.swift
+++ b/Sources/MessagingInApp/State/InAppMessageReducer.swift
@@ -26,8 +26,11 @@ func inAppMessageReducer(logger: Logger) -> InAppMessageReducer {
 /// Reducer function implementation for managing InAppMessageState based on the action received.
 private func reducer(action: InAppMessageAction, state: InAppMessageState) -> InAppMessageState {
     switch action {
-    case .initialize(let siteId, let dataCenter, let environment):
-        return InAppMessageState(siteId: siteId, dataCenter: dataCenter, environment: environment)
+    case .initialize(let siteId, let dataCenter, let environment, let colorScheme):
+        return InAppMessageState(siteId: siteId, dataCenter: dataCenter, environment: environment, colorScheme: colorScheme)
+
+    case .setColorScheme(let colorScheme):
+        return state.copy(colorScheme: colorScheme)
 
     case .setPollingInterval(let interval):
         return state.copy(pollInterval: interval)
@@ -153,7 +156,8 @@ private func reducer(action: InAppMessageAction, state: InAppMessageState) -> In
         return InAppMessageState(
             siteId: state.siteId,
             dataCenter: state.dataCenter,
-            environment: state.environment
+            environment: state.environment,
+            colorScheme: state.colorScheme
         )
     }
 }

--- a/Sources/MessagingInApp/State/InAppMessageState.swift
+++ b/Sources/MessagingInApp/State/InAppMessageState.swift
@@ -8,6 +8,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
     let siteId: String
     let dataCenter: String
     let environment: GistEnvironment
+    let colorScheme: ColorScheme
     let pollInterval: Double
     let userId: String?
     let anonymousId: String?
@@ -23,6 +24,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
         siteId: String = "",
         dataCenter: String = "",
         environment: GistEnvironment = .production,
+        colorScheme: ColorScheme = .auto,
         pollInterval: Double = 600,
         userId: String? = nil,
         anonymousId: String? = nil,
@@ -37,6 +39,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
         self.siteId = siteId
         self.dataCenter = dataCenter
         self.environment = environment
+        self.colorScheme = colorScheme
         self.pollInterval = pollInterval
         self.userId = userId
         self.anonymousId = anonymousId
@@ -52,6 +55,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
     /// Copies the current state and replaces the given properties with the new values.
     /// It is useful when updating state with only a few properties and keeping the rest as is.
     func copy(
+        colorScheme: ColorScheme? = nil,
         pollInterval: Double? = nil,
         userId: String? = nil,
         anonymousId: String? = nil,
@@ -67,6 +71,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
             siteId: siteId,
             dataCenter: dataCenter,
             environment: environment,
+            colorScheme: colorScheme ?? self.colorScheme,
             pollInterval: pollInterval ?? self.pollInterval,
             userId: userId ?? self.userId,
             anonymousId: anonymousId ?? self.anonymousId,
@@ -84,6 +89,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
         lhs.siteId == rhs.siteId &&
             lhs.dataCenter == rhs.dataCenter &&
             lhs.environment == rhs.environment &&
+            lhs.colorScheme == rhs.colorScheme &&
             lhs.pollInterval == rhs.pollInterval &&
             lhs.userId == rhs.userId &&
             lhs.anonymousId == rhs.anonymousId &&
@@ -101,6 +107,7 @@ struct InAppMessageState: Equatable, CustomStringConvertible {
             siteId: '\(siteId)',
             dataCenter: '\(dataCenter)',
             environment: \(environment),
+            colorScheme: \(colorScheme),
             pollInterval: \(pollInterval),
             userId: \(String(describing: userId)),
             anonymousId: \(String(describing: anonymousId)),
@@ -150,6 +157,7 @@ extension InAppMessageState {
         putIfDifferent(\.siteId, as: "siteId")
         putIfDifferent(\.dataCenter, as: "dataCenter")
         putIfDifferent(\.environment, as: "environment")
+        putIfDifferent(\.colorScheme, as: "colorScheme")
         putIfDifferent(\.pollInterval, as: "pollInterval")
         putIfDifferent(\.userId, as: "userId")
         putIfDifferent(\.anonymousId, as: "anonymousId")

--- a/Sources/MessagingInApp/Type/ColorScheme.swift
+++ b/Sources/MessagingInApp/Type/ColorScheme.swift
@@ -1,0 +1,18 @@
+import UIKit
+
+public enum ColorScheme: Equatable {
+    case light
+    case dark
+    case auto
+
+    func resolve(with traitCollection: UITraitCollection) -> String {
+        switch self {
+        case .light:
+            return "light"
+        case .dark:
+            return "dark"
+        case .auto:
+            return traitCollection.userInterfaceStyle == .dark ? "dark" : "light"
+        }
+    }
+}

--- a/Tests/MessagingInApp/MessagingInAppImplementationTest.swift
+++ b/Tests/MessagingInApp/MessagingInAppImplementationTest.swift
@@ -108,10 +108,11 @@ class MessagingInAppImplementationTest: IntegrationTest {
         inAppMessageManagerMock.subscribeReturnValue = Task {}
 
         if let dispatchArgs = inAppMessageManagerMock.dispatchReceivedArguments?.action {
-            if case .initialize(let siteId, let dataCenter, let environment) = dispatchArgs {
+            if case .initialize(let siteId, let dataCenter, let environment, let colorScheme) = dispatchArgs {
                 XCTAssertEqual(siteId, messagingInAppConfigOptions.siteId)
                 XCTAssertEqual(dataCenter, messagingInAppConfigOptions.region.rawValue)
                 XCTAssertEqual(environment, GistEnvironment.production)
+                XCTAssertEqual(colorScheme, messagingInAppConfigOptions.colorScheme)
             } else {
                 XCTFail("Expected dispatch action to be .initialize")
             }

--- a/Tests/Mocks/MessagingInApp/AutoMockable.generated.swift
+++ b/Tests/Mocks/MessagingInApp/AutoMockable.generated.swift
@@ -494,6 +494,27 @@ class EngineWebInstanceMock: @unchecked Sendable, EngineWebInstance, Mock {
         _cleanEngineWebCallsCount += 1
         cleanEngineWebClosure?()
     }
+
+    // MARK: - updateColorScheme
+
+    private let _updateColorSchemeCallsCount: CioInternalCommon.Synchronized<Int> = .init(0)
+    var updateColorSchemeCallsCount: Int {
+        _updateColorSchemeCallsCount.wrappedValue
+    }
+
+    var updateColorSchemeCalled: Bool {
+        updateColorSchemeCallsCount > 0
+    }
+
+    var updateColorSchemeReceivedArguments: String?
+    var updateColorSchemeClosure: ((String) -> Void)?
+
+    func updateColorScheme(_ scheme: String) {
+        mockCalled = true
+        _updateColorSchemeCallsCount += 1
+        updateColorSchemeReceivedArguments = scheme
+        updateColorSchemeClosure?(scheme)
+    }
 }
 
 /**
@@ -1913,6 +1934,27 @@ public class MessagingInAppInstanceMock: @unchecked Sendable, MessagingInAppInst
         mockCalled = true
         _dismissMessageCallsCount += 1
         dismissMessageClosure?()
+    }
+
+    // MARK: - setColorScheme
+
+    private let _setColorSchemeCallsCount: CioInternalCommon.Synchronized<Int> = .init(0)
+    public var setColorSchemeCallsCount: Int {
+        _setColorSchemeCallsCount.wrappedValue
+    }
+
+    public var setColorSchemeCalled: Bool {
+        setColorSchemeCallsCount > 0
+    }
+
+    public var setColorSchemeReceivedArguments: ColorScheme?
+    public var setColorSchemeClosure: ((ColorScheme) -> Void)?
+
+    public func setColorScheme(_ colorScheme: ColorScheme) {
+        mockCalled = true
+        _setColorSchemeCallsCount += 1
+        setColorSchemeReceivedArguments = colorScheme
+        setColorSchemeClosure?(colorScheme)
     }
 }
 

--- a/api-docs/CioMessagingInApp.api
+++ b/api-docs/CioMessagingInApp.api
@@ -8,10 +8,13 @@ public final class CioMessagingInApp.AnyEncodable {
 public interface CioMessagingInApp.AnyStoreSubscriber {
 	public fun func _newState(state: Any);
 }
+public enum CioMessagingInApp.ColorScheme {
+}
 public final class CioMessagingInApp.EngineWeb {
 	public var delegate: (any EngineWebDelegate)?;
 	public var view: UIView;
 	public var currentRoute: String;
+	public fun func updateColorScheme(_ scheme: String);
 	public fun func cleanEngineWeb();
 }
 public interface CioMessagingInApp.EngineWebDelegate {
@@ -44,6 +47,7 @@ public final class CioMessagingInApp.GistProperties {
 public final class CioMessagingInApp.GistView {
 	public var delegate: (any GistViewDelegate)?;
 	public var lifecycleDelegate: (any GistViewLifecycleDelegate)?;
+	public fun override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?);
 	public fun override func removeFromSuperview();
 }
 public interface CioMessagingInApp.GistViewDelegate {
@@ -140,9 +144,11 @@ public final class CioMessagingInApp.MessagingInApp {
 	public fun func initialize(withConfig config: MessagingInAppConfigOptions) -> MessagingInAppInstance;
 	public fun func setEventListener(_ eventListener: InAppEventListener?);
 	public fun func dismissMessage();
+	public fun func setColorScheme(_ colorScheme: ColorScheme);
 }
 public final class CioMessagingInApp.MessagingInAppConfigBuilder {
 	public fun init(siteId: String, region: Region);
+	public fun func setColorScheme(_ colorScheme: ColorScheme) -> MessagingInAppConfigBuilder;
 	public fun func build() -> MessagingInAppConfigOptions;
 }
 public enum CioMessagingInApp.MessagingInAppConfigBuilderError {
@@ -150,11 +156,13 @@ public enum CioMessagingInApp.MessagingInAppConfigBuilderError {
 public final class CioMessagingInApp.MessagingInAppConfigOptions {
 	public final val siteId: String;
 	public final val region: Region;
+	public final val colorScheme: ColorScheme;
 }
 public interface CioMessagingInApp.MessagingInAppInstance {
 	public var inbox: any NotificationInbox;
 	public fun func setEventListener(_ eventListener: InAppEventListener?);
 	public fun func dismissMessage();
+	public fun func setColorScheme(_ colorScheme: ColorScheme);
 }
 public final class CioMessagingInApp.ModalMessageManager {
 	public fun deinit;


### PR DESCRIPTION
https://github.com/user-attachments/assets/3280486d-c245-481b-bba4-d94468ef6313

## Summary
- Adds `ColorScheme` enum (`.light`, `.dark`, `.auto`) as a public API on `MessagingInAppConfigOptions`
- `.auto` (the default) resolves the current app dark mode state via `UITraitCollection.userInterfaceStyle` and sends `"light"` or `"dark"` to the Gist renderer via the existing `postMessage` protocol
- **Modal messages**: Sets `overrideUserInterfaceStyle` on the modal UIWindow to control WKWebView's CSS `prefers-color-scheme`. For `.auto`, inherits the app window's override if present (supports apps with in-app dark mode toggles)
- **Inline messages**: Sets `overrideUserInterfaceStyle` on the WKWebView directly, since inline views live in the app's own window
- Live theme changes are detected via `GistView.traitCollectionDidChange` and pushed to active WebViews
- Exposes `MessagingInApp.shared.setColorScheme()` for runtime changes — stored synchronously to avoid async Task race conditions, then dispatched to the state store for consistency
- Color scheme flows through the state store (`initialize` action → `InAppMessageState`) for consistency and testability

Companion to Android PR: https://github.com/customerio/customerio-android/pull/761

## Usage
```swift
// Default: follows app dark mode automatically
let config = MessagingInAppConfigBuilder(siteId: siteId, region: .US).build()

// Force light or dark at init
let config = MessagingInAppConfigBuilder(siteId: siteId, region: .US)
    .setColorScheme(.dark)
    .build()

// Change at runtime (persists for the session)
MessagingInApp.shared.setColorScheme(.dark)
```

## Test plan
- [x] `AUTO` mode: in-app message follows system dark mode toggle
- [x] `AUTO` mode with app window override (`.overrideUserInterfaceStyle = .dark`): message matches app, ignores system
- [x] `AUTO` mode with Info.plist `UIUserInterfaceStyle = Dark`: message renders dark, ignores system
- [x] `.dark` via builder: message always dark regardless of system
- [x] `.dark` via runtime `setColorScheme()`: message always dark regardless of system
- [x] Toggling system dark mode while message displayed: message updates live (AUTO) or stays locked (LIGHT/DARK)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches message display (modal windows, WKWebView styling, JS bridge) and introduces dual sync/static + store state that must stay consistent; behavior is UI-facing but not auth or data-path critical.
> 
> **Overview**
> Adds a public **`ColorScheme`** (`.light`, `.dark`, `.auto`, default `.auto`) on in-app config and **`MessagingInApp.shared.setColorScheme()`**, with wrapper SDK parsing for `colorScheme` strings.
> 
> Theme is stored in **`InAppMessageState`** (`initialize` / **`setColorScheme`** actions) and mirrored synchronously on **`MessagingInAppImplementation.currentColorScheme`** so rendering does not race the async store.
> 
> **Gist WebViews** get resolved `"light"`/`"dark"` in **`EngineWebConfiguration`**, **`overrideUserInterfaceStyle`** on the WKWebView, and live updates via **`updateColorScheme`** (`postMessage` + JS). **Modal** overlays apply the scheme on a dedicated **`UIWindow`** (with **`.auto`** inheriting the app window’s override); **inline** paths use **`BaseMessageManager`** subscriptions and **`GistView.traitCollectionDidChange`** for system toggles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c5d980f420ce1ff2812c2b6b3bf3b7bdd3e54e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->