### PR TITLE
chore(live-activities): [2/3] LiveActivities runtime (registration, lifecycle, delivery)

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,7 +5,8 @@ disabled_rules:
   - line_length # The swiftformat tool formats the swift code for us to not have super long lines. This rule after swiftformat has become more of an annoyance then a value where most errors are error message strings being too long. 
   - unused_optional_binding # `let _ =` can be easier to read sometimes then `!= nil` which is what this rule is trying to catch. 
   - nesting # It can be easier to read code when a class has many nested classes inside of it (example: JSON Codable structs for deserializing JSON). 
-  - identifier_name # Variable names that are short in length can sometimes make code hard to read which this rule tries to catch. However, sometimes variable names that are 2 characters long are OK. We can catch bad variable naming in pull requests. 
+  - identifier_name # Variable names that are short in length can sometimes make code hard to read which this rule tries to catch. However, sometimes variable names that are 2 characters long are OK. We can catch bad variable naming in pull requests.
+  - multiple_closures_with_trailing_closure # SwiftUI and Swift's own APIs routinely pass multiple trailing closures; this rule conflicts with idiomatic Swift style.
 
 excluded: # paths or files to ignore during linting. Takes precedence over `included`.  
   - .build

--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,7 @@ var products: [PackageDescription.Product] = [
     .library(name: "MessagingPushFCM", targets: ["CioMessagingPushFCM"]),
     .library(name: "MessagingInApp", targets: ["CioMessagingInApp"]),
     .library(name: "Location", targets: ["CioLocation"]),
+    .library(name: "LiveActivities", targets: ["CioLiveActivities"]),
     .library(name: "LiveActivities_Attributes", targets: ["CioLiveActivities_Attributes"])
 ]
 
@@ -175,5 +176,13 @@ let package = Package(
         .target(name: "CioLiveActivities_Attributes",
                 dependencies: [],
                 path: "Sources/LiveActivities_Attributes"),
+
+        // Live Activities — observation module.
+        .target(name: "CioLiveActivities",
+                dependencies: ["CioInternalCommon", "CioLiveActivities_Attributes"],
+                path: "Sources/LiveActivities"),
+        .testTarget(name: "LiveActivitiesTests",
+                    dependencies: ["CioLiveActivities", "CioInternalCommon"],
+                    path: "Tests/LiveActivities"),
     ]
 )

--- a/Sources/Common/Util/KeyValueStorageKey.swift
+++ b/Sources/Common/Util/KeyValueStorageKey.swift
@@ -11,4 +11,6 @@ public enum KeyValueStorageKey: String {
     case broadcastMessagesExpiry = "broadcast_messages_expiry"
     case broadcastMessagesTracking = "broadcast_messages_tracking"
     case inboxMessagesOpenedStatus = "inbox_messages_opened_status"
+    case liveActivityRegistrations = "live_activity_registrations"
+    case liveActivityDeliveries = "live_activity_deliveries"
 }

--- a/Sources/LiveActivities/ActivityTypeRegistration.swift
+++ b/Sources/LiveActivities/ActivityTypeRegistration.swift
@@ -1,0 +1,61 @@
+import CioLiveActivities_Attributes
+import Foundation
+
+/// Sinks the observation bridge calls as ActivityKit emits tokens and lifecycle transitions.
+///
+/// The bridge only forwards raw signals; all policy (dedup, auth gating, event emission) lives
+/// in `LiveActivityRegistrar` / `LiveActivityReporter`. `onActivityEnded` is used for cleanup
+/// only. The one lifecycle *event* observation emits is `onUserDismissed` — a user's manual
+/// swipe-away — which the bridge distinguishes from an app/SDK/backend-initiated end via the
+/// terminal-state path and `consumeLocalEnd`.
+struct LiveActivityObservationSinks: Sendable {
+    let onPushToStartToken: @Sendable (_ token: Data) -> Void
+    let onInstanceToken: @Sendable (_ cioInstanceId: String, _ token: Data) -> Void
+    let onActivityEnded: @Sendable (_ cioInstanceId: String) -> Void
+
+    /// Called only when the user manually dismisses (swipes away) the activity — never for an
+    /// app/SDK `end()` or a backend/system end. The reporter turns this into an `end` event.
+    let onUserDismissed: @Sendable (_ cioInstanceId: String) -> Void
+
+    /// Called with the Customer.io delivery metadata carried in a content-state — on first
+    /// observation (the start push's state) and on every subsequent push update. Used to report
+    /// `delivered` receipts and to record the current tap destination for `opened` tracking.
+    /// Not called for content-states without metadata (e.g. locally-driven updates).
+    let onContentMetadata: @Sendable (_ cioInstanceId: String, _ metadata: CIOLiveActivityMetadata) -> Void
+
+    /// Returns whether this activity was ended locally by the SDK (via `CIOLiveActivity.end`),
+    /// consuming the marker. Used to suppress a spurious user-dismissal report when a local end
+    /// reaches `.dismissed` without an observed `.ended` (e.g. `.immediate` dismissal policy).
+    let consumeLocalEnd: @Sendable (_ cioInstanceId: String) -> Bool
+
+    /// Resolves the stable CIO instance id for an observed activity, given the system `Activity.id`
+    /// and the id read from the activity's attributes (`cioInstanceId`) when the type conforms to
+    /// `CIOActivityAttribute`, or `nil` for a plain `ActivityAttributes` type. Backed by the token
+    /// store's persisted map so a locally-started activity keeps its minted id across relaunch.
+    let resolveInstanceId: @Sendable (_ activityId: String, _ attributesInstanceId: String?) -> String
+
+    /// Drops the `Activity.id` → instance id mapping when the activity reaches a terminal state.
+    let clearInstanceIdMapping: @Sendable (_ activityId: String) -> Void
+}
+
+/// Type-erased descriptor for a single registered `ActivityAttributes` type.
+///
+/// Created by `LiveActivityConfigBuilder.register(_:identifier:)` (which delegates to
+/// `LiveActivityObservation`) and stored as pure data in `LiveActivityConfig`. All generic
+/// `Activity<T>` interaction is captured inside `startObserving`, so this type carries no
+/// `@available` restriction and the config stays free of observation logic.
+struct ActivityTypeRegistration: Sendable {
+    /// The reverse-DNS `notificationType` for this activity type (used in events and API routing).
+    let activityIdentifier: String
+
+    /// The Swift `ActivityAttributes` type name (`String(describing: T.self)`), sent to the
+    /// backend as the APNs `attributes-type` so it can build push-to-start payloads.
+    let attributesTypeName: String
+
+    /// Bridges this type's ActivityKit streams into `sinks`. Returns the root observation task;
+    /// cancelling it stops all observation for this type.
+    let startObserving: @Sendable (_ sinks: LiveActivityObservationSinks) -> Task<Void, Never>
+
+    /// Ends all currently-running activities of this type immediately (used on reset).
+    let endAllActivities: @Sendable () async -> Void
+}

--- a/Sources/LiveActivities/CIOLiveActivitiesSDKProviding.swift
+++ b/Sources/LiveActivities/CIOLiveActivitiesSDKProviding.swift
@@ -1,0 +1,32 @@
+import CioInternalCommon
+import Foundation
+
+/// The SDK capabilities that the Live Activities module requires from the host SDK.
+///
+/// Declared as a protocol so the module can be tested without depending on the real
+/// `CustomerIO.shared` singleton. Pass a conforming fake in unit tests; the default
+/// (`CustomerIO.shared`) is used in production.
+protocol CIOLiveActivitiesSDKProviding {
+    var registeredDeviceToken: String? { get }
+    var eventBusHandler: EventBusHandler { get }
+    var logger: Logger { get }
+    var sharedKeyValueStorage: SharedKeyValueStorage { get }
+    func track(name: String, properties: [String: Any]?)
+}
+
+extension CustomerIO: CIOLiveActivitiesSDKProviding {
+    var eventBusHandler: EventBusHandler {
+        DIGraphShared.shared.eventBusHandler
+    }
+
+    var logger: Logger {
+        DIGraphShared.shared.logger
+    }
+
+    var sharedKeyValueStorage: SharedKeyValueStorage {
+        DIGraphShared.shared.sharedKeyValueStorage
+    }
+
+    // registeredDeviceToken is already declared on CustomerIO via CustomerIOInstance.
+    // track(name:properties:) is also already on CustomerIO.
+}

--- a/Sources/LiveActivities/Config/LiveActivityConfig.swift
+++ b/Sources/LiveActivities/Config/LiveActivityConfig.swift
@@ -1,0 +1,27 @@
+import CioInternalCommon
+import Foundation
+
+/// Configuration for the Live Activities module.
+///
+/// Build instances via `LiveActivityConfigBuilder` and pass the result to
+/// `LiveActivitiesModule.initialize(_:)`:
+/// ```swift
+/// CustomerIO.initialize(withConfig: config)
+/// LiveActivitiesModule.initialize(
+///     LiveActivityConfigBuilder()
+///         .register(OrderAttributes.self, identifier: "io.customer.liveactivities.order")
+///         .build()
+/// )
+/// ```
+public struct LiveActivityConfig {
+    /// Module-level log level override. When `nil`, the SDK-wide log level is used.
+    public var logLevel: CioLogLevel?
+
+    /// Activity types registered for SDK observation via `LiveActivityConfigBuilder.register(_:identifier:)`.
+    var registrations: [ActivityTypeRegistration]
+
+    init(logLevel: CioLogLevel? = nil) {
+        self.logLevel = logLevel
+        self.registrations = []
+    }
+}

--- a/Sources/LiveActivities/Config/LiveActivityConfigBuilder.swift
+++ b/Sources/LiveActivities/Config/LiveActivityConfigBuilder.swift
@@ -1,0 +1,74 @@
+import CioInternalCommon
+import CioLiveActivities_Attributes
+import Foundation
+
+#if os(iOS)
+import ActivityKit
+#endif
+
+/// Fluent builder for `LiveActivityConfig`.
+///
+/// ```swift
+/// LiveActivityConfigBuilder()
+///     .logLevel(.debug)
+///     .register(OrderAttributes.self, identifier: "io.customer.liveactivities.order")
+///     .build()
+/// ```
+public struct LiveActivityConfigBuilder {
+    private var config: LiveActivityConfig
+
+    public init() {
+        self.config = LiveActivityConfig()
+    }
+
+    // MARK: - Fluent configuration
+
+    /// Override the SDK-wide log level for the Live Activities module only.
+    public func logLevel(_ level: CioLogLevel) -> Self {
+        var copy = self
+        copy.config.logLevel = level
+        return copy
+    }
+
+    /// Register an `ActivityAttributes` type for SDK observation.
+    ///
+    /// The SDK monitors all live activities whose attributes type is `T`, forwarding
+    /// push-to-start and per-instance push tokens to the Customer.io backend, and enables the
+    /// local `start`/`update`/`end` API for this type. Call once per distinct type.
+    ///
+    /// - Parameters:
+    ///   - type: The `ActivityAttributes` conformance to observe.
+    ///   - identifier: A stable reverse-DNS identifier for this activity type,
+    ///     e.g. `"io.customer.liveactivities.scoreboard"`. Sent as `notificationType` and matched
+    ///     server-side to route pushes. Must be consistent between the app and the backend.
+    ///
+    /// Conform `T` to `CIOActivityAttribute` (adding a `cioInstanceId` field) to also enable
+    /// **push-to-start**. A plain `ActivityAttributes` type is fully supported for local
+    /// `start`/`adopt`, instance-token push updates, and relaunch recovery — everything except
+    /// push-to-start. The correct behavior is selected automatically by which overload applies.
+    #if os(iOS)
+    @available(iOS 16.2, *)
+    public func register<T: CIOActivityAttribute>(_ type: T.Type, identifier: String) -> Self {
+        var copy = self
+        copy.config.registrations.append(
+            LiveActivityObservation.registration(for: T.self, identifier: identifier)
+        )
+        return copy
+    }
+
+    @available(iOS 16.2, *)
+    public func register<T: ActivityAttributes>(_ type: T.Type, identifier: String) -> Self {
+        var copy = self
+        copy.config.registrations.append(
+            LiveActivityObservation.registration(for: T.self, identifier: identifier)
+        )
+        return copy
+    }
+    #endif
+
+    // MARK: - Build
+
+    public func build() -> LiveActivityConfig {
+        config
+    }
+}

--- a/Sources/LiveActivities/LiveActivitiesModule.swift
+++ b/Sources/LiveActivities/LiveActivitiesModule.swift
@@ -247,13 +247,14 @@ public final class LiveActivitiesModule {
     @discardableResult
     public func handleDeepLinkOpen(_ url: URL) -> Bool {
         let target = url.absoluteString
-        let matched: CIOLiveActivityMetadata? = latestMetadata.mutating { map in
-            guard let key = map.first(where: { $0.value.deepLink == target })?.key else { return nil }
-            // Attribute the open exactly once: remove the entry so a repeated open of the same URL
-            // isn't reported again against an activity we've already credited.
-            return map.removeValue(forKey: key)
-        }
-        guard let metadata = matched else { return false }
+        // Match without consuming: `opened` is intentionally NOT deduped — each tap is a distinct
+        // open (matching push). Staleness is handled by evicting metadata when the activity ends
+        // (see the observer's `onActivityEnded`), not here. Only a push-backed activity (non-empty
+        // deliveryId) yields an `opened` metric, so require one — otherwise return false rather than
+        // claim we handled an open we didn't report (e.g. a locally-started activity with no id).
+        guard let metadata = latestMetadata.wrappedValue.values.first(where: {
+            $0.deepLink == target && !($0.deliveryId ?? "").isEmpty
+        }) else { return false }
         deliveryTracker.reportOpened(metadata: metadata)
         return true
     }

--- a/Sources/LiveActivities/LiveActivitiesModule.swift
+++ b/Sources/LiveActivities/LiveActivitiesModule.swift
@@ -110,6 +110,11 @@ public final class LiveActivitiesModule {
                 // `delivered` receipt (deduped by delivery id) and remember the tap destination.
                 latestMetadata.mutating { $0[cioInstanceId] = metadata }
                 deliveryTracker.reportDelivered(metadata: metadata)
+            },
+            onActivityEnded: { [latestMetadata] cioInstanceId in
+                // Drop the tap destination once the activity terminates, so a later open of the same
+                // URL can't be misattributed to this (ended) delivery.
+                latestMetadata.mutating { $0[cioInstanceId] = nil }
             }
         )
     }
