### PR TITLE
chore(live-activities): [1/3] LiveActivities_Attributes wire-contract module

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.10
 
 /**
  Manifest file for Swift Package Manager. This file defines our Swift Package for customers to install our SDK modules into their app. 
@@ -19,7 +19,8 @@ var products: [PackageDescription.Product] = [
     .library(name: "MessagingPushAPN", targets: ["CioMessagingPushAPN"]),
     .library(name: "MessagingPushFCM", targets: ["CioMessagingPushFCM"]),
     .library(name: "MessagingInApp", targets: ["CioMessagingInApp"]),
-    .library(name: "Location", targets: ["CioLocation"])
+    .library(name: "Location", targets: ["CioLocation"]),
+    .library(name: "LiveActivities_Attributes", targets: ["CioLiveActivities_Attributes"])
 ]
 
 // When we execute the automated test suite, we use tools to determine the code coverage of our tests. 
@@ -168,5 +169,11 @@ let package = Package(
         .testTarget(name: "LocationTests",
                     dependencies: ["CioLocation", "CioInternalCommon", "SharedTests", "CioInternalCommonMocks"],
                     path: "Tests/Location"),
+
+        // Live Activities — protocol only, no SDK dependency.
+        // Safe to import in any target (app, widget extension) that needs CIOActivityAttribute.
+        .target(name: "CioLiveActivities_Attributes",
+                dependencies: [],
+                path: "Sources/LiveActivities_Attributes"),
     ]
 )

--- a/Sources/LiveActivities_Attributes/CIOActivityAttribute.swift
+++ b/Sources/LiveActivities_Attributes/CIOActivityAttribute.swift
@@ -29,9 +29,10 @@ import Foundation
 public protocol CIOActivityAttribute: ActivityAttributes {
     /// SDK-managed correlation id for this activity instance.
     ///
-    /// Populated by the SDK (local start) or the Customer.io backend (push-to-start) and
-    /// matched server-side to route push updates to the correct activity. Declare it with a
-    /// default value and never set it yourself.
-    var cioInstanceId: String { get }
+    /// The SDK writes this on local `start` (minting a ULID) and the Customer.io backend writes
+    /// it for push-to-start; it is then matched server-side to route push updates to the correct
+    /// activity. It is `{ get set }` so the SDK can inject the id into your attributes on local
+    /// start — declare it as a `var` with a default value and never set it yourself.
+    var cioInstanceId: String { get set }
 }
 #endif

--- a/Sources/LiveActivities_Attributes/CIOActivityAttribute.swift
+++ b/Sources/LiveActivities_Attributes/CIOActivityAttribute.swift
@@ -1,0 +1,37 @@
+#if os(iOS)
+import ActivityKit
+import Foundation
+
+/// Extends `ActivityAttributes` with an SDK-managed correlation id, enabling
+/// **push-to-start** for the conforming activity type.
+///
+/// Conform your `ActivityAttributes` type to this protocol only when you want the
+/// Customer.io backend to be able to *start* activities remotely. For that case the
+/// backend stamps `cioInstanceId` into the attributes it creates on-device, so the SDK
+/// can correlate the resulting activity with the server-side instance.
+///
+/// You never populate `cioInstanceId` yourself: declare it with a default (`= ""`) and
+/// omit it from your initializer. The SDK fills it in on local `start`, and the backend
+/// fills it in for push-to-start.
+///
+/// A plain `ActivityAttributes` type (not conforming to this protocol) is fully supported
+/// for local `start`/`adopt`, instance-token push updates, and relaunch recovery —
+/// everything except push-to-start.
+///
+/// ```swift
+/// struct OrderAttributes: CIOActivityAttribute {
+///     var cioInstanceId: String = ""   // SDK/backend-managed; leave defaulted
+///     var orderNumber: String
+///     struct ContentState: Codable, Hashable { … }
+/// }
+/// ```
+@available(iOS 16.2, *)
+public protocol CIOActivityAttribute: ActivityAttributes {
+    /// SDK-managed correlation id for this activity instance.
+    ///
+    /// Populated by the SDK (local start) or the Customer.io backend (push-to-start) and
+    /// matched server-side to route push updates to the correct activity. Declare it with a
+    /// default value and never set it yourself.
+    var cioInstanceId: String { get }
+}
+#endif

--- a/Sources/LiveActivities_Attributes/CIOLiveActivityMetadata.swift
+++ b/Sources/LiveActivities_Attributes/CIOLiveActivityMetadata.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Customer.io delivery + routing metadata carried inside a Live Activity's `ContentState`.
+///
+/// Because iOS delivers Live Activity pushes straight to ActivityKit (the app never sees the raw
+/// APNs payload or its headers), the Customer.io backend embeds the push's delivery identifiers
+/// and tap destination *inside* the encoded `content-state`. The SDK reads them off the decoded
+/// state to report `delivered`/`opened` metrics (the same pipeline normal push uses) and to set the
+/// activity's tap `widgetURL`.
+///
+/// This is the iOS carrier for the same values Android reads from the FCM data payload
+/// (`CIO-Delivery-ID` / `CIO-Delivery-Token` / deep link) — one logical contract, two transports.
+///
+/// Locally-started/updated activities leave this `nil`; there is no push to attribute, so no
+/// delivery metric is reported.
+public struct CIOLiveActivityMetadata: Codable, Hashable, Sendable {
+    /// The `CIO-Delivery-ID` of the push that produced this content-state. Present ⇒ the SDK
+    /// reports a `delivered` metric for it (deduped), and attributes an `opened` metric to it on tap.
+    public var deliveryId: String?
+    /// The `CIO-Delivery-Token` of the push, sent alongside the metric.
+    public var deliveryToken: String?
+    /// Optional deep link opened when the user taps the activity (backend-driven, mirrors Android's
+    /// push deep link). Rendered as the activity's `widgetURL`.
+    public var deepLink: String?
+
+    public init(deliveryId: String? = nil, deliveryToken: String? = nil, deepLink: String? = nil) {
+        self.deliveryId = deliveryId
+        self.deliveryToken = deliveryToken
+        self.deepLink = deepLink
+    }
+}
+
+/// Opt-in conformance for a template's `ContentState` that carries Customer.io delivery metadata.
+///
+/// Built-in Customer.io templates conform so remote pushes can be attributed. Custom
+/// `ActivityAttributes` types may conform to receive the same `delivered`/`opened`/deep-link
+/// handling; types that don't conform simply skip metric reporting.
+public protocol CIOMetadataCarrying {
+    /// Delivery + routing metadata for the push that produced the current content-state, or `nil`
+    /// for a locally-driven state.
+    var cioMetadata: CIOLiveActivityMetadata? { get }
+}

--- a/Sources/LiveActivities_Attributes/EpochSecondsDate.swift
+++ b/Sources/LiveActivities_Attributes/EpochSecondsDate.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// A `Date` wrapper that is `Codable` as an epoch-**second** number.
+///
+/// Live Activity content-state and attributes are decoded on-device by ActivityKit
+/// using its **own** `JSONDecoder` when a backend push arrives — the SDK cannot inject a
+/// `dateDecodingStrategy` there. To keep the wire format unambiguous across the local CDP
+/// event path (`LiveActivityReporter`) and the server push path (ActivityKit), every date
+/// field on a template's `Attributes`/`ContentState` is represented by this type instead of
+/// a bare `Date`.
+///
+/// - Decodes from a JSON number interpreted as seconds since 1970 (UTC).
+/// - Encodes to a JSON number of seconds since 1970 (UTC).
+///
+/// Seconds is the Customer.io backend contract for content-state timestamps; the reporter's
+/// `payloadEncoder` produces the same representation, so a round trip is lossless to the second.
+public struct EpochSecondsDate: Codable, Hashable, Sendable {
+    /// The wrapped date value.
+    public var date: Date
+
+    public init(_ date: Date) {
+        self.date = date
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let seconds = try container.decode(Int64.self)
+        self.date = Date(timeIntervalSince1970: TimeInterval(seconds))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        let seconds = Int64(date.timeIntervalSince1970.rounded())
+        try container.encode(seconds)
+    }
+}
+
+public extension EpochSecondsDate {
+    /// Convenience accessor for the wrapped `Date`.
+    var value: Date { date }
+}

--- a/api-docs/CioLiveActivities_Attributes.api
+++ b/api-docs/CioLiveActivities_Attributes.api
@@ -1,0 +1,18 @@
+public interface CioLiveActivities_Attributes.CIOActivityAttribute {
+	public var cioInstanceId: String;
+}
+public final class CioLiveActivities_Attributes.CIOLiveActivityMetadata {
+	public var deliveryId: String?;
+	public var deliveryToken: String?;
+	public var deepLink: String?;
+	public fun init(deliveryId: String? = nil, deliveryToken: String? = nil, deepLink: String? = nil);
+}
+public interface CioLiveActivities_Attributes.CIOMetadataCarrying {
+	public var cioMetadata: CIOLiveActivityMetadata?;
+}
+public final class CioLiveActivities_Attributes.EpochSecondsDate {
+	public var date: Date;
+	public fun init(_ date: Date);
+	public fun init(from decoder: Decoder) throws;
+	public fun func encode(to encoder: Encoder) throws;
+}

--- a/scripts/generate-api-docs.sh
+++ b/scripts/generate-api-docs.sh
@@ -26,6 +26,7 @@ declare -a PUBLIC_MODULES=(
     "MessagingPushFCM:CioMessagingPushFCM"
     "MessagingInApp:CioMessagingInApp"
     "Location:CioLocation"
+    "LiveActivities_Attributes:CioLiveActivities_Attributes"
 )
 
 # Internal modules (only available when CI environment variable is set)


### PR DESCRIPTION
## Stack: Live Activities feature split (1 of 3)

This is the **base** of a 3-PR stack that reconstructs the Live Activities feature on top of the latest `main`, split into reviewable, independently-compilable units. All merge into `feat/live-activities`.

1. **[1/3] `LiveActivities_Attributes` wire-contract module** ← _this PR_
2. [2/3] LiveActivities runtime → targets `la/1-attributes`
3. [3/3] Sample app delivery-tracking example → targets `la/2-runtime`

## What this PR adds
The standalone, dependency-free module defining the Live Activities **wire contract** shared between the SDK runtime and customer widget extensions:

- `CIOActivityAttribute` — `ActivityAttributes` conformance carrying the SDK-managed `cioInstanceId` (push-to-start correlation).
- `CIOLiveActivityMetadata` / `CIOMetadataCarrying` — `deliveryId`, `deliveryToken`, `deepLink` carried in content-state.
- `EpochSecondsDate` — encodes date fields as epoch **seconds** to match the backend contract.

No SDK dependency, so it's safe to import in any target (app or widget extension).

`Package.swift`: adds the `LiveActivities_Attributes` product/target, bumps `swift-tools-version` → 5.10. api-docs baseline + `generate-api-docs.sh` entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public API and packaging only; no runtime behavior or existing modules are modified beyond SPM manifest and docs tooling.
> 
> **Overview**
> Introduces a new public SPM product **`LiveActivities_Attributes`** (`CioLiveActivities_Attributes`) with **no SDK dependencies**, so apps and widget extensions can share the Live Activities wire types without pulling in the full SDK.
> 
> The module defines the cross-target contract for upcoming runtime work: **`CIOActivityAttribute`** (optional `cioInstanceId` on `ActivityAttributes` for push-to-start correlation), **`CIOLiveActivityMetadata`** / **`CIOMetadataCarrying`** (delivery id/token and deep link embedded in content-state for metrics and tap routing), and **`EpochSecondsDate`** (dates as epoch seconds to match backend and ActivityKit decoding).
> 
> **`Package.swift`** bumps the Swift tools version to **5.10**, registers the new library product and target, and adds **`api-docs/CioLiveActivities_Attributes.api`** plus a **`generate-api-docs.sh`** entry for doc generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82552de2b1f1eb6b72d6733da66366a8c08cf760. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->