### PR TITLE
fix: stabilize flaky tests that keep breaking CI on main

### DIFF
--- a/Sources/Common/Communication/CombinedCacheEventBusHandler.swift
+++ b/Sources/Common/Communication/CombinedCacheEventBusHandler.swift
@@ -12,12 +12,34 @@ public class CombinedCacheEventBusHandler: EventBusHandler {
     let eventStorage: EventStorage
     let logger: Logger
 
+    /// Tail of the FIFO operation chain. Every bus operation started from a synchronous
+    /// entry point (`addObserver`, `removeObserver`, `postEvent`) is appended here so that
+    /// operations reach the actor in call order. Without this, each entry point spawning
+    /// an independent `Task` allowed e.g. `addObserver` followed by `removeObserver` to be
+    /// applied in reverse, leaving the observer registered.
+    private let lastOperation = Synchronized<Task<Void, Never>?>(nil)
+
     public init(eventStorage: EventStorage, logger: Logger) {
         self.bus = CioEventBus()
         self.eventStorage = eventStorage
         self.logger = logger
-        Task { [weak self] in
+        enqueue { [weak self] in
             await self?.loadEventsFromStorage()
+        }
+    }
+
+    /// Appends `operation` to the FIFO chain. Each operation awaits the previous one,
+    /// guaranteeing call-order execution while callers remain synchronous.
+    @discardableResult
+    private func enqueue(_ operation: @escaping () async -> Void) -> Task<Void, Never> {
+        lastOperation.mutating { last in
+            let previous = last
+            let next = Task {
+                await previous?.value
+                await operation()
+            }
+            last = next
+            return next
         }
     }
 
@@ -46,7 +68,7 @@ public class CombinedCacheEventBusHandler: EventBusHandler {
         _ eventType: E.Type, action: @escaping (E) -> Void
     ) {
         logger.debug("CombinedCacheEventBusHandler: Adding observer for \(eventType)")
-        Task { [weak self] in
+        enqueue { [weak self] in
             guard let self else { return }
             let registration = await bus.addObserver(key: E.key) { [weak self] event in
                 guard self != nil else { return }
@@ -70,7 +92,7 @@ public class CombinedCacheEventBusHandler: EventBusHandler {
 
     /// Removes all observers for `eventType`.
     public func removeObserver<E: EventRepresentable>(for eventType: E.Type) {
-        Task { [weak self] in
+        enqueue { [weak self] in
             guard let self else { return }
             await bus.removeAllObservers(key: E.key)
         }
@@ -79,9 +101,9 @@ public class CombinedCacheEventBusHandler: EventBusHandler {
     /// Posts `event` asynchronously. Prefer `postEventAndWait` when delivery must
     /// complete before the next line of code runs (e.g. in tests).
     public func postEvent<E: EventRepresentable>(_ event: E) {
-        Task { [weak self] in
+        enqueue { [weak self] in
             guard let self else { return }
-            await postEventAndWait(event)
+            await postAndDeliver(event)
         }
     }
 
@@ -90,7 +112,17 @@ public class CombinedCacheEventBusHandler: EventBusHandler {
     /// The event is always added to the in-memory cache. If no observers exist at
     /// post time, the event is also written to persistent storage so that a future
     /// observer can receive it via replay.
+    ///
+    /// Joins the FIFO operation chain, so any `addObserver`/`removeObserver` call made
+    /// before this one is guaranteed to be applied before the event is delivered.
     public func postEventAndWait<E: EventRepresentable>(_ event: E) async {
+        await enqueue { [weak self] in
+            guard let self else { return }
+            await postAndDeliver(event)
+        }.value
+    }
+
+    private func postAndDeliver<E: EventRepresentable>(_ event: E) async {
         logger.debug("CombinedCacheEventBusHandler: Posting event \(event)")
         let observers = await bus.post(event)
         // Deliver outside the actor so callbacks run concurrently and cannot deadlock.

--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -19,7 +19,7 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
     /// The most recent pending-metrics flush task dispatched by `schedulePendingPushDeliveryMetricsFlush()`.
     /// Internal so tests can await its completion deterministically: a flush task that outlives a test
     /// would otherwise resolve `DataPipelineTracking` mocks registered by the next test and track into them.
-    @Atomic static var pendingMetricsFlushTask: Task<Void, Never>? = nil
+    @Atomic static var pendingMetricsFlushTask: Task<Void, Never>?
 
     private var globalDataStore: GlobalDataStore
 

--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -16,6 +16,11 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
 
     private static let moduleName = "MessagingPush"
 
+    /// The most recent pending-metrics flush task dispatched by `schedulePendingPushDeliveryMetricsFlush()`.
+    /// Internal so tests can await its completion deterministically: a flush task that outlives a test
+    /// would otherwise resolve `DataPipelineTracking` mocks registered by the next test and track into them.
+    @Atomic static var pendingMetricsFlushTask: Task<Void, Never>? = nil
+
     private var globalDataStore: GlobalDataStore
 
     /// Holds a strong reference to the installed CioNotificationCenterDelegate. UNUserNotificationCenter only holds a weak reference.
@@ -256,7 +261,7 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
         // graph if initialize() is called concurrently with other DI graph setup.
         let store = DIGraphShared.shared.pendingPushDeliveryStore
         let logger = DIGraphShared.shared.logger
-        Task.detached(priority: .utility) {
+        pendingMetricsFlushTask = Task.detached(priority: .utility) {
             let pending = store.loadAll()
             guard !pending.isEmpty else {
                 logger.debug(

--- a/Tests/Common/Communication/CombinedCacheEventBusHandlerTests.swift
+++ b/Tests/Common/Communication/CombinedCacheEventBusHandlerTests.swift
@@ -167,18 +167,14 @@ class CombinedCacheEventBusHandlerTest: UnitTest {
         let handler = makeHandler()
         var received = false
 
-        // Register and then immediately remove.
+        // Register and then immediately remove. The handler applies operations in call
+        // order (FIFO chain), and postEventAndWait joins that chain, so by the time it
+        // returns the add and remove have both been applied and delivery has completed.
         handler.addObserver(ProfileIdentifiedEvent.self) { _ in received = true }
         handler.removeObserver(for: ProfileIdentifiedEvent.self)
 
-        // postEventAndWait goes through the actor. The remove Task ran earlier and
-        // will have completed its actor call before the post call in most runs.
-        // Use a short sleep to give both Tasks time to schedule their actor calls.
-        try? await Task.sleep(nanoseconds: 100000000)
-
         await handler.postEventAndWait(ProfileIdentifiedEvent(identifier: "after-remove"))
 
-        try? await Task.sleep(nanoseconds: 100000000)
         XCTAssertFalse(received, "removed observer must not receive events")
     }
 }

--- a/Tests/Common/Synchronized/SynchronizedTests.swift
+++ b/Tests/Common/Synchronized/SynchronizedTests.swift
@@ -237,25 +237,33 @@ struct SynchronizedEquatableTests {
         #expect(!(a != a))
     }
 
-    // Calls a == b and b == a concurrently. Without the ObjectIdentifier lock-ordering in ==,
-    // this reliably deadlocks. The 30s timeout converts a hang into a test failure.
+    // Calls a == b and b == a concurrently from two threads in tight loops. Without the
+    // ObjectIdentifier lock-ordering in ==, this reliably deadlocks; the timeout converts
+    // a hang into a test failure. Exactly two threads are used on purpose: dispatching
+    // thousands of separate blocks to the global queue caused GCD thread explosion and
+    // false timeouts on loaded CI runners, while two looping threads apply constant
+    // opposite-order lock pressure and finish in milliseconds when the ordering is correct.
     @Test func equalsConcurrentlyDoesNotDeadlock() {
         let a = Synchronized(1)
         let b = Synchronized(1)
         let group = DispatchGroup()
 
-        for _ in 0 ..< 1000 {
-            group.enter()
-            DispatchQueue.global().async { _ = a == b
-                group.leave()
+        group.enter()
+        DispatchQueue.global().async {
+            for _ in 0 ..< 1000 {
+                _ = a == b
             }
-            group.enter()
-            DispatchQueue.global().async { _ = b == a
-                group.leave()
+            group.leave()
+        }
+        group.enter()
+        DispatchQueue.global().async {
+            for _ in 0 ..< 1000 {
+                _ = b == a
             }
+            group.leave()
         }
 
-        #expect(group.wait(timeout: .now() + 30) == .success)
+        #expect(group.wait(timeout: .now() + 60) == .success)
     }
 }
 

--- a/Tests/Location/LocationServicesImplementationTest.swift
+++ b/Tests/Location/LocationServicesImplementationTest.swift
@@ -47,6 +47,15 @@ struct LocationServicesImplementationTests {
         }
     }
 
+    /// Polls until `condition` is true, with a generous deadline for loaded CI machines.
+    /// Use when a later step depends on a fire-and-forget task having fully completed.
+    private func waitUntil(_ condition: () -> Bool) async {
+        let deadline = Date().addingTimeInterval(5)
+        while !condition(), Date() < deadline {
+            await Task.yield()
+        }
+    }
+
     @Test
     func setLastKnownLocation_givenTrackingDisabled_expectNoTrackCalled() async {
         let pipelineMock = DataPipelineTrackingMock()
@@ -98,6 +107,10 @@ struct LocationServicesImplementationTests {
         let location2 = CLLocation(latitude: 40.7128, longitude: -74.0060)
 
         service.setLastKnownLocation(location1)
+        // Each setLastKnownLocation call spawns an independent task, so back-to-back calls
+        // can be processed out of order. Wait until location1 is tracked (and recorded by
+        // the filter) before posting location2, so the filter deterministically denies it.
+        await waitUntil { pipelineMock.trackCallsCount == 1 }
         service.setLastKnownLocation(location2)
         await yieldForLocationTask()
 

--- a/Tests/MessagingInApp/Gist/Network/GistQueueNetworkTest.swift
+++ b/Tests/MessagingInApp/Gist/Network/GistQueueNetworkTest.swift
@@ -14,6 +14,9 @@ class GistQueueNetworkTest: UnitTest {
 
     // MARK: - User Identifier Validation
 
+    // Flake-fix: drop the `waitForExpectations` and `expectation`, same rationale as
+    // `test_request_withAnonymousId_expectSuccess` below. The wait stalled on a real
+    // `URLSession.shared` round-trip, which repeatedly exceeded the timeout on CI.
     func test_request_withUserId_expectSuccess() throws {
         let state = InAppMessageState(
             siteId: "test-site",
@@ -23,14 +26,8 @@ class GistQueueNetworkTest: UnitTest {
             anonymousId: nil
         )
 
-        let expectation = expectation(description: "Request completes")
-
         // Should not throw
-        XCTAssertNoThrow(try network.request(state: state, request: QueueEndpoint.getUserQueue, completionHandler: { _ in
-            expectation.fulfill()
-        }))
-
-        waitForExpectations(timeout: 5.0)
+        XCTAssertNoThrow(try network.request(state: state, request: QueueEndpoint.getUserQueue, completionHandler: { _ in }))
     }
 
     // Flake-fix: drop the `waitForExpectations` and `expectation` — the
@@ -50,6 +47,7 @@ class GistQueueNetworkTest: UnitTest {
         XCTAssertNoThrow(try network.request(state: state, request: QueueEndpoint.getUserQueue, completionHandler: { _ in }))
     }
 
+    // Flake-fix: same rationale as `test_request_withAnonymousId_expectSuccess` above.
     func test_request_withBothIdentifiers_expectSuccessWithUserId() throws {
         let state = InAppMessageState(
             siteId: "test-site",
@@ -59,14 +57,8 @@ class GistQueueNetworkTest: UnitTest {
             anonymousId: "anon123"
         )
 
-        let expectation = expectation(description: "Request completes")
-
         // Should not throw and should prefer userId
-        XCTAssertNoThrow(try network.request(state: state, request: QueueEndpoint.getUserQueue, completionHandler: { _ in
-            expectation.fulfill()
-        }))
-
-        waitForExpectations(timeout: 5.0)
+        XCTAssertNoThrow(try network.request(state: state, request: QueueEndpoint.getUserQueue, completionHandler: { _ in }))
     }
 
     func test_request_withNoIdentifiers_expectThrowsMissingUserIdentifier() {

--- a/Tests/MessagingPush/PushDeliveryFlushTests.swift
+++ b/Tests/MessagingPush/PushDeliveryFlushTests.swift
@@ -47,24 +47,20 @@ final class MessagingPushPendingPushFlushTests: UnitTest {
         nil
     }
 
-    func test_initialize_flushesPendingMetrics_loadAllThenRemoveAllAfterEnqueue() {
-        let loadExpectation = expectation(description: "pending store loadAll during MessagingPush flush")
-        let removeExpectation = expectation(description: "pending store removeAll(ids:) after flushed metrics")
+    // All tests below await MessagingPush.pendingMetricsFlushTask instead of waiting on
+    // expectations with a wall-clock timeout. This is deterministic on loaded CI machines
+    // and, critically, guarantees the detached flush task cannot outlive the test: a leaked
+    // task resolves DataPipelineTracking at flush time, so it would track into whichever
+    // mock the *next* test registered in the DI graph.
+
+    func test_initialize_flushesPendingMetrics_loadAllThenRemoveAllAfterEnqueue() async {
         let metric = pendingMetric
-        pendingStoreMock.loadAllClosure = {
-            loadExpectation.fulfill()
-            return [metric]
-        }
-        pendingStoreMock.removeAllClosure = { ids in
-            if ids.contains(metric.id) {
-                removeExpectation.fulfill()
-            }
-            return true
-        }
+        pendingStoreMock.loadAllReturnValue = [metric]
+        pendingStoreMock.removeAllReturnValue = true
 
         MessagingPush.initialize(withConfig: messagingPushConfigOptions)
+        await MessagingPush.pendingMetricsFlushTask?.value
 
-        wait(for: [loadExpectation, removeExpectation], timeout: 2.0)
         XCTAssertEqual(pendingStoreMock.loadAllCallsCount, 1, "startup should read pending list from app group store")
         XCTAssertEqual(pendingStoreMock.removeAllCallsCount, 1, "flushed rows should be batch-removed via removeAll(ids:)")
         XCTAssertEqual(pendingStoreMock.removeAllReceivedArguments, Set([metric.id]))
@@ -74,37 +70,29 @@ final class MessagingPushPendingPushFlushTests: UnitTest {
         XCTAssertEqual(pipelineMock.trackDeliveryEventInvocations.first?.event, metric.event.rawValue)
     }
 
-    func test_initialize_whenNoPendingMetrics_expectLoadAllOnlyNoRemoves() {
-        let loadExpectation = expectation(description: "pending store loadAll during MessagingPush flush (empty store)")
-        pendingStoreMock.loadAllClosure = {
-            loadExpectation.fulfill()
-            return []
-        }
+    func test_initialize_whenNoPendingMetrics_expectLoadAllOnlyNoRemoves() async {
+        pendingStoreMock.loadAllReturnValue = []
 
         MessagingPush.initialize(withConfig: messagingPushConfigOptions)
+        await MessagingPush.pendingMetricsFlushTask?.value
 
-        wait(for: [loadExpectation], timeout: 2.0)
         XCTAssertEqual(pendingStoreMock.loadAllCallsCount, 1)
         XCTAssertEqual(pendingStoreMock.removeAllCallsCount, 0, "removeAll should not be called when store is empty")
         XCTAssertEqual(pipelineMock.trackDeliveryEventCallsCount, 0, "no metrics should be forwarded when store is empty")
     }
 
-    func test_initialize_whenDataPipelineNotInitialized_expectLoadAllButNoTracking() {
-        // Simulate DataPipeline not being initialized — no DataPipelineTracking registered
+    func test_initialize_whenDataPipelineNotInitialized_expectLoadAllButNoTracking() async {
+        // Simulate DataPipeline not being initialized: no DataPipelineTracking registered
         diGraphShared.reset()
         diGraphShared.override(value: pendingStoreMock, forType: PendingPushDeliveryStore.self)
 
-        let loadExpectation = expectation(description: "pending store loadAll called even without DataPipeline")
-        let metric = pendingMetric
-        pendingStoreMock.loadAllClosure = {
-            loadExpectation.fulfill()
-            return [metric]
-        }
+        pendingStoreMock.loadAllReturnValue = [pendingMetric]
         pendingStoreMock.removeAllReturnValue = true
 
         MessagingPush.initialize(withConfig: messagingPushConfigOptions)
+        await MessagingPush.pendingMetricsFlushTask?.value
 
-        wait(for: [loadExpectation], timeout: 2.0)
+        XCTAssertEqual(pendingStoreMock.loadAllCallsCount, 1, "pending store should be read even without DataPipeline")
         XCTAssertEqual(pipelineMock.trackDeliveryEventCallsCount, 0, "no events should be tracked when DataPipeline is absent")
         XCTAssertEqual(pendingStoreMock.removeAllCallsCount, 0, "metrics must be preserved in the store when DataPipeline is absent")
     }


### PR DESCRIPTION
## Problem

The **Tests** workflow on `main` has been failing intermittently for weeks (latest: [run 28548337547](https://github.com/customerio/customerio-ios/actions/runs/28548337405), [run 28243876792](https://github.com/customerio/customerio-ios/actions/runs/28243876765)). Each red run fails on a *different* single test, so this is a cluster of race conditions rather than one bad commit:

| Run date | Failing test | Root cause |
|---|---|---|
| 07-01 | `CombinedCacheEventBusHandlerTest.test_removeObserver_...` | `addObserver`/`removeObserver` each spawn an independent `Task`, so the remove can be applied to the bus actor *before* the add, leaving the observer registered |
| 06-26 | `SynchronizedEquatableTests.equalsConcurrentlyDoesNotDeadlock` | 2000 blocks dispatched to `DispatchQueue.global()` cause GCD thread explosion on loaded runners; the 30s `group.wait` times out even though there is no deadlock |
| 06-05 | `LocationServicesImplementationTests.setLastKnownLocation_givenMultipleCalls_...` | back-to-back `setLastKnownLocation` calls spawn independent tasks; when the second wins the race, the filter tracks NYC instead of SF |
| 06-04, 05-21, 04-22 | `GistQueueNetworkTest` (two tests) | real `URLSession.shared` round-trip with no assertions in the handler; the wait exceeds its timeout on CI |
| 05-08 | `MessagingPushPendingPushFlushTests.test_initialize_whenNoPendingMetrics_...` | the detached flush task from the *previous* test outlives it, resolves `DataPipelineTracking` at flush time, and tracks into the next test's mock |

## Fixes

- **`CombinedCacheEventBusHandler`**: operations from synchronous entry points are now chained FIFO (each enqueued `Task` awaits the previous one), so `addObserver` / `removeObserver` / `postEvent` are applied to the bus actor in call order. `postEventAndWait` joins the chain, which also let the test drop its sleeps. This fixes a real production-visible ordering race, not just the test.
- **`SynchronizedTests`**: the deadlock test now uses exactly two threads looping in opposite lock order (stronger ABBA pressure, no thread explosion) with a generous timeout.
- **`MessagingPush`**: the pending-metrics flush task is stored in an internal `@Atomic` static so tests can await its completion instead of racing wall-clock expectations; the flush can no longer leak across tests.
- **`LocationServicesImplementationTests`**: the multiple-calls test waits for the first location to be tracked before posting the second.
- **`GistQueueNetworkTest`**: dropped the two remaining real-network waits, same rationale as the existing flake-fix comments in that file.

## Verification

No Xcode available locally, so the two `CioInternalCommon` fixes were verified with a standalone stress harness against the real implementation:

- 2,000 iterations of add-remove-post: removed observer never received an event (previously flaked)
- 2,000 iterations of concurrent post + register: exactly-once delivery every time
- 200 x 2,000 opposite-order `==` comparisons: no deadlock, completes in milliseconds

The simulator-dependent suites (Location, MessagingInApp, MessagingPush) are covered by this PR's CI run. Suggest re-running the Tests workflow a few times on this branch before merging to confirm stability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The event bus FIFO change alters observer registration and delivery ordering for all SDK event subscribers; incorrect chaining could affect profile/identity and other cached events, though the change targets a known race.
> 
> **Overview**
> Addresses intermittent **Tests** workflow failures by fixing real ordering races and making async tests deterministic instead of timing-dependent.
> 
> **`CombinedCacheEventBusHandler`** now serializes `addObserver`, `removeObserver`, and `postEvent` through a FIFO `enqueue` chain (each operation awaits the previous `Task`), so synchronous call order is preserved on the actor. **`postEventAndWait`** joins that chain and shares **`postAndDeliver`** with async posts. This fixes a production case where immediate add-then-remove could leave an observer registered.
> 
> **`MessagingPush`** records the detached pending-metrics flush in **`pendingMetricsFlushTask`** so tests can **`await`** completion and prevent flush work from leaking into the next test’s DI mocks.
> 
> Test-only hardening: event-bus remove test drops sleeps; **`Synchronized`** deadlock test uses two tight-loop threads (avoids GCD thread explosion); location multi-call test waits for the first track before the second; **Gist** queue tests stop waiting on real **URLSession** round-trips; push flush tests use async **`await`** on the flush task instead of wall-clock expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 514818d8c443b36bd4259690250da43e50d80664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->