@@ -197,9 +202,13 @@ public final class LiveActivitiesModule {
     @discardableResult
     public func handleDeepLinkOpen(_ url: URL) -> Bool {
         let target = url.absoluteString
-        guard let metadata = latestMetadata.wrappedValue.values.first(where: { $0.deepLink == target }) else {
-            return false
+        let matched: CIOLiveActivityMetadata? = latestMetadata.mutating { map in
+            guard let key = map.first(where: { $0.value.deepLink == target })?.key else { return nil }
+            // Attribute the open exactly once: remove the entry so a repeated open of the same URL
+            // isn't reported again against an activity we've already credited.
+            return map.removeValue(forKey: key)
         }
+        guard let metadata = matched else { return false }
         deliveryTracker.reportOpened(metadata: metadata)
         return true
     }
@@ -211,6 +220,13 @@ public final class LiveActivitiesModule {
     }
 
     private func performInitialization() {
+        // Apply the optional module log-level override. The SDK exposes a single shared logger, so
+        // this raises/lowers the level used by Live Activities logging (and the shared logger with it);
+        // when `nil` the existing SDK-wide level is left untouched.
+        if let logLevel = config.logLevel {
+            sdk.logger.setLogLevel(logLevel)
+        }
+
         sdk.logger.debug("LiveActivities module initialized.", "LiveActivities")
 
         identity.deviceToken = sdk.registeredDeviceToken

--- a/Sources/LiveActivities/LiveActivitiesModule.swift
+++ b/Sources/LiveActivities/LiveActivitiesModule.swift
@@ -166,6 +166,51 @@ public final class LiveActivitiesModule {
         )
     }
 
+    /// Start a Live Activity locally for a `CIOActivityAttribute` type. Same as the generic
+    /// `start`, except the SDK mints the correlation id and **injects it into `cioInstanceId`** on
+    /// your attributes *before* requesting the activity — so the live activity itself, the reported
+    /// `start` event, and later token registrations all carry the identical id, matching the
+    /// push-to-start contract. Overload resolution prefers this over the generic `start` whenever
+    /// `Attributes` conforms to `CIOActivityAttribute`.
+    @available(iOS 16.2, *)
+    @discardableResult
+    public func start<Attributes: CIOActivityAttribute>(
+        _ attributes: Attributes,
+        contentState: Attributes.ContentState,
+        staleDate: Date? = nil,
+        relevanceScore: Double = 0
+    ) throws -> CIOLiveActivity<Attributes> {
+        guard let notificationType = notificationType(forTypeName: String(describing: Attributes.self)) else {
+            throw LiveActivityError.typeNotRegistered(String(describing: Attributes.self))
+        }
+        // Mint first and inject, so the activity carries the id (a plain ActivityAttributes type has
+        // no field to hold it). Persist the Activity.id → id mapping so the observer and relaunch
+        // recovery resolve the identical id even though the mint happened here.
+        let id = ULID.generate()
+        var attributes = attributes
+        attributes.cioInstanceId = id
+        let activity = try Activity.request(
+            attributes: attributes,
+            content: ActivityContent(state: contentState, staleDate: staleDate, relevanceScore: relevanceScore),
+            pushType: .token
+        )
+        _ = tokenStorage.resolveInstanceId(forActivityId: activity.id) { id }
+        reporter.reportStart(
+            instanceUUID: id,
+            notificationType: notificationType,
+            attributes: LiveActivityReporter.encode(attributes),
+            contentState: LiveActivityReporter.encode(contentState)
+        )
+        return CIOLiveActivity(
+            id: id,
+            activity: activity,
+            reporter: reporter,
+            notificationType: notificationType,
+            logger: sdk.logger,
+            markLocalEnd: { [localEndTracker] in localEndTracker.markEnded($0) }
+        )
+    }
+
     /// Wrap an activity your app created directly, so you can report `update`/`end` through the
     /// returned handle. Does not report a `start` event (use `start` for that). Token capture for
     /// registered types happens automatically via observation regardless of `adopt`. Works with any

--- a/Sources/LiveActivities/LiveActivitiesModule.swift
+++ b/Sources/LiveActivities/LiveActivitiesModule.swift
@@ -1,0 +1,264 @@
+import CioInternalCommon
+import CioLiveActivities_Attributes
+import Foundation
+
+#if os(iOS)
+import ActivityKit
+#endif
+
+/// Errors thrown by the Live Activities public API.
+public enum LiveActivityError: Error {
+    /// `start` was called for an attributes type that was not passed to
+    /// `LiveActivityConfigBuilder.register(_:identifier:)`.
+    case typeNotRegistered(String)
+}
+
+/// Live Activities module for the Customer.io SDK.
+///
+/// Call `initialize` after `CustomerIO.initialize(withConfig:)` and hold the returned instance
+/// for the lifetime of your app:
+/// ```swift
+/// CustomerIO.initialize(withConfig: config)
+/// let liveActivities = LiveActivitiesModule.initialize(
+///     LiveActivityConfigBuilder()
+///         .register(OrderAttributes.self, identifier: "io.customer.liveactivities.order")
+///         .build()
+/// )
+/// // Start an activity locally — the SDK mints its id and reports a `start` event:
+/// let handle = try liveActivities.start(contentState: .init(...)) { id in
+///     OrderAttributes(cioInstanceId: id, ...)
+/// }
+/// await handle.update(.init(...))
+/// await handle.end(.init(...))
+/// ```
+public final class LiveActivitiesModule {
+    private let config: LiveActivityConfig
+    private let sdk: CIOLiveActivitiesSDKProviding
+    private let tokenStorage: LiveActivityTokenStorage
+
+    private let identity = LiveActivityIdentity()
+    private let localEndTracker = LiveActivityLocalEndTracker()
+    private let reporter: LiveActivityReporter
+    private let registrar: LiveActivityRegistrar
+    private let deliveryTracker: LiveActivityDeliveryTracker
+    private let observer: LiveActivityObserver
+
+    /// Latest delivery metadata observed per activity instance, used to attribute an `opened`
+    /// metric and resolve the deep link when the app is opened from a tapped activity.
+    private let latestMetadata = Synchronized<[String: CIOLiveActivityMetadata]>([:])
+
+    // MARK: - Entry point
+
+    /// Initialize the Live Activities module. Call after `CustomerIO.initialize(withConfig:)`.
+    /// Hold the returned instance for the app's lifetime — it is not a singleton.
+    @discardableResult
+    public static func initialize(_ config: LiveActivityConfig) -> LiveActivitiesModule {
+        let sdk = CustomerIO.shared
+        let module = LiveActivitiesModule(
+            config: config,
+            sdk: sdk,
+            tokenStorage: KeyValueLiveActivityTokenStore(storage: sdk.sharedKeyValueStorage)
+        )
+        module.performInitialization()
+        return module
+    }
+
+    // MARK: - Init (also used by tests)
+
+    init(
+        config: LiveActivityConfig,
+        sdk: CIOLiveActivitiesSDKProviding,
+        tokenStorage: LiveActivityTokenStorage
+    ) {
+        self.config = config
+        self.sdk = sdk
+        self.tokenStorage = tokenStorage
+
+        let identity = self.identity
+        let reporter = LiveActivityReporter(
+            track: { name, properties in sdk.track(name: name, properties: properties) },
+            currentUserId: { identity.userId },
+            deviceToken: { identity.deviceToken },
+            logger: sdk.logger
+        )
+        let registrar = LiveActivityRegistrar(identity: identity, store: tokenStorage, reporter: reporter)
+        self.reporter = reporter
+        self.registrar = registrar
+
+        let deliveryTracker = LiveActivityDeliveryTracker(
+            postMetric: { [sdk] deliveryId, event, deliveryToken in
+                sdk.eventBusHandler.postEvent(
+                    TrackMetricEvent(deliveryID: deliveryId, event: event, deviceToken: deliveryToken)
+                )
+            },
+            store: tokenStorage,
+            logger: sdk.logger
+        )
+        self.deliveryTracker = deliveryTracker
+
+        self.observer = LiveActivityObserver(
+            registrations: config.registrations,
+            registrar: registrar,
+            localEndTracker: localEndTracker,
+            store: tokenStorage,
+            onUserDismissed: { [reporter] notificationType, cioInstanceId in
+                // A user swipe-away — report `end` (matches Android's dismiss-intent behavior).
+                reporter.reportEnd(instanceUUID: cioInstanceId, notificationType: notificationType)
+            },
+            onContentMetadata: { [deliveryTracker, latestMetadata] _, cioInstanceId, metadata in
+                // A backend push (start or update) carrying Customer.io delivery metadata: report a
+                // `delivered` receipt (deduped by delivery id) and remember the tap destination.
+                latestMetadata.mutating { $0[cioInstanceId] = metadata }
+                deliveryTracker.reportDelivered(metadata: metadata)
+            }
+        )
+    }
+
+    // MARK: - Local lifecycle API
+
+    #if os(iOS)
+    /// Start a Live Activity locally. Pass your fully-built `attributes` and initial
+    /// `contentState`; the SDK requests the activity, mints and tracks its correlation id
+    /// internally, and reports a `start` event. You never supply or see the id at the call site.
+    ///
+    /// Works with any `ActivityAttributes` type — conforming to `CIOActivityAttribute` is only
+    /// required for push-to-start.
+    ///
+    /// - Returns: A handle whose `update`/`end` report the corresponding events.
+    /// - Throws: `LiveActivityError.typeNotRegistered` if `Attributes` was not registered.
+    @available(iOS 16.2, *)
+    @discardableResult
+    public func start<Attributes: ActivityAttributes>(
+        _ attributes: Attributes,
+        contentState: Attributes.ContentState,
+        staleDate: Date? = nil,
+        relevanceScore: Double = 0
+    ) throws -> CIOLiveActivity<Attributes> {
+        guard let notificationType = notificationType(forTypeName: String(describing: Attributes.self)) else {
+            throw LiveActivityError.typeNotRegistered(String(describing: Attributes.self))
+        }
+        let activity = try Activity.request(
+            attributes: attributes,
+            content: ActivityContent(state: contentState, staleDate: staleDate, relevanceScore: relevanceScore),
+            pushType: .token
+        )
+        // Mint (and persist) the correlation id keyed by the system Activity.id, atomically so the
+        // registration observer picking up this same activity resolves to the identical id.
+        let id = tokenStorage.resolveInstanceId(forActivityId: activity.id) { ULID.generate() }
+        reporter.reportStart(
+            instanceUUID: id,
+            notificationType: notificationType,
+            attributes: LiveActivityReporter.encode(attributes),
+            contentState: LiveActivityReporter.encode(contentState)
+        )
+        return CIOLiveActivity(
+            id: id,
+            activity: activity,
+            reporter: reporter,
+            notificationType: notificationType,
+            logger: sdk.logger,
+            markLocalEnd: { [localEndTracker] in localEndTracker.markEnded($0) }
+        )
+    }
+
+    /// Wrap an activity your app created directly, so you can report `update`/`end` through the
+    /// returned handle. Does not report a `start` event (use `start` for that). Token capture for
+    /// registered types happens automatically via observation regardless of `adopt`. Works with any
+    /// `ActivityAttributes` type.
+    @available(iOS 16.2, *)
+    @discardableResult
+    public func adopt<Attributes: ActivityAttributes>(_ activity: Activity<Attributes>) -> CIOLiveActivity<Attributes> {
+        let notificationType = notificationType(forTypeName: String(describing: Attributes.self))
+            ?? String(describing: Attributes.self)
+        let id = tokenStorage.resolveInstanceId(forActivityId: activity.id) { ULID.generate() }
+        return CIOLiveActivity(
+            id: id,
+            activity: activity,
+            reporter: reporter,
+            notificationType: notificationType,
+            logger: sdk.logger,
+            markLocalEnd: { [localEndTracker] in localEndTracker.markEnded($0) }
+        )
+    }
+    #endif
+
+    // MARK: - Deep link / open tracking
+
+    /// Report an `opened` metric when the app is opened from a tapped Live Activity. Call this from
+    /// your `UIApplicationDelegate.application(_:open:options:)` /
+    /// `UISceneDelegate.scene(_:openURLContexts:)` — the same place you already route your app's
+    /// deep links — mirroring how push taps are forwarded to the SDK.
+    ///
+    /// If the URL matches a Customer.io-tracked activity's deep link, the SDK reports an `opened`
+    /// metric (the same metric normal push uses) and returns `true`. Returns `false` for unrelated
+    /// URLs. Navigation stays with your existing URL routing: because a Live Activity tap arrives
+    /// through the normal `openURL` path (not a push-tap callback), the SDK does not re-open the URL
+    /// — that would re-enter `openURL` and loop.
+    @discardableResult
+    public func handleDeepLinkOpen(_ url: URL) -> Bool {
+        let target = url.absoluteString
+        guard let metadata = latestMetadata.wrappedValue.values.first(where: { $0.deepLink == target }) else {
+            return false
+        }
+        deliveryTracker.reportOpened(metadata: metadata)
+        return true
+    }
+
+    // MARK: - Private
+
+    private func notificationType(forTypeName name: String) -> String? {
+        config.registrations.first { $0.attributesTypeName == name }?.activityIdentifier
+    }
+
+    private func performInitialization() {
+        sdk.logger.debug("LiveActivities module initialized.", "LiveActivities")
+
+        identity.deviceToken = sdk.registeredDeviceToken
+
+        // Seed any persisted push-to-start token before adding observers: the event-bus replays the
+        // last identify / device-token events to the new observers, and that replay flushes the
+        // seeded token — so registration no longer depends on ActivityKit re-yielding the token.
+        registrar.seedPendingPushToStartFromStore()
+
+        registerEventBusObservers()
+        observer.start()
+    }
+
+    private func registerEventBusObservers() {
+        sdk.eventBusHandler.addObserver(ProfileIdentifiedEvent.self) { [identity, registrar] event in
+            identity.userId = event.identifier
+            registrar.reevaluate()
+        }
+        sdk.eventBusHandler.addObserver(AnonymousProfileIdentifiedEvent.self) { [identity] _ in
+            // An anonymous profile is not an identified user — Live Activities stay gated off.
+            identity.userId = nil
+        }
+        sdk.eventBusHandler.addObserver(RegisterDeviceTokenEvent.self) { [identity, registrar] event in
+            identity.deviceToken = event.token
+            registrar.reevaluate()
+        }
+        sdk.eventBusHandler.addObserver(DeleteDeviceTokenEvent.self) { [identity] _ in
+            identity.deviceToken = nil
+        }
+        sdk.eventBusHandler.addObserver(ResetEvent.self) { [weak self] _ in
+            Task { [weak self] in await self?.handleReset() }
+        }
+    }
+
+    private func handleReset() async {
+        // NOTE: force-ending all activities on reset is under review (plan decision #2) —
+        // it may remove activities the user still wants and emits no `end` event.
+        //
+        // Clear the identified user *before* force-ending: reset is a logout, so no lifecycle
+        // event should fire, and gating the reporter off first ensures the terminal states these
+        // ends produce can't be misreported as user dismissals (the reporter drops when anonymous).
+        identity.userId = nil
+        localEndTracker.clearAll()
+        latestMetadata.wrappedValue = [:]
+        for registration in config.registrations {
+            await registration.endAllActivities()
+        }
+        registrar.handleReset()
+        observer.restart()
+    }
+}

--- a/Sources/LiveActivities/LiveActivityHandle.swift
+++ b/Sources/LiveActivities/LiveActivityHandle.swift
@@ -1,0 +1,83 @@
+import CioInternalCommon
+import CioLiveActivities_Attributes
+import Foundation
+
+#if os(iOS)
+import ActivityKit
+
+/// A handle to a Live Activity the SDK is managing locally.
+///
+/// Returned by `LiveActivitiesModule.start(...)` and `adopt(_:)`. Driving the activity through
+/// this handle's `update`/`end` is what emits the local `Live Notification Event`s — a backend
+/// push that changes or ends the activity is applied by the OS and is never reported.
+///
+/// > Important: Ending or updating the underlying `activity` directly (bypassing this handle)
+/// > performs the ActivityKit operation but emits no Customer.io event.
+@available(iOS 16.2, *)
+public struct CIOLiveActivity<Attributes: ActivityAttributes> {
+    /// The stable correlation id (minted by the SDK for local starts, or carried in the
+    /// attributes for push-to-start), reported to the backend as `instanceUUID`.
+    public let id: String
+
+    /// The underlying ActivityKit activity, if you need direct access.
+    public let activity: Activity<Attributes>
+
+    private let reporter: LiveActivityReporter
+    private let notificationType: String
+    private let logger: Logger
+
+    /// Marks this activity as an SDK-initiated end so observation doesn't misread the resulting
+    /// terminal state as a user dismissal and double-report.
+    private let markLocalEnd: @Sendable (String) -> Void
+
+    init(
+        id: String,
+        activity: Activity<Attributes>,
+        reporter: LiveActivityReporter,
+        notificationType: String,
+        logger: Logger,
+        markLocalEnd: @escaping @Sendable (String) -> Void
+    ) {
+        self.id = id
+        self.activity = activity
+        self.reporter = reporter
+        self.notificationType = notificationType
+        self.logger = logger
+        self.markLocalEnd = markLocalEnd
+    }
+
+    /// Apply a local content-state update and report an `update` event.
+    public func update(
+        _ contentState: Attributes.ContentState,
+        staleDate: Date? = nil,
+        alert: AlertConfiguration? = nil
+    ) async {
+        await activity.update(ActivityContent(state: contentState, staleDate: staleDate), alertConfiguration: alert)
+        reporter.reportUpdate(
+            instanceUUID: id,
+            notificationType: notificationType,
+            contentState: LiveActivityReporter.encode(contentState)
+        )
+    }
+
+    /// End the activity locally and report an `end` event with an optional final content-state.
+    public func end(
+        _ finalContentState: Attributes.ContentState? = nil,
+        dismissalPolicy: ActivityUIDismissalPolicy = .default
+    ) async {
+        // Mark before ending so the marker is set before ActivityKit emits any terminal state to
+        // the observer, avoiding a race where `.dismissed` arrives first.
+        markLocalEnd(id)
+        if let finalContentState {
+            await activity.end(ActivityContent(state: finalContentState, staleDate: nil), dismissalPolicy: dismissalPolicy)
+        } else {
+            await activity.end(nil, dismissalPolicy: dismissalPolicy)
+        }
+        reporter.reportEnd(
+            instanceUUID: id,
+            notificationType: notificationType,
+            contentState: finalContentState.flatMap(LiveActivityReporter.encode)
+        )
+    }
+}
+#endif

--- a/Sources/LiveActivities/LiveActivityLocalEndTracker.swift
+++ b/Sources/LiveActivities/LiveActivityLocalEndTracker.swift
@@ -1,0 +1,35 @@
+import CioInternalCommon
+import Foundation
+
+/// Tracks activities the SDK ended locally (via `CIOLiveActivity.end`) so observation can tell a
+/// user's manual dismissal apart from an app/SDK-initiated end.
+///
+/// When the host app ends an activity through the handle, the local-end path already reports the
+/// `end` event, so the marker lets observation *suppress* the terminal-state signal instead of
+/// double-reporting. Anything that reaches `.dismissed` without a marker (and without first passing
+/// through `.ended`) is a genuine user swipe-away, which observation then reports — mirroring
+/// Android, where a notification's delete-intent fires only on user dismissal, never on a
+/// programmatic cancel.
+final class LiveActivityLocalEndTracker: @unchecked Sendable {
+    private let ids = Synchronized<Set<String>>([])
+
+    /// Mark that `cioInstanceId` is being ended locally by the SDK.
+    func markEnded(_ cioInstanceId: String) {
+        ids.mutating { $0.insert(cioInstanceId) }
+    }
+
+    /// Returns whether `cioInstanceId` was marked as a local end, clearing the marker so it
+    /// is consumed exactly once.
+    func consume(_ cioInstanceId: String) -> Bool {
+        ids.mutating { set in
+            guard set.contains(cioInstanceId) else { return false }
+            set.remove(cioInstanceId)
+            return true
+        }
+    }
+
+    /// Drop all markers (used on reset).
+    func clearAll() {
+        ids.wrappedValue = []
+    }
+}

--- a/Sources/LiveActivities/Observation/LiveActivityObserver.swift
+++ b/Sources/LiveActivities/Observation/LiveActivityObserver.swift
@@ -248,37 +248,41 @@ enum LiveActivityObservation {
                     }
                 }
             }
-            group.addTask {
-                // The first terminal state observed distinguishes a user's manual dismissal from an
-                // app/SDK/backend end:
-                //   • `.ended` first  → the app (`CIOLiveActivity.end`), a backend push, or the
-                //                       system ended it. Not a user swipe; clean up, report nothing
-                //                       (a local end already reported via the handle; a backend end
-                //                       must not be echoed).
-                //   • `.dismissed` first → the user swiped it away. Report `end` — unless it was a
-                //                       local `end(.immediate)` whose `.ended` the stream coalesced
-                //                       (caught by the local-end marker).
-                for await state in activity.activityStateUpdates {
-                    let firstTerminalIsDismissed: Bool
-                    switch state {
-                    case .ended: firstTerminalIsDismissed = false
-                    case .dismissed: firstTerminalIsDismissed = true
-                    default: continue // not terminal — keep observing
-                    }
-                    let action = liveActivityTerminalAction(
-                        firstTerminalIsDismissed: firstTerminalIsDismissed,
-                        // Consume the marker on any terminal so a local end never leaks a marker
-                        // and never double-reports.
-                        wasLocalEnd: sinks.consumeLocalEnd(instanceId)
-                    )
-                    if action == .reportUserDismiss {
-                        sinks.onUserDismissed(instanceId)
-                    }
-                    sinks.onActivityEnded(instanceId)
-                    sinks.clearInstanceIdMapping(activity.id)
-                    return
+            // Drive terminal detection here (not in a child task) so that on the first terminal we can
+            // cancel the sibling token/content tasks immediately — otherwise a late instance-token
+            // emission after teardown could re-register an instance the registrar just ended.
+            //
+            // The first terminal state observed distinguishes a user's manual dismissal from an
+            // app/SDK/backend end:
+            //   • `.ended` first  → the app (`CIOLiveActivity.end`), a backend push, or the system
+            //                       ended it. Not a user swipe; clean up, report nothing (a local end
+            //                       already reported via the handle; a backend end must not be echoed).
+            //   • `.dismissed` first → the user swiped it away. Report `end` — unless it was a local
+            //                       `end(.immediate)` whose `.ended` the stream coalesced (caught by
+            //                       the local-end marker).
+            for await state in activity.activityStateUpdates {
+                let firstTerminalIsDismissed: Bool
+                switch state {
+                case .ended: firstTerminalIsDismissed = false
+                case .dismissed: firstTerminalIsDismissed = true
+                default: continue // not terminal — keep observing
                 }
+                let action = liveActivityTerminalAction(
+                    firstTerminalIsDismissed: firstTerminalIsDismissed,
+                    // Consume the marker on any terminal so a local end never leaks a marker
+                    // and never double-reports.
+                    wasLocalEnd: sinks.consumeLocalEnd(instanceId)
+                )
+                if action == .reportUserDismiss {
+                    sinks.onUserDismissed(instanceId)
+                }
+                sinks.onActivityEnded(instanceId)
+                sinks.clearInstanceIdMapping(activity.id)
+                break
             }
+            // Terminal reached (or the state stream ended): stop observing tokens/content for this
+            // instance so nothing is routed to the registrar after teardown.
+            group.cancelAll()
         }
     }
     #endif

