### PR TITLE
ci: pin mobile-ci-tools refs to commit SHAs

### DIFF
--- a/.github/actions/build-sample-app/action.yml
+++ b/.github/actions/build-sample-app/action.yml
@@ -72,7 +72,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@MacOS-15+iOS-26
+    - uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@6249921af6c2171d4b71e5e18045a474729b412c # head of MacOS-15+iOS-26 (Xcode 26.2 + simulator pre-warm); replace once merged and tagged
       with:
         xcode-version: ${{ inputs.xcode-version }}
 
@@ -173,7 +173,7 @@ runs:
 
     - name: Send Slack Notification for Sample App Builds
       if: ${{ always() && inputs.apn-or-fcm == 'APN' && inputs.SLACK_WEBHOOK_URL != '' }}
-      uses: customerio/mobile-ci-tools/github-actions/slack-notify-sample-app/v1@main
+      uses: customerio/mobile-ci-tools/github-actions/slack-notify-sample-app/v1@e64ad53841ed1b30b2022778702cb30c8f931231 # main as of 2026-07-01; bump deliberately, do not track a branch
       with:
         build_status: ${{ job.status }}
         app_icon_emoji: ":ios:"

--- a/.github/workflows/check-api-breaking-changes.yml
+++ b/.github/workflows/check-api-breaking-changes.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@MacOS-15+iOS-26
+      - uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@6249921af6c2171d4b71e5e18045a474729b412c # head of MacOS-15+iOS-26 (Xcode 26.2 + simulator pre-warm); replace once merged and tagged
       
       - name: Install sourcekitten
         run: brew install sourcekitten

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -210,7 +210,7 @@ jobs:
             echo "version=${{ inputs.existing-git-tag }}" >> $GITHUB_OUTPUT
           fi
 
-      - uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@MacOS-15+iOS-26
+      - uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@6249921af6c2171d4b71e5e18045a474729b412c # head of MacOS-15+iOS-26 (Xcode 26.2 + simulator pre-warm); replace once merged and tagged
 
       - name: Install cocoapods
         # Pinned so a new cocoapods release cannot break deployments. Bump deliberately.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,4 +4,4 @@ on: [pull_request]
 
 jobs:
   lint:
-    uses: customerio/mobile-ci-tools/.github/workflows/ios-lint.yml@main
+    uses: customerio/mobile-ci-tools/.github/workflows/ios-lint.yml@e64ad53841ed1b30b2022778702cb30c8f931231 # main as of 2026-07-01; bump deliberately, do not track a branch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ concurrency: # cancel previous workflow run if one exists.
 
 jobs:
   test:
-    uses: customerio/mobile-ci-tools/.github/workflows/ios-test.yml@main
+    uses: customerio/mobile-ci-tools/.github/workflows/ios-test.yml@e64ad53841ed1b30b2022778702cb30c8f931231 # main as of 2026-07-01; bump deliberately, do not track a branch
     with:
       scheme: 'Customer.io-Package'
       xcresult-name: 'Customer.io-Package.xcresult'


### PR DESCRIPTION
## Why

Our CI consumed `mobile-ci-tools` at mutable refs: `@main` for ios-lint, ios-test, and slack-notify, and the `@MacOS-15+iOS-26` side branch for setup-ios. Any push to those refs silently changes our builds, which is one of the root causes of our "nobody changed anything and CI broke" incidents (most recently the Danger/Node breakage last week was this same unpinned-tooling class). The two refs have also drifted apart: the side branch carries the Xcode 26.2 setup-ios default and the simulator pre-warm step, while main carries other changes, so different jobs in this repo were getting different setup behavior depending on which ref they used.

## What

Pin every `mobile-ci-tools` ref to the exact commit it resolves to today:

- `ios-lint.yml`, `ios-test.yml`, `slack-notify-sample-app` pin main's current head.
- `setup-ios` (deploy-sdk, check-api-breaking-changes, build-sample-app) pins the current head of `MacOS-15+iOS-26`, preserving the Xcode 26.2 + pre-warm behavior those jobs rely on.

This is a behavior-preserving no-op today. The payoff is that future changes to shared tooling arrive here as deliberate version-bump PRs instead of instant rollouts.

## Follow-ups

- Once customerio/mobile-ci-tools cuts versioned release tags (companion PR adds a Tag release workflow there), move these SHA pins to `v1` tags.
- `Apps/fastlane/Fastfile` still imports `apple-code-signing` at `branch: "main"`; that repo has no tags yet, so it can't be pinned from this side. Same treatment needed there.
