### PR TITLE
chore(geofence): acquire location without emitting analytics events

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/View/location/LocationTestViewController+CLLocationManagerDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/location/LocationTestViewController+CLLocationManagerDelegate.swift
@@ -1,5 +1,6 @@
 import CioDataPipelines
 import CioLocation
+import CioLocationGeofence
 import CoreLocation
 import UIKit
 
@@ -42,22 +43,22 @@ extension LocationTestViewController: @MainActor CLLocationManagerDelegate {
         showToast(withMessage: "Failed to get location: \(error.localizedDescription)")
     }
 
-    /// **Customer integration pattern.** Call `CustomerIO.location.requestLocationUpdate()`
-    /// when permission lands in a granted state — the SDK uses that fix to bootstrap its
-    /// geofence sync. The call is idempotent, so it's safe to invoke on every delegate
-    /// firing.
+    /// **Customer integration pattern.** Call `CustomerIO.geofence.refreshFromCurrentLocation()`
+    /// when permission lands in a granted state — it bootstraps geofence sync from the current
+    /// location without emitting a `CIO Location Update` analytics event (unlike
+    /// `requestLocationUpdate()`). Safe to invoke on every delegate firing.
     @available(iOS 14.0, *)
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         let status = manager.authorizationStatus
         if status == .authorizedWhenInUse || status == .authorizedAlways {
-            CustomerIO.location.requestLocationUpdate()
+            CustomerIO.geofence.refreshFromCurrentLocation()
         }
         handleAuthorizationChange(status)
     }
 
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
         if status == .authorizedWhenInUse || status == .authorizedAlways {
-            CustomerIO.location.requestLocationUpdate()
+            CustomerIO.geofence.refreshFromCurrentLocation()
         }
         handleAuthorizationChange(status)
     }

