### PR TITLE
ci: remove fixed 20 minute release wait, parallelize pod pushes, pin release tooling

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -91,14 +91,15 @@ jobs:
         uses: cycjimmy/semantic-release-action@0a51e81a6baff2acad3ee88f4121c589c73d0f0e # v4.2.0
         id: semantic-release
         with:
-          # version numbers below can be in many forms: M, M.m, M.m.p
-          # version should be greater than the 22.0.1 (https://github.com/semantic-release/semantic-release/releases/tag/v22.0.1)
-          # because previous version had a bug in commit analyzer
-          semantic_version: latest
+          # Versions are pinned so a new semantic-release or plugin release cannot change
+          # deployment behavior without a change in this repo. Bump deliberately.
+          # Must stay above 22.0.1, which had a bug in the commit analyzer:
+          # https://github.com/semantic-release/semantic-release/releases/tag/v22.0.1
+          semantic_version: 25.0.5
           extra_plugins: |
             conventional-changelog-conventionalcommits@8
-            @semantic-release/github
-            @semantic-release/exec
+            @semantic-release/github@12.0.9
+            @semantic-release/exec@7.1.0
         env:
           # Needs to push git commits to repo. Needs write access.
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
@@ -185,6 +186,8 @@ jobs:
     env:
       COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
     runs-on: macos-15
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
     steps:
       - name: Checkout git tag that got created in previous step
         uses: actions/checkout@v4
@@ -210,27 +213,45 @@ jobs:
       - uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@MacOS-15+iOS-26
 
       - name: Install cocoapods
-        run: gem install cocoapods
-      - name: '⚠️ Note: Pushing to cocoapods is flaky. If you see some errors in these logs while deploying, re-run this GitHub Action to try deployment again and it might fix the issue.'
-        run: echo ''
+        # Pinned so a new cocoapods release cannot break deployments. Bump deliberately.
+        run: gem install cocoapods -v 1.16.2
+
       - name: Push all podspecs to CocoaPods
         run: |
