### PR TITLE
fix(inbox): backfill inbox on SSE-connect transitions (fresh-login empty inbox)

### DIFF
--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -126,6 +126,11 @@ class Gist: GistProvider {
             // SSE is now active - stop polling
             logger.logWithModuleTag("Gist: SSE enabled for identified user - stopping polling timer", level: .info)
             invalidateTimer()
+            // SSE does not deliver pending messages on connect. Backfill any messages that already
+            // exist for the user (mirrors SseLifecycleManager's foreground fetch); otherwise a fresh
+            // login shows an empty inbox until the next foreground. Calls fetchUserQueue directly
+            // because fetchUserMessages() no-ops when shouldUseSse is true.
+            fetchUserQueue(state: state)
         } else if !state.useSse {
             // SSE disabled - start polling
             logger.logWithModuleTag("Gist: SSE disabled - starting polling with interval: \(state.pollInterval)s", level: .info)
@@ -149,6 +154,11 @@ class Gist: GistProvider {
             // User became identified and SSE is enabled - stop polling (SSE will take over)
             logger.logWithModuleTag("Gist: User identified with SSE enabled - stopping polling (SSE will handle messages)", level: .info)
             invalidateTimer()
+            // SSE does not deliver pending messages on connect. Backfill the messages that already
+            // exist for the now-identified user (mirrors SseLifecycleManager's foreground fetch);
+            // otherwise a fresh login shows an empty inbox until the next foreground. Calls
+            // fetchUserQueue directly because fetchUserMessages() no-ops when shouldUseSse is true.
+            fetchUserQueue(state: state)
         } else if !state.isUserIdentified, state.useSse {
             // User became anonymous but SSE flag is still enabled - start polling
             // (SSE won't be used for anonymous users)


### PR DESCRIPTION
## Problem
On a **fresh install + login**, the Visual Inbox stayed empty until the app was backgrounded→foregrounded. (iOS counterpart of customerio-android #771.)

## Root cause (device-verified, iPhone 15)
SSE does **not** deliver pending messages on connect. Only `SseLifecycleManager`'s `foregroundFetchHandler` performed the one-time HTTP backfill (`fetchUserQueue`). The **identify** and **SSE-enable** transitions in `Gist.swift` (`handleUserIdentificationChange` / `handleSseEnabledChange`) only stopped polling (`invalidateTimer()`) without fetching, so on fresh login the existing messages were never loaded until the next foreground.

## Fix
Trigger `fetchUserQueue(state:)` on both `shouldUseSse` transitions (mirrors the foreground fetch and the Android fix). Uses `fetchUserQueue` directly because `fetchUserMessages()` no-ops when `shouldUseSse` is true. One file: `Gist.swift`.

## Verification
Device (iPhone 15), fresh install + login → `visible(16)` with **no relaunch**:
```
Gist: User identified with SSE enabled - stopping polling
Gist queue fetch response: 200 → Found 0 in-app messages, 16 inbox messages → visible(16)
```

## Note
A subscriber-driven unit test asserting the backfill fires on these transitions didn't reliably fire in the existing `InAppMessageStateTests` harness (Sovran subscriber delivery), so it's deferred as a follow-up. The behavior is unit-covered on Android (customerio-android #771) and device-verified on both platforms.

Draft, targeting `feat/overlay-inbox`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change in in-app message fetching only; reuses existing `fetchUserQueue` with no auth or data-model changes.
> 
> **Overview**
> Fixes the **Visual Inbox staying empty after fresh install + login** when SSE is active: connecting over SSE does not replay pending messages, and the identify/SSE-enable paths in `Gist` only stopped polling without loading the queue.
> 
> When `shouldUseSse` becomes true in **`handleSseEnabledChange`** and **`handleUserIdentificationChange`**, the PR now calls **`fetchUserQueue(state:)`** right after stopping the timer—the same HTTP backfill already used on foreground via `SseLifecycleManager`, and bypassing **`fetchUserMessages()`** because it returns early while SSE is active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 848da740c6b6340a4b7e69dd1f0bbf656b65a41f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->