### PR TITLE
chore(geofence): emit one transition event per (fence, geoset), fence as metadata

### DIFF
--- a/Sources/Common/Communication/Event.swift
+++ b/Sources/Common/Communication/Event.swift
@@ -171,6 +171,9 @@ public struct TrackGeofenceMetricEvent: EventRepresentable, GeofenceMetric {
     public let timestamp: Date
     public let name: String?
     public let transitionId: String
+    /// The geoset this event was fanned out for, or `nil` when the geofence is in no geoset.
+    /// Optional with a decode fallback so events persisted by pre-geoset SDK versions replay.
+    public let geosetId: String?
 
     public init(
         storageId: String = UUID().uuidString,
@@ -179,6 +182,7 @@ public struct TrackGeofenceMetricEvent: EventRepresentable, GeofenceMetric {
         timestamp: Date = Date(),
         name: String?,
         transitionId: String,
+        geosetId: String? = nil,
         params: [String: String] = [:]
     ) {
         self.storageId = storageId
@@ -188,6 +192,7 @@ public struct TrackGeofenceMetricEvent: EventRepresentable, GeofenceMetric {
         self.timestamp = timestamp
         self.name = name
         self.transitionId = transitionId
+        self.geosetId = geosetId
     }
 }
 

--- a/Sources/Common/Type/GeofenceMetric.swift
+++ b/Sources/Common/Type/GeofenceMetric.swift
@@ -12,6 +12,10 @@ public protocol GeofenceMetric {
     var name: String? { get }
     /// Uniquely identifies this transition; stable across delivery retries.
     var transitionId: String { get }
+    /// The geoset this event was emitted for, or `nil` when the geofence is in
+    /// no geoset. A geofence in N geosets produces N metrics per transition,
+    /// each carrying one geoset ID, so every event stands alone.
+    var geosetId: String? { get }
 }
 
 public extension GeofenceMetric {
@@ -19,7 +23,7 @@ public extension GeofenceMetric {
     /// `transition` property.
     var trackEventName: String { "Geofence Transition" }
 
-    /// `/track` event properties. `geofenceName` is included only when a name is available.
+    /// `/track` event properties. `geofenceName` and `geosetId` are included only when available.
     /// `transitionId` uniquely identifies the transition and stays stable across delivery retries.
     /// `timestamp` is not a property — it is set on the event envelope by each path.
     var trackEventProperties: [String: Any] {
@@ -30,6 +34,9 @@ public extension GeofenceMetric {
         ]
         if let name {
             properties["geofenceName"] = name
+        }
+        if let geosetId {
+            properties["geosetId"] = geosetId
         }
         return properties
     }

--- a/Sources/Common/Type/GeofenceMetric.swift
+++ b/Sources/Common/Type/GeofenceMetric.swift
@@ -36,8 +36,7 @@ public extension GeofenceMetric {
             properties["geofenceName"] = name
         }
         if let geosetId {
-            // Numeric ids go out as a number (type-preserving) so scalar campaign matching is consistent.
-            properties["geosetId"] = Int64(geosetId) ?? geosetId
+            properties["geosetId"] = geosetId
         }
         return properties
     }

--- a/Sources/Common/Type/GeofenceMetric.swift
+++ b/Sources/Common/Type/GeofenceMetric.swift
@@ -36,7 +36,8 @@ public extension GeofenceMetric {
             properties["geofenceName"] = name
         }
         if let geosetId {
-            properties["geosetId"] = geosetId
+            // Numeric ids go out as a number (type-preserving) so scalar campaign matching is consistent.
+            properties["geosetId"] = Int64(geosetId) ?? geosetId
         }
         return properties
     }

--- a/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
@@ -43,16 +43,12 @@ extension GeofenceApiRegion {
         case id, name, latitude, longitude, radius, externalId, transitionTypes, lastUpdated, geosetIds
     }
 
-    /// The backend sends `id` as a JSON number; mocked/legacy payloads used strings. Accept either
-    /// and normalize to `String` — the value is used verbatim as the OS region identifier, which is
-    /// string-typed. Declared in an extension so the memberwise init stays available to tests.
+    /// `id` and `geoset_ids` are `int64` on the wire but strings in some mocked/legacy payloads;
+    /// both normalize to `String`. Declared in an extension so the memberwise init stays available
+    /// to tests.
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        if let stringId = try? container.decode(String.self, forKey: .id) {
-            self.id = stringId
-        } else {
-            self.id = try String(container.decode(Int.self, forKey: .id))
-        }
+        self.id = try container.decodeStringOrInt(forKey: .id)
         self.name = try container.decodeIfPresent(String.self, forKey: .name)
         self.latitude = try container.decode(Double.self, forKey: .latitude)
         self.longitude = try container.decode(Double.self, forKey: .longitude)
@@ -60,7 +56,24 @@ extension GeofenceApiRegion {
         self.externalId = try container.decodeIfPresent(String.self, forKey: .externalId)
         self.transitionTypes = try container.decodeIfPresent([String].self, forKey: .transitionTypes)
         self.lastUpdated = try container.decodeIfPresent(Double.self, forKey: .lastUpdated)
-        self.geosetIds = try container.decodeIfPresent([String].self, forKey: .geosetIds)
+        self.geosetIds = try container.decodeStringOrIntArrayIfPresent(forKey: .geosetIds)
+    }
+}
+
+/// Decodes ids that arrive as JSON numbers or strings, normalized to `String`. `int64` is the wire
+/// type so it's tried first, with `String` as the legacy/mocked fallback; `Int64` (not `Double`)
+/// keeps large ids exact.
+private extension KeyedDecodingContainer {
+    func decodeStringOrInt(forKey key: Key) throws -> String {
+        if let int = try? decode(Int64.self, forKey: key) { return String(int) }
+        return try decode(String.self, forKey: key)
+    }
+
+    /// Absent or null → nil, so a not-yet-rolled-out field is treated as "no value" rather than throwing.
+    func decodeStringOrIntArrayIfPresent(forKey key: Key) throws -> [String]? {
+        guard contains(key), try !decodeNil(forKey: key) else { return nil }
+        if let ints = try? decode([Int64].self, forKey: key) { return ints.map(String.init) }
+        return try decode([String].self, forKey: key)
     }
 }
 

--- a/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
@@ -34,11 +34,13 @@ struct GeofenceApiRegion: Decodable {
     let transitionTypes: [String]?
     /// Wire format is milliseconds since epoch.
     let lastUpdated: Double?
+    /// IDs of the geosets this geofence belongs to; missing or empty means none.
+    let geosetIds: [String]?
 }
 
 extension GeofenceApiRegion {
     private enum CodingKeys: String, CodingKey {
-        case id, name, latitude, longitude, radius, externalId, transitionTypes, lastUpdated
+        case id, name, latitude, longitude, radius, externalId, transitionTypes, lastUpdated, geosetIds
     }
 
     /// The backend sends `id` as a JSON number; mocked/legacy payloads used strings. Accept either
@@ -58,6 +60,7 @@ extension GeofenceApiRegion {
         self.externalId = try container.decodeIfPresent(String.self, forKey: .externalId)
         self.transitionTypes = try container.decodeIfPresent([String].self, forKey: .transitionTypes)
         self.lastUpdated = try container.decodeIfPresent(Double.self, forKey: .lastUpdated)
+        self.geosetIds = try container.decodeIfPresent([String].self, forKey: .geosetIds)
     }
 }
 
@@ -139,7 +142,8 @@ extension GeofenceApiRegion {
             radius: radius,
             name: name ?? "",
             transitionTypes: Self.resolveTransitionTypes(transitionTypes),
-            lastUpdated: lastUpdated.map { Date(timeIntervalSince1970: $0 / 1000) } ?? Date(timeIntervalSince1970: 0)
+            lastUpdated: lastUpdated.map { Date(timeIntervalSince1970: $0 / 1000) } ?? Date(timeIntervalSince1970: 0),
+            geosetIds: geosetIds ?? []
         )
     }
 

--- a/Sources/LocationGeofence/Api/GeofenceApiService.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiService.swift
@@ -20,9 +20,11 @@ protocol GeofenceApiService: AutoMockable, Sendable {
 
     /// Fetch-nearby: returns the set ranked around the device location. The request carries no user
     /// identifier (only the workspace API key), so the coordinate can't be attributed to a person.
+    /// `radius` bounds the search in metres (the caller's server-fetch distance).
     func fetchNearbyGeofences(
         latitude: Double,
         longitude: Double,
+        radius: Double,
         completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void
     )
 }