-          podspecs=(
-            CustomerIOCommon.podspec
-            CustomerIOTrackingMigration.podspec
-            CustomerIODataPipelines.podspec
-            CustomerIOMessagingPush.podspec
-            CustomerIOMessagingPushAPN.podspec
-            CustomerIOMessagingPushFCM.podspec
-            CustomerIOMessagingInApp.podspec
-            CustomerIOLocation.podspec
-            CustomerIO.podspec
+          # Podspecs are grouped into tiers by their dependencies on each other.
+          # Pods within a tier do not depend on each other, so they push in parallel.
+          # Tiers push in order because `pod trunk push` lints each podspec and the
+          # dependency versions pushed by the previous tier must already exist.
+          tiers=(
+            "CustomerIOCommon.podspec"
+            "CustomerIOTrackingMigration.podspec CustomerIOMessagingPush.podspec CustomerIOMessagingInApp.podspec CustomerIOLocation.podspec"
+            "CustomerIODataPipelines.podspec CustomerIOMessagingPushAPN.podspec CustomerIOMessagingPushFCM.podspec"
+            "CustomerIO.podspec"
           )
 
           failed_pods=()
-          for podspec in "${podspecs[@]}"; do
-            if ! ./scripts/push-cocoapod.sh "$podspec"; then
-              failed_pods+=("$podspec")
+          for tier in "${tiers[@]}"; do
+            pids=()
+            specs=()
+            for podspec in $tier; do
+              ./scripts/push-cocoapod.sh "$podspec" > "push-log-$podspec.txt" 2>&1 &
+              pids+=($!)
+              specs+=("$podspec")
+            done
+
+            for i in "${!pids[@]}"; do
+              if ! wait "${pids[$i]}"; then
+                failed_pods+=("${specs[$i]}")
+              fi
+              echo "::group::${specs[$i]}"
+              cat "push-log-${specs[$i]}.txt"
+              echo "::endgroup::"
+            done
+
+            # Stop if anything in this tier failed. Later tiers depend on this one,
+            # so pushing them would fail anyway.
+            if [[ ${#failed_pods[@]} -gt 0 ]]; then
+              break
             fi
           done
 
@@ -322,8 +343,47 @@ jobs:
     steps:
       - name: Wait for CocoaPods CDN propagation
         run: |
-          echo "Waiting for CocoaPods CDN to propagate..."
-          sleep 1200 # Wait for 20 minute to allow CocoaPods CDN to propagate the changes.
+          # Poll the CocoaPods CDN until it serves the new version of every pod,
+          # instead of sleeping a fixed 20 minutes. Propagation usually takes a few
+          # minutes, so this typically saves 15+ minutes per release.
+          # The CDN shards its pod index by the first 3 hex chars of md5(pod name).
+          version="${{ needs.deploy-cocoapods.outputs.version }}"
+          if [[ -z "$version" ]]; then
+            echo "::error::Could not determine the released version to wait for."
+            exit 1
+          fi
+
+          pods=(
+            CustomerIOCommon
+            CustomerIOTrackingMigration
+            CustomerIODataPipelines
+            CustomerIOMessagingPush
+            CustomerIOMessagingPushAPN
+            CustomerIOMessagingPushFCM
+            CustomerIOMessagingInApp
+            CustomerIOLocation
+            CustomerIO
+          )
+
+          # Give up after 20 minutes, the previous fixed wait time. On timeout we
+          # continue instead of failing, matching the old behavior of proceeding
+          # after the sleep regardless of CDN state.
+          deadline=$((SECONDS + 1200))
+          for pod in "${pods[@]}"; do
+            md5=$(printf '%s' "$pod" | md5sum | cut -c1-3)
+            shard="${md5:0:1}_${md5:1:1}_${md5:2:1}"
+            url="https://cdn.cocoapods.org/all_pods_versions_${shard}.txt"
+
+            until curl -sf "${url}?cachebust=$(date +%s)" | grep "^${pod}/" | tr '/' '\n' | grep -qx "$version"; do
+              if (( SECONDS >= deadline )); then
+                echo "::warning::Timed out waiting for the CDN to serve ${pod} ${version}. Continuing anyway."
+                exit 0
+              fi
+              echo "CDN does not serve ${pod} ${version} yet. Retrying in 30s..."
+              sleep 30
+            done
+            echo "CDN serves ${pod} ${version}."
+          done
           echo "CocoaPods CDN propagation completed."
 
   # New job to build sample apps after successful deployment to CocoaPods


### PR DESCRIPTION
## What

Three changes to `deploy-sdk.yml`, all in the release path. No SDK code changes.

**1. Replace the fixed 20 minute `sleep 1200` with active CDN polling.**
The `wait-for-cocoapods` job now polls the CocoaPods CDN index until it serves the newly released version of all 9 pods, checking every 30s. It keeps the same 20 minute ceiling and, like today, proceeds (with a warning) if that ceiling is hit. CDN propagation usually takes a few minutes, so a typical release gets 15+ minutes back before sample app builds start.

**2. Push podspecs in dependency tiers, in parallel within each tier.**
Previously all 9 podspecs pushed one at a time, each with `--synchronous`. They now push in 4 tiers derived from the actual `.podspec` dependency graph:

1. `CustomerIOCommon`
2. `CustomerIOTrackingMigration`, `CustomerIOMessagingPush`, `CustomerIOMessagingInApp`, `CustomerIOLocation`
3. `CustomerIODataPipelines`, `CustomerIOMessagingPushAPN`, `CustomerIOMessagingPushFCM`
4. `CustomerIO`

Pods within a tier have no dependencies on each other so they push concurrently; tiers stay ordered so `pod trunk push` lint can resolve dependencies (the reason `--synchronous` exists, which is unchanged). Each pod's output is captured to its own log file and printed in a collapsible group, so logs do not interleave. If anything in a tier fails, later tiers are skipped since they would fail anyway, and the job fails listing the exact pods.

**3. Pin release tooling.**
`gem install cocoapods` and `semantic_version: latest` meant every release installed whatever shipped upstream that day, so the pipeline could break with no changes in this repo. Now pinned to exactly what `latest` resolves to today, so this PR changes no behavior on its own: cocoapods 1.16.2, semantic-release 25.0.5, `@semantic-release/github@12.0.9`, `@semantic-release/exec@7.1.0`. Future bumps are deliberate one-line PRs.

Also removed the step titled "Pushing to cocoapods is flaky... re-run this Action", since the failure mode it apologized for is what the above addresses.

## Why

Our two lowest DX survey scores are CI flakiness and deploy lead time, and the release pipeline contributes directly to both: 20 guaranteed dead minutes per release, 9 serial synchronous pushes, and unpinned tooling installed at release time.

## Testing

- `actionlint` passes with no new findings (two pre-existing findings in untouched steps remain).
- Tier push loop dry-run under bash with a stubbed push script: happy path pushes all 9 in 4 waves; a simulated tier 2 failure skips tiers 3 and 4 and exits non-zero naming the failed pod. Bash constructs verified compatible with the macOS runner's bash 3.2.
- CDN polling logic run for real against the live index for the current 4.5.3 release: correct shard URLs, all pods detected.
- The workflow only runs on push to release branches / manual dispatch, so the real end-to-end validation happens on the next release. Worst case behavior (CDN slow or poll wrong) degrades to exactly the old 20 minute wait.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the production release path (tagging, CocoaPods publish, gating sample builds); parallel tier pushes and CDN poll logic could mis-detect propagation, though timeout behavior matches the old fixed wait.
> 
> **Overview**
> **Release pipeline only** (`deploy-sdk.yml`)—no SDK code changes. It shortens typical releases and makes tooling behavior predictable.
> 
> **Pins release dependencies** so upstream releases cannot change the pipeline silently: `semantic-release` **25.0.5**, `@semantic-release/github@12.0.9`, `@semantic-release/exec@7.1.0`, and CocoaPods **1.16.2** (replacing `latest` / unpinned `gem install`).
> 
> **CocoaPods publishing** pushes the nine podspecs in **four dependency tiers**, running pods **in parallel within each tier** (still ordered across tiers for `pod trunk push` lint). Per-pod logs go to collapsible groups; a failure in a tier **stops later tiers** and reports which podspecs failed. The job now **exports the released version** for downstream steps. The old “cocoapods is flaky, re-run” notice step is removed.
> 
> **Post-deploy wait** replaces a fixed **20-minute sleep** with **CDN polling** (30s interval, same 20-minute cap): it checks the CocoaPods CDN shard index until all nine pods show the new version, then continues to sample app builds—on timeout it **warns and proceeds**, matching prior behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3815e643e929bc111e63fff5e11a6200bac1086f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->