### PR TITLE
fix(inbox): NotificationInboxView renders nothing when inbox is hidden

### DIFF
--- a/Sources/MessagingInbox/NotificationInboxView.swift
+++ b/Sources/MessagingInbox/NotificationInboxView.swift
@@ -58,11 +58,16 @@ public struct NotificationInboxView: View {
             .onAppear { if marksOpenedOnAppear { model.markVisibleMessagesOpened() } }
     }
 
-    /// Panel body driven by load state: spinner while loading, empty placeholder when visible-but-empty,
-    /// otherwise the Jist-rendered list.
+    /// Panel body driven by load state: nothing when the inbox is hidden, spinner while loading,
+    /// empty placeholder when visible-but-empty, otherwise the Jist-rendered list.
     @ViewBuilder
     private var content: some View {
-        if model.messages.isEmpty, case .visible = model.state {
+        if case .hidden = model.state {
+            // Inbox is not renderable (disabled workspace, missing templates/branding). Render
+            // nothing — matching the overlay, which hides its chrome entirely in this state —
+            // rather than a perpetual spinner (empty + hidden) or a stale list (messages + hidden).
+            EmptyView()
+        } else if model.messages.isEmpty, case .visible = model.state {
             // Genuinely caught up: visible with NO messages at all. Keyed off the full message list
             // (not `renderableMessages`) so messages that merely lack a template don't read as
             // "caught up". (When embedded standalone; the overlay hides chrome entirely in that case.)


### PR DESCRIPTION
Addresses two Cursor Bugbot findings on the standalone `NotificationInboxView` (the view behind the sample "View Inbox" screen).

## Problem
`NotificationInboxView.content` handled only visible/empty/list and never gated on the `.hidden` load state:
- **Empty + hidden** fell into the "no messages" branch → showed a `ProgressView`, so a standalone embedding could **spin indefinitely** when the inbox is disabled or branding/templates are missing. (Bugbot: "Hidden inbox shows spinner")
- **Messages + hidden** rendered the list → showed **rows when policy is to hide**. (Bugbot: "List ignores hidden state")

## Fix
Add a leading `if case .hidden` branch that renders `EmptyView()` — matching `NotificationInboxOverlay`, which hides its chrome entirely in this state (and `VisualInboxModel.showsChrome`, which is already `false` for `.hidden`). One file: `NotificationInboxView.swift`.

Verified it compiles (Customer.io-Package, iOS simulator). Draft, targeting `feat/overlay-inbox`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single SwiftUI branch in presentation logic; no auth, data, or API changes.
> 
> **Overview**
> Standalone **`NotificationInboxView`** now treats **`model.state == .hidden`** as a first-class UI state: it renders **`EmptyView()`** instead of falling through to loading or list branches.
> 
> That aligns embedded inbox screens with **`NotificationInboxOverlay`** / **`showsChrome`** behavior when the inbox is not renderable (disabled workspace, missing templates/branding). **Empty + hidden** no longer shows an endless spinner; **messages + hidden** no longer shows stale rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffdafeb59b83f06cc448fd3bd51344075ddb2228. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->