@@ -33,7 +35,8 @@ protocol GeofenceApiService: AutoMockable, Sendable {
 /// inside the injected stores/runner (already thread-safe). Lets callers invoke this from
 /// a `Task` without an isolation hop.
 final class GeofenceApiServiceImpl: GeofenceApiService, @unchecked Sendable {
-    private static let endpointPath = "/geofences/nearby"
+    private static let nearestPath = "/geofences/nearest"
+    private static let allPath = "/geofences/nearby"
 
     private let contextStore: BackgroundDeliveryContextStore
     private let requestRunner: HttpRequestRunner
@@ -55,22 +58,28 @@ final class GeofenceApiServiceImpl: GeofenceApiService, @unchecked Sendable {
     func fetchAllGeofences(
         completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void
     ) {
-        request(queryItems: [], completion: completion)
+        request(path: Self.allPath, method: "GET", body: nil, completion: completion)
     }
 
     func fetchNearbyGeofences(
         latitude: Double,
         longitude: Double,
+        radius: Double,
         completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void
     ) {
-        request(queryItems: [
-            URLQueryItem(name: "latitude", value: "\(latitude)"),
-            URLQueryItem(name: "longitude", value: "\(longitude)")
-        ], completion: completion)
+        let body: Data
+        do {
+            body = try JSONEncoder().encode(NearestRequest(latitude: latitude, longitude: longitude, radius: radius))
+        } catch {
+            return completion(.failure(.invalidRequest))
+        }
+        request(path: Self.nearestPath, method: "POST", body: body, completion: completion)
     }
 
     private func request(
-        queryItems: [URLQueryItem],
+        path: String,
+        method: String,
+        body: Data?,
         completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void
     ) {
         guard let apiHost = contextStore.currentApiHost, !apiHost.isEmpty else {
@@ -79,18 +88,22 @@ final class GeofenceApiServiceImpl: GeofenceApiService, @unchecked Sendable {
         guard let cdpApiKey = contextStore.currentCdpApiKey, !cdpApiKey.isEmpty else {
             return completion(.failure(.missingCdpApiKey))
         }
-        guard let url = Self.composeUrl(apiHost: apiHost, queryItems: queryItems) else {
+        guard let url = Self.composeUrl(apiHost: apiHost, path: path) else {
             return completion(.failure(.invalidRequest))
         }
 
+        var headers: HttpHeaders = [
+            "Accept": "application/json",
+            "Authorization": "Basic \(BackgroundDeliveryHttp.basicAuthValue(cdpApiKey: cdpApiKey))"
+        ]
+        if body != nil {
+            headers["Content-Type"] = "application/json"
+        }
         let params = HttpRequestParams(
-            method: "GET",
+            method: method,
             url: url,
-            headers: [
-                "Accept": "application/json",
-                "Authorization": "Basic \(BackgroundDeliveryHttp.basicAuthValue(cdpApiKey: cdpApiKey))"
-            ],
-            body: nil
+            headers: headers,
+            body: body
         )
 
         requestRunner.request(params: params, session: session) { data, response, error in
@@ -113,13 +126,18 @@ final class GeofenceApiServiceImpl: GeofenceApiService, @unchecked Sendable {
         }
     }
 
-    /// Composes `https://{apiHost}/geofences/nearby` with the given query items (empty for
-    /// fetch-all). URLComponents handles percent-encoding for the query values.
-    static func composeUrl(apiHost: String, queryItems: [URLQueryItem]) -> URL? {
-        var components = URLComponents(string: BackgroundDeliveryHttp.absoluteHost(apiHost) + endpointPath)
-        components?.queryItems = queryItems.isEmpty ? nil : queryItems
-        return components?.url
+    /// Composes `https://{apiHost}{path}`. URLComponents normalizes the host + path.
+    static func composeUrl(apiHost: String, path: String) -> URL? {
+        URLComponents(string: BackgroundDeliveryHttp.absoluteHost(apiHost) + path)?.url
     }
+}
+
+/// Body of `POST /geofences/nearest`. `radius` bounds the search in metres; `limit` is optional
+/// server-side and omitted.
+private struct NearestRequest: Encodable {
+    let latitude: Double
+    let longitude: Double
+    let radius: Double
 }
 
 private extension JSONDecoder {

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
@@ -244,7 +244,10 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         longitude: Double,
         cachedConfig: GeofenceConfig?
     ) async -> Result<Void, GeofenceSyncError> {
-        let fetchResult = await awaitApiFetch(latitude: latitude, longitude: longitude)
+        // Radius is derived from the config known before the fetch (the response carries the fresh
+        // one). First fetch has no cache → `.fallback`.
+        let radius = (cachedConfig ?? .fallback).searchRadius
+        let fetchResult = await awaitApiFetch(latitude: latitude, longitude: longitude, radius: radius)
         let response: GeofenceApiResponse
         switch fetchResult {
         case .success(let value):
@@ -318,14 +321,14 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
 
 private extension GeofenceSyncCoordinatorImpl {
     /// Dispatches the fetch per `syncMode`. `fetchAll` sends no location; `fetchNearby` sends the
-    /// device coordinate (the request carries no user identifier). See `GeofenceSyncMode`.
-    func awaitApiFetch(latitude: Double, longitude: Double) async -> Result<GeofenceApiResponse, GeofenceApiError> {
+    /// device coordinate + search `radius` (the request carries no user identifier). See `GeofenceSyncMode`.
+    func awaitApiFetch(latitude: Double, longitude: Double, radius: Double) async -> Result<GeofenceApiResponse, GeofenceApiError> {
         await withCheckedContinuation { continuation in
             switch syncMode {
             case .fetchAll:
                 apiService.fetchAllGeofences { continuation.resume(returning: $0) }
             case .fetchNearby:
-                apiService.fetchNearbyGeofences(latitude: latitude, longitude: longitude) { continuation.resume(returning: $0) }
+                apiService.fetchNearbyGeofences(latitude: latitude, longitude: longitude, radius: radius) { continuation.resume(returning: $0) }
             }
         }
     }

--- a/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
@@ -83,12 +83,15 @@ final class GeofenceEventTracker: @unchecked Sendable {
         let cachedGeofence = await storage.getCachedGeofences().first { $0.id == geofenceId }
         let cachedName = cachedGeofence?.name
         let geofenceName = (cachedName?.isEmpty == false) ? cachedName : nil
-        // One standalone event per geoset, each carrying a scalar geosetId plus the
-        // geofence id/name as metadata, so segment and campaign matching needs no joins
-        // at ingest. No geoset membership (or the geofence has left the cache) emits a
-        // single event without a geosetId, preserving pre-geoset behavior.
-        let memberGeosetIds = cachedGeofence?.geosetIds ?? []
+        // One event per geoset (scalar geosetId + geofence id/name as metadata) so matching needs no
+        // joins; no geosets (or the fence left the cache) → one event without a geosetId.
+        // Dedupe geoset ids so a fence listing the same one twice doesn't emit duplicate events.
+        var seenGeosetIds = Set<String>()
+        let memberGeosetIds = (cachedGeofence?.geosetIds ?? []).filter { seenGeosetIds.insert($0).inserted }
         let geosetIds: [String?] = memberGeosetIds.isEmpty ? [nil] : memberGeosetIds
+        // One transitionId for the whole crossing so downstream correlates the fan-out as one
+        // transition; geosetId distinguishes the rows.
+        let transitionId = UUID().uuidString
         let metrics = geosetIds.map { geosetId in
             PendingGeofenceMetric(
                 geofenceId: geofenceId,
@@ -96,18 +99,21 @@ final class GeofenceEventTracker: @unchecked Sendable {
                 timestamp: now,
                 userId: stampedUserId,
                 name: geofenceName,
-                transitionId: UUID().uuidString,
+                transitionId: transitionId,
                 geosetId: geosetId
             )
         }
-        // Persist every row before any send attempt so an app kill mid-delivery
-        // loses none of the fan-out.
-        for metric in metrics {
-            _ = await pendingStore.append(metric)
-        }
+        // Persist all rows in one atomic write: a per-row loop could save some and lose the rest on
+        // an app kill, and the cooldown is already spent so the lost ones would never retry.
+        _ = await pendingStore.append(metrics)
 
-        for metric in metrics {
-            await deliver(metric: metric)
+        // Deliver concurrently so N geosets don't serialize N round-trips inside the OS's short
+        // background wake window. Safe: distinct keys (no dedup-claim collision), and rows are
+        // already persisted so any that don't finish are retried by flushPending.
+        await withTaskGroup(of: Void.self) { group in
+            for metric in metrics {
+                group.addTask { await self.deliver(metric: metric) }
+            }
         }
         await storage.purgeExpiredCooldowns(now: now, interval: interval)
     }

--- a/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
@@ -108,11 +108,13 @@ final class GeofenceEventTracker: @unchecked Sendable {
         // an app kill, and the cooldown is already spent so the lost ones would never retry.
         let persisted = await pendingStore.append(metrics)
         if !persisted {
-            // Persist-first failed (disk error): the cooldown is already spent, so release it to let
-            // the next crossing retry instead of being suppressed against rows that never reached the
-            // queue. Delivery below is still attempted best-effort for this crossing.
+            // Persist-first failed (disk error): release the just-claimed cooldown so the next
+            // crossing retries from a clean state instead of being suppressed. Skip delivery — a row
+            // that never reached disk has nothing to retry, and sending it anyway would let its
+            // success-path remove(key:) drop a later same-second crossing's row (keys omit transitionId).
             logger.geofencePendingPersistFailed(geofenceId: geofenceId, transition: transition)
             await storage.releaseCooldown(key: cooldownKey)
+            return
         }
 
         // Deliver concurrently so N geosets don't serialize N round-trips inside the OS's short

--- a/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
@@ -85,9 +85,10 @@ final class GeofenceEventTracker: @unchecked Sendable {
         let geofenceName = (cachedName?.isEmpty == false) ? cachedName : nil
         // One event per geoset (scalar geosetId + geofence id/name as metadata) so matching needs no
         // joins; no geosets (or the fence left the cache) → one event without a geosetId.
-        // Dedupe geoset ids so a fence listing the same one twice doesn't emit duplicate events.
+        // Dedupe geoset ids, and drop blanks, so a fence listing the same one twice — or an empty
+        // id — doesn't emit a duplicate or a stray empty-geoset event.
         var seenGeosetIds = Set<String>()
-        let memberGeosetIds = (cachedGeofence?.geosetIds ?? []).filter { seenGeosetIds.insert($0).inserted }
+        let memberGeosetIds = (cachedGeofence?.geosetIds ?? []).filter { !$0.isEmpty && seenGeosetIds.insert($0).inserted }
         let geosetIds: [String?] = memberGeosetIds.isEmpty ? [nil] : memberGeosetIds
         // One transitionId for the whole crossing so downstream correlates the fan-out as one
         // transition; geosetId distinguishes the rows.

--- a/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
@@ -52,8 +52,11 @@ final class GeofenceEventTracker: @unchecked Sendable {
         self.cooldownInterval = cooldownInterval
     }
 
-    /// Tracks a geofence transition event, suppressing duplicates within the cooldown window.
-    /// Persists the metric, then hands it to `deliver`.
+    /// Tracks a geofence transition, suppressing duplicates within the cooldown window.
+    /// Fans the transition out to one metric per geoset the geofence belongs to (a single
+    /// metric without a geosetId when it belongs to none), persists every row, then hands
+    /// each to `deliver`. The cooldown is evaluated once per geofence, before fan-out, so
+    /// all rows of one transition are suppressed or emitted together.
     func trackTransition(
         geofenceId: String,
         transition: GeofenceTransition
@@ -74,21 +77,38 @@ final class GeofenceEventTracker: @unchecked Sendable {
         // is identified at capture time; `deliver` routes nil-stamped rows to EventBus.
         let liveUserId = contextStore.currentUserId
         let stampedUserId: String? = (liveUserId?.isEmpty == false) ? liveUserId : nil
-        // Resolve the geofence name now and carry it on the metric; nil when unavailable so the
-        // event omits `geofence_name` rather than sending an empty value.
-        let cachedName = await storage.getCachedGeofences().first { $0.id == geofenceId }?.name
+        // Resolve the geofence name and geoset membership now and carry them on the metric;
+        // name is nil when unavailable so the event omits `geofenceName` rather than sending
+        // an empty value.
+        let cachedGeofence = await storage.getCachedGeofences().first { $0.id == geofenceId }
+        let cachedName = cachedGeofence?.name
         let geofenceName = (cachedName?.isEmpty == false) ? cachedName : nil
-        let metric = PendingGeofenceMetric(
-            geofenceId: geofenceId,
-            transition: transition,
-            timestamp: now,
-            userId: stampedUserId,
-            name: geofenceName,
-            transitionId: UUID().uuidString
-        )
-        _ = await pendingStore.append(metric)
+        // One standalone event per geoset, each carrying a scalar geosetId plus the
+        // geofence id/name as metadata, so segment and campaign matching needs no joins
+        // at ingest. No geoset membership (or the geofence has left the cache) emits a
+        // single event without a geosetId, preserving pre-geoset behavior.
+        let memberGeosetIds = cachedGeofence?.geosetIds ?? []
+        let geosetIds: [String?] = memberGeosetIds.isEmpty ? [nil] : memberGeosetIds
+        let metrics = geosetIds.map { geosetId in
+            PendingGeofenceMetric(
+                geofenceId: geofenceId,
+                transition: transition,
+                timestamp: now,
+                userId: stampedUserId,
+                name: geofenceName,
+                transitionId: UUID().uuidString,
+                geosetId: geosetId
+            )
+        }
+        // Persist every row before any send attempt so an app kill mid-delivery
+        // loses none of the fan-out.
+        for metric in metrics {
+            _ = await pendingStore.append(metric)
+        }
 
-        await deliver(metric: metric)
+        for metric in metrics {
+            await deliver(metric: metric)
+        }
         await storage.purgeExpiredCooldowns(now: now, interval: interval)
     }
 
@@ -147,7 +167,8 @@ final class GeofenceEventTracker: @unchecked Sendable {
             transition: metric.transition,
             timestamp: metric.timestamp,
             name: metric.name,
-            transitionId: metric.transitionId
+            transitionId: metric.transitionId,
+            geosetId: metric.geosetId
         ))
         logger.geofenceEventTracked(geofenceId: metric.geofenceId, transition: metric.transition)
     }

--- a/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
@@ -106,7 +106,14 @@ final class GeofenceEventTracker: @unchecked Sendable {
         }
         // Persist all rows in one atomic write: a per-row loop could save some and lose the rest on
         // an app kill, and the cooldown is already spent so the lost ones would never retry.
-        _ = await pendingStore.append(metrics)
+        let persisted = await pendingStore.append(metrics)
+        if !persisted {
+            // Persist-first failed (disk error): the cooldown is already spent, so release it to let
+            // the next crossing retry instead of being suppressed against rows that never reached the
+            // queue. Delivery below is still attempted best-effort for this crossing.
+            logger.geofencePendingPersistFailed(geofenceId: geofenceId, transition: transition)
+            await storage.releaseCooldown(key: cooldownKey)
+        }
 
         // Deliver concurrently so N geosets don't serialize N round-trips inside the OS's short
         // background wake window. Safe: distinct keys (no dedup-claim collision), and rows are

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -58,6 +58,14 @@ extension Logger {
         )
     }
 
+    func geofencePendingPersistFailed(geofenceId: String, transition: GeofenceTransition) {
+        error(
+            "Failed to persist \(transition.rawValue) event for geofence \(geofenceId) before send; cooldown released so the next crossing can retry",
+            geofenceTag,
+            nil
+        )
+    }
+
     // MARK: - Sync
 
     func geofenceSyncSkipped(reason: String) {

--- a/Sources/LocationGeofence/Model/Geofence.swift
+++ b/Sources/LocationGeofence/Model/Geofence.swift
@@ -11,4 +11,41 @@ struct Geofence: Codable, Equatable, Sendable {
     let name: String
     let transitionTypes: Set<GeofenceTransition>
     let lastUpdated: Date
+    /// IDs of the geosets this geofence belongs to. Empty when the geofence is
+    /// in no geoset. Stamped onto transition events, one event per geoset.
+    let geosetIds: [String]
+
+    init(
+        id: String,
+        latitude: Double,
+        longitude: Double,
+        radius: Double,
+        name: String,
+        transitionTypes: Set<GeofenceTransition>,
+        lastUpdated: Date,
+        geosetIds: [String] = []
+    ) {
+        self.id = id
+        self.latitude = latitude
+        self.longitude = longitude
+        self.radius = radius
+        self.name = name
+        self.transitionTypes = transitionTypes
+        self.lastUpdated = lastUpdated
+        self.geosetIds = geosetIds
+    }
+
+    /// Custom decode so geofences cached to disk by SDK versions that predate
+    /// `geosetIds` still decode (missing key means no geoset membership).
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.latitude = try container.decode(Double.self, forKey: .latitude)
+        self.longitude = try container.decode(Double.self, forKey: .longitude)
+        self.radius = try container.decode(Double.self, forKey: .radius)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.transitionTypes = try container.decode(Set<GeofenceTransition>.self, forKey: .transitionTypes)
+        self.lastUpdated = try container.decode(Date.self, forKey: .lastUpdated)
+        self.geosetIds = try container.decodeIfPresent([String].self, forKey: .geosetIds) ?? []
+    }
 }

--- a/Sources/LocationGeofence/Model/GeofenceConfig.swift
+++ b/Sources/LocationGeofence/Model/GeofenceConfig.swift
@@ -44,4 +44,14 @@ extension GeofenceConfig {
         maxBusinessGeofences: GeofenceConstants.maxMonitoredGeofences,
         maxMonitoringDistance: GeofenceConstants.defaultMaxMonitoringDistance
     )
+
+    /// Search radius (m) for the nearby fetch: the wider of the re-fetch distance and the monitoring
+    /// cap, so it covers everything we might register. Uncapped falls back to the default ceiling (an
+    /// unbounded radius can't go on the wire). Interim, pending BE confirming `radius` semantics.
+    var searchRadius: Double {
+        let cap = maxMonitoringDistance == GeofenceConstants.noMonitoringDistanceCap
+            ? GeofenceConstants.defaultMaxMonitoringDistance
+            : maxMonitoringDistance
+        return max(remoteFetchRefreshTriggerRadius, cap)
+    }
 }

--- a/Sources/LocationGeofence/Storage/GeofenceStorage.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage.swift
@@ -77,6 +77,16 @@ actor GeofenceStorage {
         saveToDisk(state)
     }
 
+    /// Removes the cooldown entry for `key`, if present. Called when persist-first fails after the
+    /// cooldown was already claimed, so the next transition of this type isn't suppressed against a
+    /// metric that never reached the pending queue.
+    func releaseCooldown(key: String) {
+        var state = loadFromDisk() ?? GeofenceState()
+        guard var cooldowns = state.eventCooldowns, cooldowns.removeValue(forKey: key) != nil else { return }
+        state.eventCooldowns = cooldowns
+        saveToDisk(state)
+    }
+
     func clearEventCooldowns() {
         var state = loadFromDisk() ?? GeofenceState()
         state.eventCooldowns = nil

--- a/Sources/LocationGeofence/Storage/PendingGeofenceMetric.swift
+++ b/Sources/LocationGeofence/Storage/PendingGeofenceMetric.swift
@@ -13,14 +13,21 @@ struct PendingGeofenceMetric: Codable, Equatable, Sendable, GeofenceMetric {
     /// metric so a delayed flush still has it even after the geofence leaves the cache.
     let name: String?
     let transitionId: String
+    /// The geoset this row was fanned out for, or `nil` when the geofence is in no geoset.
+    /// One physical transition of a geofence in N geosets produces N rows, one per geoset.
+    /// Optional so rows persisted by pre-geoset SDK versions still decode.
+    let geosetId: String?
 
-    /// Composite key over `(geofenceId, transition, timestamp_sec)` used for
+    /// Composite key over `(geofenceId, transition, timestamp_sec, geosetId)` used for
     /// storage-layer dedup. Matches Android's `PendingGeofenceDelivery.key`.
     /// Seconds (not ms) — cooldown gate dedups by `(geofenceId, transition)`
-    /// upstream, so finer precision adds nothing.
+    /// upstream, so finer precision adds nothing. The geoset suffix keeps the
+    /// fan-out rows of one transition from colliding with each other.
     var key: String {
         let sec = Int(timestamp.timeIntervalSince1970)
-        return "\(geofenceId)_\(transition.rawValue)_\(sec)"
+        let base = "\(geofenceId)_\(transition.rawValue)_\(sec)"
+        guard let geosetId else { return base }
+        return "\(base)_\(geosetId)"
     }
 
     init(
@@ -29,7 +36,8 @@ struct PendingGeofenceMetric: Codable, Equatable, Sendable, GeofenceMetric {
         timestamp: Date,
         userId: String?,
         name: String?,
-        transitionId: String
+        transitionId: String,
+        geosetId: String? = nil
     ) {
         self.geofenceId = geofenceId
         self.transition = transition
@@ -37,6 +45,7 @@ struct PendingGeofenceMetric: Codable, Equatable, Sendable, GeofenceMetric {
         self.userId = userId
         self.name = name
         self.transitionId = transitionId
+        self.geosetId = geosetId
     }
 
     enum CodingKeys: String, CodingKey {
@@ -46,5 +55,6 @@ struct PendingGeofenceMetric: Codable, Equatable, Sendable, GeofenceMetric {
         case userId = "user_id"
         case name = "geofence_name"
         case transitionId = "transition_id"
+        case geosetId = "geoset_id"
     }
 }

--- a/Sources/LocationGeofence/Storage/PendingGeofenceMetricStore.swift
+++ b/Sources/LocationGeofence/Storage/PendingGeofenceMetricStore.swift
@@ -32,16 +32,17 @@ actor PendingGeofenceMetricStore {
         self.directoryURL = directoryURL
     }
 
-    /// Appends a metric. When over capacity, drops the **oldest** entries first.
-    /// A row with the same `key` is a no-op.
+    /// Appends metrics in one read-modify-write so a transition's fan-out persists atomically —
+    /// a crash can't save some rows and lose the rest. Rows whose `key` already exists (on disk
+    /// or earlier in `metrics`) are a no-op. When over capacity, drops the **oldest** first.
     /// Returns `false` if the file could not be persisted.
-    func append(_ metric: PendingGeofenceMetric) -> Bool {
+    func append(_ metrics: [PendingGeofenceMetric]) -> Bool {
+        guard !metrics.isEmpty else { return true }
         var items = loadFromDisk()
-        if items.contains(where: { $0.key == metric.key }) {
-            // Already persisted — treat as success so the caller doesn't retry.
-            return true
+        var keys = Set(items.map(\.key))
+        for metric in metrics where keys.insert(metric.key).inserted {
+            items.append(metric)
         }
-        items.append(metric)
         if items.count > Self.maxEntries {
             items = Array(items.suffix(Self.maxEntries))
         }

--- a/Tests/LocationGeofence/Geofence/Api/GeofenceApiResponseTests.swift
+++ b/Tests/LocationGeofence/Geofence/Api/GeofenceApiResponseTests.swift
@@ -256,10 +256,42 @@ struct GeofenceApiResponseTests {
     }
 
     @Test
+    func toDomainRegions_givenNumericGeosetIds_expectNormalizedToStrings() throws {
+        // The server contract: `geoset_ids` is `[]int64`, so ids arrive as JSON numbers. This is the
+        // common case and must always decode; we normalize to String for downstream flexibility.
+        let json = """
+        {"geofences":[{"id":"g1","latitude":1,"longitude":2,"radius":100,"geoset_ids":[1,3,7]}]}
+        """
+        let response = try decode(json)
+        #expect(response.toDomainRegions().first?.geosetIds == ["1", "3", "7"])
+    }
+
+    @Test
+    func toDomainRegions_givenLargeInt64GeosetId_expectNoPrecisionLoss() throws {
+        // int64 exceeds JSON/Double safe-integer range; decoding via Int64 (not Double) keeps large
+        // ids exact. 9007199254740993 (2^53 + 1) would collapse to ...992 through a Double.
+        let json = """
+        {"geofences":[{"id":"g1","latitude":1,"longitude":2,"radius":100,"geoset_ids":[9007199254740993]}]}
+        """
+        let response = try decode(json)
+        #expect(response.toDomainRegions().first?.geosetIds == ["9007199254740993"])
+    }
+
+    @Test
     func toDomainRegions_givenMissingGeosetIds_expectEmpty() throws {
         // Backend rolls `geoset_ids` out gradually; absent means no geoset membership.
         let json = """
         {"geofences":[{"id":"g1","latitude":1,"longitude":2,"radius":100}]}
+        """
+        let response = try decode(json)
+        #expect(response.toDomainRegions().first?.geosetIds == [])
+    }
+
+    @Test
+    func toDomainRegions_givenNullGeosetIds_expectEmpty() throws {
+        // Explicit JSON null must decode to no membership, not throw and fail the whole response.
+        let json = """
+        {"geofences":[{"id":"g1","latitude":1,"longitude":2,"radius":100,"geoset_ids":null}]}
         """
         let response = try decode(json)
         #expect(response.toDomainRegions().first?.geosetIds == [])

--- a/Tests/LocationGeofence/Geofence/Api/GeofenceApiResponseTests.swift
+++ b/Tests/LocationGeofence/Geofence/Api/GeofenceApiResponseTests.swift
@@ -245,4 +245,23 @@ struct GeofenceApiResponseTests {
         let response = try decode(json)
         #expect(response.toDomainRegions().first?.transitionTypes == [.enter, .exit])
     }
+
+    @Test
+    func toDomainRegions_givenGeosetIds_expectCarriedToDomain() throws {
+        let json = """
+        {"geofences":[{"id":"g1","latitude":1,"longitude":2,"radius":100,"geoset_ids":["set_y","set_z"]}]}
+        """
+        let response = try decode(json)
+        #expect(response.toDomainRegions().first?.geosetIds == ["set_y", "set_z"])
+    }
+
+    @Test
+    func toDomainRegions_givenMissingGeosetIds_expectEmpty() throws {
+        // Backend rolls `geoset_ids` out gradually; absent means no geoset membership.
+        let json = """
+        {"geofences":[{"id":"g1","latitude":1,"longitude":2,"radius":100}]}
+        """
+        let response = try decode(json)
+        #expect(response.toDomainRegions().first?.geosetIds == [])
+    }
 }

--- a/Tests/LocationGeofence/Geofence/Api/GeofenceApiServiceTests.swift
+++ b/Tests/LocationGeofence/Geofence/Api/GeofenceApiServiceTests.swift
@@ -55,7 +55,7 @@ struct GeofenceApiServiceTests {
     }
 
     @Test
-    func fetchNearbyGeofences_givenCoordinate_expectLatLonQuerySentAsIs() async {
+    func fetchNearbyGeofences_givenCoordinate_expectPostToNearestWithJsonBody() async {
         let (service, runner) = makeService(store: makeStore())
         runner.requestClosure = { _, _, onComplete in
             onComplete("{\"geofences\":[]}".data(using: .utf8), makeOkResponse(), nil)
@@ -63,13 +63,17 @@ struct GeofenceApiServiceTests {
 
         await withCheckedContinuation { continuation in
             // The request carries no user identifier, so the exact coordinate is sent unmodified.
-            service.fetchNearbyGeofences(latitude: 37.7749295, longitude: -122.4194155) { _ in continuation.resume() }
+            service.fetchNearbyGeofences(latitude: 37.7749295, longitude: -122.4194155, radius: 20000) { _ in continuation.resume() }
         }
 
-        let url = runner.requestReceivedArguments?.params.url
-        let items = URLComponents(url: url!, resolvingAgainstBaseURL: false)?.queryItems
-        #expect(items?.first(where: { $0.name == "latitude" })?.value == "37.7749295")
-        #expect(items?.first(where: { $0.name == "longitude" })?.value == "-122.4194155")
+        let params = runner.requestReceivedArguments?.params
+        #expect(params?.method == "POST")
+        #expect(params?.url.absoluteString == "https://cdp.customer.io/v1/geofences/nearest")
+        #expect(params?.headers?["Content-Type"] == "application/json")
+        let body = (try? JSONSerialization.jsonObject(with: params?.body ?? Data())) as? [String: Double]
+        #expect(body?["latitude"] == 37.7749295)
+        #expect(body?["longitude"] == -122.4194155)
+        #expect(body?["radius"] == 20000)
     }
 
     @Test

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -1014,7 +1014,7 @@ struct GeofenceSyncCoordinatorTests {
         await storage.setCachedConfig(config)
         await storage.recordSync(timestamp: Date(timeIntervalSince1970: 100), location: LocationData(latitude: 0, longitude: 0))
         let api = GeofenceApiServiceMock()
-        api.fetchNearbyGeofencesClosure = { _, _, completion in
+        api.fetchNearbyGeofencesClosure = { _, _, _, completion in
             completion(.success(makeApiResponse(regions: [makeRegion(id: "g1", latitude: 1, longitude: 1)])))
         }
         let setup = makeCoordinator(api: api, storage: storage, syncMode: .fetchNearby)
@@ -1033,7 +1033,7 @@ struct GeofenceSyncCoordinatorTests {
         // fetchNearbyGeofences (not fetchAll).
         let storage = makeStorage()
         let api = GeofenceApiServiceMock()
-        api.fetchNearbyGeofencesClosure = { _, _, completion in
+        api.fetchNearbyGeofencesClosure = { _, _, _, completion in
             completion(.success(makeApiResponse(regions: [makeRegion(id: "g1", latitude: 1, longitude: 2)])))
         }
         let setup = makeCoordinator(api: api, storage: storage, syncMode: .fetchNearby)
@@ -1043,6 +1043,54 @@ struct GeofenceSyncCoordinatorTests {
         #expect(result.isSuccess)
         #expect(setup.api.fetchNearbyGeofencesCallsCount == 1)
         #expect(setup.api.fetchAllGeofencesCallsCount == 0)
+    }
+
+    @Test
+    func fetchNearby_givenCappedMonitoringDistance_expectRadiusIsMaxOfFetchDistanceAndCap() async {
+        // Search radius = max(remoteFetchRefreshTriggerRadius, maxMonitoringDistance) so the search
+        // covers everything within the monitoring cap we might register.
+        let storage = makeStorage()
+        await storage.setCachedConfig(GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 5000,
+            remoteFetchRefreshExpiry: 3600,
+            duplicateEventsExpiry: 3600,
+            maxBusinessGeofences: 10,
+            maxMonitoringDistance: 50000
+        ))
+        let api = GeofenceApiServiceMock()
+        api.fetchNearbyGeofencesClosure = { _, _, _, completion in
+            completion(.success(makeApiResponse(regions: [])))
+        }
+        let setup = makeCoordinator(api: api, storage: storage, syncMode: .fetchNearby)
+
+        _ = await setup.coordinator.handleMovement(latitude: 1, longitude: 2)
+
+        #expect(setup.api.fetchNearbyGeofencesReceivedArguments?.radius == 50000)
+    }
+
+    @Test
+    func fetchNearby_givenUncappedMonitoringDistance_expectRadiusFallsBackToDefaultCeiling() async {
+        // An uncapped monitoring distance can't go on the wire, so it falls back to the default
+        // ceiling — which still wins over the smaller fetch distance.
+        let storage = makeStorage()
+        await storage.setCachedConfig(GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 5000,
+            remoteFetchRefreshExpiry: 3600,
+            duplicateEventsExpiry: 3600,
+            maxBusinessGeofences: 10,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
+        ))
+        let api = GeofenceApiServiceMock()
+        api.fetchNearbyGeofencesClosure = { _, _, _, completion in
+            completion(.success(makeApiResponse(regions: [])))
+        }
+        let setup = makeCoordinator(api: api, storage: storage, syncMode: .fetchNearby)
+
+        _ = await setup.coordinator.handleMovement(latitude: 1, longitude: 2)
+
+        #expect(setup.api.fetchNearbyGeofencesReceivedArguments?.radius == GeofenceConstants.defaultMaxMonitoringDistance)
     }
 
     @Test
@@ -1089,7 +1137,7 @@ struct GeofenceSyncCoordinatorTests {
         // Fetched recently (time-fresh) at (0, 0).
         await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-100), location: LocationData(latitude: 0, longitude: 0))
         let api = GeofenceApiServiceMock()
-        api.fetchNearbyGeofencesClosure = { _, _, completion in
+        api.fetchNearbyGeofencesClosure = { _, _, _, completion in
             completion(.success(makeApiResponse(regions: [makeRegion(id: "g1", latitude: 1, longitude: 1)])))
         }
         let setup = makeCoordinator(api: api, storage: storage, dateUtil: dateUtil, syncMode: .fetchNearby)

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -84,7 +84,8 @@ struct GeofenceSyncCoordinatorTests {
                 radius: region.radius,
                 externalId: nil,
                 transitionTypes: region.transitionTypes.map(\.rawValue),
-                lastUpdated: region.lastUpdated.timeIntervalSince1970
+                lastUpdated: region.lastUpdated.timeIntervalSince1970,
+                geosetIds: region.geosetIds.isEmpty ? nil : region.geosetIds
             )
         }
         let apiConfig = config.map { config in

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceDeliveryTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceDeliveryTrackerTests.swift
@@ -109,6 +109,25 @@ struct GeofenceDeliveryTrackerTests {
         #expect(properties["geosetId"] as? String == "set_alpha")
     }
 
+    @Test
+    func trackMetric_givenNumericGeosetId_expectEmittedAsStringNotNumber() async {
+        // A numeric-looking geoset must serialize as a JSON string, not a number, to stay aligned
+        // with Android (which also emits it as a string). Guards against re-introducing numeric
+        // coercion in trackEventProperties.
+        let (tracker, httpClient) = makeTracker()
+        httpClient.sendTrackEventClosure = { _, completion in completion(.success(())) }
+
+        await withCheckedContinuation { continuation in
+            tracker.trackMetric(metric: makeMetric(geosetId: "123"), userId: "user_42") { _ in
+                continuation.resume()
+            }
+        }
+
+        let properties = httpClient.sendTrackEventReceivedArguments?.request.properties ?? [:]
+        #expect(properties["geosetId"] as? String == "123")
+        #expect(properties["geosetId"] as? Int == nil)
+    }
+
     // MARK: - Guard clauses
 
     @Test

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceDeliveryTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceDeliveryTrackerTests.swift
@@ -19,7 +19,8 @@ struct GeofenceDeliveryTrackerTests {
         transition: GeofenceTransition = .enter,
         timestamp: Date = Date(timeIntervalSince1970: 1700000000),
         name: String? = nil,
-        transitionId: String = "txn_abc"
+        transitionId: String = "txn_abc",
+        geosetId: String? = nil
     ) -> PendingGeofenceMetric {
         PendingGeofenceMetric(
             geofenceId: geofenceId,
@@ -27,7 +28,8 @@ struct GeofenceDeliveryTrackerTests {
             timestamp: timestamp,
             userId: nil,
             name: name,
-            transitionId: transitionId
+            transitionId: transitionId,
+            geosetId: geosetId
         )
     }
 
@@ -90,6 +92,38 @@ struct GeofenceDeliveryTrackerTests {
         let args = httpClient.sendTrackEventReceivedArguments
         #expect(args?.request.eventName == "Geofence Transition")
         #expect(args?.request.properties["transition"] as? String == "exit")
+    }
+
+    @Test
+    func trackMetric_givenNumericGeosetId_expectGeosetIdEmittedAsNumber() async {
+        let (tracker, httpClient) = makeTracker()
+        httpClient.sendTrackEventClosure = { _, completion in completion(.success(())) }
+
+        await withCheckedContinuation { continuation in
+            tracker.trackMetric(metric: makeMetric(geosetId: "42"), userId: "user_42") { _ in
+                continuation.resume()
+            }
+        }
+
+        let properties = httpClient.sendTrackEventReceivedArguments?.request.properties ?? [:]
+        // Type-preserving: a numeric geoset id goes out as a number, not a string.
+        #expect(properties["geosetId"] as? Int64 == 42)
+        #expect(properties["geosetId"] as? String == nil)
+    }
+
+    @Test
+    func trackMetric_givenNonNumericGeosetId_expectGeosetIdEmittedAsString() async {
+        let (tracker, httpClient) = makeTracker()
+        httpClient.sendTrackEventClosure = { _, completion in completion(.success(())) }
+
+        await withCheckedContinuation { continuation in
+            tracker.trackMetric(metric: makeMetric(geosetId: "set_alpha"), userId: "user_42") { _ in
+                continuation.resume()
+            }
+        }
+
+        let properties = httpClient.sendTrackEventReceivedArguments?.request.properties ?? [:]
+        #expect(properties["geosetId"] as? String == "set_alpha")
     }
 
     // MARK: - Guard clauses

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceDeliveryTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceDeliveryTrackerTests.swift
@@ -95,24 +95,7 @@ struct GeofenceDeliveryTrackerTests {
     }
 
     @Test
-    func trackMetric_givenNumericGeosetId_expectGeosetIdEmittedAsNumber() async {
-        let (tracker, httpClient) = makeTracker()
-        httpClient.sendTrackEventClosure = { _, completion in completion(.success(())) }
-
-        await withCheckedContinuation { continuation in
-            tracker.trackMetric(metric: makeMetric(geosetId: "42"), userId: "user_42") { _ in
-                continuation.resume()
-            }
-        }
-
-        let properties = httpClient.sendTrackEventReceivedArguments?.request.properties ?? [:]
-        // Type-preserving: a numeric geoset id goes out as a number, not a string.
-        #expect(properties["geosetId"] as? Int64 == 42)
-        #expect(properties["geosetId"] as? String == nil)
-    }
-
-    @Test
-    func trackMetric_givenNonNumericGeosetId_expectGeosetIdEmittedAsString() async {
+    func trackMetric_givenGeosetId_expectGeosetIdEmittedAsString() async {
         let (tracker, httpClient) = makeTracker()
         httpClient.sendTrackEventClosure = { _, completion in completion(.success(())) }
 

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -100,7 +100,7 @@ struct GeofenceEventTrackerTests {
     }
 
     @Test
-    func trackTransition_givenPersistFailsAndSendFails_expectCooldownReleasedForRetry() async {
+    func trackTransition_givenPersistFails_expectDeliverySkippedAndCooldownReleased() async {
         // Force the pending store onto an unwritable path: a regular file stands where its parent
         // directory should be, so createDirectory + write both fail and append() returns false.
         let blocker = makeTempDirectory()
@@ -113,7 +113,7 @@ struct GeofenceEventTrackerTests {
         let storage = makeStorage(directory: storageDir)
         let dateUtil = DateUtilStub()
         let delivery = GeofenceDeliveryTrackerMock()
-        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.failure(.transport)) }
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
         let tracker = makeTracker(
             storage: storage,
             pendingStore: makePendingStore(directory: unwritablePendingDir),
@@ -124,9 +124,11 @@ struct GeofenceEventTrackerTests {
 
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
 
-        // Nothing was queued (persist failed), and the cooldown claimed for this crossing was
-        // released — so the same transition can be re-acquired instead of staying suppressed against
-        // a metric that never reached the queue. A held cooldown would make this claim return false.
+        // Delivery is skipped for a row that never reached disk: sending it and then draining on
+        // success could remove a later same-second crossing's row (keys omit transitionId).
+        #expect(delivery.trackMetricCallsCount == 0)
+        // The cooldown claimed for this crossing was released, so the next crossing retries from a
+        // clean state instead of being suppressed. A held cooldown would make this claim return false.
         let canRetry = await storage.tryAcquireCooldown(key: "geo_1:enter", now: dateUtil.now, interval: cooldownInterval)
         #expect(canRetry)
     }

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -666,6 +666,31 @@ struct GeofenceEventTrackerTests {
     }
 
     @Test
+    func trackTransition_givenBlankGeosetIds_expectSingleMetricWithoutGeosetId() async {
+        // Blank ids are dropped, so an all-empty membership behaves like no geoset — one event
+        // without a geosetId, not a stray event carrying an empty string.
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        await seedGeofence(storage, id: "geo_1", name: "HQ", geosetIds: ["", ""])
+        let pending = makePendingStore(directory: dir)
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
+        let tracker = makeTracker(
+            storage: storage,
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_42")
+        )
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+
+        let metrics = delivery.trackMetricReceivedInvocations.map(\.metric)
+        #expect(metrics.count == 1)
+        #expect(metrics.first?.geosetId == nil)
+    }
+
+    @Test
     func trackTransition_givenDuplicateGeosetIds_expectOneEventPerDistinctGeoset() async {
         // A fence that lists the same geoset twice must fan out once per distinct geoset — not
         // deliver the duplicate twice (the rows would share a pending key but the deliver loop
@@ -739,7 +764,7 @@ struct GeofenceEventTrackerTests {
         #expect(await pending.loadAll().isEmpty)
         let posted = postedGeofenceEvents(from: bus)
         #expect(posted.count == 2)
-        #expect(posted.map(\.geosetId) == ["set_y", "set_z"])
+        #expect(Set(posted.compactMap(\.geosetId)) == ["set_y", "set_z"]) // delivery order is not guaranteed (concurrent)
         #expect(posted.allSatisfy { $0.geofenceId == "geo_1" })
     }
 

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -370,7 +370,7 @@ struct GeofenceEventTrackerTests {
         // either metric from being delivered twice.
         async let flush1: Void = tracker.flushPending()
         async let flush2: Void = tracker.flushPending()
-        _ = await(flush1, flush2)
+        _ = await (flush1, flush2)
 
         #expect(delivery.trackMetricCallsCount == 2)
         #expect(await pending.loadAll().isEmpty)

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -370,7 +370,7 @@ struct GeofenceEventTrackerTests {
         // either metric from being delivered twice.
         async let flush1: Void = tracker.flushPending()
         async let flush2: Void = tracker.flushPending()
-        _ = await (flush1, flush2)
+        _ = await(flush1, flush2)
 
         #expect(delivery.trackMetricCallsCount == 2)
         #expect(await pending.loadAll().isEmpty)

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -100,6 +100,38 @@ struct GeofenceEventTrackerTests {
     }
 
     @Test
+    func trackTransition_givenPersistFailsAndSendFails_expectCooldownReleasedForRetry() async {
+        // Force the pending store onto an unwritable path: a regular file stands where its parent
+        // directory should be, so createDirectory + write both fail and append() returns false.
+        let blocker = makeTempDirectory()
+        FileManager.default.createFile(atPath: blocker.path, contents: Data())
+        defer { try? FileManager.default.removeItem(at: blocker) }
+        let unwritablePendingDir = blocker.appendingPathComponent("nested")
+
+        let storageDir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: storageDir) }
+        let storage = makeStorage(directory: storageDir)
+        let dateUtil = DateUtilStub()
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.failure(.transport)) }
+        let tracker = makeTracker(
+            storage: storage,
+            pendingStore: makePendingStore(directory: unwritablePendingDir),
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_42"),
+            dateUtil: dateUtil
+        )
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+
+        // Nothing was queued (persist failed), and the cooldown claimed for this crossing was
+        // released — so the same transition can be re-acquired instead of staying suppressed against
+        // a metric that never reached the queue. A held cooldown would make this claim return false.
+        let canRetry = await storage.tryAcquireCooldown(key: "geo_1:enter", now: dateUtil.now, interval: cooldownInterval)
+        #expect(canRetry)
+    }
+
+    @Test
     func trackTransition_givenDeliveryFailsThenFlush_expectSameTransitionIdReused() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -598,4 +598,146 @@ struct GeofenceEventTrackerTests {
 
         #expect(await pending.loadAll().first?.name == nil)
     }
+
+    // MARK: - Geoset fan-out
+
+    private func seedGeofence(_ storage: GeofenceStorage, id: String, name: String, geosetIds: [String]) async {
+        await storage.setCachedGeofences([
+            Geofence(
+                id: id, latitude: 1, longitude: 2, radius: 100,
+                name: name, transitionTypes: [.enter], lastUpdated: Date(timeIntervalSince1970: 0),
+                geosetIds: geosetIds
+            )
+        ])
+    }
+
+    @Test
+    func trackTransition_givenGeofenceInTwoGeosets_expectOneStandaloneMetricPerGeoset() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        await seedGeofence(storage, id: "geo_1", name: "HQ", geosetIds: ["set_y", "set_z"])
+        let pending = makePendingStore(directory: dir)
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
+        let tracker = makeTracker(
+            storage: storage,
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_42")
+        )
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+
+        // One delivery per geoset, each a standalone event with a scalar geosetId
+        // plus full geofence metadata.
+        let metrics = delivery.trackMetricReceivedInvocations.map(\.metric)
+        #expect(metrics.count == 2)
+        #expect(metrics.map(\.geosetId) == ["set_y", "set_z"])
+        #expect(metrics.allSatisfy { $0.geofenceId == "geo_1" })
+        #expect(metrics.allSatisfy { $0.name == "HQ" })
+        #expect(metrics.allSatisfy { $0.transition == .enter })
+        // Each fanned-out event is its own transition event with its own identity.
+        #expect(Set(metrics.map(\.transitionId)).count == 2)
+        #expect(await pending.loadAll().isEmpty)
+    }
+
+    @Test
+    func trackTransition_givenGeofenceInNoGeoset_expectSingleMetricWithoutGeosetId() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        await seedGeofence(storage, id: "geo_1", name: "HQ", geosetIds: [])
+        let pending = makePendingStore(directory: dir)
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
+        let tracker = makeTracker(
+            storage: storage,
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_42")
+        )
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+
+        let metrics = delivery.trackMetricReceivedInvocations.map(\.metric)
+        #expect(metrics.count == 1)
+        #expect(metrics.first?.geosetId == nil)
+    }
+
+    @Test
+    func trackTransition_givenTwoGeosetsAndDeliveryFailure_expectBothRowsRetained() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        await seedGeofence(storage, id: "geo_1", name: "HQ", geosetIds: ["set_y", "set_z"])
+        let pending = makePendingStore(directory: dir)
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.failure(.http(statusCode: 503))) }
+        let tracker = makeTracker(
+            storage: storage,
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_42")
+        )
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+
+        // Both fan-out rows persist independently; the pending-store key includes the
+        // geosetId so the rows of one transition cannot collide with each other.
+        let persisted = await pending.loadAll()
+        #expect(persisted.count == 2)
+        #expect(Set(persisted.compactMap(\.geosetId)) == ["set_y", "set_z"])
+    }
+
+    @Test
+    func trackTransition_givenTwoGeosetsAnonymous_expectOneEventBusEventPerGeoset() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        await seedGeofence(storage, id: "geo_1", name: "HQ", geosetIds: ["set_y", "set_z"])
+        let pending = makePendingStore(directory: dir)
+        let delivery = GeofenceDeliveryTrackerMock()
+        let bus = EventBusHandlerMock()
+        let tracker = makeTracker(
+            storage: storage,
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(),
+            eventBus: bus
+        )
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+
+        #expect(delivery.trackMetricCallsCount == 0)
+        #expect(await pending.loadAll().isEmpty)
+        let posted = postedGeofenceEvents(from: bus)
+        #expect(posted.count == 2)
+        #expect(posted.map(\.geosetId) == ["set_y", "set_z"])
+        #expect(posted.allSatisfy { $0.geofenceId == "geo_1" })
+    }
+
+    @Test
+    func trackTransition_givenTwoGeosetsWithinCooldown_expectSecondTransitionFullySuppressed() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        await seedGeofence(storage, id: "geo_1", name: "HQ", geosetIds: ["set_y", "set_z"])
+        let pending = makePendingStore(directory: dir)
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
+        let tracker = makeTracker(
+            storage: storage,
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_42")
+        )
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+
+        // The cooldown gates the physical transition, before fan-out: the second
+        // enter produces zero additional deliveries, not a partial fan-out.
+        #expect(delivery.trackMetricCallsCount == 2)
+    }
 }

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -440,13 +440,13 @@ struct GeofenceEventTrackerTests {
         defer { try? FileManager.default.removeItem(at: dir) }
         let pending = makePendingStore(directory: dir)
         // Row was captured under user_A; current user is now user_B (after sign-out + new sign-in).
-        _ = await pending.append(PendingGeofenceMetric(
+        _ = await pending.append([PendingGeofenceMetric(
             geofenceId: "geo_1", transition: .enter,
             timestamp: Date(timeIntervalSince1970: 1),
             userId: "user_A",
             name: nil,
             transitionId: "txn_a"
-        ))
+        )])
         let delivery = GeofenceDeliveryTrackerMock()
         delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
         let tracker = makeTracker(
@@ -467,13 +467,13 @@ struct GeofenceEventTrackerTests {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let pending = makePendingStore(directory: dir)
-        _ = await pending.append(PendingGeofenceMetric(
+        _ = await pending.append([PendingGeofenceMetric(
             geofenceId: "geo_1", transition: .enter,
             timestamp: Date(timeIntervalSince1970: 1),
             userId: "user_A",
             name: nil,
             transitionId: "txn_a"
-        ))
+        )])
         let delivery = GeofenceDeliveryTrackerMock()
         delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
         let tracker = makeTracker(
@@ -495,13 +495,13 @@ struct GeofenceEventTrackerTests {
         let pending = makePendingStore(directory: dir)
         // Row with no stamped userId (anonymous capture or legacy pre-upgrade).
         let capturedAt = Date(timeIntervalSince1970: 1700000000)
-        _ = await pending.append(PendingGeofenceMetric(
+        _ = await pending.append([PendingGeofenceMetric(
             geofenceId: "geo_1", transition: .enter,
             timestamp: capturedAt,
             userId: nil,
             name: nil,
             transitionId: "txn_a"
-        ))
+        )])
         let delivery = GeofenceDeliveryTrackerMock()
         let bus = EventBusHandlerMock()
         let tracker = makeTracker(
@@ -633,12 +633,12 @@ struct GeofenceEventTrackerTests {
         // plus full geofence metadata.
         let metrics = delivery.trackMetricReceivedInvocations.map(\.metric)
         #expect(metrics.count == 2)
-        #expect(metrics.map(\.geosetId) == ["set_y", "set_z"])
+        #expect(Set(metrics.compactMap(\.geosetId)) == ["set_y", "set_z"]) // delivery order is not guaranteed (concurrent)
         #expect(metrics.allSatisfy { $0.geofenceId == "geo_1" })
         #expect(metrics.allSatisfy { $0.name == "HQ" })
         #expect(metrics.allSatisfy { $0.transition == .enter })
-        // Each fanned-out event is its own transition event with its own identity.
-        #expect(Set(metrics.map(\.transitionId)).count == 2)
+        // All fan-out rows share one transitionId (same physical crossing); geosetId distinguishes them.
+        #expect(Set(metrics.map(\.transitionId)).count == 1)
         #expect(await pending.loadAll().isEmpty)
     }
 
@@ -663,6 +663,32 @@ struct GeofenceEventTrackerTests {
         let metrics = delivery.trackMetricReceivedInvocations.map(\.metric)
         #expect(metrics.count == 1)
         #expect(metrics.first?.geosetId == nil)
+    }
+
+    @Test
+    func trackTransition_givenDuplicateGeosetIds_expectOneEventPerDistinctGeoset() async {
+        // A fence that lists the same geoset twice must fan out once per distinct geoset — not
+        // deliver the duplicate twice (the rows would share a pending key but the deliver loop
+        // would still send each).
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        await seedGeofence(storage, id: "geo_1", name: "HQ", geosetIds: ["set_y", "set_y", "set_z"])
+        let pending = makePendingStore(directory: dir)
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
+        let tracker = makeTracker(
+            storage: storage,
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_42")
+        )
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+
+        let metrics = delivery.trackMetricReceivedInvocations.map(\.metric)
+        #expect(metrics.count == 2)
+        #expect(Set(metrics.compactMap(\.geosetId)) == ["set_y", "set_z"]) // duplicate dropped (delivery order not guaranteed)
     }
 
     @Test

--- a/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
@@ -216,6 +216,35 @@ struct GeofenceStorageTests {
     }
 
     @Test
+    func setCachedGeofences_givenGeosetIds_expectRoundTrip() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let geofence = Geofence(
+            id: "g1", latitude: 1.0, longitude: 2.0, radius: 100, name: "g1",
+            transitionTypes: [.enter], lastUpdated: Date(timeIntervalSince1970: 1700000000),
+            geosetIds: ["set_y", "set_z"]
+        )
+        await storage.setCachedGeofences([geofence])
+        let cached = await storage.getCachedGeofences()
+        #expect(cached.first?.geosetIds == ["set_y", "set_z"])
+    }
+
+    @Test
+    func decode_givenGeofenceCachedByPreGeosetVersion_expectEmptyGeosetIds() throws {
+        // Geofences cached to disk before the `geosetIds` field existed must keep
+        // decoding after an upgrade; a missing key means no geoset membership.
+        let legacyJson = """
+        {"id":"g1","latitude":1,"longitude":2,"radius":100,"name":"g1","transitionTypes":["enter"],"lastUpdated":1700000000}
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let geofence = try decoder.decode(Geofence.self, from: Data(legacyJson.utf8))
+
+        #expect(geofence.geosetIds == [])
+    }
+
+    @Test
     func setCachedGeofences_givenSecondCall_expectOverwrites() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }

--- a/Tests/LocationGeofence/Geofence/Storage/PendingGeofenceMetricStoreTests.swift
+++ b/Tests/LocationGeofence/Geofence/Storage/PendingGeofenceMetricStoreTests.swift
@@ -49,7 +49,7 @@ struct PendingGeofenceMetricStoreTests {
         let store = makeStore(directory: dir)
         let metric = makeMetric()
 
-        let appended = await store.append(metric)
+        let appended = await store.append([metric])
         let items = await store.loadAll()
 
         #expect(appended == true)
@@ -65,8 +65,8 @@ struct PendingGeofenceMetricStoreTests {
         let first = makeMetric(geofenceId: "geo_1")
         let second = makeMetric(geofenceId: "geo_2")
 
-        _ = await store.append(first)
-        _ = await store.append(second)
+        _ = await store.append([first])
+        _ = await store.append([second])
         let items = await store.loadAll()
 
         #expect(items.count == 2)
@@ -84,7 +84,7 @@ struct PendingGeofenceMetricStoreTests {
 
         // Append 105 metrics; cap is 100. First 5 should be dropped.
         for i in 0 ..< 105 {
-            _ = await store.append(makeMetric(geofenceId: "geo_\(i)"))
+            _ = await store.append([makeMetric(geofenceId: "geo_\(i)")])
         }
         let items = await store.loadAll()
 
@@ -101,13 +101,29 @@ struct PendingGeofenceMetricStoreTests {
 
         // Append exactly 100 (the cap); guards against an off-by-one in the `>` check.
         for i in 0 ..< 100 {
-            _ = await store.append(makeMetric(geofenceId: "geo_\(i)"))
+            _ = await store.append([makeMetric(geofenceId: "geo_\(i)")])
         }
         let items = await store.loadAll()
 
         #expect(items.count == 100)
         #expect(items.first?.geofenceId == "geo_0")
         #expect(items.last?.geofenceId == "geo_99")
+    }
+
+    @Test
+    func append_givenBatchOverCapacity_expectOldestDropped() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = makeStore(directory: dir)
+
+        // A single batch larger than the cap must trim to the newest 100 in that one write.
+        let batch = (0 ..< 105).map { makeMetric(geofenceId: "geo_\($0)") }
+        _ = await store.append(batch)
+        let items = await store.loadAll()
+
+        #expect(items.count == 100)
+        #expect(items.first?.geofenceId == "geo_5")
+        #expect(items.last?.geofenceId == "geo_104")
     }
 
     // MARK: - Remove
@@ -119,8 +135,8 @@ struct PendingGeofenceMetricStoreTests {
         let store = makeStore(directory: dir)
         let toKeep = makeMetric(geofenceId: "keep")
         let toRemove = makeMetric(geofenceId: "remove")
-        _ = await store.append(toKeep)
-        _ = await store.append(toRemove)
+        _ = await store.append([toKeep])
+        _ = await store.append([toRemove])
 
         let removed = await store.remove(key: toRemove.key)
         let items = await store.loadAll()
@@ -136,7 +152,7 @@ struct PendingGeofenceMetricStoreTests {
         defer { try? FileManager.default.removeItem(at: dir) }
         let store = makeStore(directory: dir)
         let metric = makeMetric()
-        _ = await store.append(metric)
+        _ = await store.append([metric])
 
         let removed = await store.remove(key: "nonexistent_key")
         let items = await store.loadAll()
@@ -154,8 +170,8 @@ struct PendingGeofenceMetricStoreTests {
         let store = makeStore(directory: dir)
         let first = makeMetric(geofenceId: "geo_1")
         let second = makeMetric(geofenceId: "geo_2")
-        _ = await store.append(first)
-        _ = await store.append(second)
+        _ = await store.append([first])
+        _ = await store.append([second])
 
         let success = await store.removeAll(keys: [first.key, second.key])
         let items = await store.loadAll()
@@ -171,8 +187,8 @@ struct PendingGeofenceMetricStoreTests {
         let store = makeStore(directory: dir)
         let toKeep = makeMetric(geofenceId: "keep")
         let toRemove = makeMetric(geofenceId: "remove")
-        _ = await store.append(toKeep)
-        _ = await store.append(toRemove)
+        _ = await store.append([toKeep])
+        _ = await store.append([toRemove])
 
         let success = await store.removeAll(keys: [toRemove.key, "nonexistent_key"])
         let items = await store.loadAll()
@@ -186,7 +202,7 @@ struct PendingGeofenceMetricStoreTests {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let store = makeStore(directory: dir)
-        _ = await store.append(makeMetric())
+        _ = await store.append([makeMetric()])
 
         let success = await store.removeAll(keys: [])
         let items = await store.loadAll()
@@ -195,51 +211,65 @@ struct PendingGeofenceMetricStoreTests {
         #expect(items.count == 1)
     }
 
-    // MARK: - Duplicate-key dedup at append
+    // MARK: - Append dedup + atomic fan-out
 
     @Test
-    func append_givenDuplicateKey_expectNoOpReturnTrue() async {
+    func append_givenDuplicateKeysInBatchAndOnDisk_expectDeduped() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let store = makeStore(directory: dir)
-        let metric = makeMetric()
-        _ = await store.append(metric)
+        let existing = makeMetric(geofenceId: "geo_1") // key already on disk
+        _ = await store.append([existing])
 
-        // Same geofenceId + transition + timestamp produces the same composite key.
-        // Storage layer rejects the duplicate so a cooldown-slip can't produce two rows.
-        let duplicate = makeMetric()
-        let appended = await store.append(duplicate)
+        // Batch repeats the on-disk key and an in-batch duplicate; both must be skipped so a
+        // cooldown-slip or re-fan-out can't produce duplicate rows.
+        let batch = [existing, makeMetric(geofenceId: "geo_2"), makeMetric(geofenceId: "geo_2")]
+        let appended = await store.append(batch)
         let items = await store.loadAll()
 
         #expect(appended == true)
-        #expect(items.count == 1)
+        #expect(items.count == 2)
+        #expect(Set(items.map(\.geofenceId)) == ["geo_1", "geo_2"])
     }
 
-    // MARK: - Geoset fan-out keys
-
     @Test
-    func append_givenSameTransitionDifferentGeosets_expectBothRowsKept() async {
+    func append_givenSameTransitionDifferentGeosets_expectBothRowsKeptInOneWrite() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let store = makeStore(directory: dir)
         let timestamp = Date(timeIntervalSince1970: 1700000000)
         // One physical transition fanned out to two geosets: identical
-        // (geofenceId, transition, timestamp), distinct geosetId suffixes.
+        // (geofenceId, transition, timestamp), distinct geosetId suffixes. Persisted atomically.
         let rowY = PendingGeofenceMetric(
             geofenceId: "geo_1", transition: .enter, timestamp: timestamp,
-            userId: nil, name: nil, transitionId: "txn_y", geosetId: "set_y"
+            userId: nil, name: nil, transitionId: "txn", geosetId: "set_y"
         )
         let rowZ = PendingGeofenceMetric(
             geofenceId: "geo_1", transition: .enter, timestamp: timestamp,
-            userId: nil, name: nil, transitionId: "txn_z", geosetId: "set_z"
+            userId: nil, name: nil, transitionId: "txn", geosetId: "set_z"
         )
 
-        _ = await store.append(rowY)
-        _ = await store.append(rowZ)
+        let appended = await store.append([rowY, rowZ])
         let items = await store.loadAll()
 
-        #expect(rowY.key != rowZ.key)
+        #expect(appended == true)
+        #expect(rowY.key != rowZ.key) // geoset suffix keeps fan-out rows distinct
         #expect(items.count == 2)
+        #expect(Set(items.compactMap(\.geosetId)) == ["set_y", "set_z"])
+    }
+
+    @Test
+    func append_givenEmpty_expectNoOpReturnTrue() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = makeStore(directory: dir)
+        _ = await store.append([makeMetric()])
+
+        let appended = await store.append([])
+        let items = await store.loadAll()
+
+        #expect(appended == true)
+        #expect(items.count == 1)
     }
 
     @Test
@@ -264,8 +294,8 @@ struct PendingGeofenceMetricStoreTests {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let store = makeStore(directory: dir)
-        _ = await store.append(makeMetric(geofenceId: "geo_1"))
-        _ = await store.append(makeMetric(geofenceId: "geo_2"))
+        _ = await store.append([makeMetric(geofenceId: "geo_1")])
+        _ = await store.append([makeMetric(geofenceId: "geo_2")])
 
         await store.clearAll()
         let items = await store.loadAll()
@@ -282,7 +312,7 @@ struct PendingGeofenceMetricStoreTests {
         let metric = makeMetric()
 
         let firstStore = makeStore(directory: dir)
-        _ = await firstStore.append(metric)
+        _ = await firstStore.append([metric])
 
         let secondStore = makeStore(directory: dir)
         let items = await secondStore.loadAll()
@@ -304,14 +334,14 @@ struct PendingGeofenceMetricStoreTests {
                     for j in 0 ..< 10 {
                         switch (i + j) % 3 {
                         case 0:
-                            _ = await store.append(PendingGeofenceMetric(
+                            _ = await store.append([PendingGeofenceMetric(
                                 geofenceId: "geo_\(i)_\(j)",
                                 transition: .enter,
                                 timestamp: Date(),
                                 userId: nil,
                                 name: nil,
                                 transitionId: "txn_\(i)_\(j)"
-                            ))
+                            )])
                         case 1:
                             _ = await store.loadAll()
                         case 2:

--- a/Tests/LocationGeofence/Geofence/Storage/PendingGeofenceMetricStoreTests.swift
+++ b/Tests/LocationGeofence/Geofence/Storage/PendingGeofenceMetricStoreTests.swift
@@ -215,6 +215,48 @@ struct PendingGeofenceMetricStoreTests {
         #expect(items.count == 1)
     }
 
+    // MARK: - Geoset fan-out keys
+
+    @Test
+    func append_givenSameTransitionDifferentGeosets_expectBothRowsKept() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = makeStore(directory: dir)
+        let timestamp = Date(timeIntervalSince1970: 1700000000)
+        // One physical transition fanned out to two geosets: identical
+        // (geofenceId, transition, timestamp), distinct geosetId suffixes.
+        let rowY = PendingGeofenceMetric(
+            geofenceId: "geo_1", transition: .enter, timestamp: timestamp,
+            userId: nil, name: nil, transitionId: "txn_y", geosetId: "set_y"
+        )
+        let rowZ = PendingGeofenceMetric(
+            geofenceId: "geo_1", transition: .enter, timestamp: timestamp,
+            userId: nil, name: nil, transitionId: "txn_z", geosetId: "set_z"
+        )
+
+        _ = await store.append(rowY)
+        _ = await store.append(rowZ)
+        let items = await store.loadAll()
+
+        #expect(rowY.key != rowZ.key)
+        #expect(items.count == 2)
+    }
+
+    @Test
+    func decode_givenLegacyRowWithoutGeosetId_expectNilGeosetId() throws {
+        // Rows persisted by pre-geoset SDK versions have no `geoset_id` field and
+        // must keep decoding after an upgrade.
+        let legacyJson = """
+        {"geofence_id":"geo_1","transition":"enter","timestamp":1700000000,"transition_id":"txn_legacy"}
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let metric = try decoder.decode(PendingGeofenceMetric.self, from: Data(legacyJson.utf8))
+
+        #expect(metric.geosetId == nil)
+        #expect(metric.key == "geo_1_enter_1700000000")
+    }
+
     // MARK: - Clear
 
     @Test

--- a/Tests/Mocks/LocationGeofence/AutoMockable.generated.swift
+++ b/Tests/Mocks/LocationGeofence/AutoMockable.generated.swift
@@ -165,29 +165,29 @@ class GeofenceApiServiceMock: @unchecked Sendable, GeofenceApiService, Mock {
     }
 
     /// The arguments from the *last* time the function was called.
-    private let _fetchNearbyGeofencesReceivedArguments: CioInternalCommon.Synchronized<(latitude: Double, longitude: Double, completion: (Result<GeofenceApiResponse, GeofenceApiError>) -> Void)?> = .init(nil)
-    var fetchNearbyGeofencesReceivedArguments: (latitude: Double, longitude: Double, completion: (Result<GeofenceApiResponse, GeofenceApiError>) -> Void)? {
+    private let _fetchNearbyGeofencesReceivedArguments: CioInternalCommon.Synchronized<(latitude: Double, longitude: Double, radius: Double, completion: (Result<GeofenceApiResponse, GeofenceApiError>) -> Void)?> = .init(nil)
+    var fetchNearbyGeofencesReceivedArguments: (latitude: Double, longitude: Double, radius: Double, completion: (Result<GeofenceApiResponse, GeofenceApiError>) -> Void)? {
         _fetchNearbyGeofencesReceivedArguments.wrappedValue
     }
 
     /// Arguments from *all* of the times that the function was called.
-    private let _fetchNearbyGeofencesReceivedInvocations: CioInternalCommon.Synchronized<[(latitude: Double, longitude: Double, completion: (Result<GeofenceApiResponse, GeofenceApiError>) -> Void)]> = .init([])
-    var fetchNearbyGeofencesReceivedInvocations: [(latitude: Double, longitude: Double, completion: (Result<GeofenceApiResponse, GeofenceApiError>) -> Void)] {
+    private let _fetchNearbyGeofencesReceivedInvocations: CioInternalCommon.Synchronized<[(latitude: Double, longitude: Double, radius: Double, completion: (Result<GeofenceApiResponse, GeofenceApiError>) -> Void)]> = .init([])
+    var fetchNearbyGeofencesReceivedInvocations: [(latitude: Double, longitude: Double, radius: Double, completion: (Result<GeofenceApiResponse, GeofenceApiError>) -> Void)] {
         _fetchNearbyGeofencesReceivedInvocations.wrappedValue
     }
 
     /**
      Set closure to get called when function gets called. Great way to test logic or return a value for the function.
      */
-    var fetchNearbyGeofencesClosure: ((Double, Double, @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void) -> Void)?
+    var fetchNearbyGeofencesClosure: ((Double, Double, Double, @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void) -> Void)?
 
-    /// Mocked function for `fetchNearbyGeofences(latitude: Double, longitude: Double, completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
-    func fetchNearbyGeofences(latitude: Double, longitude: Double, completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void) {
+    /// Mocked function for `fetchNearbyGeofences(latitude: Double, longitude: Double, radius: Double, completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
+    func fetchNearbyGeofences(latitude: Double, longitude: Double, radius: Double, completion: @escaping (Result<GeofenceApiResponse, GeofenceApiError>) -> Void) {
         mockCalled = true
         _fetchNearbyGeofencesCallsCount += 1
-        _fetchNearbyGeofencesReceivedArguments.wrappedValue = (latitude: latitude, longitude: longitude, completion: completion)
-        _fetchNearbyGeofencesReceivedInvocations.append((latitude: latitude, longitude: longitude, completion: completion))
-        fetchNearbyGeofencesClosure?(latitude, longitude, completion)
+        _fetchNearbyGeofencesReceivedArguments.wrappedValue = (latitude: latitude, longitude: longitude, radius: radius, completion: completion)
+        _fetchNearbyGeofencesReceivedInvocations.append((latitude: latitude, longitude: longitude, radius: radius, completion: completion))
+        fetchNearbyGeofencesClosure?(latitude, longitude, radius, completion)
     }
 }
 

--- a/Tests/Shared/Mocks/EventBusHandler.swift
+++ b/Tests/Shared/Mocks/EventBusHandler.swift
@@ -1,4 +1,5 @@
 import CioInternalCommon
+import Foundation
 
 /// Mock of the EventBusHandler class, designed to mimic AutoMockable
 /// Once the class is generated using AutoMockable, it should seamlessly replace the current implementation without any issues
@@ -46,8 +47,13 @@ public class EventBusHandlerMock: EventBusHandler, Mock {
     public var postEventCalled: Bool { postEventCallsCount > 0 }
     public private(set) var postEventArguments: (any EventRepresentable)?
     public private(set) var postEventReceivedInvocations: [any EventRepresentable] = []
+    // Production `postEvent` is safe to call concurrently (it hops onto an actor), so record
+    // invocations under a lock to match — otherwise concurrent callers race this state.
+    private let postEventLock = NSLock()
 
     public func postEvent<E: EventRepresentable>(_ event: E) {
+        postEventLock.lock()
+        defer { postEventLock.unlock() }
         mockCalled = true
         postEventCallsCount += 1
         postEventArguments = event
@@ -55,6 +61,8 @@ public class EventBusHandlerMock: EventBusHandler, Mock {
     }
 
     public func postEventAndWait<E>(_ event: E) async where E: EventRepresentable {
+        postEventLock.lock()
+        defer { postEventLock.unlock() }
         mockCalled = true
         postEventCallsCount += 1
         postEventArguments = event

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -300,6 +300,7 @@ public interface CioInternalCommon.GeofenceMetric {
 	public var timestamp: Date;
 	public var name: String?;
 	public var transitionId: String;
+	public var geosetId: String?;
 }
 public enum CioInternalCommon.GeofenceTransition {
 }
@@ -604,7 +605,8 @@ public final class CioInternalCommon.TrackGeofenceMetricEvent {
 	public final val timestamp: Date;
 	public final val name: String?;
 	public final val transitionId: String;
-	public fun init(storageId: String = UUID().uuidString, geofenceId: String, transition: GeofenceTransition, timestamp: Date = Date(), name: String?, transitionId: String, params: List<String: String> = List<:>);
+	public final val geosetId: String?;
+	public fun init(storageId: String = UUID().uuidString, geofenceId: String, transition: GeofenceTransition, timestamp: Date = Date(), name: String?, transitionId: String, geosetId: String? = nil, params: List<String: String> = List<:>);
 }
 public final class CioInternalCommon.TrackInAppMetricEvent {
 	public final val storageId: String;


### PR DESCRIPTION
Starting point for MBL-2008, for Rehan to take over when he's online. Ticket deliberately left unclaimed. Targets `feature/geofence-on-device`.

## What this does

The SDK learns geoset membership from the nearby response and stamps it onto transition events, so every event stands alone and campaign/segment matching needs no joins at ingest:

- `GeofenceApiRegion` decodes optional `geoset_ids` per fence (the endpoint's snake_case wire convention via `convertFromSnakeCase`); absent or empty means no membership, so backend can roll the field out gradually
- Cached `Geofence` carries `geosetIds`; geofences cached by pre-geoset SDK versions still decode (missing key defaults to empty)
- `trackTransition` fans one physical transition out to one `PendingGeofenceMetric` per geoset. Each event carries a scalar `geosetId` plus `geofenceId` / `geofenceName` metadata; a fence in sets Y and Z produces two standalone events, a fence in no geoset produces today's single fence-only event
- The cooldown/dedup gate still runs once per fence, before fan-out, so all rows of one transition are suppressed or emitted together
- The pending-store composite key gains a `geosetId` suffix so fan-out rows of one transition persist and retry independently (rows written by older versions keep their key shape)
- Both delivery paths carry `geosetId`: direct HTTP (`GeofenceMetric.trackEventProperties`) and EventBus (`TrackGeofenceMetricEvent`, new optional field, defaulted so persisted events replay)
- Event name unchanged (`Geofence Transition`), so ingest, journey-start gating, and analytics are untouched

Scalar `geosetId` rather than an array: campaign triggers and segment conditions match on scalar attribute equality (proposal section 5.4).

## Testing

New coverage in `GeofenceEventTrackerTests` (fan-out per geoset on both delivery paths, no-geoset fallback, failure retention of all fan-out rows, cooldown suppressing the whole transition), `GeofenceApiResponseTests` (wire decode present/absent), `GeofenceStorageTests` and `PendingGeofenceMetricStoreTests` (round-trips plus legacy decode compatibility for pre-geoset cached data). Existing tests compile unchanged (new params are defaulted).

Note: verified by CI only; local `swift build` on this machine can't target iOS.

## Open questions for Rehan

- Each fanned-out event gets its own `transitionId` (each is a standalone event per the ticket). If downstream dedup should instead treat the fan-out as one physical transition, they could share one id; flagging since #1129 introduced the field
- The pending-store key doc says it matches Android's `PendingGeofenceDelivery.key`; Android will need the same geoset suffix when it picks up its half
- `geosetId` (camelCase) follows the payload convention from #1121; confirm that's the agreed event property name

Linear: https://linear.app/customerio/issue/MBL-2008/sdk-emit-one-transition-event-per-fence-geoset-fence-as-metadata

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes geofence analytics volume (N events per crossing), alters the nearby-fetch API contract and radius semantics, and touches persist-first delivery edge cases; backward-compatible decoding limits upgrade risk.
> 
> **Overview**
> Adds **geoset-aware geofence transitions**: the API response can include `geoset_ids` (decoded as strings, including int64 wire values), cached `Geofence` models carry `geosetIds`, and **`trackTransition` fans one OS crossing into one metric/event per distinct geoset** (or a single event with no `geosetId` when the fence has none). Cooldown still applies once per fence before fan-out; fan-out rows share one **`transitionId`** and get distinct pending keys via a **`geosetId` suffix**. **`geosetId`** is added to **`GeofenceMetric` / track properties** and **`TrackGeofenceMetricEvent`**, with optional decode for older persisted events.
> 
> **Delivery and durability** changes: the pending queue **`append` accepts batches** so all fan-out rows persist atomically; delivery runs **concurrently** per row; if persist fails after claiming cooldown, **`releaseCooldown`** runs and send is skipped.
> 
> **Sync/API**: nearby fetch moves from **GET `/geofences/nearby` with query params** to **POST `/geofences/nearest`** with a JSON body (`latitude`, `longitude`, **`radius`**). **`GeofenceConfig.searchRadius`** supplies that radius from cached config (max of refetch distance and monitoring cap). Fetch-all stays **GET `/geofences/nearby`**.
> 
> Tests and mocks are updated for the new API signature, geoset decode/fan-out, persist-failure cooldown behavior, and legacy on-disk compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8e8a0eeb6bda2f3d9064fd54cfb6d02acce57d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->