--- a/Sources/LiveActivities/Observation/LiveActivityObserver.swift
+++ b/Sources/LiveActivities/Observation/LiveActivityObserver.swift
@@ -35,6 +35,7 @@ final class LiveActivityObserver: @unchecked Sendable {
     private let store: LiveActivityTokenStorage
     private let onUserDismissed: @Sendable (_ notificationType: String, _ cioInstanceId: String) -> Void
     private let onContentMetadata: @Sendable (_ notificationType: String, _ cioInstanceId: String, _ metadata: CIOLiveActivityMetadata) -> Void
+    private let onActivityEnded: @Sendable (_ cioInstanceId: String) -> Void
 
     /// Running root tasks keyed by notificationType.
     private let tasks = Synchronized<[String: Task<Void, Never>]>([:])
@@ -45,7 +46,8 @@ final class LiveActivityObserver: @unchecked Sendable {
         localEndTracker: LiveActivityLocalEndTracker,
         store: LiveActivityTokenStorage,
         onUserDismissed: @escaping @Sendable (_ notificationType: String, _ cioInstanceId: String) -> Void,
-        onContentMetadata: @escaping @Sendable (_ notificationType: String, _ cioInstanceId: String, _ metadata: CIOLiveActivityMetadata) -> Void
+        onContentMetadata: @escaping @Sendable (_ notificationType: String, _ cioInstanceId: String, _ metadata: CIOLiveActivityMetadata) -> Void,
+        onActivityEnded: @escaping @Sendable (_ cioInstanceId: String) -> Void
     ) {
         self.registrations = registrations
         self.registrar = registrar
@@ -53,6 +55,7 @@ final class LiveActivityObserver: @unchecked Sendable {
         self.store = store
         self.onUserDismissed = onUserDismissed
         self.onContentMetadata = onContentMetadata
+        self.onActivityEnded = onActivityEnded
     }
 
     func start() {
@@ -85,6 +88,7 @@ final class LiveActivityObserver: @unchecked Sendable {
         let store = self.store
         let onUserDismissed = self.onUserDismissed
         let onContentMetadata = self.onContentMetadata
+        let onActivityEnded = self.onActivityEnded
         let identifier = registration.activityIdentifier
         let attributesType = registration.attributesTypeName
 
@@ -97,6 +101,9 @@ final class LiveActivityObserver: @unchecked Sendable {
             },
             onActivityEnded: { instanceId in
                 registrar.handleActivityEnded(instanceUUID: instanceId)
+                // Notify the module so it can evict any per-instance state (e.g. deep-link
+                // metadata) — a terminated activity must not keep matching later opens.
+                onActivityEnded(instanceId)
             },
             onUserDismissed: { instanceId in
                 onUserDismissed(identifier, instanceId)

--- a/Sources/LiveActivities/Observation/LiveActivityObserver.swift
+++ b/Sources/LiveActivities/Observation/LiveActivityObserver.swift
@@ -1,0 +1,278 @@
+import CioInternalCommon
+import CioLiveActivities_Attributes
+import Foundation
+
+#if os(iOS)
+import ActivityKit
+#endif
+
+/// How the first observed terminal ActivityKit state should be handled.
+enum LiveActivityTerminalAction: Equatable {
+    /// App/SDK/backend/system end — clean up local state, report nothing.
+    case cleanupOnly
+    /// User swiped the activity away — report an `end` event, then clean up.
+    case reportUserDismiss
+}
+
+/// Pure decision for the terminal-state discriminator, factored out of ActivityKit observation so
+/// it is unit-testable. A user dismissal is the case where the *first* terminal state observed is
+/// `.dismissed` and the SDK did not end the activity itself.
+func liveActivityTerminalAction(firstTerminalIsDismissed: Bool, wasLocalEnd: Bool) -> LiveActivityTerminalAction {
+    (firstTerminalIsDismissed && !wasLocalEnd) ? .reportUserDismiss : .cleanupOnly
+}
+
+/// Owns the ActivityKit observation lifecycle for all registered activity types.
+///
+/// Starts one root task per registration, can `restart` after a reset, and cancels everything
+/// on `stop`/`deinit`. Observation only *captures tokens* (routed to the registrar) and surfaces
+/// appeared/ended signals — it never emits lifecycle events. Those come exclusively from the
+/// `start`/`update`/`end` API via `LiveActivityReporter`, so backend-initiated (push) changes
+/// are never echoed back.
+final class LiveActivityObserver: @unchecked Sendable {
+    private let registrations: [ActivityTypeRegistration]
+    private let registrar: LiveActivityRegistrar
+    private let localEndTracker: LiveActivityLocalEndTracker
+    private let store: LiveActivityTokenStorage
+    private let onUserDismissed: @Sendable (_ notificationType: String, _ cioInstanceId: String) -> Void
+    private let onContentMetadata: @Sendable (_ notificationType: String, _ cioInstanceId: String, _ metadata: CIOLiveActivityMetadata) -> Void
+
+    /// Running root tasks keyed by notificationType.
+    private let tasks = Synchronized<[String: Task<Void, Never>]>([:])
+
+    init(
+        registrations: [ActivityTypeRegistration],
+        registrar: LiveActivityRegistrar,
+        localEndTracker: LiveActivityLocalEndTracker,
+        store: LiveActivityTokenStorage,
+        onUserDismissed: @escaping @Sendable (_ notificationType: String, _ cioInstanceId: String) -> Void,
+        onContentMetadata: @escaping @Sendable (_ notificationType: String, _ cioInstanceId: String, _ metadata: CIOLiveActivityMetadata) -> Void
+    ) {
+        self.registrations = registrations
+        self.registrar = registrar
+        self.localEndTracker = localEndTracker
+        self.store = store
+        self.onUserDismissed = onUserDismissed
+        self.onContentMetadata = onContentMetadata
+    }
+
+    func start() {
+        for registration in registrations {
+            startObserving(registration)
+        }
+    }
+
+    /// Cancel and re-start all observation (used after a reset so a new session is observed).
+    func restart() {
+        stop()
+        start()
+    }
+
+    func stop() {
+        let running = tasks.wrappedValue
+        for (_, task) in running {
+            task.cancel()
+        }
+        tasks.wrappedValue = [:]
+    }
+
+    deinit {
+        stop()
+    }
+
+    private func startObserving(_ registration: ActivityTypeRegistration) {
+        let registrar = self.registrar
+        let localEndTracker = self.localEndTracker
+        let store = self.store
+        let onUserDismissed = self.onUserDismissed
+        let onContentMetadata = self.onContentMetadata
+        let identifier = registration.activityIdentifier
+        let attributesType = registration.attributesTypeName
+
+        let sinks = LiveActivityObservationSinks(
+            onPushToStartToken: { token in
+                registrar.handlePushToStartToken(notificationType: identifier, attributesType: attributesType, token: token)
+            },
+            onInstanceToken: { instanceId, token in
+                registrar.handleInstanceToken(notificationType: identifier, instanceUUID: instanceId, token: token)
+            },
+            onActivityEnded: { instanceId in
+                registrar.handleActivityEnded(instanceUUID: instanceId)
+            },
+            onUserDismissed: { instanceId in
+                onUserDismissed(identifier, instanceId)
+            },
+            onContentMetadata: { instanceId, metadata in
+                onContentMetadata(identifier, instanceId, metadata)
+            },
+            consumeLocalEnd: { instanceId in
+                localEndTracker.consume(instanceId)
+            },
+            resolveInstanceId: { activityId, attributesInstanceId in
+                store.resolveInstanceId(forActivityId: activityId) {
+                    if let attributesInstanceId, !attributesInstanceId.isEmpty { return attributesInstanceId }
+                    return ULID.generate()
+                }
+            },
+            clearInstanceIdMapping: { activityId in
+                store.clearInstanceId(forActivityId: activityId)
+            }
+        )
+
+        tasks.mutating { existing in
+            // Cancel any prior task for this type before replacing, so a repeated `start()`
+            // (double init / re-entrancy) can't leave a second observer running in parallel.
+            existing[identifier]?.cancel()
+            existing[identifier] = registration.startObserving(sinks)
+        }
+    }
+}
+
+// MARK: - ActivityKit bridge
+
+/// Builds the type-erased `ActivityTypeRegistration` for a concrete attributes type, keeping all
+/// generic `Activity<T>` stream handling here rather than in the config builder.
+enum LiveActivityObservation {
+    #if os(iOS)
+    /// Registration for a `CIOActivityAttribute` type: full observation **including push-to-start**.
+    /// For a backend-created activity the instance id is read from its attributes (`cioInstanceId`).
+    @available(iOS 16.2, *)
+    static func registration<T: CIOActivityAttribute>(for type: T.Type, identifier: String) -> ActivityTypeRegistration {
+        makeRegistration(for: T.self, identifier: identifier, observesPushToStart: true) { $0.attributes.cioInstanceId }
+    }
+
+    /// Registration for a plain `ActivityAttributes` type: instance-token, lifecycle and relaunch
+    /// observation only — **no push-to-start** (the backend can't stamp an id into attributes the
+    /// SDK can read), so the instance id is the SDK-minted one recovered from the persisted map.
+    @available(iOS 16.2, *)
+    static func registration<T: ActivityAttributes>(for type: T.Type, identifier: String) -> ActivityTypeRegistration {
+        makeRegistration(for: T.self, identifier: identifier, observesPushToStart: false) { _ in nil }
+    }
+
+    /// Shared observation wiring for both registration flavors. `attributesInstanceId` extracts the
+    /// id from an activity's attributes (conforming types) or returns `nil` (plain types); the
+    /// resolved id then comes from the token store's persisted map, falling back to that value or a
+    /// freshly minted ULID.
+    @available(iOS 16.2, *)
+    private static func makeRegistration<T: ActivityAttributes>(
+        for type: T.Type,
+        identifier: String,
+        observesPushToStart: Bool,
+        attributesInstanceId: @escaping @Sendable (Activity<T>) -> String?
+    ) -> ActivityTypeRegistration {
+        ActivityTypeRegistration(
+            activityIdentifier: identifier,
+            attributesTypeName: String(describing: T.self),
+            startObserving: { sinks in
+                Task {
+                    await withTaskGroup(of: Void.self) { group in
+                        if observesPushToStart {
+                            group.addTask {
+                                // Push-to-start is the only iOS 17.2 dependency. On 16.2–17.1 the SDK
+                                // still observes instance-token updates, content/state changes, and
+                                // local start/update/end — it just can't receive push-to-start tokens.
+                                if #available(iOS 17.2, *) {
+                                    for await token in Activity<T>.pushToStartTokenUpdates {
+                                        sinks.onPushToStartToken(token)
+                                    }
+                                }
+                            }
+                        }
+                        group.addTask {
+                            // Observe each activity instance exactly once, deduped by the system
+                            // `activity.id`, across BOTH sources:
+                            //   1. `Activity.activities` — the current snapshot, which resumes
+                            //      activities that started while the app was terminated (e.g.
+                            //      push-to-start) or that survive a relaunch.
+                            //   2. `activityUpdates` — activities started from now on.
+                            // `activityUpdates` alone does not reliably replay already-running
+                            // activities on a cold-launch subscription, so the snapshot is required
+                            // to avoid missing their instance-token updates and end. The shared
+                            // dedup set makes observing both sources safe.
+                            let observedIds = Synchronized<Set<String>>([])
+                            let claimUnobserved: @Sendable (String) -> Bool = { activityId in
+                                observedIds.mutating { ids -> Bool in
+                                    guard !ids.contains(activityId) else { return false }
+                                    ids.insert(activityId)
+                                    return true
+                                }
+                            }
+                            await withTaskGroup(of: Void.self) { perActivity in
+                                for activity in Activity<T>.activities where claimUnobserved(activity.id) {
+                                    perActivity.addTask { await observe(activity, attributesInstanceId: attributesInstanceId(activity), sinks: sinks) }
+                                }
+                                for await activity in Activity<T>.activityUpdates where claimUnobserved(activity.id) {
+                                    perActivity.addTask { await observe(activity, attributesInstanceId: attributesInstanceId(activity), sinks: sinks) }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            endAllActivities: {
+                for activity in Activity<T>.activities {
+                    await activity.end(nil, dismissalPolicy: .immediate)
+                }
+            }
+        )
+    }
+
+    @available(iOS 16.2, *)
+    private static func observe<T: ActivityAttributes>(_ activity: Activity<T>, attributesInstanceId: String?, sinks: LiveActivityObservationSinks) async {
+        let instanceId = sinks.resolveInstanceId(activity.id, attributesInstanceId)
+        // The initial content-state (from the start push) may carry Customer.io delivery metadata;
+        // surface it so a push-to-start `delivered` receipt is reported and the tap destination is
+        // recorded — even on a cold-launch snapshot where no `contentUpdates` will replay.
+        if let metadata = (activity.content.state as? CIOMetadataCarrying)?.cioMetadata {
+            sinks.onContentMetadata(instanceId, metadata)
+        }
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask {
+                for await token in activity.pushTokenUpdates {
+                    sinks.onInstanceToken(instanceId, token)
+                }
+            }
+            group.addTask {
+                // Each backend push update carries its own delivery id in the content-state; surface
+                // it for a per-update `delivered` receipt. (Runs only while the process is alive —
+                // updates delivered to a killed app can't be observed and are dropped by design.)
+                for await content in activity.contentUpdates {
+                    if let metadata = (content.state as? CIOMetadataCarrying)?.cioMetadata {
+                        sinks.onContentMetadata(instanceId, metadata)
+                    }
+                }
+            }
+            group.addTask {
+                // The first terminal state observed distinguishes a user's manual dismissal from an
+                // app/SDK/backend end:
+                //   • `.ended` first  → the app (`CIOLiveActivity.end`), a backend push, or the
+                //                       system ended it. Not a user swipe; clean up, report nothing
+                //                       (a local end already reported via the handle; a backend end
+                //                       must not be echoed).
+                //   • `.dismissed` first → the user swiped it away. Report `end` — unless it was a
+                //                       local `end(.immediate)` whose `.ended` the stream coalesced
+                //                       (caught by the local-end marker).
+                for await state in activity.activityStateUpdates {
+                    let firstTerminalIsDismissed: Bool
+                    switch state {
+                    case .ended: firstTerminalIsDismissed = false
+                    case .dismissed: firstTerminalIsDismissed = true
+                    default: continue // not terminal — keep observing
+                    }
+                    let action = liveActivityTerminalAction(
+                        firstTerminalIsDismissed: firstTerminalIsDismissed,
+                        // Consume the marker on any terminal so a local end never leaks a marker
+                        // and never double-reports.
+                        wasLocalEnd: sinks.consumeLocalEnd(instanceId)
+                    )
+                    if action == .reportUserDismiss {
+                        sinks.onUserDismissed(instanceId)
+                    }
+                    sinks.onActivityEnded(instanceId)
+                    sinks.clearInstanceIdMapping(activity.id)
+                    return
+                }
+            }
+        }
+    }
+    #endif
+}

--- a/Sources/LiveActivities/Registration/LiveActivityIdentity.swift
+++ b/Sources/LiveActivities/Registration/LiveActivityIdentity.swift
@@ -1,0 +1,22 @@
+import CioInternalCommon
+import Foundation
+
+/// Thread-safe holder for the two values that gate Live Activity reporting: the currently
+/// identified user id (`nil` while anonymous or logged out) and the latest APNs device token.
+///
+/// Shared by `LiveActivityRegistrar` (which decides when to register) and `LiveActivityReporter`
+/// (which gates every event on it), so both read a single source of truth without a dependency cycle.
+final class LiveActivityIdentity: @unchecked Sendable {
+    private let _userId = Synchronized<String?>(nil)
+    private let _deviceToken = Synchronized<String?>(nil)
+
+    var userId: String? {
+        get { _userId.wrappedValue }
+        set { _userId.wrappedValue = newValue }
+    }
+
+    var deviceToken: String? {
+        get { _deviceToken.wrappedValue }
+        set { _deviceToken.wrappedValue = newValue }
+    }
+}

--- a/Sources/LiveActivities/Registration/LiveActivityRegistrar.swift
+++ b/Sources/LiveActivities/Registration/LiveActivityRegistrar.swift
@@ -1,0 +1,173 @@
+import CioInternalCommon
+import Foundation
+
+/// Decides *when* to register Live Activity push tokens with Customer.io.
+///
+/// Registration is a CDP track event, so the data pipeline owns delivery — this type only
+/// decides timing. It holds the latest observed tokens and (re)sends them whenever the device
+/// token or user changes, for each type whose `"<deviceToken>|<pushToStartToken>|<userId>"`
+/// signature isn't already stored — the deviceToken is part of the signature so a device-token
+/// rotation re-registers the token against the new device. Because a token captured while
+/// anonymous or before a device token exists is held
+/// pending (not sent, not stored), a registration skipped in that state re-fires automatically
+/// once the user is identified / a token arrives — the same model as the Android registrar.
+final class LiveActivityRegistrar: @unchecked Sendable {
+    private struct PendingPushToStart {
+        let attributesType: String
+        let tokenHex: String
+    }
+
+    private struct PendingInstance {
+        let notificationType: String
+        let tokenHex: String
+    }
+
+    private let identity: LiveActivityIdentity
+    private let store: LiveActivityTokenStorage
+    private let reporter: LiveActivityReporter
+
+    /// Latest observed push-to-start token per notificationType, awaiting a registrable state.
+    private let pendingPushToStart = Synchronized<[String: PendingPushToStart]>([:])
+    /// Latest observed instance token per instanceUUID, awaiting a registrable state.
+    private let pendingInstance = Synchronized<[String: PendingInstance]>([:])
+    /// Serializes `flushPending` so concurrent callers (the push-to-start task, per-activity
+    /// observers, and identity/device-token events) can't each pass the dedup checks and
+    /// double-send. Cheap: the body only enqueues CDP track events.
+    private let flushLock = NSLock()
+
+    init(identity: LiveActivityIdentity, store: LiveActivityTokenStorage, reporter: LiveActivityReporter) {
+        self.identity = identity
+        self.store = store
+        self.reporter = reporter
+    }
+
+    // MARK: - Identity / device token changes (called by the module on event bus events)
+
+    /// Device token or user changed — try to flush anything pending.
+    func reevaluate() {
+        flushPending()
+    }
+
+    /// Reset (logout): clear the dedup signatures so the next identified session re-registers, and
+    /// drop instance state (reset ends all activities).
+    ///
+    /// The *persisted push-to-start token values* (`ptsvalue:` keys) are deliberately preserved:
+    /// they're per-app and stay valid across logout, and ActivityKit does not re-emit an unchanged
+    /// token to the restarted observer — so keeping the value lets the next login re-register it,
+    /// even across a process restart (the in-memory `pendingPushToStart` alone would be lost then).
+    func handleReset() {
+        pendingInstance.wrappedValue = [:]
+        for key in store.allRegistrationKeys() where !key.hasPrefix(Self.pushToStartValuePrefix) {
+            store.clearRegistrationSignature(activityType: key)
+        }
+    }
+
+    /// Seed `pendingPushToStart` from the persisted token values so a push-to-start token can be
+    /// registered on a launch where ActivityKit does not re-yield it. Call once at init, before the
+    /// event-bus observers are added (their replayed identify / device-token events trigger the
+    /// flush that actually registers). Persisted values never clobber a fresher in-memory capture.
+    func seedPendingPushToStartFromStore() {
+        for key in store.allRegistrationKeys() where key.hasPrefix(Self.pushToStartValuePrefix) {
+            let notificationType = String(key.dropFirst(Self.pushToStartValuePrefix.count))
+            guard
+                let raw = store.registrationSignature(activityType: key),
+                let separator = raw.firstIndex(of: "|")
+            else { continue }
+            let attributesType = String(raw[..<separator])
+            let tokenHex = String(raw[raw.index(after: separator)...])
+            guard !tokenHex.isEmpty else { continue }
+            pendingPushToStart.mutating { pending in
+                if pending[notificationType] == nil {
+                    pending[notificationType] = PendingPushToStart(attributesType: attributesType, tokenHex: tokenHex)
+                }
+            }
+        }
+        flushPending()
+    }
+
+    // MARK: - Observation callbacks
+
+    func handlePushToStartToken(notificationType: String, attributesType: String, token: Data) {
+        let tokenHex = token.hexString
+        pendingPushToStart.mutating {
+            $0[notificationType] = PendingPushToStart(attributesType: attributesType, tokenHex: tokenHex)
+        }
+        // Persist the token *value* (not just the dedup signature) so a future cold launch can
+        // re-seed and register it even if ActivityKit doesn't re-yield the (unchanged) token.
+        store.setRegistrationSignature(
+            activityType: Self.pushToStartValueKey(notificationType),
+            signature: "\(attributesType)|\(tokenHex)"
+        )
+        flushPending()
+    }
+
+    func handleInstanceToken(notificationType: String, instanceUUID: String, token: Data) {
+        let tokenHex = token.hexString
+        pendingInstance.mutating {
+            $0[instanceUUID] = PendingInstance(notificationType: notificationType, tokenHex: tokenHex)
+        }
+        flushPending()
+    }
+
+    /// An activity ended — drop its per-instance state (in-memory + persisted) so the store
+    /// doesn't grow unbounded and a reused id would re-register.
+    func handleActivityEnded(instanceUUID: String) {
+        pendingInstance.mutating { $0[instanceUUID] = nil }
+        store.clearRegistrationSignature(activityType: Self.instanceStoreKey(instanceUUID))
+    }
+
+    /// Store key for a per-instance signature. Namespaced so it can't collide with a
+    /// push-to-start key (an activity type identifier).
+    private static func instanceStoreKey(_ instanceUUID: String) -> String {
+        "instance:\(instanceUUID)"
+    }
+
+    /// Key prefix for a persisted push-to-start token value. Namespaced so it can't collide with a
+    /// push-to-start dedup signature (bare activity type) or a per-instance signature.
+    private static let pushToStartValuePrefix = "ptsvalue:"
+    private static func pushToStartValueKey(_ notificationType: String) -> String {
+        pushToStartValuePrefix + notificationType
+    }
+
+    // MARK: - Flush
+
+    private func flushPending() {
+        flushLock.lock()
+        defer { flushLock.unlock() }
+
+        guard
+            let userId = identity.userId,
+            let deviceToken = identity.deviceToken,
+            !deviceToken.isEmpty
+        else { return }
+
+        for (notificationType, pending) in pendingPushToStart.wrappedValue {
+            // Include the deviceToken so a device-token rotation (same push-to-start token + user)
+            // re-registers against the new device rather than being skipped as unchanged.
+            let signature = "\(deviceToken)|\(pending.tokenHex)|\(userId)"
+            guard store.registrationSignature(activityType: notificationType) != signature else { continue }
+            reporter.sendPushToStartToken(
+                notificationType: notificationType,
+                attributesType: pending.attributesType,
+                pushToStartToken: pending.tokenHex
+            )
+            store.setRegistrationSignature(activityType: notificationType, signature: signature)
+        }
+
+        for (instanceUUID, pending) in pendingInstance.wrappedValue {
+            // Dedup persists across launches (like push-to-start): keyed by instanceUUID with a
+            // `deviceToken|token` value, so an unchanged instance token on relaunch is skipped,
+            // while a rotated token or a new device re-registers. `flushPending` is serialized by
+            // `flushLock`, so this check-then-set is atomic against concurrent callers.
+            let storeKey = Self.instanceStoreKey(instanceUUID)
+            let sendKey = "\(deviceToken)|\(pending.tokenHex)"
+            guard store.registrationSignature(activityType: storeKey) != sendKey else { continue }
+            reporter.sendInstanceToken(
+                notificationType: pending.notificationType,
+                instanceUUID: instanceUUID,
+                instanceToken: pending.tokenHex
+            )
+            store.setRegistrationSignature(activityType: storeKey, signature: sendKey)
+        }
+    }
+}

--- a/Sources/LiveActivities/Reporting/LiveActivityContract.swift
+++ b/Sources/LiveActivities/Reporting/LiveActivityContract.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Single source of truth for the Live Activities CDP wire contract.
+///
+/// Event names, property keys, and enumerated values are shared with the Android SDK
+/// (`LiveNotificationLifecycleClient`) so one backend contract serves both platforms.
+/// Changing any value here changes the wire format — keep it in lockstep with Android.
+enum LiveActivityContract {
+    /// Track event names.
+    enum Event {
+        /// Lifecycle event: start / update / end.
+        static let lifecycle = "Live Notification Event"
+        /// Token registration event: push_to_start / instance.
+        static let token = "Live Notification Token"
+    }
+
+    /// Property keys carried under an event's `properties`.
+    enum Key {
+        static let eventType = "eventType"
+        static let registrationType = "registrationType"
+        static let cioInstanceId = "cioInstanceId"
+        static let deviceId = "deviceId"
+        static let platform = "platform"
+        static let notificationType = "notificationType"
+        /// Static attributes object (encoded `Attributes`). Sent on `start` only.
+        static let attributes = "attributes"
+        /// Dynamic content-state object (encoded `ContentState`). Sent on `start`/`update`,
+        /// and optionally on `end`.
+        static let contentState = "contentState"
+        static let pushToStartToken = "pushToStartToken"
+        static let attributesType = "attributesType"
+        static let instanceToken = "instanceToken"
+    }
+
+    /// `eventType` values for the lifecycle event.
+    enum EventType {
+        static let start = "start"
+        static let update = "update"
+        static let end = "end"
+    }
+
+    /// `registrationType` values for the token event.
+    enum RegistrationType {
+        static let pushToStart = "push_to_start"
+        static let instance = "instance"
+    }
+
+    /// `platform` value for this SDK.
+    static let platform = "ios"
+}

--- a/Sources/LiveActivities/Reporting/LiveActivityDeliveryTracker.swift
+++ b/Sources/LiveActivities/Reporting/LiveActivityDeliveryTracker.swift
@@ -1,0 +1,55 @@
+import CioInternalCommon
+import CioLiveActivities_Attributes
+import Foundation
+
+/// Reports Live Activity push **delivery/open receipts** through the SAME pipeline normal push
+/// uses — a `TrackMetricEvent` (consumed by DataPipeline → "Report Delivery Event") carrying the
+/// shared `Metric.delivered` / `Metric.opened` values. One backend contract serves push, Live
+/// Activities (iOS), and Live Notifications (Android).
+///
+/// The delivery identifiers ride inside the decoded `content-state` (`CIOLiveActivityMetadata`),
+/// because iOS never exposes the raw Live Activity push to the app. `delivered` is deduped by
+/// `CIO-Delivery-ID` so ActivityKit's content re-emissions and the cold-launch snapshot replay
+/// can't double-report; `opened` is not deduped (each tap is a distinct open, matching push).
+///
+/// This type does no user gating: a delivery is a device-level receipt, reported whenever a
+/// `CIO-Delivery-ID` is present (matching normal push).
+final class LiveActivityDeliveryTracker: @unchecked Sendable {
+    /// Posts the metric onto the shared event bus. Injected so the tracker stays decoupled from the
+    /// SDK facade (mirrors `LiveActivityReporter`'s `track` closure).
+    private let postMetric: @Sendable (_ deliveryId: String, _ event: String, _ deliveryToken: String) -> Void
+    private let store: LiveActivityTokenStorage
+    private let logger: Logger
+
+    /// Retention window for `delivered` dedup markers. Matches Android's `LiveNotificationStore`
+    /// TTL. A delivery id older than this can't be re-reported in practice (ActivityKit won't
+    /// replay a week-old snapshot, and delivery ids are unique per push), so pruning is lossless.
+    private static let deliveredTTL: TimeInterval = 7 * 24 * 60 * 60
+
+    init(
+        postMetric: @escaping @Sendable (_ deliveryId: String, _ event: String, _ deliveryToken: String) -> Void,
+        store: LiveActivityTokenStorage,
+        logger: Logger
+    ) {
+        self.postMetric = postMetric
+        self.store = store
+        self.logger = logger
+    }
+
+    /// Reports `delivered` for the push that produced this content-state — at most once per
+    /// `CIO-Delivery-ID`. No-op when the state carries no delivery id (e.g. a locally-driven state).
+    func reportDelivered(metadata: CIOLiveActivityMetadata) {
+        guard let deliveryId = metadata.deliveryId, !deliveryId.isEmpty else { return }
+        guard !store.hasFreshDeliveredMarker(deliveryId, ttl: Self.deliveredTTL) else { return }
+        postMetric(deliveryId, Metric.delivered.rawValue, metadata.deliveryToken ?? "")
+        store.setDeliveredMarker(deliveryId, at: Date())
+        logger.debug("Reported Live Activity 'delivered' deliveryId=\(deliveryId)", "LiveActivities")
+    }
+
+    /// Reports `opened` for a tapped activity. Not deduped — each tap is a distinct open.
+    func reportOpened(metadata: CIOLiveActivityMetadata) {
+        guard let deliveryId = metadata.deliveryId, !deliveryId.isEmpty else { return }
+        postMetric(deliveryId, Metric.opened.rawValue, metadata.deliveryToken ?? "")
+        logger.debug("Reported Live Activity 'opened' deliveryId=\(deliveryId)", "LiveActivities")
+    }
+}

--- a/Sources/LiveActivities/Reporting/LiveActivityDeliveryTracker.swift
+++ b/Sources/LiveActivities/Reporting/LiveActivityDeliveryTracker.swift
@@ -40,9 +40,10 @@ final class LiveActivityDeliveryTracker: @unchecked Sendable {
     /// `CIO-Delivery-ID`. No-op when the state carries no delivery id (e.g. a locally-driven state).
     func reportDelivered(metadata: CIOLiveActivityMetadata) {
         guard let deliveryId = metadata.deliveryId, !deliveryId.isEmpty else { return }
-        guard !store.hasFreshDeliveredMarker(deliveryId, ttl: Self.deliveredTTL) else { return }
+        // Atomic check-and-set: only the first caller to claim this delivery id reports, so
+        // concurrent content re-emissions / snapshot replay can't double-report `delivered`.
+        guard store.markDeliveredIfFresh(deliveryId, ttl: Self.deliveredTTL, at: Date()) else { return }
         postMetric(deliveryId, Metric.delivered.rawValue, metadata.deliveryToken ?? "")
-        store.setDeliveredMarker(deliveryId, at: Date())
         logger.debug("Reported Live Activity 'delivered' deliveryId=\(deliveryId)", "LiveActivities")
     }
 

--- a/Sources/LiveActivities/Reporting/LiveActivityReporter.swift
+++ b/Sources/LiveActivities/Reporting/LiveActivityReporter.swift
@@ -1,0 +1,158 @@
+import CioInternalCommon
+import Foundation
+
+/// Maps Live Activities lifecycle and token registration to Customer.io CDP track events.
+///
+/// Emits two events — `Live Notification Event` (start/update/end) and
+/// `Live Notification Token` (push_to_start/instance) — carrying the contract fields under
+/// the event's `properties`. The data pipeline owns batching, retry and flush, so this type
+/// is a thin mapper.
+///
+/// Live Activities require an identified user and a registered device token: any event
+/// emitted while anonymous or before a device token exists is dropped (logged at debug),
+/// matching the Android contract. The `userId` itself rides the CDP identify context, so it
+/// is not duplicated into `properties`.
+final class LiveActivityReporter: @unchecked Sendable {
+    private let track: (String, [String: Any]) -> Void
+    private let currentUserId: () -> String?
+    private let deviceToken: () -> String?
+    private let logger: Logger
+
+    init(
+        track: @escaping (String, [String: Any]) -> Void,
+        currentUserId: @escaping () -> String?,
+        deviceToken: @escaping () -> String?,
+        logger: Logger
+    ) {
+        self.track = track
+        self.currentUserId = currentUserId
+        self.deviceToken = deviceToken
+        self.logger = logger
+    }
+
+    // MARK: - Lifecycle events (local operations only)
+
+    /// Reports a `start`: sends both the static `attributes` object and the dynamic
+    /// `contentState` object (both nil-omitted if not encodable).
+    func reportStart(instanceUUID: String, notificationType: String, attributes: [String: Any]?, contentState: [String: Any]?) {
+        reportLifecycle(
+            eventType: LiveActivityContract.EventType.start,
+            instanceUUID: instanceUUID,
+            notificationType: notificationType,
+            attributes: attributes,
+            contentState: contentState
+        )
+    }
+
+    /// Reports an `update`: sends the dynamic `contentState` object.
+    func reportUpdate(instanceUUID: String, notificationType: String, contentState: [String: Any]?) {
+        reportLifecycle(
+            eventType: LiveActivityContract.EventType.update,
+            instanceUUID: instanceUUID,
+            notificationType: notificationType,
+            attributes: nil,
+            contentState: contentState
+        )
+    }
+
+    /// Reports an `end`: optionally sends a final `contentState` object (nil-omitted).
+    func reportEnd(instanceUUID: String, notificationType: String, contentState: [String: Any]? = nil) {
+        reportLifecycle(
+            eventType: LiveActivityContract.EventType.end,
+            instanceUUID: instanceUUID,
+            notificationType: notificationType,
+            attributes: nil,
+            contentState: contentState
+        )
+    }
+
+    private func reportLifecycle(eventType: String, instanceUUID: String, notificationType: String, attributes: [String: Any]?, contentState: [String: Any]?) {
+        guard let deviceId = gatedDeviceId(for: "\(eventType) event") else { return }
+        var properties: [String: Any] = [
+            LiveActivityContract.Key.eventType: eventType,
+            LiveActivityContract.Key.cioInstanceId: instanceUUID,
+            LiveActivityContract.Key.deviceId: deviceId,
+            LiveActivityContract.Key.platform: LiveActivityContract.platform,
+            LiveActivityContract.Key.notificationType: notificationType
+        ]
+        if let attributes, !attributes.isEmpty {
+            properties[LiveActivityContract.Key.attributes] = attributes
+        }
+        if let contentState, !contentState.isEmpty {
+            properties[LiveActivityContract.Key.contentState] = contentState
+        }
+        track(LiveActivityContract.Event.lifecycle, properties)
+        logger.debug(
+            "Sent 'Live Notification Event' eventType=\(eventType) instanceUUID=\(instanceUUID) notificationType=\(notificationType)",
+            "LiveActivities"
+        )
+    }
+
+    // MARK: - Token registration events
+
+    func sendPushToStartToken(notificationType: String, attributesType: String, pushToStartToken: String) {
+        guard let deviceId = gatedDeviceId(for: "push_to_start token") else { return }
+        track(LiveActivityContract.Event.token, [
+            LiveActivityContract.Key.registrationType: LiveActivityContract.RegistrationType.pushToStart,
+            LiveActivityContract.Key.notificationType: notificationType,
+            LiveActivityContract.Key.platform: LiveActivityContract.platform,
+            LiveActivityContract.Key.deviceId: deviceId,
+            LiveActivityContract.Key.pushToStartToken: pushToStartToken,
+            LiveActivityContract.Key.attributesType: attributesType
+        ])
+        logger.debug(
+            "Sent 'Live Notification Token' registrationType=push_to_start notificationType=\(notificationType) attributesType=\(attributesType)",
+            "LiveActivities"
+        )
+    }
+
+    func sendInstanceToken(notificationType: String, instanceUUID: String, instanceToken: String) {
+        guard let deviceId = gatedDeviceId(for: "instance token") else { return }
+        track(LiveActivityContract.Event.token, [
+            LiveActivityContract.Key.registrationType: LiveActivityContract.RegistrationType.instance,
+            LiveActivityContract.Key.notificationType: notificationType,
+            LiveActivityContract.Key.platform: LiveActivityContract.platform,
+            LiveActivityContract.Key.deviceId: deviceId,
+            LiveActivityContract.Key.cioInstanceId: instanceUUID,
+            LiveActivityContract.Key.instanceToken: instanceToken
+        ])
+        logger.debug(
+            "Sent 'Live Notification Token' registrationType=instance notificationType=\(notificationType) instanceUUID=\(instanceUUID)",
+            "LiveActivities"
+        )
+    }
+
+    // MARK: - Gate
+
+    /// Returns the device token when an identified user and a non-empty device token both
+    /// exist; otherwise logs the reason and returns `nil` so the caller drops the event.
+    private func gatedDeviceId(for what: String) -> String? {
+        guard currentUserId() != nil else {
+            logger.debug("Live Notifications require an identified user; dropping \(what).", "LiveActivities")
+            return nil
+        }
+        guard let token = deviceToken(), !token.isEmpty else {
+            logger.debug("No device token available yet; dropping \(what).", "LiveActivities")
+            return nil
+        }
+        return token
+    }
+
+    // MARK: - Payload encoding
+
+    // Pinned encoder for the `attributes` / `contentState` objects. Date fields are modeled
+    // with `EpochSecondsDate`, which encodes to an epoch-second number, so no
+    // `dateEncodingStrategy` is needed here — this keeps the local CDP-event wire format
+    // byte-for-byte consistent with what ActivityKit decodes on a server push.
+    static let payloadEncoder = JSONEncoder()
+
+    /// Encodes a `Codable` value (`Attributes` or `ContentState`) into a JSON object.
+    /// Returns `nil` when the value is not encodable as a JSON object.
+    static func encode(_ value: some Encodable) -> [String: Any]? {
+        guard
+            let data = try? payloadEncoder.encode(value),
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return object
+    }
+}

--- a/Sources/LiveActivities/Storage/KeyValueLiveActivityTokenStore.swift
+++ b/Sources/LiveActivities/Storage/KeyValueLiveActivityTokenStore.swift
@@ -88,6 +88,23 @@ final class KeyValueLiveActivityTokenStore: LiveActivityTokenStorage {
         }
     }
 
+    func markDeliveredIfFresh(_ deliveryId: String, ttl: TimeInterval, at date: Date) -> Bool {
+        lock.withLock {
+            var map = loadDelivered()
+            let prunedChanged = pruneDeliveredIfNeeded(&map, ttl: ttl)
+            if let millis = map[deliveryId],
+               date.timeIntervalSince1970 - Double(millis) / 1000 <= ttl {
+                // A fresh marker already exists — skip. Persist only if pruning changed the map.
+                if prunedChanged { saveDelivered(map) }
+                return false
+            }
+            map[deliveryId] = Int64((date.timeIntervalSince1970 * 1000).rounded())
+            capDelivered(&map)
+            saveDelivered(map)
+            return true
+        }
+    }
+
     /// Drops markers older than `ttl`. Runs at most once per process (first delivered-marker
     /// access). Returns whether the map changed and therefore needs persisting.
     private func pruneDeliveredIfNeeded(_ map: inout [String: Int64], ttl: TimeInterval) -> Bool {

--- a/Sources/LiveActivities/Storage/KeyValueLiveActivityTokenStore.swift
+++ b/Sources/LiveActivities/Storage/KeyValueLiveActivityTokenStore.swift
@@ -1,0 +1,166 @@
+import CioInternalCommon
+import Foundation
+
+/// `LiveActivityTokenStorage` backed by the SDK's shared key-value storage — the same
+/// UserDefaults-backed store that holds the push device token.
+///
+/// All per-activity-type signatures are persisted together as a single JSON
+/// `[activityType: signature]` map under one key, so the store needs no schema and no
+/// SQL layer. Reads and writes tolerate missing or corrupt data by treating the map as
+/// empty; the only observable effect of a failure is that a push-to-start registration
+/// may be re-sent on a future launch.
+///
+/// `delivered` dedup markers are kept in a **separate** `[deliveryId: epochMillis]` map under
+/// their own key, so the hot registration-signature lookups (run on every device-token/user
+/// change) never deserialize the delivery history. The delivery map is TTL-bounded (see
+/// `hasFreshDeliveredMarker`).
+final class KeyValueLiveActivityTokenStore: LiveActivityTokenStorage {
+    private let storage: SharedKeyValueStorage
+    private let key: KeyValueStorageKey = .liveActivityRegistrations
+    private let deliveredKey: KeyValueStorageKey = .liveActivityDeliveries
+    private let lock = NSLock()
+
+    /// Cap on retained `delivered` markers after TTL pruning — defense-in-depth against a burst of
+    /// unique deliveries inside the TTL window. When exceeded, the oldest markers are evicted.
+    private static let deliveredMarkerCap = 500
+
+    /// One-shot guard so the O(n) TTL trim runs once per process (first delivered-marker access),
+    /// not on every push. Guarded by `lock`.
+    private var didPruneDelivered = false
+
+    init(storage: SharedKeyValueStorage) {
+        self.storage = storage
+    }
+
+    func registrationSignature(activityType: String) -> String? {
+        lock.withLock { load()[activityType] }
+    }
+
+    func setRegistrationSignature(activityType: String, signature: String) {
+        lock.withLock {
+            var map = load()
+            map[activityType] = signature
+            save(map)
+        }
+    }
+
+    func clearRegistrationSignature(activityType: String) {
+        lock.withLock {
+            var map = load()
+            map[activityType] = nil
+            save(map)
+        }
+    }
+
+    func allRegistrationKeys() -> [String] {
+        lock.withLock { Array(load().keys) }
+    }
+
+    func clearAll() {
+        // Only remove our own keys — `SharedKeyValueStorage.deleteAll()` would wipe the
+        // entire shared store (device token, …).
+        lock.withLock {
+            storage.setString(nil, forKey: key)
+            storage.setString(nil, forKey: deliveredKey)
+        }
+    }
+
+    // MARK: - Delivered dedup markers (separate, TTL-bounded map)
+
+    func hasFreshDeliveredMarker(_ deliveryId: String, ttl: TimeInterval) -> Bool {
+        lock.withLock {
+            var map = loadDelivered()
+            if pruneDeliveredIfNeeded(&map, ttl: ttl) {
+                saveDelivered(map)
+            }
+            guard let millis = map[deliveryId] else { return false }
+            let ageSeconds = Date().timeIntervalSince1970 - Double(millis) / 1000
+            return ageSeconds <= ttl
+        }
+    }
+
+    func setDeliveredMarker(_ deliveryId: String, at date: Date) {
+        lock.withLock {
+            var map = loadDelivered()
+            map[deliveryId] = Int64((date.timeIntervalSince1970 * 1000).rounded())
+            capDelivered(&map)
+            saveDelivered(map)
+        }
+    }
+
+    /// Drops markers older than `ttl`. Runs at most once per process (first delivered-marker
+    /// access). Returns whether the map changed and therefore needs persisting.
+    private func pruneDeliveredIfNeeded(_ map: inout [String: Int64], ttl: TimeInterval) -> Bool {
+        guard !didPruneDelivered else { return false }
+        didPruneDelivered = true
+        let cutoffMillis = Int64((Date().timeIntervalSince1970 - ttl) * 1000)
+        let before = map.count
+        map = map.filter { $0.value >= cutoffMillis }
+        return map.count != before
+    }
+
+    /// Backstop: keep only the newest `deliveredMarkerCap` markers by timestamp.
+    private func capDelivered(_ map: inout [String: Int64]) {
+        guard map.count > Self.deliveredMarkerCap else { return }
+        let newest = map.sorted { $0.value > $1.value }.prefix(Self.deliveredMarkerCap)
+        map = Dictionary(uniqueKeysWithValues: newest.map { ($0.key, $0.value) })
+    }
+
+    func resolveInstanceId(forActivityId activityId: String, orCreate: () -> String) -> String {
+        lock.withLock {
+            var map = load()
+            let mapKey = Self.instanceIdKey(activityId)
+            if let existing = map[mapKey] { return existing }
+            let created = orCreate()
+            map[mapKey] = created
+            save(map)
+            return created
+        }
+    }
+
+    func clearInstanceId(forActivityId activityId: String) {
+        lock.withLock {
+            var map = load()
+            map[Self.instanceIdKey(activityId)] = nil
+            save(map)
+        }
+    }
+
+    /// Namespaced key for an `Activity.id` → instance id mapping, so it can't collide with a
+    /// registration signature (bare activity type / `instance:` / `ptsvalue:` keys).
+    private static func instanceIdKey(_ activityId: String) -> String {
+        "aid:" + activityId
+    }
+
+    // MARK: - JSON map persistence
+
+    private func load() -> [String: String] {
+        guard let raw = storage.string(key),
+              let data = raw.data(using: .utf8),
+              let map = try? JSONDecoder().decode([String: String].self, from: data)
+        else { return [:] }
+        return map
+    }
+
+    private func save(_ map: [String: String]) {
+        guard let data = try? JSONEncoder().encode(map),
+              let raw = String(data: data, encoding: .utf8)
+        else { return }
+        storage.setString(raw, forKey: key)
+    }
+
+    private func loadDelivered() -> [String: Int64] {
+        guard let raw = storage.string(deliveredKey),
+              let data = raw.data(using: .utf8),
+              let map = try? JSONDecoder().decode([String: Int64].self, from: data)
+        else { return [:] }
+        return map
+    }
+
+    private func saveDelivered(_ map: [String: Int64]) {
+        guard let data = try? JSONEncoder().encode(map),
+              let raw = String(data: data, encoding: .utf8)
+        else { return }
+        storage.setString(raw, forKey: deliveredKey)
+    }
+}

--- a/Sources/LiveActivities/Storage/LiveActivityTokenStorage.swift
+++ b/Sources/LiveActivities/Storage/LiveActivityTokenStorage.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Persists Live Activity token-registration state so unchanged tokens are not re-sent across
+/// app launches.
+///
+/// Several kinds of entry share this store, distinguished by their key:
+/// - push-to-start dedup signature, keyed by activity type — value `"<deviceToken>|<pushToStartToken>|<userId>"`.
+/// - per-instance dedup signature, keyed by `"instance:<instanceUUID>"` — value `"<deviceToken>|<instanceToken>"`.
+/// - persisted push-to-start token value, keyed by `"ptsvalue:<activityType>"` — value `"<attributesType>|<pushToStartToken>"`.
+/// The registrar skips a registration whose stored signature is unchanged; a new token, user, or
+/// device yields a new signature and re-registers. The persisted token value lets the registrar
+/// re-seed and register a push-to-start token on a launch where ActivityKit does not re-yield it.
+///
+/// The store is a plain keyed string map; all key-namespacing policy lives in the registrar.
+protocol LiveActivityTokenStorage {
+    /// The last stored value for `activityType` (a signature or a persisted token), or `nil`.
+    func registrationSignature(activityType: String) -> String?
+    /// Record `signature` as the last value for `activityType`.
+    func setRegistrationSignature(activityType: String, signature: String)
+    /// Remove the stored value for a single `activityType` (e.g. when an instance ends).
+    func clearRegistrationSignature(activityType: String)
+    /// All keys currently held, so the registrar can seed persisted push-to-start tokens at launch
+    /// and clear dedup signatures selectively (preserving persisted tokens) on reset.
+    func allRegistrationKeys() -> [String]
+    /// Remove all stored entries (e.g. full teardown), forcing re-registration.
+    func clearAll()
+
+    /// Whether a still-fresh `delivered` dedup marker exists for `deliveryId` (reported less than
+    /// `ttl` ago). Markers older than `ttl` are pruned lazily (once per process) before answering,
+    /// so the delivery history stays bounded. Delivery markers live in their own storage map, so
+    /// registration-signature lookups never parse delivery history.
+    func hasFreshDeliveredMarker(_ deliveryId: String, ttl: TimeInterval) -> Bool
+    /// Record a `delivered` dedup marker for `deliveryId`, timestamped `date` (enables TTL expiry).
+    func setDeliveredMarker(_ deliveryId: String, at date: Date)
+
+    /// Returns the CIO instance id mapped to a system `Activity.id`, creating and persisting one
+    /// via `orCreate` if none exists yet. Atomic: concurrent callers (a local `start` and the
+    /// registration observer picking up the same activity) resolve to a single id. Persisting the
+    /// mapping lets the observer recover a locally-started activity's id after a relaunch, where the
+    /// minted id is no longer in memory and — for non-`CIOActivityAttribute` types — is not in the
+    /// activity's attributes either.
+    func resolveInstanceId(forActivityId activityId: String, orCreate: () -> String) -> String
+    /// Remove the `Activity.id` → instance id mapping (on activity end).
+    func clearInstanceId(forActivityId activityId: String)
+}

--- a/Sources/LiveActivities/Storage/LiveActivityTokenStorage.swift
+++ b/Sources/LiveActivities/Storage/LiveActivityTokenStorage.swift
@@ -32,6 +32,11 @@ protocol LiveActivityTokenStorage {
     func hasFreshDeliveredMarker(_ deliveryId: String, ttl: TimeInterval) -> Bool
     /// Record a `delivered` dedup marker for `deliveryId`, timestamped `date` (enables TTL expiry).
     func setDeliveredMarker(_ deliveryId: String, at date: Date)
+    /// Atomically dedup a `delivered` receipt: if no fresh marker (within `ttl`) exists for
+    /// `deliveryId`, record one timestamped `date` and return `true` (the caller should report);
+    /// otherwise return `false`. The check-and-set runs under a single lock so concurrent pushes
+    /// carrying the same delivery id can't both pass the check and double-report.
+    func markDeliveredIfFresh(_ deliveryId: String, ttl: TimeInterval, at date: Date) -> Bool
 
     /// Returns the CIO instance id mapped to a system `Activity.id`, creating and persisting one
     /// via `orCreate` if none exists yet. Atomic: concurrent callers (a local `start` and the

--- a/Sources/LiveActivities/Support/Data+Hex.swift
+++ b/Sources/LiveActivities/Support/Data+Hex.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+extension Data {
+    /// Lowercase hex-string encoding of the bytes, used for APNs push tokens.
+    var hexString: String {
+        map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Sources/LiveActivities/Util/ULID.swift
+++ b/Sources/LiveActivities/Util/ULID.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Security
+
+/// Generates [ULID](https://github.com/ulid/spec) identifiers for locally-minted
+/// Live Notification instances.
+///
+/// A ULID is a 128-bit, lexicographically sortable identifier:
+/// - the most-significant 48 bits are a Unix-epoch **millisecond** timestamp, and
+/// - the remaining 80 bits are cryptographic randomness.
+///
+/// It is rendered as a 26-character, **UPPERCASE** Crockford Base32 string. The first
+/// 10 characters encode the timestamp and the last 16 encode the randomness. Because
+/// `26 * 5 = 130` bits but the value is only 128 bits, the leading character carries just
+/// 3 significant timestamp bits, so it is always in the range `0`–`7`.
+///
+/// The output is not lowercased: Crockford Base32 is case-insensitive on decode, but the
+/// canonical form is uppercase and the backend expects the canonical form.
+enum ULID {
+    /// Crockford Base32 alphabet (excludes `I`, `L`, `O`, and `U` to avoid ambiguity).
+    private static let alphabet = Array("0123456789ABCDEFGHJKMNPQRSTVWXYZ")
+
+    /// Generate a new ULID string for the given instant (defaults to now).
+    ///
+    /// - Parameter date: The instant whose millisecond timestamp seeds the first 48 bits.
+    /// - Returns: A 26-character uppercase Crockford Base32 ULID.
+    static func generate(date: Date = Date()) -> String {
+        let milliseconds = timestampMilliseconds(from: date)
+        return encodeTimestamp(milliseconds) + encodeRandomness(randomBytes())
+    }
+
+    // MARK: - Timestamp
+
+    /// Clamp the date's millisecond timestamp into the representable 48-bit ULID range.
+    private static func timestampMilliseconds(from date: Date) -> UInt64 {
+        let millis = date.timeIntervalSince1970 * 1000
+        guard millis > 0 else { return 0 }
+        let maxTimestamp = (UInt64(1) << 48) - 1
+        return min(UInt64(millis), maxTimestamp)
+    }
+
+    /// Encode the 48-bit timestamp as the first 10 Crockford Base32 characters,
+    /// most-significant 5-bit group first.
+    private static func encodeTimestamp(_ timestamp: UInt64) -> String {
+        var characters = [Character]()
+        characters.reserveCapacity(10)
+        for index in 0 ..< 10 {
+            let shift = UInt64((9 - index) * 5)
+            let value = Int((timestamp >> shift) & 0x1F)
+            characters.append(alphabet[value])
+        }
+        return String(characters)
+    }
+
+    // MARK: - Randomness
+
+    /// 10 cryptographically random bytes (80 bits) from `SecRandomCopyBytes`.
+    ///
+    /// A non-`errSecSuccess` result falls back to `arc4random_buf` rather than throwing, so
+    /// id generation never fails at the call site.
+    private static func randomBytes() -> [UInt8] {
+        var bytes = [UInt8](repeating: 0, count: 10)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        if status != errSecSuccess {
+            arc4random_buf(&bytes, bytes.count)
+        }
+        return bytes
+    }
+
+    /// Encode 10 random bytes (80 bits) as the last 16 Crockford Base32 characters.
+    ///
+    /// The bytes are read as one big-endian bit stream split into 16 groups of 5 bits; no
+    /// padding is required because `16 * 5 == 80`.
+    private static func encodeRandomness(_ bytes: [UInt8]) -> String {
+        var characters = [Character]()
+        characters.reserveCapacity(16)
+        for group in 0 ..< 16 {
+            var value = 0
+            for offset in 0 ..< 5 {
+                let bitIndex = group * 5 + offset
+                let bit = (bytes[bitIndex / 8] >> (7 - (bitIndex % 8))) & 1
+                value = (value << 1) | Int(bit)
+            }
+            characters.append(alphabet[value])
+        }
+        return String(characters)
+    }
+
+    // MARK: - Decoding (test support)
+
+    /// Decode the millisecond timestamp from the first 10 characters of a ULID.
+    ///
+    /// - Returns: The 48-bit timestamp, or `nil` if `ulid` is malformed.
+    static func timestampMilliseconds(from ulid: String) -> UInt64? {
+        guard ulid.count == 26 else { return nil }
+        var timestamp: UInt64 = 0
+        for character in ulid.prefix(10) {
+            guard let value = alphabet.firstIndex(of: character) else { return nil }
+            timestamp = (timestamp << 5) | UInt64(value)
+        }
+        return timestamp
+    }
+}

--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -9,7 +9,7 @@ disabled_rules:
   # let foo = try? ...
   # XCTAssertNotNil(foo)
   # XCTAssertEqual(foo?.bar, "")
-  # - force_try
+  - force_try
 
   # `as!` in a test can result in tests being halted and not finish executing. Instead, we would rather have a test fail and continue executing the suite. 
   # Instead of `as!` use: 

--- a/Tests/LiveActivities/LiveActivitiesConfigTests.swift
+++ b/Tests/LiveActivities/LiveActivitiesConfigTests.swift
@@ -34,7 +34,7 @@ private struct TestActivityAttributes: CIOActivityAttribute {
         var progress: Double
     }
 
-    let cioInstanceId: String
+    var cioInstanceId: String
 }
 
 @available(iOS 17.2, *)
@@ -43,7 +43,7 @@ private struct AnotherActivityAttributes: CIOActivityAttribute {
         var label: String
     }
 
-    let cioInstanceId: String
+    var cioInstanceId: String
 }
 
 struct LiveActivityConfigBuilderTests {

--- a/Tests/LiveActivities/LiveActivitiesConfigTests.swift
+++ b/Tests/LiveActivities/LiveActivitiesConfigTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+
+@testable import CioLiveActivities
+
+// MARK: - LiveActivityConfig defaults
+
+struct LiveActivityConfigDefaultTests {
+    @Test func defaultLogLevel_isNil() {
+        let config = LiveActivityConfig()
+        #expect(config.logLevel == nil)
+    }
+
+    @Test func defaultRegistrations_isEmpty() {
+        let config = LiveActivityConfig()
+        #expect(config.registrations.isEmpty)
+    }
+
+    @Test func initWithLogLevel_setsLogLevel() {
+        let config = LiveActivityConfig(logLevel: .debug)
+        #expect(config.logLevel == .debug)
+    }
+}
+
+// MARK: - LiveActivityConfigBuilder (iOS only)
+
+#if os(iOS)
+import ActivityKit
+import CioLiveActivities_Attributes
+
+@available(iOS 17.2, *)
+private struct TestActivityAttributes: CIOActivityAttribute {
+    struct ContentState: Codable, Hashable {
+        var progress: Double
+    }
+
+    let cioInstanceId: String
+}
+
+@available(iOS 17.2, *)
+private struct AnotherActivityAttributes: CIOActivityAttribute {
+    struct ContentState: Codable, Hashable {
+        var label: String
+    }
+
+    let cioInstanceId: String
+}
+
+struct LiveActivityConfigBuilderTests {
+    @Test func defaultBuilder_hasNoRegistrations() {
+        let config = LiveActivityConfigBuilder().build()
+        #expect(config.registrations.isEmpty)
+    }
+
+    @Test func logLevelFluent_setsLogLevel() {
+        let config = LiveActivityConfigBuilder()
+            .logLevel(.error)
+            .build()
+        #expect(config.logLevel == .error)
+    }
+
+    @Test func register_addsOneRegistration() {
+        guard #available(iOS 17.2, *) else { return }
+        let config = LiveActivityConfigBuilder()
+            .register(TestActivityAttributes.self, identifier: "com.test.activity")
+            .build()
+        #expect(config.registrations.count == 1)
+    }
+
+    @Test func register_setsCorrectActivityIdentifier() {
+        guard #available(iOS 17.2, *) else { return }
+        let config = LiveActivityConfigBuilder()
+            .register(TestActivityAttributes.self, identifier: "com.test.activity")
+            .build()
+        #expect(config.registrations[0].activityIdentifier == "com.test.activity")
+    }
+
+    @Test func registerMultiple_addsAllRegistrations() {
+        guard #available(iOS 17.2, *) else { return }
+        let config = LiveActivityConfigBuilder()
+            .register(TestActivityAttributes.self, identifier: "com.test.activity")
+            .register(AnotherActivityAttributes.self, identifier: "com.test.another")
+            .build()
+        #expect(config.registrations.count == 2)
+    }
+
+    @Test func registerMultiple_preservesDistinctIdentifiers() {
+        guard #available(iOS 17.2, *) else { return }
+        let config = LiveActivityConfigBuilder()
+            .register(TestActivityAttributes.self, identifier: "com.test.activity")
+            .register(AnotherActivityAttributes.self, identifier: "com.test.another")
+            .build()
+        let ids = Set(config.registrations.map(\.activityIdentifier))
+        #expect(ids.contains("com.test.activity"))
+        #expect(ids.contains("com.test.another"))
+    }
+
+    @Test func builderIsValueType_mutationsDoNotAlias() {
+        let base = LiveActivityConfigBuilder()
+        let withLog = base.logLevel(.debug)
+        let baseConfig = base.build()
+        let withLogConfig = withLog.build()
+        #expect(baseConfig.logLevel == nil)
+        #expect(withLogConfig.logLevel == .debug)
+    }
+}
+#endif

--- a/Tests/LiveActivities/LiveActivitiesDeliveryTests.swift
+++ b/Tests/LiveActivities/LiveActivitiesDeliveryTests.swift
@@ -1,0 +1,106 @@
+import CioInternalCommon
+import CioLiveActivities_Attributes
+import Foundation
+import Testing
+
+@testable import CioLiveActivities
+
+struct LiveActivitiesDeliveryTests {
+    /// One metric the tracker posted to the shared event bus.
+    private struct RecordedMetric: Sendable {
+        let deliveryId: String
+        let event: String
+        let deliveryToken: String
+    }
+
+    /// Captures the metrics the tracker would post to the shared event bus.
+    private final class MetricCapture: @unchecked Sendable {
+        private let lock = NSLock()
+        private(set) var metrics: [RecordedMetric] = []
+        func record(_ deliveryId: String, _ event: String, _ deliveryToken: String) {
+            lock.withLock { metrics.append(RecordedMetric(deliveryId: deliveryId, event: event, deliveryToken: deliveryToken)) }
+        }
+    }
+
+    private struct Harness {
+        let cap: MetricCapture
+        let store: FakeTokenStore
+        let tracker: LiveActivityDeliveryTracker
+    }
+
+    private func makeHarness() -> Harness {
+        let cap = MetricCapture()
+        let store = FakeTokenStore()
+        let tracker = LiveActivityDeliveryTracker(
+            postMetric: { id, event, token in cap.record(id, event, token) },
+            store: store,
+            logger: NoopLogger()
+        )
+        return Harness(cap: cap, store: store, tracker: tracker)
+    }
+
+    @Test func delivered_reportsOnce_perDeliveryId() {
+        let h = makeHarness()
+        h.tracker.reportDelivered(metadata: .init(deliveryId: "d1", deliveryToken: "t1"))
+        h.tracker.reportDelivered(metadata: .init(deliveryId: "d1", deliveryToken: "t1")) // re-emit / snapshot replay
+        #expect(h.cap.metrics.count == 1)
+        #expect(h.cap.metrics[0].deliveryId == "d1")
+        #expect(h.cap.metrics[0].event == Metric.delivered.rawValue)
+        #expect(h.cap.metrics[0].deliveryToken == "t1")
+    }
+
+    @Test func delivered_distinctIds_eachReported() {
+        let h = makeHarness()
+        h.tracker.reportDelivered(metadata: .init(deliveryId: "d1"))
+        h.tracker.reportDelivered(metadata: .init(deliveryId: "d2"))
+        #expect(h.cap.metrics.count == 2)
+        // Missing delivery token defaults to empty (matches push's optional token handling).
+        #expect(h.cap.metrics[0].deliveryToken.isEmpty)
+    }
+
+    @Test func delivered_noDeliveryId_isNoOp() {
+        let h = makeHarness()
+        h.tracker.reportDelivered(metadata: .init(deepLink: "app://x")) // no id ⇒ local/no push
+        h.tracker.reportDelivered(metadata: .init(deliveryId: "")) // empty id
+        #expect(h.cap.metrics.isEmpty)
+    }
+
+    @Test func delivered_dedupPersists_acrossTrackerInstances() {
+        // A shared store simulates persistence across launches: a cold-launch snapshot must not
+        // re-report `delivered` for an id already reported in a prior process.
+        let cap = MetricCapture()
+        let store = FakeTokenStore()
+        func makeTracker() -> LiveActivityDeliveryTracker {
+            LiveActivityDeliveryTracker(postMetric: { id, e, t in cap.record(id, e, t) }, store: store, logger: NoopLogger())
+        }
+        makeTracker().reportDelivered(metadata: .init(deliveryId: "d1"))
+        makeTracker().reportDelivered(metadata: .init(deliveryId: "d1")) // fresh "process", same store
+        #expect(cap.metrics.count == 1)
+    }
+
+    @Test func delivered_expiredMarker_reReports() {
+        // A dedup marker older than the 7-day TTL must not suppress a (practically impossible)
+        // re-report: the stale marker is ignored and the delivery is reported again.
+        let h = makeHarness()
+        h.store.setDeliveredMarker("d1", at: Date(timeIntervalSinceNow: -(7 * 24 * 60 * 60 + 60)))
+        h.tracker.reportDelivered(metadata: .init(deliveryId: "d1", deliveryToken: "t1"))
+        #expect(h.cap.metrics.count == 1)
+        // …and the refreshed marker now dedups again.
+        h.tracker.reportDelivered(metadata: .init(deliveryId: "d1", deliveryToken: "t1"))
+        #expect(h.cap.metrics.count == 1)
+    }
+
+    @Test func opened_reportsEachTap_notDeduped() {
+        let h = makeHarness()
+        h.tracker.reportOpened(metadata: .init(deliveryId: "d1", deliveryToken: "t1"))
+        h.tracker.reportOpened(metadata: .init(deliveryId: "d1", deliveryToken: "t1"))
+        #expect(h.cap.metrics.count == 2)
+        #expect(h.cap.metrics.allSatisfy { $0.event == Metric.opened.rawValue })
+    }
+
+    @Test func opened_noDeliveryId_isNoOp() {
+        let h = makeHarness()
+        h.tracker.reportOpened(metadata: .init(deepLink: "app://x"))
+        #expect(h.cap.metrics.isEmpty)
+    }
+}

--- a/Tests/LiveActivities/LiveActivitiesDismissTests.swift
+++ b/Tests/LiveActivities/LiveActivitiesDismissTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+
+@testable import CioLiveActivities
+
+// MARK: - Terminal-state discriminator (user dismiss vs app/backend end)
+
+struct LiveActivityTerminalActionTests {
+    @Test func dismissedFirst_notLocalEnd_isUserDismiss() {
+        // User swiped it away: first terminal state is `.dismissed`, SDK didn't end it.
+        #expect(liveActivityTerminalAction(firstTerminalIsDismissed: true, wasLocalEnd: false) == .reportUserDismiss)
+    }
+
+    @Test func endedFirst_isCleanupOnly() {
+        // App/SDK/backend/system end: first terminal state is `.ended` — never a user dismiss.
+        #expect(liveActivityTerminalAction(firstTerminalIsDismissed: false, wasLocalEnd: false) == .cleanupOnly)
+    }
+
+    @Test func dismissedFirst_butLocalEnd_isCleanupOnly() {
+        // Local `end(.immediate)` whose `.ended` the stream coalesced to `.dismissed`: the marker
+        // suppresses a spurious user-dismiss report (the handle already reported the end).
+        #expect(liveActivityTerminalAction(firstTerminalIsDismissed: true, wasLocalEnd: true) == .cleanupOnly)
+    }
+
+    @Test func endedFirst_localEnd_isCleanupOnly() {
+        #expect(liveActivityTerminalAction(firstTerminalIsDismissed: false, wasLocalEnd: true) == .cleanupOnly)
+    }
+}
+
+// MARK: - Local-end tracker
+
+struct LiveActivityLocalEndTrackerTests {
+    @Test func consume_returnsFalse_whenNotMarked() {
+        let tracker = LiveActivityLocalEndTracker()
+        #expect(tracker.consume("i1") == false)
+    }
+
+    @Test func consume_returnsTrueOnce_afterMark() {
+        let tracker = LiveActivityLocalEndTracker()
+        tracker.markEnded("i1")
+        #expect(tracker.consume("i1") == true)
+        // Consumed exactly once — a later terminal state for the same id reads false.
+        #expect(tracker.consume("i1") == false)
+    }
+
+    @Test func markAndConsume_areKeyedPerActivity() {
+        let tracker = LiveActivityLocalEndTracker()
+        tracker.markEnded("i1")
+        #expect(tracker.consume("i2") == false)
+        #expect(tracker.consume("i1") == true)
+    }
+
+    @Test func clearAll_dropsMarkers() {
+        let tracker = LiveActivityLocalEndTracker()
+        tracker.markEnded("i1")
+        tracker.markEnded("i2")
+        tracker.clearAll()
+        #expect(tracker.consume("i1") == false)
+        #expect(tracker.consume("i2") == false)
+    }
+}

--- a/Tests/LiveActivities/LiveActivitiesRegistrarTests.swift
+++ b/Tests/LiveActivities/LiveActivitiesRegistrarTests.swift
@@ -1,0 +1,264 @@
+import Foundation
+import Testing
+
+@testable import CioLiveActivities
+
+struct LiveActivityRegistrarTests {
+    private struct Harness {
+        let cap: TrackCapture
+        let store: FakeTokenStore
+        let identity: LiveActivityIdentity
+        let registrar: LiveActivityRegistrar
+    }
+
+    private func makeHarness() -> Harness {
+        let cap = TrackCapture()
+        let store = FakeTokenStore()
+        let identity = LiveActivityIdentity()
+        let reporter = LiveActivityReporter(
+            track: { name, props in cap.record(name, props) },
+            currentUserId: { identity.userId },
+            deviceToken: { identity.deviceToken },
+            logger: NoopLogger()
+        )
+        let registrar = LiveActivityRegistrar(identity: identity, store: store, reporter: reporter)
+        return Harness(cap: cap, store: store, identity: identity, registrar: registrar)
+    }
+
+    // token = Data([0xaa, 0xbb]) → "aabb"
+    private let token = Data([0xAA, 0xBB])
+
+    @Test func pushToStart_whileAnonymous_isDeferred_valuePersisted_noDedupSignature() {
+        let h = makeHarness()
+        h.identity.deviceToken = "dev"
+        h.registrar.handlePushToStartToken(notificationType: "t", attributesType: "A", token: token)
+        #expect(h.cap.isEmpty)
+        // No dedup signature yet (so it will register on identify) …
+        #expect(h.store.signatures["t"] == nil)
+        // … but the token value IS persisted, so a future launch can re-seed and register it.
+        #expect(h.store.signatures["ptsvalue:t"] == "A|aabb")
+    }
+
+    @Test func pushToStart_refires_onIdentify() {
+        let h = makeHarness()
+        h.identity.deviceToken = "dev"
+        h.registrar.handlePushToStartToken(notificationType: "t", attributesType: "A", token: token)
+        #expect(h.cap.isEmpty)
+
+        h.identity.userId = "user-1"
+        h.registrar.reevaluate()
+        #expect(h.cap.count == 1)
+        #expect(h.store.signatures["t"] == "dev|aabb|user-1")
+    }
+
+    @Test func pushToStart_deferred_untilDeviceTokenArrives() {
+        let h = makeHarness()
+        h.identity.userId = "user-1"
+        h.registrar.handlePushToStartToken(notificationType: "t", attributesType: "A", token: token)
+        #expect(h.cap.isEmpty)
+
+        h.identity.deviceToken = "dev"
+        h.registrar.reevaluate()
+        #expect(h.cap.count == 1)
+    }
+
+    @Test func pushToStart_sameTokenAndUser_isNotResent() {
+        let h = makeHarness()
+        h.identity.userId = "user-1"
+        h.identity.deviceToken = "dev"
+        h.registrar.handlePushToStartToken(notificationType: "t", attributesType: "A", token: token)
+        #expect(h.cap.count == 1)
+
+        h.registrar.reevaluate()
+        h.registrar.reevaluate()
+        #expect(h.cap.count == 1)
+    }
+
+    @Test func pushToStart_newUser_reRegisters() {
+        let h = makeHarness()
+        h.identity.userId = "user-1"
+        h.identity.deviceToken = "dev"
+        h.registrar.handlePushToStartToken(notificationType: "t", attributesType: "A", token: token)
+        #expect(h.cap.count == 1)
+
+        h.identity.userId = "user-2"
+        h.registrar.reevaluate()
+        #expect(h.cap.count == 2)
+        #expect(h.store.signatures["t"] == "dev|aabb|user-2")
+    }
+
+    @Test func pushToStart_deviceTokenRotation_reRegisters() {
+        let h = makeHarness()
+        h.identity.userId = "user-1"
+        h.identity.deviceToken = "dev"
+        h.registrar.handlePushToStartToken(notificationType: "t", attributesType: "A", token: token)
+        #expect(h.cap.count == 1)
+
+        // Device token rotates (same push-to-start token + user): must re-register against the
+        // new device rather than dedup as unchanged.
+        h.identity.deviceToken = "dev2"
+        h.registrar.reevaluate()
+        #expect(h.cap.count == 2)
+        #expect(h.store.signatures["t"] == "dev2|aabb|user-1")
+    }
+
+    @Test func instanceToken_dedupsByToken_reSendsOnChange() {
+        let h = makeHarness()
+        h.identity.userId = "user-1"
+        h.identity.deviceToken = "dev"
+
+        h.registrar.handleInstanceToken(notificationType: "t", instanceUUID: "i1", token: Data([0x01]))
+        #expect(h.cap.count == 1)
+
+        // Same token again — deduped.
+        h.registrar.handleInstanceToken(notificationType: "t", instanceUUID: "i1", token: Data([0x01]))
+        #expect(h.cap.count == 1)
+
+        // Rotated token — re-sent.
+        h.registrar.handleInstanceToken(notificationType: "t", instanceUUID: "i1", token: Data([0x02]))
+        #expect(h.cap.count == 2)
+    }
+
+    @Test func instanceToken_concurrentSameToken_sendsExactlyOnce() async {
+        let h = makeHarness()
+        h.identity.userId = "user-1"
+        h.identity.deviceToken = "dev"
+        let registrar = h.registrar
+        let token = Data([0x0A, 0x0B])
+
+        // Many concurrent observers reporting the same instance token must not each send.
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0 ..< 100 {
+                group.addTask {
+                    registrar.handleInstanceToken(notificationType: "t", instanceUUID: "i1", token: token)
+                }
+            }
+        }
+        #expect(h.cap.count == 1)
+    }
+
+    @Test func instanceToken_notResent_onRelaunch_withPersistedStore() {
+        // Shared store simulates persistence across launches; each registrar is a fresh process.
+        let sharedStore = FakeTokenStore()
+        // Each call is a fresh "process": new in-memory registrar/identity (identified, with a
+        // device token) over the SAME persisted store.
+        func makeRegistrar() -> (LiveActivityRegistrar, TrackCapture) {
+            let cap = TrackCapture()
+            let identity = LiveActivityIdentity()
+            identity.userId = "user-1"
+            identity.deviceToken = "dev"
+            let reporter = LiveActivityReporter(
+                track: { name, props in cap.record(name, props) },
+                currentUserId: { identity.userId },
+                deviceToken: { identity.deviceToken },
+                logger: NoopLogger()
+            )
+            return (LiveActivityRegistrar(identity: identity, store: sharedStore, reporter: reporter), cap)
+        }
+
+        // Launch 1: observe instance token → sends once.
+        let (r1, cap1) = makeRegistrar()
+        r1.handleInstanceToken(notificationType: "t", instanceUUID: "i1", token: token)
+        #expect(cap1.count == 1)
+
+        // Relaunch: fresh in-memory registrar, SAME persisted store, re-observe the same token.
+        let (r2, cap2) = makeRegistrar()
+        r2.handleInstanceToken(notificationType: "t", instanceUUID: "i1", token: token)
+        #expect(cap2.isEmpty) // persisted signature ⇒ no re-send
+    }
+
+    @Test func instanceToken_reSent_afterEnded() {
+        let h = makeHarness()
+        h.identity.userId = "user-1"
+        h.identity.deviceToken = "dev"
+        h.registrar.handleInstanceToken(notificationType: "t", instanceUUID: "i1", token: token)
+        #expect(h.cap.count == 1)
+
+        // Ending clears the persisted instance signature, so the same token re-registers after.
+        h.registrar.handleActivityEnded(instanceUUID: "i1")
+        h.registrar.handleInstanceToken(notificationType: "t", instanceUUID: "i1", token: token)
+        #expect(h.cap.count == 2)
+    }
+
+    @Test func handleReset_clearsDedupSignatures_keepsPersistedPushToStartTokens() {
+        let h = makeHarness()
+        h.identity.userId = "user-1"
+        h.identity.deviceToken = "dev"
+        h.registrar.handlePushToStartToken(notificationType: "t", attributesType: "A", token: token)
+        #expect(h.store.signatures["t"] == "dev|aabb|user-1")
+        #expect(h.store.signatures["ptsvalue:t"] == "A|aabb")
+
+        h.registrar.handleReset()
+        // Dedup signature cleared (forces re-register next session) …
+        #expect(h.store.signatures["t"] == nil)
+        // … but the persisted per-app token value survives logout.
+        #expect(h.store.signatures["ptsvalue:t"] == "A|aabb")
+    }
+
+    @Test func seedFromStore_registersPersistedToken_onLaunch_withoutActivityKitReemission() {
+        // A previous launch persisted the token value while identified (dedup signature present):
+        // a fresh "process" with a cleared dedup signature must re-register from the persisted
+        // value alone — no `handlePushToStartToken` call (ActivityKit didn't re-yield).
+        let sharedStore = FakeTokenStore()
+        sharedStore.setRegistrationSignature(activityType: "ptsvalue:t", signature: "A|aabb")
+
+        let cap = TrackCapture()
+        let identity = LiveActivityIdentity()
+        identity.userId = "user-1"
+        identity.deviceToken = "dev"
+        let reporter = LiveActivityReporter(
+            track: { name, props in cap.record(name, props) },
+            currentUserId: { identity.userId },
+            deviceToken: { identity.deviceToken },
+            logger: NoopLogger()
+        )
+        let registrar = LiveActivityRegistrar(identity: identity, store: sharedStore, reporter: reporter)
+
+        registrar.seedPendingPushToStartFromStore()
+        #expect(cap.count == 1)
+        #expect(cap.string(0, "pushToStartToken") == "aabb")
+        #expect(cap.string(0, "attributesType") == "A")
+        #expect(sharedStore.signatures["t"] == "dev|aabb|user-1")
+    }
+
+    @Test func seedFromStore_deferred_whileAnonymous_thenRegistersOnIdentify() {
+        let sharedStore = FakeTokenStore()
+        sharedStore.setRegistrationSignature(activityType: "ptsvalue:t", signature: "A|aabb")
+
+        let cap = TrackCapture()
+        let identity = LiveActivityIdentity()
+        identity.deviceToken = "dev" // anonymous at launch
+        let reporter = LiveActivityReporter(
+            track: { name, props in cap.record(name, props) },
+            currentUserId: { identity.userId },
+            deviceToken: { identity.deviceToken },
+            logger: NoopLogger()
+        )
+        let registrar = LiveActivityRegistrar(identity: identity, store: sharedStore, reporter: reporter)
+
+        registrar.seedPendingPushToStartFromStore()
+        #expect(cap.isEmpty) // gated off while anonymous
+
+        identity.userId = "user-1"
+        registrar.reevaluate()
+        #expect(cap.count == 1) // seeded token registers on identify
+    }
+
+    @Test func pushToStart_reRegisters_afterResetThenReidentify() {
+        let h = makeHarness()
+        h.identity.userId = "user-1"
+        h.identity.deviceToken = "dev"
+        h.registrar.handlePushToStartToken(notificationType: "t", attributesType: "A", token: token)
+        #expect(h.cap.count == 1)
+
+        // Logout: reset clears signatures but keeps the per-app push-to-start token pending.
+        h.identity.userId = nil
+        h.registrar.handleReset()
+
+        // Re-login: the retained token + cleared signature must re-register (the device bug we hit).
+        h.identity.userId = "user-1"
+        h.registrar.reevaluate()
+        #expect(h.cap.count == 2)
+        #expect(h.store.signatures["t"] == "dev|aabb|user-1")
+    }
+}

--- a/Tests/LiveActivities/LiveActivitiesReporterTests.swift
+++ b/Tests/LiveActivities/LiveActivitiesReporterTests.swift
@@ -1,0 +1,158 @@
+import CioLiveActivities_Attributes
+import Foundation
+import Testing
+
+@testable import CioLiveActivities
+
+// MARK: - Auth / device-token gating
+
+struct LiveActivityReporterGateTests {
+    @Test func reportStart_dropped_whenNoUserIdentified() {
+        let cap = TrackCapture()
+        cap.deviceToken = "dev-token"
+        cap.makeReporter().reportStart(instanceUUID: "i1", notificationType: "t", attributes: nil, contentState: nil)
+        #expect(cap.isEmpty)
+    }
+
+    @Test func reportStart_dropped_whenNoDeviceToken() {
+        let cap = TrackCapture()
+        cap.userId = "user-1"
+        cap.makeReporter().reportStart(instanceUUID: "i1", notificationType: "t", attributes: nil, contentState: nil)
+        #expect(cap.isEmpty)
+    }
+
+    @Test func reportStart_dropped_whenDeviceTokenEmpty() {
+        let cap = TrackCapture()
+        cap.userId = "user-1"
+        cap.deviceToken = ""
+        cap.makeReporter().reportStart(instanceUUID: "i1", notificationType: "t", attributes: nil, contentState: nil)
+        #expect(cap.isEmpty)
+    }
+
+    @Test func tokenEvent_dropped_whenAnonymous() {
+        let cap = TrackCapture()
+        cap.deviceToken = "dev-token"
+        cap.makeReporter().sendPushToStartToken(notificationType: "t", attributesType: "A", pushToStartToken: "aabb")
+        #expect(cap.isEmpty)
+    }
+}
+
+// MARK: - Event shape
+
+struct LiveActivityReporterShapeTests {
+    private func identifiedCapture() -> TrackCapture {
+        let cap = TrackCapture()
+        cap.userId = "user-1"
+        cap.deviceToken = "dev-token"
+        return cap
+    }
+
+    @Test func reportStart_emitsAttributesAndContentState_withoutInstallationId() {
+        let cap = identifiedCapture()
+        cap.makeReporter().reportStart(
+            instanceUUID: "i1",
+            notificationType: "type.a",
+            attributes: ["league": "premier"],
+            contentState: ["home": 1, "away": 2]
+        )
+        #expect(cap.count == 1)
+        #expect(cap.events[0].name == "Live Notification Event")
+        #expect(cap.string(0, "eventType") == "start")
+        #expect(cap.string(0, "cioInstanceId") == "i1")
+        #expect(cap.string(0, "notificationType") == "type.a")
+        #expect(cap.string(0, "deviceId") == "dev-token")
+        #expect(cap.string(0, "platform") == "ios")
+        #expect(cap.events[0].properties["installationId"] == nil)
+        // No single `payload` property anymore — split into attributes + contentState.
+        #expect(cap.events[0].properties["payload"] == nil)
+        #expect(cap.events[0].properties["attributes"] != nil)
+        #expect(cap.events[0].properties["contentState"] != nil)
+        let attributes = cap.events[0].properties["attributes"] as? [String: Any]
+        #expect(attributes?["league"] as? String == "premier")
+        let contentState = cap.events[0].properties["contentState"] as? [String: Any]
+        #expect(contentState?["home"] as? Int == 1)
+        #expect(contentState?["away"] as? Int == 2)
+    }
+
+    @Test func reportUpdate_sendsContentStateOnly() {
+        let cap = identifiedCapture()
+        cap.makeReporter().reportUpdate(instanceUUID: "i1", notificationType: "type.a", contentState: ["home": 3])
+        #expect(cap.string(0, "eventType") == "update")
+        #expect(cap.events[0].properties["attributes"] == nil)
+        #expect(cap.events[0].properties["contentState"] != nil)
+    }
+
+    @Test func reportEnd_withFinalContentState_sendsIt() {
+        let cap = identifiedCapture()
+        cap.makeReporter().reportEnd(instanceUUID: "i1", notificationType: "type.a", contentState: ["home": 5])
+        #expect(cap.string(0, "eventType") == "end")
+        #expect(cap.events[0].properties["contentState"] != nil)
+    }
+
+    @Test func reportEnd_withoutContentState_omitsIt() {
+        let cap = identifiedCapture()
+        cap.makeReporter().reportEnd(instanceUUID: "i1", notificationType: "type.a")
+        #expect(cap.string(0, "eventType") == "end")
+        #expect(cap.events[0].properties["contentState"] == nil)
+        #expect(cap.events[0].properties["attributes"] == nil)
+    }
+
+    @Test func pushToStartToken_includesAttributesType_andNoInstallationId() {
+        let cap = identifiedCapture()
+        cap.makeReporter().sendPushToStartToken(notificationType: "type.a", attributesType: "MyAttributes", pushToStartToken: "aabbcc")
+        #expect(cap.events[0].name == "Live Notification Token")
+        #expect(cap.string(0, "registrationType") == "push_to_start")
+        #expect(cap.string(0, "attributesType") == "MyAttributes")
+        #expect(cap.string(0, "pushToStartToken") == "aabbcc")
+        #expect(cap.events[0].properties["installationId"] == nil)
+    }
+
+    @Test func instanceToken_includesInstanceFields() {
+        let cap = identifiedCapture()
+        cap.makeReporter().sendInstanceToken(notificationType: "type.a", instanceUUID: "i1", instanceToken: "ddeeff")
+        #expect(cap.string(0, "registrationType") == "instance")
+        #expect(cap.string(0, "cioInstanceId") == "i1")
+        #expect(cap.string(0, "instanceToken") == "ddeeff")
+    }
+}
+
+// MARK: - Date wire format (epoch seconds round-trip)
+
+struct EpochSecondsDateTests {
+    /// The reporter's `payloadEncoder` must emit epoch-second numbers for date fields,
+    /// and `EpochSecondsDate` must decode those same numbers back to the original instant —
+    /// this is the contract ActivityKit relies on when it decodes a server push.
+    @Test func encodesToEpochSecondsNumber() throws {
+        // 2021-01-01T00:00:00Z == 1_609_459_200 s
+        let date = Date(timeIntervalSince1970: 1609459200)
+        let wrapper = EpochSecondsDate(date)
+        let data = try LiveActivityReporter.payloadEncoder.encode(wrapper)
+        #expect(String(decoding: data, as: UTF8.self) == "1609459200")
+    }
+
+    @Test func roundTripsThroughJSON_toTheSecond() throws {
+        let original = EpochSecondsDate(Date(timeIntervalSince1970: 1700000000.4))
+        let data = try LiveActivityReporter.payloadEncoder.encode(original)
+        let decoded = try JSONDecoder().decode(EpochSecondsDate.self, from: data)
+        // Encoded as whole seconds (rounded), so the round-trip is exact to the second.
+        let expectedSeconds = original.date.timeIntervalSince1970.rounded()
+        #expect(decoded.date.timeIntervalSince1970.rounded() == expectedSeconds)
+    }
+
+    @Test func decodesFromEpochSecondsNumber() throws {
+        let json = Data("1609459200".utf8)
+        let decoded = try JSONDecoder().decode(EpochSecondsDate.self, from: json)
+        #expect(decoded.date == Date(timeIntervalSince1970: 1609459200))
+    }
+
+    /// Encoding a content-state that contains an `EpochSecondsDate` through the reporter's
+    /// `encode(_:)` helper must yield an epoch-second number under the field key.
+    @Test func contentStateEncodesDateAsEpochSeconds() throws {
+        struct State: Encodable {
+            let endTime: EpochSecondsDate
+        }
+        let state = State(endTime: EpochSecondsDate(Date(timeIntervalSince1970: 1609459200)))
+        let object = LiveActivityReporter.encode(state)
+        #expect(object?["endTime"] as? Int64 == 1609459200 || object?["endTime"] as? Int == 1609459200)
+    }
+}

--- a/Tests/LiveActivities/LiveActivitiesStorageTests.swift
+++ b/Tests/LiveActivities/LiveActivitiesStorageTests.swift
@@ -1,0 +1,160 @@
+import CioInternalCommon
+import Foundation
+import Testing
+
+@testable import CioLiveActivities
+
+// MARK: - Helpers
+
+private func makeStore() -> (KeyValueLiveActivityTokenStore, InMemoryKeyValueStorage) {
+    let kv = InMemoryKeyValueStorage()
+    return (KeyValueLiveActivityTokenStore(storage: kv), kv)
+}
+
+// MARK: - registrationSignature
+
+struct LiveActivityRegistrationGetTests {
+    @Test func getSignature_returnsNil_whenNoRecordExists() {
+        let (store, _) = makeStore()
+        #expect(store.registrationSignature(activityType: "OrderActivity") == nil)
+    }
+
+    @Test func getSignature_returnsNil_forUnknownActivityType() {
+        let (store, _) = makeStore()
+        store.setRegistrationSignature(activityType: "OrderActivity", signature: "aabbcc|user-1")
+        #expect(store.registrationSignature(activityType: "ShipmentActivity") == nil)
+    }
+
+    @Test func getSignature_returnsStoredSignature() {
+        let (store, _) = makeStore()
+        store.setRegistrationSignature(activityType: "OrderActivity", signature: "deadbeef|user-1")
+        #expect(store.registrationSignature(activityType: "OrderActivity") == "deadbeef|user-1")
+    }
+}
+
+// MARK: - setRegistrationSignature
+
+struct LiveActivityRegistrationSetTests {
+    @Test func setSignature_persistsValue() {
+        let (store, _) = makeStore()
+        store.setRegistrationSignature(activityType: "OrderActivity", signature: "cafebabe|user-1")
+        #expect(store.registrationSignature(activityType: "OrderActivity") == "cafebabe|user-1")
+    }
+
+    @Test func setSignature_upserts_onConflict() {
+        let (store, _) = makeStore()
+        store.setRegistrationSignature(activityType: "OrderActivity", signature: "first|user-1")
+        store.setRegistrationSignature(activityType: "OrderActivity", signature: "second|user-2")
+        #expect(store.registrationSignature(activityType: "OrderActivity") == "second|user-2")
+    }
+
+    @Test func setSignature_storesIndependentlyPerActivityType() {
+        let (store, _) = makeStore()
+        store.setRegistrationSignature(activityType: "OrderActivity", signature: "order|user-1")
+        store.setRegistrationSignature(activityType: "ShipmentActivity", signature: "ship|user-1")
+        #expect(store.registrationSignature(activityType: "OrderActivity") == "order|user-1")
+        #expect(store.registrationSignature(activityType: "ShipmentActivity") == "ship|user-1")
+    }
+
+    @Test func setSignature_survivesReload_fromSameBackingStore() {
+        let kv = InMemoryKeyValueStorage()
+        KeyValueLiveActivityTokenStore(storage: kv)
+            .setRegistrationSignature(activityType: "OrderActivity", signature: "persisted|user-1")
+        // A fresh store instance over the same backing storage sees the value.
+        let reopened = KeyValueLiveActivityTokenStore(storage: kv)
+        #expect(reopened.registrationSignature(activityType: "OrderActivity") == "persisted|user-1")
+    }
+}
+
+// MARK: - clearAll
+
+struct LiveActivityRegistrationClearTests {
+    @Test func clear_removesAllRecords() {
+        let (store, _) = makeStore()
+        store.setRegistrationSignature(activityType: "OrderActivity", signature: "aaa|u")
+        store.setRegistrationSignature(activityType: "ShipmentActivity", signature: "bbb|u")
+        store.clearAll()
+        #expect(store.registrationSignature(activityType: "OrderActivity") == nil)
+        #expect(store.registrationSignature(activityType: "ShipmentActivity") == nil)
+    }
+
+    @Test func clear_isNoOp_whenAlreadyEmpty() {
+        let (store, _) = makeStore()
+        store.clearAll()
+        #expect(store.registrationSignature(activityType: "Any") == nil)
+    }
+
+    @Test func setSignature_afterClear_persistsCorrectly() {
+        let (store, _) = makeStore()
+        store.setRegistrationSignature(activityType: "OrderActivity", signature: "old|u")
+        store.clearAll()
+        store.setRegistrationSignature(activityType: "OrderActivity", signature: "new|u")
+        #expect(store.registrationSignature(activityType: "OrderActivity") == "new|u")
+    }
+
+    @Test func clearRegistrationSignature_removesOnlyThatKey() {
+        let (store, _) = makeStore()
+        store.setRegistrationSignature(activityType: "OrderActivity", signature: "a|u")
+        store.setRegistrationSignature(activityType: "instance:i1", signature: "dev|tok")
+        store.clearRegistrationSignature(activityType: "instance:i1")
+        #expect(store.registrationSignature(activityType: "instance:i1") == nil)
+        #expect(store.registrationSignature(activityType: "OrderActivity") == "a|u")
+    }
+
+    @Test func clear_leavesUnrelatedKeysIntact() {
+        let kv = InMemoryKeyValueStorage()
+        kv.setString("device-token-abc", forKey: .pushDeviceToken)
+        let store = KeyValueLiveActivityTokenStore(storage: kv)
+        store.setRegistrationSignature(activityType: "OrderActivity", signature: "aaa|u")
+        store.clearAll()
+        // clearAll must only remove our own key, not wipe the shared store.
+        #expect(kv.string(.pushDeviceToken) == "device-token-abc")
+    }
+}
+
+// MARK: - Delivered dedup markers (TTL-bounded, separate map)
+
+struct LiveActivityDeliveredMarkerTests {
+    private let ttl: TimeInterval = 7 * 24 * 60 * 60
+
+    @Test func freshMarker_isDeduped() {
+        let (store, _) = makeStore()
+        #expect(store.hasFreshDeliveredMarker("d1", ttl: ttl) == false)
+        store.setDeliveredMarker("d1", at: Date())
+        #expect(store.hasFreshDeliveredMarker("d1", ttl: ttl) == true)
+    }
+
+    @Test func expiredMarker_isNotFresh() {
+        let (store, _) = makeStore()
+        store.setDeliveredMarker("d1", at: Date(timeIntervalSinceNow: -(ttl + 60)))
+        #expect(store.hasFreshDeliveredMarker("d1", ttl: ttl) == false)
+    }
+
+    @Test func expiredMarker_isPrunedFromStorage() {
+        let (store, kv) = makeStore()
+        store.setDeliveredMarker("old", at: Date(timeIntervalSinceNow: -(ttl + 60)))
+        store.setDeliveredMarker("new", at: Date())
+        // First delivered-marker access lazily prunes expired entries and persists the result.
+        _ = store.hasFreshDeliveredMarker("new", ttl: ttl)
+        // A fresh store over the same backing sees only the surviving marker.
+        let reopened = KeyValueLiveActivityTokenStore(storage: kv)
+        #expect(reopened.hasFreshDeliveredMarker("new", ttl: ttl) == true)
+        #expect(reopened.hasFreshDeliveredMarker("old", ttl: ttl) == false)
+    }
+
+    @Test func deliveredMarkers_areIsolatedFromRegistrationMap() {
+        let (store, _) = makeStore()
+        store.setDeliveredMarker("d1", at: Date())
+        store.setRegistrationSignature(activityType: "OrderActivity", signature: "sig|u")
+        // Delivery markers live in a separate map: registration lookups never see them.
+        #expect(store.registrationSignature(activityType: "d1") == nil)
+        #expect(store.allRegistrationKeys() == ["OrderActivity"])
+    }
+
+    @Test func clearAll_dropsDeliveredMarkers() {
+        let (store, _) = makeStore()
+        store.setDeliveredMarker("d1", at: Date())
+        store.clearAll()
+        #expect(store.hasFreshDeliveredMarker("d1", ttl: ttl) == false)
+    }
+}

--- a/Tests/LiveActivities/LiveActivitiesStorageTests.swift
+++ b/Tests/LiveActivities/LiveActivitiesStorageTests.swift
@@ -157,4 +157,18 @@ struct LiveActivityDeliveredMarkerTests {
         store.clearAll()
         #expect(store.hasFreshDeliveredMarker("d1", ttl: ttl) == false)
     }
+
+    @Test func markDeliveredIfFresh_returnsTrueOnce_thenFalse() {
+        let (store, _) = makeStore()
+        // First claim wins (report); a fresh repeat is deduped.
+        #expect(store.markDeliveredIfFresh("d1", ttl: ttl, at: Date()) == true)
+        #expect(store.markDeliveredIfFresh("d1", ttl: ttl, at: Date()) == false)
+    }
+
+    @Test func markDeliveredIfFresh_reclaims_afterExpiry() {
+        let (store, _) = makeStore()
+        #expect(store.markDeliveredIfFresh("d1", ttl: ttl, at: Date(timeIntervalSinceNow: -(ttl + 60))) == true)
+        // The prior marker is expired, so the next delivery for the same id reports again.
+        #expect(store.markDeliveredIfFresh("d1", ttl: ttl, at: Date()) == true)
+    }
 }

--- a/Tests/LiveActivities/Support/LiveActivitiesTestSupport.swift
+++ b/Tests/LiveActivities/Support/LiveActivitiesTestSupport.swift
@@ -1,0 +1,161 @@
+import CioInternalCommon
+import Foundation
+
+@testable import CioLiveActivities
+
+/// No-op `Logger` for tests that only need the dependency satisfied.
+final class NoopLogger: Logger {
+    var logLevel: CioLogLevel = .error
+    func setLogDispatcher(_ dispatcher: ((CioLogLevel, String) -> Void)?) {}
+    func setLogLevel(_ level: CioLogLevel) {}
+    func debug(_ message: String, _ tag: String?) {}
+    func info(_ message: String, _ tag: String?) {}
+    func error(_ message: String, _ tag: String?, _ throwable: Error?) {}
+}
+
+/// Captures the events a `LiveActivityReporter` would send, plus controllable identity, so
+/// tests can drive gating and dedup deterministically.
+final class TrackCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _events: [(name: String, properties: [String: Any])] = []
+    var events: [(name: String, properties: [String: Any])] { lock.withLock { _events } }
+    var userId: String?
+    var deviceToken: String?
+
+    func record(_ name: String, _ properties: [String: Any]) {
+        lock.withLock { _events.append((name, properties)) }
+    }
+
+    func makeReporter() -> LiveActivityReporter {
+        LiveActivityReporter(
+            track: { name, props in self.record(name, props) },
+            currentUserId: { self.userId },
+            deviceToken: { self.deviceToken },
+            logger: NoopLogger()
+        )
+    }
+
+    var count: Int { events.count }
+    // Defined via `events.isEmpty` (not `count == 0`) so SwiftLint's empty_count autofix
+    // doesn't rewrite it into a self-referential loop.
+    var isEmpty: Bool { events.isEmpty }
+    func string(_ index: Int, _ key: String) -> String? {
+        events[index].properties[key] as? String
+    }
+}
+
+/// In-memory `SharedKeyValueStorage` for exercising `KeyValueLiveActivityTokenStore`
+/// without touching real UserDefaults.
+final class InMemoryKeyValueStorage: SharedKeyValueStorage, @unchecked Sendable {
+    private let lock = NSLock()
+    private var store: [String: Any] = [:]
+
+    func integer(_ key: KeyValueStorageKey) -> Int? {
+        lock.withLock { store[key.rawValue] as? Int }
+    }
+
+    func setInt(_ value: Int?, forKey key: KeyValueStorageKey) {
+        set(value, key)
+    }
+
+    func double(_ key: KeyValueStorageKey) -> Double? {
+        lock.withLock { store[key.rawValue] as? Double }
+    }
+
+    func setDouble(_ value: Double?, forKey key: KeyValueStorageKey) {
+        set(value, key)
+    }
+
+    func string(_ key: KeyValueStorageKey) -> String? {
+        lock.withLock { store[key.rawValue] as? String }
+    }
+
+    func setString(_ value: String?, forKey key: KeyValueStorageKey) {
+        set(value, key)
+    }
+
+    func date(_ key: KeyValueStorageKey) -> Date? {
+        lock.withLock { store[key.rawValue] as? Date }
+    }
+
+    func setDate(_ value: Date?, forKey key: KeyValueStorageKey) {
+        set(value, key)
+    }
+
+    func data(_ key: KeyValueStorageKey) -> Data? {
+        lock.withLock { store[key.rawValue] as? Data }
+    }
+
+    func setData(_ value: Data?, forKey key: KeyValueStorageKey) {
+        set(value, key)
+    }
+
+    func deleteAll() {
+        lock.withLock { store.removeAll() }
+    }
+
+    private func set(_ value: Any?, _ key: KeyValueStorageKey) {
+        lock.withLock {
+            if let value { store[key.rawValue] = value } else { store[key.rawValue] = nil }
+        }
+    }
+}
+
+/// In-memory `LiveActivityTokenStorage` for registrar tests.
+final class FakeTokenStore: LiveActivityTokenStorage, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _signatures: [String: String] = [:]
+    var signatures: [String: String] { lock.withLock { _signatures } }
+
+    func registrationSignature(activityType: String) -> String? {
+        lock.withLock { _signatures[activityType] }
+    }
+
+    func setRegistrationSignature(activityType: String, signature: String) {
+        lock.withLock { _signatures[activityType] = signature }
+    }
+
+    func clearRegistrationSignature(activityType: String) {
+        lock.withLock { _signatures[activityType] = nil }
+    }
+
+    func allRegistrationKeys() -> [String] {
+        lock.withLock { Array(_signatures.keys) }
+    }
+
+    func clearAll() {
+        lock.withLock {
+            _signatures.removeAll()
+            _delivered.removeAll()
+        }
+    }
+
+    private var _delivered: [String: Date] = [:]
+
+    func hasFreshDeliveredMarker(_ deliveryId: String, ttl: TimeInterval) -> Bool {
+        lock.withLock {
+            _delivered = _delivered.filter { Date().timeIntervalSince($0.value) <= ttl }
+            guard let at = _delivered[deliveryId] else { return false }
+            return Date().timeIntervalSince(at) <= ttl
+        }
+    }
+
+    func setDeliveredMarker(_ deliveryId: String, at date: Date) {
+        lock.withLock { _delivered[deliveryId] = date }
+    }
+
+    private var _instanceIds: [String: String] = [:]
+
+    func resolveInstanceId(forActivityId activityId: String, orCreate: () -> String) -> String {
+        lock.withLock {
+            if let existing = _instanceIds[activityId] { return existing }
+            let created = orCreate()
+            _instanceIds[activityId] = created
+            return created
+        }
+    }
+
+    func clearInstanceId(forActivityId activityId: String) {
+        lock.withLock { _instanceIds[activityId] = nil }
+    }
+}

--- a/Tests/LiveActivities/Support/LiveActivitiesTestSupport.swift
+++ b/Tests/LiveActivities/Support/LiveActivitiesTestSupport.swift
@@ -144,6 +144,15 @@ final class FakeTokenStore: LiveActivityTokenStorage, @unchecked Sendable {
         lock.withLock { _delivered[deliveryId] = date }
     }
 
+    func markDeliveredIfFresh(_ deliveryId: String, ttl: TimeInterval, at date: Date) -> Bool {
+        lock.withLock {
+            _delivered = _delivered.filter { date.timeIntervalSince($0.value) <= ttl }
+            if let at = _delivered[deliveryId], date.timeIntervalSince(at) <= ttl { return false }
+            _delivered[deliveryId] = date
+            return true
+        }
+    }
+
     private var _instanceIds: [String: String] = [:]
 
     func resolveInstanceId(forActivityId activityId: String, orCreate: () -> String) -> String {

--- a/Tests/LiveActivities/ULIDTests.swift
+++ b/Tests/LiveActivities/ULIDTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+
+@testable import CioLiveActivities
+
+// MARK: - Format
+
+struct ULIDFormatTests {
+    /// Every character allowed in a canonical ULID (Crockford Base32, no I/L/O/U).
+    private static let crockfordAlphabet = Set("0123456789ABCDEFGHJKMNPQRSTVWXYZ")
+
+    @Test func generate_isExactly26Characters() {
+        for _ in 0 ..< 1000 {
+            #expect(ULID.generate().count == 26)
+        }
+    }
+
+    @Test func generate_usesOnlyCrockfordAlphabet() {
+        for _ in 0 ..< 1000 {
+            let ulid = ULID.generate()
+            #expect(ulid.allSatisfy { Self.crockfordAlphabet.contains($0) })
+        }
+    }
+
+    @Test func generate_isAlreadyUppercase() {
+        for _ in 0 ..< 1000 {
+            let ulid = ULID.generate()
+            #expect(ulid == ulid.uppercased())
+        }
+    }
+
+    @Test func generate_leadingCharacter_isAtMost7() {
+        // 26 * 5 = 130 bits but the value is only 128 bits, so the first character carries
+        // just 3 significant timestamp bits and can never exceed '7'.
+        for _ in 0 ..< 1000 {
+            let leading = ULID.generate().first!
+            #expect("01234567".contains(leading))
+        }
+    }
+
+    @Test func generate_encodesCanonicalSpecVector() {
+        // Canonical ULID spec example: 1469918176385 ms -> timestamp prefix "01ARYZ6S41"
+        // (full spec ULID 01ARYZ6S41QJQECH4KPG6SEF3Y). Pins spec-exact encoding, not just a
+        // decode round-trip.
+        let date = Date(timeIntervalSince1970: 1469918176.385)
+        #expect(ULID.generate(date: date).prefix(10) == "01ARYZ6S41")
+    }
+}
+
+// MARK: - Uniqueness
+
+struct ULIDUniquenessTests {
+    @Test func generate_producesUniqueValues_overManyIterations() {
+        var seen = Set<String>()
+        for _ in 0 ..< 10000 {
+            #expect(seen.insert(ULID.generate()).inserted)
+        }
+    }
+
+    @Test func generate_randomnessDiffers_forSameTimestamp() {
+        let date = Date(timeIntervalSince1970: 1700000000)
+        let a = ULID.generate(date: date)
+        let b = ULID.generate(date: date)
+        // Same timestamp prefix, but the 16-character randomness suffix should differ.
+        #expect(a.prefix(10) == b.prefix(10))
+        #expect(a.suffix(16) != b.suffix(16))
+    }
+}
+
+// MARK: - Ordering
+
+struct ULIDOrderingTests {
+    @Test func generate_isLexicographicallyOrderedByTimestamp() {
+        let earlier = ULID.generate(date: Date(timeIntervalSince1970: 1000))
+        let middle = ULID.generate(date: Date(timeIntervalSince1970: 1700000000))
+        let later = ULID.generate(date: Date(timeIntervalSince1970: 4000000000))
+        #expect(earlier < middle)
+        #expect(middle < later)
+    }
+
+    @Test func generate_millisecondResolution_ordersWithinSameSecond() {
+        let base = Date(timeIntervalSince1970: 1700000000.000)
+        let oneMillisLater = Date(timeIntervalSince1970: 1700000000.001)
+        #expect(ULID.generate(date: base) < ULID.generate(date: oneMillisLater))
+    }
+}
+
+// MARK: - Timestamp round-trip
+
+struct ULIDTimestampTests {
+    @Test func timestampDecode_roundTripsKnownValue() {
+        // 1700000000 s -> 1_700_000_000_000 ms, which fits in 48 bits.
+        let expectedMillis: UInt64 = 1700000000000
+        let date = Date(timeIntervalSince1970: 1700000000)
+        let ulid = ULID.generate(date: date)
+        #expect(ULID.timestampMilliseconds(from: ulid) == expectedMillis)
+    }
+
+    @Test func timestampDecode_roundTripsEpochZero() {
+        let ulid = ULID.generate(date: Date(timeIntervalSince1970: 0))
+        #expect(ULID.timestampMilliseconds(from: ulid) == 0)
+        // Timestamp portion of the epoch is all zeros.
+        #expect(ulid.prefix(10) == "0000000000")
+    }
+
+    @Test func timestampDecode_returnsNil_forWrongLength() {
+        #expect(ULID.timestampMilliseconds(from: "TOOSHORT") == nil)
+    }
+
+    @Test func timestampDecode_returnsNil_forNonCrockfordCharacter() {
+        // 'I' is excluded from the Crockford alphabet.
+        let invalid = "I" + String(repeating: "0", count: 25)
+        #expect(ULID.timestampMilliseconds(from: invalid) == nil)
+    }
+}

--- a/api-docs/CioLiveActivities.api
+++ b/api-docs/CioLiveActivities.api
@@ -1,0 +1,24 @@
+public final class CioLiveActivities.CIOLiveActivity {
+	public final val id: String;
+	public final val activity: Activity<Attributes>;
+	public fun func update(_ contentState: Attributes.ContentState, staleDate: Date? = nil, alert: AlertConfiguration? = nil) async;
+	public fun func end(_ finalContentState: Attributes.ContentState? = nil, dismissalPolicy: ActivityUIDismissalPolicy = .default) async;
+}
+public final class CioLiveActivities.LiveActivitiesModule {
+	public fun func initialize(_ config: LiveActivityConfig) -> LiveActivitiesModule;
+	public fun func start<Attributes: ActivityAttributes>(_ attributes: Attributes, contentState: Attributes.ContentState, staleDate: Date? = nil, relevanceScore: Double = 0) throws -> CIOLiveActivity<Attributes>;
+	public fun func adopt<Attributes: ActivityAttributes>(_ activity: Activity<Attributes>) -> CIOLiveActivity<Attributes>;
+	public fun func handleDeepLinkOpen(_ url: URL) -> Boolean;
+}
+public final class CioLiveActivities.LiveActivityConfig {
+	public var logLevel: CioLogLevel?;
+}
+public final class CioLiveActivities.LiveActivityConfigBuilder {
+	public fun init();
+	public fun func logLevel(_ level: CioLogLevel) -> Self;
+	public fun func register<T: CIOActivityAttribute>(_ type: T.Type, identifier: String) -> Self;
+	public fun func register<T: ActivityAttributes>(_ type: T.Type, identifier: String) -> Self;
+	public fun func build() -> LiveActivityConfig;
+}
+public enum CioLiveActivities.LiveActivityError {
+}

--- a/api-docs/CioLiveActivities.api
+++ b/api-docs/CioLiveActivities.api
@@ -7,6 +7,7 @@ public final class CioLiveActivities.CIOLiveActivity {
 public final class CioLiveActivities.LiveActivitiesModule {
 	public fun func initialize(_ config: LiveActivityConfig) -> LiveActivitiesModule;
 	public fun func start<Attributes: ActivityAttributes>(_ attributes: Attributes, contentState: Attributes.ContentState, staleDate: Date? = nil, relevanceScore: Double = 0) throws -> CIOLiveActivity<Attributes>;
+	public fun func start<Attributes: CIOActivityAttribute>(_ attributes: Attributes, contentState: Attributes.ContentState, staleDate: Date? = nil, relevanceScore: Double = 0) throws -> CIOLiveActivity<Attributes>;
 	public fun func adopt<Attributes: ActivityAttributes>(_ activity: Activity<Attributes>) -> CIOLiveActivity<Attributes>;
 	public fun func handleDeepLinkOpen(_ url: URL) -> Boolean;
 }

--- a/scripts/generate-api-docs.sh
+++ b/scripts/generate-api-docs.sh
@@ -26,6 +26,7 @@ declare -a PUBLIC_MODULES=(
     "MessagingPushFCM:CioMessagingPushFCM"
     "MessagingInApp:CioMessagingInApp"
     "Location:CioLocation"
+    "LiveActivities:CioLiveActivities"
     "LiveActivities_Attributes:CioLiveActivities_Attributes"
 )
 


### PR DESCRIPTION
## Stack: Live Activities feature split (2 of 3)

Second PR in the stack. **Targets `la/1-attributes` (#1150)** — review/merge #1150 first.

1. [1/3] `LiveActivities_Attributes` wire-contract module — #1150
2. **[2/3] LiveActivities runtime** ← _this PR_
3. [3/3] Sample app delivery-tracking example → targets `la/2-runtime`

## What this PR adds
The SDK-side Live Activities runtime, built on the `LiveActivities_Attributes` wire contract. It's a **single compilable unit** — the module facade (`LiveActivitiesModule`) wires observation, registration, reporting, and delivery together, so these layers can't be split further without fabricating half-wired intermediate states.

- **Config DSL** (`LiveActivityConfig` / `LiveActivityConfigBuilder`) — pure data; registers activity types by attributes-type + notification identifier.
- **Storage** (`LiveActivityTokenStorage` / `KeyValueLiveActivityTokenStore`) — UserDefaults-backed registration-signature + instance-id maps, plus a separate **TTL-bounded (7-day)** delivered-dedup map.
- **Registration** (`LiveActivityRegistrar` + `LiveActivityIdentity`) — `token|userId` signature dedup, identified-user gate, re-register on token/user change, push-to-start + instance token capture.
- **Observation** (`LiveActivityObserver`) — ActivityKit observation; routes tokens to the registrar and terminal states to the reporter; emits no lifecycle events on launch replay.
- **Reporting** (`LiveActivityReporter` + `LiveActivityContract`) — emits `start`/`update`/`end` for locally-initiated ops only; `LiveActivityLocalEndTracker` suppresses the echo of a locally-reported end.
- **Delivery** (`LiveActivityDeliveryTracker`) — delivery/open receipts + deep-link resolution from `CIOLiveActivityMetadata`.
- **Handle** (`CIOLiveActivity`) — typed handle for local `update`/`end`.
- **Support**: `ULID` (Crockford base32, sortable local instance ids), `Data+Hex`.

Common: adds the two LA `KeyValueStorageKey`s. Package: `LiveActivities` product/target + test target. Lint: allow multiple trailing closures (SwiftUI) + `force_try` in tests. api-docs baseline + `generate-api-docs.sh` entry included.

**Tests:** 83 unit tests across 17 suites (config, storage, registrar, reporter, dismiss, delivery, ULID, EpochSecondsDate) — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New customer-facing module touches identify/device-token gating, CDP wire format, and logout reset (including force-ending activities); mistakes could mis-attribute metrics or drop token registration, but behavior is heavily unit-tested.
> 
> **Overview**
> Introduces a new **`CioLiveActivities`** library product and `LiveActivitiesModule.initialize` API so apps register activity types via **`LiveActivityConfigBuilder`**, then use **`start` / `adopt` / `CIOLiveActivity.update|end`** for local lifecycle while the SDK observes ActivityKit.
> 
> **ActivityKit observation** bridges push-to-start (iOS 17.2+) and per-instance push tokens into **`LiveActivityRegistrar`**, with signature dedup, anonymous/device-token gating, cold-launch re-seed of push-to-start tokens, and user-swipe **`end`** vs SDK/backend ends via **`LiveActivityLocalEndTracker`**.
> 
> **Reporting & metrics** emit Android-aligned CDP events (`Live Notification Event` / `Live Notification Token`) through **`LiveActivityReporter`**, and push-style **`delivered` / `opened`** via **`LiveActivityDeliveryTracker`** plus **`handleDeepLinkOpen`**, with persisted registration and 7-day delivered dedup in **`KeyValueLiveActivityTokenStore`** (new **`KeyValueStorageKey`** entries).
> 
> Also ships **ULID** instance ids, api-docs baseline, SwiftLint tweaks, and a large **`LiveActivitiesTests`** suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 477d17aa2197cee374d93f8292cf593f8e71ee15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->