--- a/Sources/Location/Coordinator/LastLocationStorage.swift
+++ b/Sources/Location/Coordinator/LastLocationStorage.swift
@@ -3,8 +3,13 @@ import Foundation
 
 /// Persists the latest cached location and the last-synced location + timestamp for the 24h + 1 km guardrails.
 protocol LastLocationStorage: AnyObject {
+    /// Persisted location from the tracking path only. Feeds identify enrichment and the sync guardrails.
     func getCachedLocation() -> LocationData?
     func setCachedLocation(_ location: LocationData)
+    /// Latest fix from any source, including silent geofence fixes. In-memory only (falls back to the
+    /// persisted cache); never persisted or used for analytics/enrichment. Backs `getLastKnownLocation`.
+    func getLastKnownLocation() -> LocationData?
+    func setLastKnownLocation(_ location: LocationData)
     func getLastSynced() -> (location: LocationData, timestamp: Date)?
     /// Records that the given location was synced at the given timestamp. Uses explicit location so the correct one is stored even if cache was overwritten before the ack arrived.
     func recordLastSync(location: LocationData, timestamp: Date)
@@ -15,6 +20,8 @@ protocol LastLocationStorage: AnyObject {
 final class LastLocationStorageImpl: LastLocationStorage {
     private let lock = NSLock()
     private let stateStore: LastLocationStateStore
+    /// In-memory last-known fix from any source (incl. silent). Not persisted; cleared on reset.
+    private var lastKnownLocation: LocationData?
 
     init(stateStore: LastLocationStateStore) {
         self.stateStore = stateStore
@@ -32,6 +39,18 @@ final class LastLocationStorageImpl: LastLocationStorage {
         var state = stateStore.load() ?? LastLocationState()
         state.cachedLocation = location
         stateStore.save(state)
+    }
+
+    func getLastKnownLocation() -> LocationData? {
+        lock.lock()
+        defer { lock.unlock() }
+        return lastKnownLocation ?? stateStore.load()?.cachedLocation
+    }
+
+    func setLastKnownLocation(_ location: LocationData) {
+        lock.lock()
+        defer { lock.unlock() }
+        lastKnownLocation = location
     }
 
     func getLastSynced() -> (location: LocationData, timestamp: Date)? {
@@ -52,6 +71,7 @@ final class LastLocationStorageImpl: LastLocationStorage {
     func clearCache() {
         lock.lock()
         defer { lock.unlock() }
+        lastKnownLocation = nil
         stateStore.clear()
     }
 }

--- a/Sources/Location/Coordinator/LocationSyncCoordinator.swift
+++ b/Sources/Location/Coordinator/LocationSyncCoordinator.swift
@@ -26,12 +26,20 @@ actor LocationSyncCoordinator {
         self.eventBusHandler = eventBusHandler
     }
 
-    /// Called for every new location (from setLastKnownLocation or requestLocationUpdate). Always updates cache; sends track via pipeline when filter allows and user is identified.
-    func processLocationUpdate(_ location: LocationData) {
-        storage.setCachedLocation(location)
+    /// Called for every new location (from setLastKnownLocation or requestLocationUpdate). Records the
+    /// fix as last-known and posts `LocationAcquiredEvent` for every fix. Only when `track` is true does
+    /// it also persist the fix (for identify enrichment) and send a `CIO Location Update` track (when the
+    /// filter allows and the user is identified). `track` is false for silent, internal fixes (e.g.
+    /// geofencing): those must not emit analytics or enrich identify, so they are not persisted.
+    func processLocationUpdate(_ location: LocationData, track: Bool = true) {
+        storage.setLastKnownLocation(location)
         // Signals the geofence first-run-refresh re-arm. Routed through the EventBus so
         // geofence can observe fixes without a direct reference to this coordinator.
         eventBusHandler.postEvent(LocationAcquiredEvent(location: location))
+
+        guard track else { return }
+
+        storage.setCachedLocation(location)
 
         guard filter.shouldSyncToServer(newLocation: location) else {
             logger.locationSyncFiltered()
@@ -41,9 +49,9 @@ actor LocationSyncCoordinator {
         trySendLocationTrack(location)
     }
 
-    /// Returns the most recently cached location, or `nil` if none has been stored.
-    func getCachedLocation() -> LocationData? {
-        storage.getCachedLocation()
+    /// Returns the last-known location from any source, or `nil` if none is known yet.
+    func getLastKnownLocation() -> LocationData? {
+        storage.getLastKnownLocation()
     }
 
     /// Called when ProfileIdentifiedEvent is received. Syncs cached location if present and the 24h + 1 km filter allows.

--- a/Sources/Location/LocationServices.swift
+++ b/Sources/Location/LocationServices.swift
@@ -43,6 +43,15 @@ public protocol LocationServices: AnyObject {
     /// (e.g. via `CLLocationManager.requestWhenInUseAuthorization()`) and only call this when permission is granted.
     func requestLocationUpdate()
 
+    /// Acquires a one-shot location fix for internal consumers (e.g. geofencing) with no analytics
+    /// side effects: no `CIO Location Update` track event, and the fix is **not** cached or persisted,
+    /// so it never reaches identify context enrichment and is not observable via `getLastKnownLocation`.
+    /// It posts `LocationAcquiredEvent` and runs regardless of `LocationConfig.mode` (geofencing needs
+    /// a location even when location tracking is `.off`).
+    /// Not part of the customer-facing API — other SDK modules call it via `@_spi(Geofence)`.
+    @_spi(Geofence)
+    func requestLocationUpdateSilently()
+
     /// Returns the most recent location the SDK has cached, or `nil` if none is known yet.
     ///
     /// The value comes from `setLastKnownLocation`, a `requestLocationUpdate` result, or a
@@ -65,6 +74,10 @@ final class UninitializedLocationServices: LocationServices {
     }
 
     func requestLocationUpdate() {
+        logger.moduleNotInitialized()
+    }
+
+    func requestLocationUpdateSilently() {
         logger.moduleNotInitialized()
     }
 
@@ -133,11 +146,17 @@ actor LocationServicesImplementation: LocationServices {
     }
 
     nonisolated func requestLocationUpdate() {
-        Task { await self.startRequestIfNeeded() }
+        Task { await self.startRequestIfNeeded(track: true, respectMode: true) }
+    }
+
+    nonisolated func requestLocationUpdateSilently() {
+        // Internal consumers (geofencing) need a fix regardless of the tracking mode, and it must
+        // not emit a track event or be cached.
+        Task { await self.startRequestIfNeeded(track: false, respectMode: false) }
     }
 
     nonisolated func getLastKnownLocation() async -> LocationData? {
-        await locationSyncCoordinator.getCachedLocation()
+        await locationSyncCoordinator.getLastKnownLocation()
     }
 
     /// Cancels any in-flight location request. No-op if nothing in progress. Called automatically when the app enters background; not exposed on the public LocationServices protocol.
@@ -178,13 +197,13 @@ actor LocationServicesImplementation: LocationServices {
         await locationSyncCoordinator.processLocationUpdate(locationData)
     }
 
-    private func startRequestIfNeeded() async {
+    private func startRequestIfNeeded(track: Bool, respectMode: Bool) async {
         guard currentTask == nil else { return }
 
         var task: Task<Void, Never>!
         task = Task { [weak self] in
             guard let self else { return }
-            await self.runLocationRequest()
+            await self.runLocationRequest(track: track, respectMode: respectMode)
             await self.clearTaskIfCurrent(task)
         }
         currentTask = task
@@ -194,15 +213,21 @@ actor LocationServicesImplementation: LocationServices {
         if currentTask == task { currentTask = nil }
     }
 
-    private func runLocationRequest() async {
-        guard config.mode != .off else {
-            logger.trackingDisabledIgnoringRequestLocationUpdate()
-            return
+    /// - Parameters:
+    ///   - track: whether a successful fix emits a `CIO Location Update` analytics event.
+    ///   - respectMode: when true, honors the `.off` tracking mode (public path); geofence-initiated
+    ///     fixes pass false so a location can be acquired even when location tracking is off.
+    private func runLocationRequest(track: Bool, respectMode: Bool) async {
+        if respectMode {
+            guard config.mode != .off else {
+                logger.trackingDisabledIgnoringRequestLocationUpdate()
+                return
+            }
         }
         if let result = await locationProvider.requestLocationOnce() {
             switch result {
             case .success(let snapshot):
-                await postLocation(snapshot)
+                await postLocation(snapshot, track: track)
             case .failure(.cancelled):
                 logger.locationRequestCancelled()
             case .failure(let error):
@@ -211,9 +236,9 @@ actor LocationServicesImplementation: LocationServices {
         }
     }
 
-    private func postLocation(_ snapshot: LocationSnapshot) async {
+    private func postLocation(_ snapshot: LocationSnapshot, track: Bool) async {
         logger.trackingLocation(latitude: snapshot.latitude, longitude: snapshot.longitude)
         let locationData = LocationData(latitude: snapshot.latitude, longitude: snapshot.longitude)
-        await locationSyncCoordinator.processLocationUpdate(locationData)
+        await locationSyncCoordinator.processLocationUpdate(locationData, track: track)
     }
 }

--- a/Sources/LocationGeofence/CustomerIO+Geofence.swift
+++ b/Sources/LocationGeofence/CustomerIO+Geofence.swift
@@ -1,0 +1,38 @@
+@_spi(Geofence) import CioLocation
+import CioInternalCommon
+import Foundation
+
+/// Public API for the Geofence module, exposed through `CustomerIO.geofence`.
+public protocol GeofenceServices {
+    /// Requests a one-shot location fix and refreshes the nearby geofence set from it, **without**
+    /// emitting a `CIO Location Update` analytics event (unlike `CustomerIO.location.requestLocationUpdate()`)
+    /// and without caching the fix.
+    ///
+    /// Call this after the host app has been granted location permission — the SDK never requests
+    /// permission itself. It is the primary way to drive geofencing when the module is configured
+    /// with `GeofenceLocationMode.manual`; with the default `.automatic` the SDK acquires location
+    /// on its own and this is only needed to force an immediate refresh.
+    ///
+    /// In `.manual`, call this once a user has been identified — a refresh requested before any
+    /// identify is not retried automatically.
+    func refreshFromCurrentLocation()
+}
+
+/// Extension to expose the Geofence module through CustomerIO.
+public extension CustomerIO {
+    /// Access the Geofence module. Register it via `SDKConfigBuilder.addModule(GeofenceModule())`
+    /// (alongside `LocationModule`) before `CustomerIO.initialize(withConfig:)`.
+    static var geofence: GeofenceServices {
+        GeofenceServicesImplementation()
+    }
+}
+
+struct GeofenceServicesImplementation: GeofenceServices {
+    func refreshFromCurrentLocation() {
+        // Arm first so the returning fix drives a sync even without a prior no-location skip,
+        // then request a silent (no-analytics) fix. Safe when the Location module isn't
+        // registered — `CustomerIO.location` returns a no-op that only logs.
+        GeofenceModuleState.shared.onRefreshRequested()
+        CustomerIO.location.requestLocationUpdateSilently()
+    }
+}

--- a/Sources/LocationGeofence/GeofenceLocationMode.swift
+++ b/Sources/LocationGeofence/GeofenceLocationMode.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Controls how the geofence module acquires the device location it needs to sync nearby geofences.
+///
+/// Location acquired for geofencing is never sent as a `CIO Location Update` analytics event, cached,
+/// or added to identify context — it is used for geofencing only.
+public enum GeofenceLocationMode {
+    /// The SDK automatically acquires a location fix whenever geofencing needs one and none is
+    /// already available from location tracking (e.g. on identify). Default.
+    case automatic
+
+    /// The SDK never acquires location on its own. The host app drives geofencing by calling
+    /// `CustomerIO.geofence.refreshFromCurrentLocation()` after granting location permission
+    /// (movement transitions still work once geofences are registered).
+    case manual
+}

--- a/Sources/LocationGeofence/GeofenceModule.swift
+++ b/Sources/LocationGeofence/GeofenceModule.swift
@@ -2,9 +2,14 @@ import CioInternalCommon
 import Foundation
 import UIKit
 
-/// Configuration options for the Geofence module. Currently has no options.
+/// Configuration options for the Geofence module.
 public struct GeofenceModuleConfig: CustomerIOModuleConfig {
-    public init() {}
+    /// How the module acquires the device location it needs for geofencing. Default is `.automatic`.
+    public let locationMode: GeofenceLocationMode
+
+    public init(locationMode: GeofenceLocationMode = .automatic) {
+        self.locationMode = locationMode
+    }
 }
 
 /// Opt-in on-device geofence module. Depends on the Location module: register both via
@@ -32,7 +37,7 @@ public final class GeofenceModule: CustomerIOModule {
     /// SDK does not retain this facade after `initialize()` returns, so the module's foreground
     /// observer and first-run state must outlive it.
     public func initialize() {
-        GeofenceModuleState.shared.setup(di: DIGraphShared.shared)
+        GeofenceModuleState.shared.setup(di: DIGraphShared.shared, locationMode: config.locationMode)
     }
 
     /// Bootstraps geofence cold-wake delivery from the host's `AppDelegate`.

--- a/Sources/LocationGeofence/GeofenceModuleState.swift
+++ b/Sources/LocationGeofence/GeofenceModuleState.swift
@@ -1,5 +1,5 @@
 import CioInternalCommon
-import CioLocation
+@_spi(Geofence) import CioLocation
 import Foundation
 
 /// Holds the Geofence module's runtime state and performs one-time setup.
@@ -17,6 +17,13 @@ final class GeofenceModuleState {
     /// (CAS true→false) on the next location fix so the first GPS update still drives the
     /// initial geofence registration.
     private let lastSkippedForNoLocation = Synchronized<Bool>(false)
+    /// Set by a host-initiated `refreshFromCurrentLocation()`. The next acquired fix drives a
+    /// refresh regardless of the no-location rearm flag, so a manual refresh works even when it
+    /// does not coincide with a first-run no-anchor skip.
+    private let explicitRefreshRequested = Synchronized<Bool>(false)
+    /// How the module acquires location (`.automatic` self-acquires; `.manual` waits for the host).
+    /// Set during `setup`; defaults to `.automatic` until then.
+    private let locationMode = Synchronized<GeofenceLocationMode>(.automatic)
     private let lock = NSLock()
     private var didSetup = false
 
@@ -29,13 +36,19 @@ final class GeofenceModuleState {
 
     /// Wires the geofence module: event subscriptions, cold-wake pending-flush, first-run
     /// rearm, and OS monitor bootstrap. Idempotent across repeat calls.
-    func setup(di: DIGraphShared) {
+    func setup(di: DIGraphShared, locationMode: GeofenceLocationMode = .automatic) {
         lock.lock()
         defer { lock.unlock() }
         guard !didSetup else { return }
         didSetup = true
+        self.locationMode.wrappedValue = locationMode
 
         registerEventSubscriptions(di: di)
+        // Run the refresh decision once at app launch (SDK/module init) so time-staleness and any
+        // missed movement EXIT are caught on cold start. Anchors at the last registration center
+        // (no GPS) when available; otherwise `.automatic` acquires a fix. Later refreshes come from
+        // identify and fresh location fixes.
+        refreshGeofencesIfPossible(di: di)
         Task { await di.geofenceEventTracker.flushPending() }
         Task { @MainActor in
             await GeofenceBootstrap.wireMonitor(di: di)
@@ -58,22 +71,35 @@ final class GeofenceModuleState {
         }
     }
 
-    /// Invoked on identify. Picks the anchor to refresh from, arming the first-run rearm when no
-    /// anchor is available so the next fix fires `refresh` once.
+    /// Arms a host-initiated refresh so the next acquired fix drives a sync even without a prior
+    /// no-location skip. Paired with `LocationServices.requestLocationUpdateSilently()` by the
+    /// `CustomerIO.geofence.refreshFromCurrentLocation()` facade.
+    func onRefreshRequested() {
+        explicitRefreshRequested.wrappedValue = true
+    }
+
+    /// Invoked at app launch and on identify. Picks the anchor to refresh from, arming the
+    /// first-run rearm only when no anchor is available so the next fix fires `refresh` once.
     private func refreshGeofencesIfPossible(di: DIGraphShared) {
-        // Arm synchronously before the async reads so a concurrent `LocationAcquiredEvent` can't
-        // slip between spawning the Task and the flag write and miss the arm. Cleared below once
-        // an anchor is found.
-        lastSkippedForNoLocation.wrappedValue = true
+        // Geofencing needs an identified user to sync, so don't refresh or self-acquire a fix when
+        // none is known (fresh launch before identify) — a later identify re-triggers this.
+        guard di.backgroundDeliveryContextStore.currentUserId?.isEmpty == false else { return }
         Task { @MainActor [weak self] in
             guard let self else { return }
             // Prefer the last registration center (walked by movement EXITs) over the Location
             // cache. Movement never updates that cache, so on relaunch it is stale — anchoring a
             // refresh there ranks from a far-away old fix and clobbers the good registration with
-            // an empty set. Fall back to the cache only before anything is registered (first run).
+            // an empty set. Fall back to the last-known fix only before anything is registered.
             let registrationCenter = await di.geofenceStorage.getLastRegistrationCenter()
-            let cached = await self.locationServicesProvider().getLastKnownLocation()
-            guard let anchor = registrationCenter ?? cached else { return }
+            let lastKnown = await self.locationServicesProvider().getLastKnownLocation()
+            guard let anchor = registrationCenter ?? lastKnown else {
+                // No location yet: arm so the next fix drives the first refresh, and in `.automatic`
+                // acquire one ourselves (its `LocationAcquiredEvent` fires the armed rearm). Arming
+                // only here — not before the async reads — avoids a false arm when an anchor exists.
+                self.lastSkippedForNoLocation.wrappedValue = true
+                self.autoAcquireIfNeeded()
+                return
+            }
             self.lastSkippedForNoLocation.wrappedValue = false
             _ = await di.geofenceSyncCoordinator.refresh(
                 latitude: anchor.latitude,
@@ -82,15 +108,29 @@ final class GeofenceModuleState {
         }
     }
 
-    /// Rising-edge CAS — fires `refresh` only on the first fix after an arming skip.
-    /// Subsequent fixes from a streaming-location host won't trigger refresh storms.
+    /// In `.automatic`, requests a silent (no-analytics) fix so geofencing self-bootstraps without
+    /// the host calling `refreshFromCurrentLocation()`. No-op in `.manual`, and no-op without
+    /// location permission (the Location module gates on it).
+    private func autoAcquireIfNeeded() {
+        guard locationMode.wrappedValue == .automatic else { return }
+        locationServicesProvider().requestLocationUpdateSilently()
+    }
+
+    /// Fires `refresh` on a host-initiated refresh or on the first fix after a no-anchor skip, then
+    /// clears both flags so a single fix is consumed once. Subsequent fixes from a streaming-location
+    /// host won't trigger refresh storms.
     private func rearmFirstRunRefreshIfArmed(location: LocationData, di: DIGraphShared) {
+        let requested = explicitRefreshRequested.mutating { requested in
+            let was = requested
+            requested = false
+            return was
+        }
         let wasArmed = lastSkippedForNoLocation.mutating { armed in
             let was = armed
             armed = false
             return was
         }
-        guard wasArmed else { return }
+        guard requested || wasArmed else { return }
         di.logger.geofenceFirstRunRearm()
         Task { @MainActor in
             _ = await di.geofenceSyncCoordinator.refresh(

--- a/Sources/LocationGeofence/GeofenceModuleState.swift
+++ b/Sources/LocationGeofence/GeofenceModuleState.swift
@@ -60,7 +60,12 @@ final class GeofenceModuleState {
             Task { await di.geofenceEventTracker.flushPending() }
             self?.refreshGeofencesIfPossible(di: di)
         }
-        di.eventBusHandler.addObserver(ResetEvent.self) { _ in
+        di.eventBusHandler.addObserver(ResetEvent.self) { [weak self] _ in
+            // Drop any pending refresh intent so a previous user's request can't drive a sync for
+            // the next user — matches the coordinator's user-scoped reset. Cleared synchronously
+            // here so it lands before a re-login's `ProfileIdentifiedEvent` re-arms.
+            self?.explicitRefreshRequested.wrappedValue = false
+            self?.lastSkippedForNoLocation.wrappedValue = false
             Task { @MainActor in
                 _ = await di.geofenceSyncCoordinator.reset()
             }

--- a/Tests/Location/Coordinator/LocationSyncCoordinatorTests.swift
+++ b/Tests/Location/Coordinator/LocationSyncCoordinatorTests.swift
@@ -28,13 +28,32 @@ struct LocationSyncCoordinatorTests {
     }
 
     @Test
-    func processLocationUpdate_alwaysUpdatesCache() async {
+    func processLocationUpdate_whenTracking_updatesCache() async {
         let (coordinator, storage) = makeCoordinator()
         let location = LocationData(latitude: 37.7749, longitude: -122.4194)
         await coordinator.processLocationUpdate(location)
         let cached = storage.getCachedLocation()
         #expect(cached?.latitude == 37.7749)
         #expect(cached?.longitude == -122.4194)
+    }
+
+    @Test
+    func processLocationUpdate_whenSilent_recordsLastKnownButDoesNotPersistOrTrack() async {
+        let pipelineMock = DataPipelineTrackingMock()
+        let bus = EventBusHandlerMock()
+        let (coordinator, storage) = makeCoordinator(dataPipeline: pipelineMock, eventBusHandler: bus)
+        let location = LocationData(latitude: 37.7749, longitude: -122.4194)
+
+        await coordinator.processLocationUpdate(location, track: false)
+
+        // Silent fix is readable as last-known and drives geofencing via the event, but must not
+        // persist (identify enrichment reads the persisted cache) or emit analytics.
+        let postedLocations = bus.postEventReceivedInvocations.compactMap { ($0 as? LocationAcquiredEvent)?.location }
+        #expect(postedLocations == [location])
+        #expect(await coordinator.getLastKnownLocation()?.latitude == 37.7749)
+        #expect(storage.getCachedLocation() == nil)
+        #expect(pipelineMock.trackCallsCount == 0)
+        #expect(storage.getLastSynced() == nil)
     }
 
     @Test

--- a/Tests/Location/LocationServicesImplementationTest.swift
+++ b/Tests/Location/LocationServicesImplementationTest.swift
@@ -1,6 +1,6 @@
 @testable import CioInternalCommon
 @testable import CioInternalCommonMocks
-@testable import CioLocation
+@_spi(Geofence) @testable import CioLocation
 import CoreLocation
 import SharedTests
 import Testing
@@ -178,6 +178,35 @@ struct LocationServicesImplementationTests {
         #expect(pipelineMock.trackCallsCount == 0)
         let requestCount = await mockProvider.requestLocationCallCount
         #expect(requestCount == 0)
+    }
+
+    @Test
+    func requestLocationUpdateSilently_givenTrackingDisabled_expectProviderCalledButNoTrack() async {
+        let mockProvider = MockLocationProvider()
+        await mockProvider.setResult(.success(LocationSnapshot(
+            latitude: 37.7749,
+            longitude: -122.4194,
+            timestamp: Date(),
+            horizontalAccuracy: 100,
+            altitude: nil
+        )))
+        let pipelineMock = DataPipelineTrackingMock()
+        let service = makeImplementation(
+            mode: .off,
+            dataPipeline: pipelineMock,
+            logger: LoggerMock(),
+            locationProvider: mockProvider
+        )
+
+        service.requestLocationUpdateSilently()
+        await yieldForLocationTask()
+
+        // Silent acquisition ignores the .off tracking mode (geofencing needs a fix even when
+        // tracking is off) but must never emit analytics. The fix is readable as last-known.
+        let requestCount = await mockProvider.requestLocationCallCount
+        #expect(requestCount == 1)
+        #expect(pipelineMock.trackCallsCount == 0)
+        #expect(await service.getLastKnownLocation()?.latitude == 37.7749)
     }
 
     @Test

--- a/Tests/Location/Storage/LastLocationStorageTests.swift
+++ b/Tests/Location/Storage/LastLocationStorageTests.swift
@@ -27,6 +27,42 @@ struct LastLocationStorageTests {
     }
 
     @Test
+    func getLastKnownLocation_whenNoInMemory_fallsBackToCached() {
+        let storage = makeStorage()
+        #expect(storage.getLastKnownLocation() == nil)
+        storage.setCachedLocation(LocationData(latitude: 1, longitude: 2))
+        let lastKnown = storage.getLastKnownLocation()
+        #expect(lastKnown?.latitude == 1)
+        #expect(lastKnown?.longitude == 2)
+    }
+
+    @Test
+    func setLastKnownLocation_returnedByGetLastKnown_butNotPersistedAsCached() {
+        let storage = makeStorage()
+        storage.setLastKnownLocation(LocationData(latitude: 3, longitude: 4))
+        // In-memory last-known is visible, but the persisted cache (enrichment source) is untouched.
+        #expect(storage.getLastKnownLocation()?.latitude == 3)
+        #expect(storage.getCachedLocation() == nil)
+    }
+
+    @Test
+    func setLastKnownLocation_overridesCachedForLastKnownRead() {
+        let storage = makeStorage()
+        storage.setCachedLocation(LocationData(latitude: 1, longitude: 2))
+        storage.setLastKnownLocation(LocationData(latitude: 3, longitude: 4))
+        #expect(storage.getLastKnownLocation()?.latitude == 3)
+        #expect(storage.getCachedLocation()?.latitude == 1)
+    }
+
+    @Test
+    func clearCache_clearsInMemoryLastKnown() {
+        let storage = makeStorage()
+        storage.setLastKnownLocation(LocationData(latitude: 3, longitude: 4))
+        storage.clearCache()
+        #expect(storage.getLastKnownLocation() == nil)
+    }
+
+    @Test
     func getLastSynced_whenEmpty_returnsNil() {
         let storage = makeStorage()
         #expect(storage.getLastSynced() == nil)

--- a/Tests/LocationGeofence/GeofenceModuleSetupTests.swift
+++ b/Tests/LocationGeofence/GeofenceModuleSetupTests.swift
@@ -1,5 +1,5 @@
 @testable import CioInternalCommon
-import CioLocation
+@_spi(Geofence) import CioLocation
 @testable import CioLocationGeofence
 @testable import CioLocationGeofenceMocks
 import CoreLocation
@@ -54,7 +54,7 @@ struct GeofenceModuleSetupTests {
 
     @Test
     @MainActor
-    func setup_givenProfileIdentifiedEventWithCachedLocation_expectRefreshCalledWithAnchor() async throws {
+    func setup_givenCachedAnchor_expectRefreshFromAnchorAtLaunch() async throws {
         let f = Fixture(cachedLocation: LocationData(latitude: 12.34, longitude: 56.78))
         defer { f.cleanup() }
 
@@ -66,9 +66,6 @@ struct GeofenceModuleSetupTests {
 
         f.wire()
 
-        let deliver = try #require(f.bus.observers[ProfileIdentifiedEvent.key], "ProfileIdentifiedEvent observer must be registered")
-        deliver(ProfileIdentifiedEvent(identifier: "u1"))
-
         var iter = refreshSignal.makeAsyncIterator()
         let received = await iter.next()
 
@@ -79,7 +76,7 @@ struct GeofenceModuleSetupTests {
 
     @Test
     @MainActor
-    func setup_givenProfileIdentifiedEventWithRegistrationCenter_expectRefreshAnchoredThereNotCache() async throws {
+    func setup_givenRegistrationCenter_expectRefreshAnchoredThereNotCacheAtLaunch() async throws {
         // A movement-walked registration center exists. It must win over the Location cache, which
         // movement never updates and is stale on relaunch — anchoring there would clobber the good
         // registration with a far-away ranking.
@@ -96,19 +93,176 @@ struct GeofenceModuleSetupTests {
 
         f.wire()
 
-        let deliver = try #require(f.bus.observers[ProfileIdentifiedEvent.key], "ProfileIdentifiedEvent observer must be registered")
-        deliver(ProfileIdentifiedEvent(identifier: "u1"))
-
         var iter = refreshSignal.makeAsyncIterator()
         let received = await iter.next()
 
         #expect(received?.0 == 10)
         #expect(received?.1 == 20)
     }
+
+    @Test
+    @MainActor
+    func setup_givenNoIdentifiedUser_expectNoRefreshOrAcquireAtLaunch() throws {
+        // Geofencing can't sync without a user, so launch must not refresh or self-acquire a fix.
+        let f = Fixture(cachedLocation: LocationData(latitude: 7, longitude: 8), identifiedUserId: nil)
+        defer { f.cleanup() }
+
+        f.spyCoordinator.refreshClosure = { _, _ in .success(()) }
+
+        f.wire()
+        // The user gate is synchronous (no Task spawned), so nothing can have run.
+        #expect(f.spyCoordinator.refreshCallsCount == 0)
+        #expect(f.stub.requestSilentlyCount.wrappedValue == 0)
+    }
+
+    @Test
+    @MainActor
+    func setup_givenAutomaticModeAndNoAnchor_expectSilentAcquireAtLaunch() async throws {
+        let f = Fixture(locationMode: .automatic)
+        defer { f.cleanup() }
+
+        let (signal, continuation) = AsyncStream<Void>.makeStream()
+        f.stub.onRequestSilently = { continuation.yield() }
+
+        f.wire()
+
+        var iter = signal.makeAsyncIterator()
+        _ = await iter.next()
+
+        #expect(f.stub.requestSilentlyCount.wrappedValue == 1)
+    }
+
+    @Test
+    @MainActor
+    func setup_givenNoAnchorAtLaunch_whenIdentifiedWithAnchor_expectRefresh() async throws {
+        // Identify is a distinct refresh trigger. Launch runs first with no anchor (arms + acquires,
+        // no refresh); a registration recorded afterward is what the identify refresh anchors on.
+        let f = Fixture()
+        defer { f.cleanup() }
+
+        let (readSignal, readContinuation) = AsyncStream<Void>.makeStream()
+        f.stub.onGetLastKnown = { readContinuation.yield() }
+
+        let (refreshSignal, refreshContinuation) = AsyncStream<(Double, Double)>.makeStream()
+        f.spyCoordinator.refreshClosure = { lat, lon in
+            refreshContinuation.yield((lat, lon))
+            return .success(())
+        }
+
+        f.wire()
+
+        // Barrier: wait for the launch pass to read location (no anchor yet) before recording one.
+        var readIter = readSignal.makeAsyncIterator()
+        _ = await readIter.next()
+
+        await f.di.geofenceStorage.recordRegistration(center: LocationData(latitude: 10, longitude: 20), businessIds: ["g1"])
+
+        let identify = try #require(f.bus.observers[ProfileIdentifiedEvent.key], "ProfileIdentifiedEvent observer must be registered")
+        identify(ProfileIdentifiedEvent(identifier: "u1"))
+
+        var refreshIter = refreshSignal.makeAsyncIterator()
+        let received = await refreshIter.next()
+
+        #expect(received?.0 == 10)
+        #expect(received?.1 == 20)
+        #expect(f.spyCoordinator.refreshCallsCount == 1)
+    }
+
+    @Test
+    @MainActor
+    func setup_givenManualModeAndNoAnchor_expectArmsButDoesNotSelfAcquire() async throws {
+        let f = Fixture(locationMode: .manual)
+        defer { f.cleanup() }
+
+        // The anchor read is the last await before the no-anchor branch runs, so awaiting it as a
+        // barrier guarantees the launch arm + acquire-gate decision has executed before we assert.
+        let (readSignal, readContinuation) = AsyncStream<Void>.makeStream()
+        f.stub.onGetLastKnown = { readContinuation.yield() }
+
+        let (refreshSignal, refreshContinuation) = AsyncStream<(Double, Double)>.makeStream()
+        f.spyCoordinator.refreshClosure = { lat, lon in
+            refreshContinuation.yield((lat, lon))
+            return .success(())
+        }
+
+        f.wire()
+
+        var readIter = readSignal.makeAsyncIterator()
+        _ = await readIter.next()
+
+        // Manual mode never self-acquires; the host must drive location.
+        #expect(f.stub.requestSilentlyCount.wrappedValue == 0)
+
+        // But launch still armed the first-run refresh, so a host-driven fix drives the sync.
+        let locAcquired = try #require(f.bus.observers[LocationAcquiredEvent.key], "LocationAcquiredEvent observer must be registered")
+        locAcquired(LocationAcquiredEvent(location: LocationData(latitude: 9, longitude: 10)))
+
+        var refreshIter = refreshSignal.makeAsyncIterator()
+        let received = await refreshIter.next()
+        #expect(received?.0 == 9)
+        #expect(received?.1 == 10)
+        #expect(f.stub.requestSilentlyCount.wrappedValue == 0)
+    }
+
+    @Test
+    @MainActor
+    func setup_givenExplicitRefreshRequested_whenLocationAcquiredWithoutPriorSkip_expectRefresh() async throws {
+        // An anchor at launch clears the no-anchor arm, so only the host-initiated arm can drive the
+        // second refresh — isolating the explicit-refresh path.
+        let f = Fixture(cachedLocation: LocationData(latitude: 1, longitude: 2))
+        defer { f.cleanup() }
+
+        let (refreshSignal, refreshContinuation) = AsyncStream<(Double, Double)>.makeStream()
+        f.spyCoordinator.refreshClosure = { lat, lon in
+            refreshContinuation.yield((lat, lon))
+            return .success(())
+        }
+
+        f.wire()
+
+        var iter = refreshSignal.makeAsyncIterator()
+        _ = await iter.next() // drain the launch refresh (clears the no-anchor arm)
+
+        f.state.onRefreshRequested()
+
+        let deliver = try #require(f.bus.observers[LocationAcquiredEvent.key], "LocationAcquiredEvent observer must be registered")
+        deliver(LocationAcquiredEvent(location: LocationData(latitude: 5, longitude: 6)))
+
+        let received = await iter.next()
+
+        #expect(received?.0 == 5)
+        #expect(received?.1 == 6)
+        #expect(f.spyCoordinator.refreshCallsCount == 2)
+    }
+
+    @Test
+    @MainActor
+    func setup_givenAnchorAtLaunch_whenLocationAcquired_expectNoDuplicateRefresh() async throws {
+        // An anchor at launch must NOT arm the first-run flag, so a later fix does not fire a second,
+        // competing refresh (guards against the false-arm race).
+        let f = Fixture(cachedLocation: LocationData(latitude: 1, longitude: 2))
+        defer { f.cleanup() }
+
+        let (refreshSignal, refreshContinuation) = AsyncStream<Void>.makeStream()
+        f.spyCoordinator.refreshClosure = { _, _ in
+            refreshContinuation.yield()
+            return .success(())
+        }
+
+        f.wire()
+
+        var iter = refreshSignal.makeAsyncIterator()
+        _ = await iter.next() // launch refresh fired (anchor cleared the flag)
+
+        let locAcquired = try #require(f.bus.observers[LocationAcquiredEvent.key], "LocationAcquiredEvent observer must be registered")
+        locAcquired(LocationAcquiredEvent(location: LocationData(latitude: 3, longitude: 4)))
+
+        #expect(f.spyCoordinator.refreshCallsCount == 1)
+    }
 }
 
 /// Per-test setup: overrides the DI shared singleton with capturing/mocking deps and builds
-/// a fresh `GeofenceModuleState` with a no-op lifecycle notifier and a stub `LocationServices`.
+/// a fresh `GeofenceModuleState` with a stub `LocationServices`.
 @MainActor
 private struct Fixture {
     let di: DIGraphShared
@@ -117,12 +271,21 @@ private struct Fixture {
     let mockMonitor: MockGeofenceRegionMonitor
     let tempDir: URL
     let state: GeofenceModuleState
+    let stub: StubLocationServices
+    let locationMode: GeofenceLocationMode
 
-    init(cachedLocation: LocationData? = nil) {
+    init(cachedLocation: LocationData? = nil, locationMode: GeofenceLocationMode = .automatic, identifiedUserId: String? = "test-user") {
+        self.locationMode = locationMode
         self.di = DIGraphShared()
 
         self.bus = CapturingEventBusHandler()
         di.override(value: bus as EventBusHandler, forType: EventBusHandler.self)
+
+        // Geofence refreshes require an identified user; seed one so launch/identify proceed.
+        self.tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let contextStore = BackgroundDeliveryContextStore(fileManager: .default, directoryURL: tempDir)
+        contextStore.setUserId(identifiedUserId)
+        di.override(value: contextStore, forType: BackgroundDeliveryContextStore.self)
 
         self.spyCoordinator = GeofenceSyncCoordinatorMock()
         di.override(value: spyCoordinator as GeofenceSyncCoordinator, forType: GeofenceSyncCoordinator.self)
@@ -130,18 +293,18 @@ private struct Fixture {
         self.mockMonitor = MockGeofenceRegionMonitor()
         di.override(value: mockMonitor as GeofenceRegionMonitoring, forType: GeofenceRegionMonitoring.self)
 
-        self.tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         let testStorage = GeofenceStorage(fileManager: .default, directoryURL: tempDir)
         di.override(value: testStorage, forType: GeofenceStorage.self)
 
         let stubServices = StubLocationServices(cachedLocation: cachedLocation)
+        self.stub = stubServices
         self.state = GeofenceModuleState(
             locationServicesProvider: { stubServices }
         )
     }
 
     func wire() {
-        state.setup(di: di)
+        state.setup(di: di, locationMode: locationMode)
     }
 
     func cleanup() {
@@ -150,9 +313,12 @@ private struct Fixture {
     }
 }
 
-/// Stub `LocationServices` returning a fixed cached location; other operations are no-ops.
+/// Stub `LocationServices` returning a fixed cached location and recording silent-acquire calls.
 private final class StubLocationServices: LocationServices, @unchecked Sendable {
     private let cachedLocation: LocationData?
+    let requestSilentlyCount = Synchronized<Int>(0)
+    var onRequestSilently: (() -> Void)?
+    var onGetLastKnown: (() -> Void)?
 
     init(cachedLocation: LocationData?) {
         self.cachedLocation = cachedLocation
@@ -160,8 +326,14 @@ private final class StubLocationServices: LocationServices, @unchecked Sendable 
 
     func setLastKnownLocation(_ location: CLLocation) {}
     func requestLocationUpdate() {}
+    func requestLocationUpdateSilently() {
+        requestSilentlyCount.mutating { $0 += 1 }
+        onRequestSilently?()
+    }
+
     func getLastKnownLocation() async -> LocationData? {
-        cachedLocation
+        onGetLastKnown?()
+        return cachedLocation
     }
 }
 

--- a/Tests/LocationGeofence/GeofenceModuleSetupTests.swift
+++ b/Tests/LocationGeofence/GeofenceModuleSetupTests.swift
@@ -41,6 +41,36 @@ struct GeofenceModuleSetupTests {
 
     @Test
     @MainActor
+    func setup_givenResetEvent_clearsRefreshArm_soLaterFixDoesNotRefresh() async throws {
+        // Reset must drop a pending refresh intent; otherwise a fix after logout would drive a
+        // refresh carried over from the previous user's session.
+        let f = Fixture(cachedLocation: LocationData(latitude: 1, longitude: 2))
+        defer { f.cleanup() }
+
+        let (refreshSignal, refreshContinuation) = AsyncStream<Void>.makeStream()
+        f.spyCoordinator.refreshClosure = { _, _ in
+            refreshContinuation.yield()
+            return .success(())
+        }
+
+        f.wire()
+        var iter = refreshSignal.makeAsyncIterator()
+        _ = await iter.next() // drain the launch refresh (cached anchor clears the no-anchor arm)
+
+        // Arm an explicit refresh, then deliver reset — reset must clear the arm.
+        f.state.onRefreshRequested()
+        let reset = try #require(f.bus.observers[ResetEvent.key], "ResetEvent observer must be registered")
+        reset(ResetEvent())
+
+        // A later fix must NOT drive a refresh, because reset cleared the explicit arm.
+        let locAcquired = try #require(f.bus.observers[LocationAcquiredEvent.key], "LocationAcquiredEvent observer must be registered")
+        locAcquired(LocationAcquiredEvent(location: LocationData(latitude: 3, longitude: 4)))
+
+        #expect(f.spyCoordinator.refreshCallsCount == 1) // only the launch refresh
+    }
+
+    @Test
+    @MainActor
     func setup_expectEventObserversRegistered() throws {
         let f = Fixture()
         defer { f.cleanup() }

--- a/Tests/LocationGeofence/GeofenceModuleTests.swift
+++ b/Tests/LocationGeofence/GeofenceModuleTests.swift
@@ -14,4 +14,14 @@ struct GeofenceModuleTests {
         // Scaffold module performs no setup yet; this guards the no-op contract.
         GeofenceModule().initialize()
     }
+
+    @Test
+    func config_defaultLocationMode_isAutomatic() {
+        #expect(GeofenceModuleConfig().locationMode == .automatic)
+    }
+
+    @Test
+    func config_givenExplicitLocationMode_isStored() {
+        #expect(GeofenceModuleConfig(locationMode: .manual).locationMode == .manual)
+    }
 }

--- a/api-docs/CioLocation.api
+++ b/api-docs/CioLocation.api
@@ -10,6 +10,7 @@ public final class CioLocation.LocationModule {
 public interface CioLocation.LocationServices {
 	public fun func setLastKnownLocation(_ location: CLLocation);
 	public fun func requestLocationUpdate();
+	public fun func requestLocationUpdateSilently();
 	public fun func getLastKnownLocation() async -> LocationData?;
 }
 public enum CioLocation.LocationTrackingMode {

--- a/api-docs/CioLocationGeofence.api
+++ b/api-docs/CioLocationGeofence.api
@@ -1,3 +1,5 @@
+public enum CioLocationGeofence.GeofenceLocationMode {
+}
 public final class CioLocationGeofence.GeofenceModule {
 	public final val moduleName: String;
 	public fun init(config: GeofenceModuleConfig = GeofenceModuleConfig());
@@ -5,5 +7,9 @@ public final class CioLocationGeofence.GeofenceModule {
 	public fun func bootstrapForBackgroundDelivery(launchOptions: List<UIApplication.LaunchOptionsKey: Any>?);
 }
 public final class CioLocationGeofence.GeofenceModuleConfig {
-	public fun init();
+	public final val locationMode: GeofenceLocationMode;
+	public fun init(locationMode: GeofenceLocationMode = .automatic);
+}
+public interface CioLocationGeofence.GeofenceServices {
+	public fun func refreshFromCurrentLocation();
 }


### PR DESCRIPTION
## What & why

Lets hosts use on-device geofencing without emitting `CIO Location Update`
analytics events or enriching identify context with precise location. Geofencing
needs a fix even when location tracking is `.off`; today acquisition and tracking
are coupled, so a geofence-only customer would leak precise location.

## Changes

**Location module**
- New internal `@_spi(Geofence) requestLocationUpdateSilently()`: acquires a
  one-shot fix, posts `LocationAcquiredEvent`, records it as last-known only — no
  `CIO Location Update` track, not persisted, not in identify enrichment. Runs
  regardless of `LocationConfig.mode`; still requires location permission.
- Split last-location storage: in-memory `lastKnownLocation` (any source, incl.
  silent) backs `getLastKnownLocation()`; the persisted cache (analytics/identify
  + 24h/1km guardrails) stays tracking-only.

**Geofence module**
- `GeofenceLocationMode { automatic (default), manual }` on `GeofenceModuleConfig`.
  `.automatic` self-acquires when geofencing needs a fix and none is available;
  `.manual` waits for the host and never acquires location on its own.
- Public `CustomerIO.geofence.refreshFromCurrentLocation()` — the way to drive
  geofencing in `.manual`, and a forced refresh in `.automatic`. Arms an explicit
  refresh, then requests a silent fix.
- Run the refresh decision once at app launch (SDK/module init), alongside the
  existing identify and location-acquired triggers.

**Sample app (APN-UIKit):** on permission grant, calls
`CustomerIO.geofence.refreshFromCurrentLocation()` instead of
`requestLocationUpdate()`.

## Behavior parity

Mirrors the Android implementation: silent primitive, cache split, mode enum,
facade, explicit-refresh arm, and the refresh decision on app launch + identify +
location-acquired.

## Tests

- Storage split: last-known reflects any source, falls back to persisted cache,
  cleared on reset; persisted cache untouched by silent fixes.
- Location services: silent acquisition runs (and caches last-known) even when
  tracking is `.off`, but emits no analytics.
- Coordinator: silent update records last-known + posts event but does not persist
  or track.
- Geofence: config default/manual; refresh from cached/registration anchor at
  launch; auto-acquire at launch in `.automatic`; `.manual` arms the refresh but
  never self-acquires; identify triggers a refresh; explicit-refresh arm; no
  false-arm when an anchor already exists.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how location fixes flow into analytics, identify enrichment, and geofence refresh timing (including launch and user-reset), which affects privacy behavior and geofence correctness across sessions.
> 
> **Overview**
> Decouples **geofence-only** location use from analytics and identify enrichment so apps can sync nearby geofences without emitting `CIO Location Update` or persisting precise coordinates for profile context.
> 
> The Location module adds an internal `@_spi(Geofence)` **`requestLocationUpdateSilently()`** path that still posts `LocationAcquiredEvent` and updates in-memory **last-known**, but skips persisted cache, tracks, and identify enrichment when `track` is false. **`processLocationUpdate(_:track:)`** gates persistence and pipeline sync on `track`; public **`getLastKnownLocation()`** now reads the split storage (in-memory last-known with fallback to the tracking cache). Silent acquisition runs even when **`LocationConfig.mode` is `.off`**.
> 
> The Geofence module adds **`GeofenceLocationMode`** (`.automatic` / `.manual`), public **`CustomerIO.geofence.refreshFromCurrentLocation()`**, launch-time refresh alongside identify/location-acquired triggers, identified-user gating, explicit-refresh arming cleared on reset, and `.automatic` self-acquire via silent location when no anchor exists. The sample app calls **`refreshFromCurrentLocation()`** on permission grant instead of **`requestLocationUpdate()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c5a3c6f6fbb30251d70215e9bafd1c498ede6af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

