### PR TITLE
docs(live-activities): consumer-facing API docs + EpochSecondsDate tests

### DIFF
--- a/Sources/LiveActivities/LiveActivitiesModule.swift
+++ b/Sources/LiveActivities/LiveActivitiesModule.swift
@@ -308,12 +308,13 @@ public final class LiveActivitiesModule {
     }
 
     private func handleReset() async {
-        // NOTE: force-ending all activities on reset is under review (plan decision #2) —
-        // it may remove activities the user still wants and emits no `end` event.
+        // Reset is a logout: force-end every activity so one user's Live Activities never linger
+        // into the next session. No `end` event is reported for these — the user is being
+        // de-identified, so lifecycle events must not fire.
         //
-        // Clear the identified user *before* force-ending: reset is a logout, so no lifecycle
-        // event should fire, and gating the reporter off first ensures the terminal states these
-        // ends produce can't be misreported as user dismissals (the reporter drops when anonymous).
+        // Clear the identified user *before* force-ending: gating the reporter off first ensures the
+        // terminal states these ends produce can't be misreported as user dismissals (the reporter
+        // drops events while anonymous).
         identity.userId = nil
         localEndTracker.clearAll()
         latestMetadata.wrappedValue = [:]

--- a/Sources/LiveActivities_Attributes/CIOActivityAttribute.swift
+++ b/Sources/LiveActivities_Attributes/CIOActivityAttribute.swift
@@ -2,37 +2,28 @@
 import ActivityKit
 import Foundation
 
-/// Extends `ActivityAttributes` with an SDK-managed correlation id, enabling
-/// **push-to-start** for the conforming activity type.
+/// Conform your `ActivityAttributes` type to this protocol to let Customer.io **start Live
+/// Activities remotely** (push-to-start).
 ///
-/// Conform your `ActivityAttributes` type to this protocol only when you want the
-/// Customer.io backend to be able to *start* activities remotely. For that case the
-/// backend stamps `cioInstanceId` into the attributes it creates on-device, so the SDK
-/// can correlate the resulting activity with the server-side instance.
-///
-/// You never populate `cioInstanceId` yourself: declare it with a default (`= ""`) and
-/// omit it from your initializer. The SDK fills it in on local `start`, and the backend
-/// fills it in for push-to-start.
-///
-/// A plain `ActivityAttributes` type (not conforming to this protocol) is fully supported
-/// for local `start`/`adopt`, instance-token push updates, and relaunch recovery —
-/// everything except push-to-start.
+/// To adopt it, add a `cioInstanceId` property declared as a `var` with a default value and
+/// leave it out of your initializer — Customer.io manages that value for you, so never set or
+/// read it yourself:
 ///
 /// ```swift
 /// struct OrderAttributes: CIOActivityAttribute {
-///     var cioInstanceId: String = ""   // SDK/backend-managed; leave defaulted
+///     var cioInstanceId: String = ""   // managed by Customer.io — leave defaulted
 ///     var orderNumber: String
-///     struct ContentState: Codable, Hashable { … }
+///     struct ContentState: Codable, Hashable { /* ... */ }
 /// }
 /// ```
+///
+/// Conforming is only required for push-to-start. If you only start activities locally, a plain
+/// `ActivityAttributes` type works everywhere else — local `start`/`adopt`, push updates to a
+/// running activity, and relaunch recovery.
 @available(iOS 16.2, *)
 public protocol CIOActivityAttribute: ActivityAttributes {
-    /// SDK-managed correlation id for this activity instance.
-    ///
-    /// The SDK writes this on local `start` (minting a ULID) and the Customer.io backend writes
-    /// it for push-to-start; it is then matched server-side to route push updates to the correct
-    /// activity. It is `{ get set }` so the SDK can inject the id into your attributes on local
-    /// start — declare it as a `var` with a default value and never set it yourself.
+    /// Correlation id managed by Customer.io. Declare it as a `var` with a default value
+    /// (e.g. `= ""`) and don't set or read it yourself — Customer.io assigns it.
     var cioInstanceId: String { get set }
 }
 #endif

--- a/Sources/LiveActivities_Attributes/CIOLiveActivityMetadata.swift
+++ b/Sources/LiveActivities_Attributes/CIOLiveActivityMetadata.swift
@@ -1,26 +1,18 @@
 import Foundation
 
-/// Customer.io delivery + routing metadata carried inside a Live Activity's `ContentState`.
+/// Customer.io delivery metadata that a Customer.io push attaches to a Live Activity's
+/// `ContentState`.
 ///
-/// Because iOS delivers Live Activity pushes straight to ActivityKit (the app never sees the raw
-/// APNs payload or its headers), the Customer.io backend embeds the push's delivery identifiers
-/// and tap destination *inside* the encoded `content-state`. The SDK reads them off the decoded
-/// state to report `delivered`/`opened` metrics (the same pipeline normal push uses) and to set the
-/// activity's tap `widgetURL`.
-///
-/// This is the iOS carrier for the same values Android reads from the FCM data payload
-/// (`CIO-Delivery-ID` / `CIO-Delivery-Token` / deep link) — one logical contract, two transports.
-///
-/// Locally-started/updated activities leave this `nil`; there is no push to attribute, so no
-/// delivery metric is reported.
+/// You don't create or populate this — Customer.io sends it with a push, and the SDK reads it to
+/// report `delivered`/`opened` metrics and to set the activity's tap deep link. To let Customer.io
+/// attribute those for your activity, add a `cioMetadata` property to your `ContentState` by
+/// conforming it to ``CIOMetadataCarrying``. It is `nil` for content-states you set locally.
 public struct CIOLiveActivityMetadata: Codable, Hashable, Sendable {
-    /// The `CIO-Delivery-ID` of the push that produced this content-state. Present ⇒ the SDK
-    /// reports a `delivered` metric for it (deduped), and attributes an `opened` metric to it on tap.
+    /// Delivery id of the Customer.io push that produced this content-state.
     public var deliveryId: String?
-    /// The `CIO-Delivery-Token` of the push, sent alongside the metric.
+    /// Delivery token of the Customer.io push.
     public var deliveryToken: String?
-    /// Optional deep link opened when the user taps the activity (backend-driven, mirrors Android's
-    /// push deep link). Rendered as the activity's `widgetURL`.
+    /// Deep link opened when the user taps the activity.
     public var deepLink: String?
 
     public init(deliveryId: String? = nil, deliveryToken: String? = nil, deepLink: String? = nil) {
@@ -30,13 +22,10 @@ public struct CIOLiveActivityMetadata: Codable, Hashable, Sendable {
     }
 }
 
-/// Opt-in conformance for a template's `ContentState` that carries Customer.io delivery metadata.
-///
-/// Built-in Customer.io templates conform so remote pushes can be attributed. Custom
-/// `ActivityAttributes` types may conform to receive the same `delivered`/`opened`/deep-link
-/// handling; types that don't conform simply skip metric reporting.
+/// Conform your `ContentState` to this and add a `cioMetadata` property to opt your Live Activity
+/// into Customer.io `delivered`/`opened` metrics and tap deep links. Declare it as an optional you
+/// leave `nil` — Customer.io fills it in on the content-states it delivers via push.
 public protocol CIOMetadataCarrying {
-    /// Delivery + routing metadata for the push that produced the current content-state, or `nil`
-    /// for a locally-driven state.
+    /// Customer.io delivery metadata for the current content-state; `nil` for a state you set locally.
     var cioMetadata: CIOLiveActivityMetadata? { get }
 }

--- a/Sources/LiveActivities_Attributes/EpochSecondsDate.swift
+++ b/Sources/LiveActivities_Attributes/EpochSecondsDate.swift
@@ -1,19 +1,14 @@
 import Foundation
 
-/// A `Date` wrapper that is `Codable` as an epoch-**second** number.
+/// Use this instead of a bare `Date` for any date field in your Live Activity `Attributes` or
+/// `ContentState` (e.g. an estimated arrival time).
 ///
-/// Live Activity content-state and attributes are decoded on-device by ActivityKit
-/// using its **own** `JSONDecoder` when a backend push arrives — the SDK cannot inject a
-/// `dateDecodingStrategy` there. To keep the wire format unambiguous across the local CDP
-/// event path (`LiveActivityReporter`) and the server push path (ActivityKit), every date
-/// field on a template's `Attributes`/`ContentState` is represented by this type instead of
-/// a bare `Date`.
+/// It encodes and decodes as a JSON number of **seconds** since 1970 (UTC), which is the format
+/// Customer.io sends and expects — so the value your widget shows matches what a Customer.io push
+/// delivers. Wrap your date at the call site (`EpochSecondsDate(someDate)`) and read it back via
+/// ``date`` (or ``value``).
 ///
-/// - Decodes from a JSON number interpreted as seconds since 1970 (UTC).
-/// - Encodes to a JSON number of seconds since 1970 (UTC).
-///
-/// Seconds is the Customer.io backend contract for content-state timestamps; the reporter's
-/// `payloadEncoder` produces the same representation, so a round trip is lossless to the second.
+/// > Note: A round trip is exact to the whole second; sub-second precision is not preserved.
 public struct EpochSecondsDate: Codable, Hashable, Sendable {
     /// The wrapped date value.
     public var date: Date

--- a/Tests/LiveActivities/EpochSecondsDateTests.swift
+++ b/Tests/LiveActivities/EpochSecondsDateTests.swift
@@ -1,0 +1,101 @@
+import CioLiveActivities_Attributes
+import Foundation
+import Testing
+
+// Codable + value semantics of `EpochSecondsDate` — the epoch-seconds wire format the Customer.io
+// backend sends and ActivityKit decodes. Kept independent of the reporter so it documents the type
+// on its own.
+struct EpochSecondsDateTests {
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    // MARK: - Encoding
+
+    @Test func encodesToIntegerSeconds() throws {
+        // 2021-01-01T00:00:00Z == 1_609_459_200 s
+        let sut = EpochSecondsDate(Date(timeIntervalSince1970: 1609459200))
+        #expect(try String(decoding: encoder.encode(sut), as: UTF8.self) == "1609459200")
+    }
+
+    @Test func encodesEpochZero() throws {
+        #expect(try String(decoding: encoder.encode(EpochSecondsDate(Date(timeIntervalSince1970: 0))), as: UTF8.self) == "0")
+    }
+
+    @Test func encodesNegativePre1970() throws {
+        #expect(try String(decoding: encoder.encode(EpochSecondsDate(Date(timeIntervalSince1970: -1))), as: UTF8.self) == "-1")
+    }
+
+    @Test func encodeRoundsFractionalSecondsToNearest() throws {
+        // The encoder rounds to the nearest whole second: .6 up, .4 down.
+        #expect(try String(decoding: encoder.encode(EpochSecondsDate(Date(timeIntervalSince1970: 1609459200.6))), as: UTF8.self) == "1609459201")
+        #expect(try String(decoding: encoder.encode(EpochSecondsDate(Date(timeIntervalSince1970: 1609459200.4))), as: UTF8.self) == "1609459200")
+    }
+
+    // MARK: - Decoding
+
+    @Test func decodesFromIntegerSeconds() throws {
+        let sut = try decoder.decode(EpochSecondsDate.self, from: Data("1609459200".utf8))
+        #expect(sut.date == Date(timeIntervalSince1970: 1609459200))
+    }
+
+    @Test func decodesEpochZeroAndNegative() throws {
+        #expect(try decoder.decode(EpochSecondsDate.self, from: Data("0".utf8)).date == Date(timeIntervalSince1970: 0))
+        #expect(try decoder.decode(EpochSecondsDate.self, from: Data("-1".utf8)).date == Date(timeIntervalSince1970: -1))
+    }
+
+    @Test func decodeRejectsNonNumeric() {
+        #expect(throws: (any Error).self) {
+            try JSONDecoder().decode(EpochSecondsDate.self, from: Data("\"not-a-number\"".utf8))
+        }
+    }
+
+    // MARK: - Round trip
+
+    @Test func roundTrip_wholeSeconds_isExact() throws {
+        let sut = EpochSecondsDate(Date(timeIntervalSince1970: 1700000000))
+        let decoded = try decoder.decode(EpochSecondsDate.self, from: encoder.encode(sut))
+        #expect(decoded == sut)
+    }
+
+    @Test func roundTrip_dropsSubSecondPrecision() throws {
+        let sut = EpochSecondsDate(Date(timeIntervalSince1970: 1700000000.4))
+        let decoded = try decoder.decode(EpochSecondsDate.self, from: encoder.encode(sut))
+        #expect(decoded.date.timeIntervalSince1970 == 1700000000)
+    }
+
+    // MARK: - Value semantics
+
+    @Test func equalDates_areEqualAndHashEqual() {
+        let a = EpochSecondsDate(Date(timeIntervalSince1970: 42))
+        let b = EpochSecondsDate(Date(timeIntervalSince1970: 42))
+        #expect(a == b)
+        #expect(a.hashValue == b.hashValue)
+    }
+
+    @Test func valueAndDateAccessorsReturnWrappedDate() {
+        let date = Date(timeIntervalSince1970: 123456)
+        let sut = EpochSecondsDate(date)
+        #expect(sut.date == date)
+        #expect(sut.value == date)
+    }
+
+    // MARK: - Within a container (the real usage: a date field on a ContentState)
+
+    private struct State: Codable, Hashable {
+        let title: String
+        let eta: EpochSecondsDate
+    }
+
+    @Test func encodesAsBareNumberWithinContainer() throws {
+        let state = State(title: "On the way", eta: EpochSecondsDate(Date(timeIntervalSince1970: 1609459200)))
+        let object = try JSONSerialization.jsonObject(with: encoder.encode(state)) as? [String: Any]
+        #expect((object?["eta"] as? NSNumber)?.int64Value == 1609459200)
+    }
+
+    @Test func decodesFromBareNumberWithinContainer() throws {
+        let json = Data(#"{"title":"On the way","eta":1609459200}"#.utf8)
+        let state = try decoder.decode(State.self, from: json)
+        #expect(state.title == "On the way")
+        #expect(state.eta.date == Date(timeIntervalSince1970: 1609459200))
+    }
+}

--- a/Tests/LiveActivities/LiveActivitiesReporterTests.swift
+++ b/Tests/LiveActivities/LiveActivitiesReporterTests.swift
@@ -116,33 +116,20 @@ struct LiveActivityReporterShapeTests {
     }
 }
 
-// MARK: - Date wire format (epoch seconds round-trip)
+// MARK: - Date wire format through the reporter (epoch seconds)
 
-struct EpochSecondsDateTests {
-    /// The reporter's `payloadEncoder` must emit epoch-second numbers for date fields,
-    /// and `EpochSecondsDate` must decode those same numbers back to the original instant —
-    /// this is the contract ActivityKit relies on when it decodes a server push.
-    @Test func encodesToEpochSecondsNumber() throws {
+//
+// Pure `EpochSecondsDate` Codable behavior is covered in `EpochSecondsDateTests`; these assert the
+// reporter's own encoder/`encode(_:)` helper emit the same epoch-second wire format.
+
+struct ReporterDateEncodingTests {
+    /// The reporter's `payloadEncoder` must emit an epoch-second number for a date field, matching
+    /// what ActivityKit decodes on a server push.
+    @Test func payloadEncoder_encodesEpochSecondsNumber() throws {
         // 2021-01-01T00:00:00Z == 1_609_459_200 s
-        let date = Date(timeIntervalSince1970: 1609459200)
-        let wrapper = EpochSecondsDate(date)
+        let wrapper = EpochSecondsDate(Date(timeIntervalSince1970: 1609459200))
         let data = try LiveActivityReporter.payloadEncoder.encode(wrapper)
         #expect(String(decoding: data, as: UTF8.self) == "1609459200")
-    }
-
-    @Test func roundTripsThroughJSON_toTheSecond() throws {
-        let original = EpochSecondsDate(Date(timeIntervalSince1970: 1700000000.4))
-        let data = try LiveActivityReporter.payloadEncoder.encode(original)
-        let decoded = try JSONDecoder().decode(EpochSecondsDate.self, from: data)
-        // Encoded as whole seconds (rounded), so the round-trip is exact to the second.
-        let expectedSeconds = original.date.timeIntervalSince1970.rounded()
-        #expect(decoded.date.timeIntervalSince1970.rounded() == expectedSeconds)
-    }
-
-    @Test func decodesFromEpochSecondsNumber() throws {
-        let json = Data("1609459200".utf8)
-        let decoded = try JSONDecoder().decode(EpochSecondsDate.self, from: json)
-        #expect(decoded.date == Date(timeIntervalSince1970: 1609459200))
     }
 
     /// Encoding a content-state that contains an `EpochSecondsDate` through the reporter's


### PR DESCRIPTION
Addresses review feedback on the Live Activities feature (targets `feat/live-activities`).

## 1. Consumer-facing docs on public types
Rewrote the public Attributes-module docs to describe how consumers **use** the types rather than how they work internally:
- **`CIOActivityAttribute`** — leads with "conform + declare a defaulted `cioInstanceId` var to enable push-to-start"; dropped the ULID/server-matching mechanics.
- **`CIOLiveActivityMetadata` / `CIOMetadataCarrying`** — "add a `cioMetadata` property to your `ContentState` to opt into delivered/opened + deep links"; trimmed the iOS-vs-Android transport internals.
- **`EpochSecondsDate`** — "use for date fields on your Attributes/ContentState; encodes as epoch seconds"; trimmed the ActivityKit-decoder rationale to a brief note.

Reviewed the runtime public types too (`LiveActivitiesModule`, `CIOLiveActivity`, `LiveActivityConfig(Builder)`, `LiveActivityError`) — already usage-focused with examples; `ActivityTypeRegistration`/`CIOLiveActivitiesSDKProviding` are internal.

## 2. EpochSecondsDate tests
Added a dedicated `EpochSecondsDateTests` suite: encode/decode, epoch zero, negative/pre-1970, fractional-second rounding, sub-second-loss round trip, value semantics (Equatable/Hashable, accessors), within-container Codable, and non-numeric rejection. Removed the now-duplicated pure tests from the reporter suite (renamed it `ReporterDateEncodingTests`, keeping only the reporter-integration checks).

## 3. Planning-note comment
Replaced the internal `// NOTE: force-ending all activities on reset is under review (plan decision #2) …` note in `handleReset` with a shippable explanation of the logout force-end behavior. (It was the only such comment in the LA sources.)

**Tests:** 96 pass across 18 suites. No signature changes → api-docs baselines unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test reorganization only; the reset path behavior is unchanged aside from comment text.
> 
> **Overview**
> **Public Live Activities Attributes docs** are rewritten so integrators see *how to use* the types: push-to-start via `CIOActivityAttribute` + defaulted `cioInstanceId`, delivery metrics/deep links via `CIOMetadataCarrying` + `cioMetadata`, and date fields via `EpochSecondsDate` — with less internal wiring (ULID, ActivityKit decoder paths, Android parity).
> 
> **Tests:** New `EpochSecondsDateTests` covers encode/decode, rounding, round-trips, container usage, and invalid input; reporter tests keep only reporter-specific date encoding (`ReporterDateEncodingTests`).
> 
> **`handleReset` comment** drops the “under review” planning note and documents logout force-end behavior (no `end` events while de-identifying; clear user before ending to avoid misreported dismissals). **No runtime logic changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5d37462da9e350b66ee52b6355db1911bfade21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->