### PR TITLE
chore(geofence): hold a background-task assertion across transition delivery

### DIFF
--- a/Sources/Common/Service/BackgroundDeliveryHttpClient.swift
+++ b/Sources/Common/Service/BackgroundDeliveryHttpClient.swift
@@ -59,17 +59,17 @@ public final class BackgroundDeliveryHttpClientImpl: BackgroundDeliveryHttpClien
     private let logger: Logger
 
     /// - Parameters:
-    ///   - requestTimeout: Per-request timeout. Defaults to 8s to fit a cold-wake background window
-    ///     (e.g. region monitoring), where a slow send should fail fast and be retried by the caller
-    ///     rather than be suspended mid-flight. Callers with a roomier window (e.g. a Notification
-    ///     Service Extension) can pass a larger value.
-    ///   - resourceTimeout: Whole-resource timeout, including waiting for connectivity. Defaults to 8s.
+    ///   - requestTimeout: Per-request timeout. Defaults to 15s. Callers deliver while holding a
+    ///     background-task assertion (~25–30s of runtime), so this sits under that floor to give a
+    ///     slow send on flaky cellular a realistic first-attempt while leaving headroom for the rest
+    ///     of the flush and cleanup. A send that still times out is retried by the caller.
+    ///   - resourceTimeout: Whole-resource timeout, including waiting for connectivity. Defaults to 20s.
     public convenience init(
         contextStore: BackgroundDeliveryContextStore,
         requestRunner: HttpRequestRunner,
         logger: Logger,
-        requestTimeout: TimeInterval = 8,
-        resourceTimeout: TimeInterval = 8
+        requestTimeout: TimeInterval = 15,
+        resourceTimeout: TimeInterval = 20
     ) {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.allowsCellularAccess = true

--- a/Sources/Common/Service/BackgroundTaskRunner.swift
+++ b/Sources/Common/Service/BackgroundTaskRunner.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Requests extra background execution time so a short async unit of work can finish after the OS
+/// wakes the app briefly, instead of the app being suspended mid-flight. The assertion is released
+/// when the work returns or the OS expires it, whichever comes first.
+///
+/// Best-effort timeliness aid only — callers must not depend on it for correctness. No-op where
+/// `UIApplication` is unavailable (non-UIKit platforms, app extensions).
+public protocol BackgroundTaskRunner: Sendable {
+    func withBackgroundTime(_ work: @Sendable () async -> Void) async
+}
+
+/// No-op runner: runs the work inline, identical to not requesting background time. Default where
+/// `UIApplication` is unavailable, and in tests.
+public struct NoBackgroundTaskRunner: BackgroundTaskRunner {
+    public init() {}
+
+    public func withBackgroundTime(_ work: @Sendable () async -> Void) async {
+        await work()
+    }
+}
+
+#if canImport(UIKit)
+import UIKit
+
+/// Wraps `work` in a `UIApplication` background-task assertion. Unavailable in app extensions —
+/// `UIApplication.shared` is a main-app-only API.
+@available(iOSApplicationExtension, unavailable)
+public struct UIKitBackgroundTaskRunner: BackgroundTaskRunner {
+    /// Debug label for the assertion, shown in the debugger/Instruments. Each subsystem passes its
+    /// own (e.g. geofence vs push delivery) so tasks are distinguishable in traces.
+    private let name: String
+
+    public init(name: String) {
+        self.name = name
+    }
+
+    public func withBackgroundTime(_ work: @Sendable () async -> Void) async {
+        let assertion = BackgroundTaskAssertion()
+        await assertion.begin(name: name)
+        await work()
+        await assertion.end()
+    }
+}
+
+/// Holds the assertion id on the main actor so the normal completion path and the OS expiration
+/// handler both end it exactly once.
+@available(iOSApplicationExtension, unavailable)
+@MainActor
+private final class BackgroundTaskAssertion {
+    private var id: UIBackgroundTaskIdentifier = .invalid
+
+    nonisolated init() {}
+
+    func begin(name: String) {
+        id = UIApplication.shared.beginBackgroundTask(withName: name) { [weak self] in
+            // OS is out of patience — end synchronously (this runs on the main thread) so the app
+            // isn't killed by the watchdog. In-flight work is abandoned; the caller owns any retry.
+            self?.end()
+        }
+    }
+
+    func end() {
+        guard id != .invalid else { return }
+        UIApplication.shared.endBackgroundTask(id)
+        id = .invalid
+    }
+}
+#endif

--- a/Sources/Common/Service/BackgroundTaskRunner.swift
+++ b/Sources/Common/Service/BackgroundTaskRunner.swift
@@ -55,7 +55,8 @@ private final class BackgroundTaskAssertion {
     func begin(name: String) {
         id = UIApplication.shared.beginBackgroundTask(withName: name) { [weak self] in
             // OS is out of patience — end synchronously (this runs on the main thread) so the app
-            // isn't killed by the watchdog. In-flight work is abandoned; the caller owns any retry.
+            // isn't killed by the watchdog. Ending the assertion doesn't cancel the work; the app may
+            // be suspended before it finishes, and any persisted rows are retried on the next flush.
             self?.end()
         }
     }

--- a/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
@@ -30,6 +30,7 @@ final class GeofenceEventTracker: @unchecked Sendable {
     private let dateUtil: DateUtil
     private let logger: Logger
     private let cooldownInterval: TimeInterval
+    private let backgroundTaskRunner: BackgroundTaskRunner
     private let activeDeliveryKeys: Synchronized<Set<String>> = Synchronized([])
 
     init(
@@ -40,7 +41,8 @@ final class GeofenceEventTracker: @unchecked Sendable {
         eventBusHandler: EventBusHandler,
         dateUtil: DateUtil,
         logger: Logger,
-        cooldownInterval: TimeInterval = GeofenceConstants.eventCooldownInterval
+        cooldownInterval: TimeInterval = GeofenceConstants.eventCooldownInterval,
+        backgroundTaskRunner: BackgroundTaskRunner = NoBackgroundTaskRunner()
     ) {
         self.storage = storage
         self.pendingStore = pendingStore
@@ -50,6 +52,7 @@ final class GeofenceEventTracker: @unchecked Sendable {
         self.dateUtil = dateUtil
         self.logger = logger
         self.cooldownInterval = cooldownInterval
+        self.backgroundTaskRunner = backgroundTaskRunner
     }
 
     /// Tracks a geofence transition, suppressing duplicates within the cooldown window.
@@ -105,7 +108,8 @@ final class GeofenceEventTracker: @unchecked Sendable {
             )
         }
         // Persist all rows in one atomic write: a per-row loop could save some and lose the rest on
-        // an app kill, and the cooldown is already spent so the lost ones would never retry.
+        // an app kill, and the cooldown is already spent so the lost ones would never retry. Done
+        // before requesting background time so durability never depends on the assertion.
         let persisted = await pendingStore.append(metrics)
         if !persisted {
             // Persist-first failed (disk error): release the just-claimed cooldown so the next
@@ -117,22 +121,29 @@ final class GeofenceEventTracker: @unchecked Sendable {
             return
         }
 
-        // Deliver concurrently so N geosets don't serialize N round-trips inside the OS's short
-        // background wake window. Safe: distinct keys (no dedup-claim collision), and rows are
-        // already persisted so any that don't finish are retried by flushPending.
-        await withTaskGroup(of: Void.self) { group in
-            for metric in metrics {
-                group.addTask { await self.deliver(metric: metric) }
+        // Hold a background-task assertion across delivery so the OS doesn't suspend us mid-send when
+        // it woke us only briefly for the transition. Deliver concurrently so N geosets don't
+        // serialize N round-trips inside that window. Safe: distinct keys (no dedup-claim collision),
+        // and rows are already persisted so any that don't finish are retried by flushPending.
+        await backgroundTaskRunner.withBackgroundTime { [self] in
+            await withTaskGroup(of: Void.self) { group in
+                for metric in metrics {
+                    group.addTask { await self.deliver(metric: metric) }
+                }
             }
         }
         await storage.purgeExpiredCooldowns(now: now, interval: interval)
     }
 
-    /// Replays every queued metric through `deliver`.
+    /// Replays every queued metric through `deliver`. Runs on module init and cold-wake bootstrap,
+    /// so it holds a background-task assertion too — the backlog can be replaying in a short wake.
     func flushPending() async {
         let pending = await pendingStore.loadAll()
-        for metric in pending {
-            await deliver(metric: metric)
+        guard !pending.isEmpty else { return }
+        await backgroundTaskRunner.withBackgroundTime { [self] in
+            for metric in pending {
+                await deliver(metric: metric)
+            }
         }
     }
 
@@ -201,6 +212,15 @@ extension DIGraphShared {
 extension GeofenceEventTracker {
     private static let sharedHolder = Synchronized<GeofenceEventTracker?>(nil)
 
+    /// Real background-task assertion in the app; no-op where `UIApplication` is unavailable.
+    private static var defaultBackgroundTaskRunner: BackgroundTaskRunner {
+        #if canImport(UIKit)
+        UIKitBackgroundTaskRunner(name: "io.customer.geofence.delivery")
+        #else
+        NoBackgroundTaskRunner()
+        #endif
+    }
+
     /// Lazily constructs and caches a process-wide singleton. Both `LocationModule.initialize`
     /// (foreground) and `LocationModule.bootstrapForBackgroundDelivery` (cold-wake) resolve
     /// through this DI accessor so they share the same tracker — same active-delivery dedup
@@ -219,7 +239,8 @@ extension GeofenceEventTracker {
                 contextStore: di.backgroundDeliveryContextStore,
                 eventBusHandler: di.eventBusHandler,
                 dateUtil: di.dateUtil,
-                logger: di.logger
+                logger: di.logger,
+                backgroundTaskRunner: Self.defaultBackgroundTaskRunner
             )
             current = tracker
             return tracker

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -37,7 +37,8 @@ struct GeofenceEventTrackerTests {
         deliveryTracker: GeofenceDeliveryTracker,
         contextStore: BackgroundDeliveryContextStore,
         eventBus: EventBusHandlerMock = EventBusHandlerMock(),
-        dateUtil: DateUtil = DateUtilStub()
+        dateUtil: DateUtil = DateUtilStub(),
+        backgroundTaskRunner: BackgroundTaskRunner = NoBackgroundTaskRunner()
     ) -> GeofenceEventTracker {
         GeofenceEventTracker(
             storage: storage,
@@ -47,7 +48,8 @@ struct GeofenceEventTrackerTests {
             eventBusHandler: eventBus,
             dateUtil: dateUtil,
             logger: LoggerMock(),
-            cooldownInterval: cooldownInterval
+            cooldownInterval: cooldownInterval,
+            backgroundTaskRunner: backgroundTaskRunner
         )
     }
 
@@ -824,5 +826,106 @@ struct GeofenceEventTrackerTests {
         // The cooldown gates the physical transition, before fan-out: the second
         // enter produces zero additional deliveries, not a partial fan-out.
         #expect(delivery.trackMetricCallsCount == 2)
+    }
+
+    // MARK: - Background task assertion
+
+    @Test
+    func trackTransition_expectDeliveryRunsInsideBackgroundTask() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pending = makePendingStore(directory: dir)
+        let runner = SpyBackgroundTaskRunner()
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in
+            runner.record("deliver")
+            onComplete(.success(()))
+        }
+        let tracker = makeTracker(
+            storage: makeStorage(directory: dir),
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_42"),
+            backgroundTaskRunner: runner
+        )
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+
+        // Delivery is bracketed by the assertion so the OS keeps the app alive through the send.
+        #expect(runner.callCount.wrappedValue == 1)
+        #expect(runner.events.wrappedValue == ["begin", "deliver", "end"])
+    }
+
+    @Test
+    func flushPending_givenQueuedRow_expectReplayRunsInsideBackgroundTask() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pending = makePendingStore(directory: dir)
+        _ = await pending.append([
+            PendingGeofenceMetric(
+                geofenceId: "geo_1",
+                transition: .enter,
+                timestamp: Date(timeIntervalSince1970: 1700000000),
+                userId: "user_42",
+                name: nil,
+                transitionId: "txn_1",
+                geosetId: nil
+            )
+        ])
+        let runner = SpyBackgroundTaskRunner()
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in
+            runner.record("deliver")
+            onComplete(.success(()))
+        }
+        let tracker = makeTracker(
+            storage: makeStorage(directory: dir),
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_42"),
+            backgroundTaskRunner: runner
+        )
+
+        await tracker.flushPending()
+
+        #expect(runner.callCount.wrappedValue == 1)
+        #expect(runner.events.wrappedValue == ["begin", "deliver", "end"])
+    }
+
+    @Test
+    func flushPending_givenEmptyQueue_expectNoBackgroundTaskRequested() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let runner = SpyBackgroundTaskRunner()
+        let tracker = makeTracker(
+            storage: makeStorage(directory: dir),
+            pendingStore: makePendingStore(directory: dir),
+            deliveryTracker: GeofenceDeliveryTrackerMock(),
+            contextStore: makeContextStore(userId: "user_42"),
+            backgroundTaskRunner: runner
+        )
+
+        await tracker.flushPending()
+
+        // Nothing to replay → no background time requested.
+        #expect(runner.callCount.wrappedValue == 0)
+    }
+}
+
+/// Records begin/end around the work and lets the work append its own markers, so tests can assert
+/// delivery runs strictly inside the assertion window.
+private final class SpyBackgroundTaskRunner: BackgroundTaskRunner, @unchecked Sendable {
+    let callCount = Synchronized(0)
+    let events = Synchronized<[String]>([])
+
+    func record(_ event: String) {
+        events.mutating { $0.append(event) }
+    }
+
+    func withBackgroundTime(_ work: @Sendable () async -> Void) async {
+        callCount.mutating { $0 += 1 }
+        record("begin")
+        await work()
+        record("end")
     }
 }

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -58,7 +58,7 @@ public interface CioInternalCommon.BackgroundDeliveryHttpClient {
 	public fun func sendTrackEvent(_ request: BackgroundTrackRequest, completion: @escaping (Result<Unit, BackgroundDeliveryHttpError>) -> Unit);
 }
 public final class CioInternalCommon.BackgroundDeliveryHttpClientImpl {
-	public fun convenience init(contextStore: BackgroundDeliveryContextStore, requestRunner: HttpRequestRunner, logger: Logger, requestTimeout: TimeInterval = 8, resourceTimeout: TimeInterval = 8);
+	public fun convenience init(contextStore: BackgroundDeliveryContextStore, requestRunner: HttpRequestRunner, logger: Logger, requestTimeout: TimeInterval = 15, resourceTimeout: TimeInterval = 20);
 	public fun func sendTrackEvent(_ request: BackgroundTrackRequest, completion: @escaping (Result<Unit, BackgroundDeliveryHttpError>) -> Unit);
 }
 public enum CioInternalCommon.BackgroundDeliveryHttpError {

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -63,6 +63,9 @@ public final class CioInternalCommon.BackgroundDeliveryHttpClientImpl {
 }
 public enum CioInternalCommon.BackgroundDeliveryHttpError {
 }
+public interface CioInternalCommon.BackgroundTaskRunner {
+	public fun func withBackgroundTime(_ work: @Sendable () async -> Unit) async;
+}
 public final class CioInternalCommon.BackgroundTrackRequest {
 	public final val eventName: String;
 	public final val userId: String;
@@ -410,6 +413,10 @@ public final class CioInternalCommon.NewSubscriptionEvent {
 	public final val subscribedEventType: String;
 	public final val timestamp: Date;
 }
+public final class CioInternalCommon.NoBackgroundTaskRunner {
+	public fun init();
+	public fun func withBackgroundTime(_ work: @Sendable () async -> Unit) async;
+}
 public final class CioInternalCommon.PendingPushDeliveryMetric {
 	public final val id: UUID;
 	public final val deliveryId: String;
@@ -624,6 +631,10 @@ public final class CioInternalCommon.TrackMetricEvent {
 	public final val deviceToken: String;
 	public final val timestamp: Date;
 	public fun init(storageId: String = UUID().uuidString, deliveryID: String, event: String, deviceToken: String, timestamp: Date = Date(), params: List<String: String> = List<:>);
+}
+public final class CioInternalCommon.UIKitBackgroundTaskRunner {
+	public fun init(name: String);
+	public fun func withBackgroundTime(_ work: @Sendable () async -> Unit) async;
 }
 public interface CioInternalCommon.UIKitWrapper {
 	public fun func open(url: URL);


### PR DESCRIPTION
When the OS wakes the app briefly for a geofence transition, delivery ran as an async task with no background-execution assertion — so the app could be suspended mid-send, leaving delivery to the next `flushPending`. This wraps the fan-out delivery (and the `flushPending` replay) in a `UIApplication` background-task assertion so the parallel sends can finish in the same wake.

## What changed
- New `Common/Service/BackgroundTaskRunner.swift`:
  - `BackgroundTaskRunner` protocol (`withBackgroundTime`).
  - `NoBackgroundTaskRunner` — runs inline, identical to today's behavior; extension-safe; the constructor default.
  - `UIKitBackgroundTaskRunner(name:)` — real assertion, `@available(iOSApplicationExtension, unavailable)` (mirrors the existing `UIKitWrapper` pattern so Common still compiles for the NSE). `name` is required so each subsystem labels its task in Instruments/traces.
- `GeofenceEventTracker` wraps both `trackTransition` delivery and `flushPending` replay. **Persist happens before the assertion** — durability never depends on it.
- `BackgroundDeliveryHttpClient` request/resource timeouts raised 8s→15s/20s — the assertion now guarantees the runtime to afford them, kept under the assertion floor to leave headroom for flush/cleanup. `flushPending`'s sequential replay is the one backlog caveat; delivery is persist-first + at-least-once, so a timeout only defers, never loses.

## Why it's safe
Best-effort timeliness aid, not a correctness dependency:
- Rows are persisted to disk before delivery; `deliver()` drains a row only on success.
- Anything unfinished replays via `flushPending` (module init / `ProfileIdentifiedEvent` / next wake), deduped by `transitionId` (at-least-once).
- `endBackgroundTask` is idempotent (guards `.invalid`) — the completion path and the OS expiration handler can't double-end. If the OS denies the grant, work runs unprotected = today's behavior.

## Tests
- Spy runner verifies delivery runs strictly inside the assertion for both `trackTransition` and `flushPending`, and that an empty queue requests no background time.
- `NoBackgroundTaskRunner` (the default) is exercised by every existing tracker test.
- api-docs baseline regenerated for the new public Common symbols.

## Stack
Independent of the fetchAll removal (touches different files), based on the fan-out it extends:
1. **This PR** → `mbl-2008-geoset-fanout`
2. #1148 (`chore/geofence-remove-fetchall`) → `mbl-2008-geoset-fanout` — sibling
3. #1146 (`mbl-2008-geoset-fanout`) → `feature/geofence-on-device`
4. #1130 (`feature/geofence-on-device`) → `main`

Merge order: #1146 first, then this and #1148 (either order), then #1130.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cold-wake geofence delivery and shared background HTTP defaults; correctness still depends on persist-first + retry, but longer timeouts and OS background limits can change timing of first-attempt sends.
> 
> **Overview**
> Geofence transition delivery and pending replay now run inside a **UIApplication background-task assertion** so brief OS wakes are less likely to suspend the app mid-HTTP send. A new **`BackgroundTaskRunner`** abstraction in Common provides **`UIKitBackgroundTaskRunner`** (main app, labeled `io.customer.geofence.delivery`) and **`NoBackgroundTaskRunner`** for extensions and tests.
> 
> **`GeofenceEventTracker`** still **persists metrics before** requesting background time; it wraps concurrent fan-out delivery in `trackTransition` and sequential replay in **`flushPending`** (skipping the assertion when the queue is empty). **`BackgroundDeliveryHttpClient`** default timeouts increase from **8s to 15s / 20s** to align with the longer assertion window. Tests use a spy runner; internal API docs list the new public symbols.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e66266564eeabeaaeaee5e361fa1668d7a8a253d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

