### PR TITLE
chore(geofence): enrich transition events with geofence metadata

### DIFF
--- a/Sources/Common/Communication/Event.swift
+++ b/Sources/Common/Communication/Event.swift
@@ -174,6 +174,9 @@ public struct TrackGeofenceMetricEvent: EventRepresentable, GeofenceMetric {
     /// The geoset this event was fanned out for, or `nil` when the geofence is in no geoset.
     /// Optional with a decode fallback so events persisted by pre-geoset SDK versions replay.
     public let geosetId: String?
+    /// Workspace-defined geofence metadata, or `nil` when none. Optional so events persisted before
+    /// metadata still replay.
+    public let metadata: [String: GeofenceMetadataValue]?
 
     public init(
         storageId: String = UUID().uuidString,
@@ -183,6 +186,7 @@ public struct TrackGeofenceMetricEvent: EventRepresentable, GeofenceMetric {
         name: String?,
         transitionId: String,
         geosetId: String? = nil,
+        metadata: [String: GeofenceMetadataValue]? = nil,
         params: [String: String] = [:]
     ) {
         self.storageId = storageId
@@ -193,6 +197,7 @@ public struct TrackGeofenceMetricEvent: EventRepresentable, GeofenceMetric {
         self.name = name
         self.transitionId = transitionId
         self.geosetId = geosetId
+        self.metadata = metadata
     }
 }
 

--- a/Sources/Common/Type/GeofenceMetadataValue.swift
+++ b/Sources/Common/Type/GeofenceMetadataValue.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// A single value in a geofence's `metadata` map. Values are JSON scalars only (metadata are
+/// flat, no nesting); the primitive type is preserved through decode → persistence → event payload so
+/// campaign matching stays type-consistent (a numeric `priority` goes out as a number, not a string).
+public enum GeofenceMetadataValue: Codable, Equatable, Sendable {
+    case string(String)
+    case int(Int64)
+    case double(Double)
+    case bool(Bool)
+
+    /// The native Swift value, for building `[String: Any]` event properties.
+    public var anyValue: Any {
+        switch self {
+        case .string(let value): return value
+        case .int(let value): return value
+        case .double(let value): return value
+        case .bool(let value): return value
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        // Order matters: Bool before Int so JSON `true`/`false` isn't coerced to a number; Int before
+        // Double so whole numbers stay integers; String last as the catch-all.
+        if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Int64.self) {
+            self = .int(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .double(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unsupported metadata value (expected string, number, or bool)"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let value): try container.encode(value)
+        case .int(let value): try container.encode(value)
+        case .double(let value): try container.encode(value)
+        case .bool(let value): try container.encode(value)
+        }
+    }
+}

--- a/Sources/Common/Type/GeofenceMetric.swift
+++ b/Sources/Common/Type/GeofenceMetric.swift
@@ -16,6 +16,9 @@ public protocol GeofenceMetric {
     /// no geoset. A geofence in N geosets produces N metrics per transition,
     /// each carrying one geoset ID, so every event stands alone.
     var geosetId: String? { get }
+    /// Workspace-defined metadata, or `nil` when none carried. Emitted as a nested `metadata`
+    /// object on the event (empty when absent).
+    var metadata: [String: GeofenceMetadataValue]? { get }
 }
 
 public extension GeofenceMetric {
@@ -23,14 +26,15 @@ public extension GeofenceMetric {
     /// `transition` property.
     var trackEventName: String { "Geofence Transition" }
 
-    /// `/track` event properties. `geofenceName` and `geosetId` are included only when available.
-    /// `transitionId` uniquely identifies the transition and stays stable across delivery retries.
-    /// `timestamp` is not a property — it is set on the event envelope by each path.
+    /// `/track` event properties. `geofenceName` and `geosetId` are included only when available;
+    /// `metadata` is always present (empty object when none). `timestamp` is not a property — it is
+    /// set on the event envelope by each path.
     var trackEventProperties: [String: Any] {
         var properties: [String: Any] = [
             "transition": transition.rawValue,
             "geofenceId": geofenceId,
-            "transitionId": transitionId
+            "transitionId": transitionId,
+            "metadata": (metadata ?? [:]).mapValues(\.anyValue)
         ]
         if let name {
             properties["geofenceName"] = name

--- a/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
@@ -36,11 +36,15 @@ struct GeofenceApiRegion: Decodable {
     let lastUpdated: Double?
     /// IDs of the geosets this geofence belongs to; missing or empty means none.
     let geosetIds: [String]?
+    /// Workspace-defined metadata; missing or empty means none. Scalar values (string/number/bool)
+    /// keep their type; null/array/object values are dropped during decode rather than failing the
+    /// whole region.
+    let metadata: [String: GeofenceMetadataValue]?
 }
 
 extension GeofenceApiRegion {
     private enum CodingKeys: String, CodingKey {
-        case id, name, latitude, longitude, radius, externalId, transitionTypes, lastUpdated, geosetIds
+        case id, name, latitude, longitude, radius, externalId, transitionTypes, lastUpdated, geosetIds, metadata
     }
 
     /// `id` and `geoset_ids` are `int64` on the wire but strings in some mocked/legacy payloads;
@@ -57,6 +61,18 @@ extension GeofenceApiRegion {
         self.transitionTypes = try container.decodeIfPresent([String].self, forKey: .transitionTypes)
         self.lastUpdated = try container.decodeIfPresent(Double.self, forKey: .lastUpdated)
         self.geosetIds = try container.decodeStringOrIntArrayIfPresent(forKey: .geosetIds)
+        self.metadata = try container.decodeMetadataIfPresent(forKey: .metadata)
+    }
+}
+
+/// A metadata value that never throws on decode: a scalar (string/number/bool) keeps its type, and
+/// a null/array/object maps to `nil` so one bad entry doesn't fail the whole region. Used only at the
+/// API boundary.
+private struct LenientMetadataValue: Decodable {
+    let value: GeofenceMetadataValue?
+
+    init(from decoder: Decoder) throws {
+        self.value = try? GeofenceMetadataValue(from: decoder)
     }
 }
 
@@ -67,6 +83,16 @@ private extension KeyedDecodingContainer {
     func decodeStringOrInt(forKey key: Key) throws -> String {
         if let int = try? decode(Int64.self, forKey: key) { return String(int) }
         return try decode(String.self, forKey: key)
+    }
+
+    /// Metadata can never fail the region: a wrong-typed block (not an object) or absent/null/empty →
+    /// nil, and non-scalar (array/object/null) values inside are dropped so a single bad value is
+    /// skipped rather than failing decode; scalars keep their type.
+    func decodeMetadataIfPresent(forKey key: Key) throws -> [String: GeofenceMetadataValue]? {
+        guard contains(key), try !decodeNil(forKey: key) else { return nil }
+        guard let raw = try? decode([String: LenientMetadataValue].self, forKey: key) else { return nil }
+        let filtered = raw.compactMapValues(\.value)
+        return filtered.isEmpty ? nil : filtered
     }
 
     /// Absent or null → nil, so a not-yet-rolled-out field is treated as "no value" rather than throwing.
@@ -156,7 +182,8 @@ extension GeofenceApiRegion {
             name: name ?? "",
             transitionTypes: Self.resolveTransitionTypes(transitionTypes),
             lastUpdated: lastUpdated.map { Date(timeIntervalSince1970: $0 / 1000) } ?? Date(timeIntervalSince1970: 0),
-            geosetIds: geosetIds ?? []
+            geosetIds: geosetIds ?? [],
+            metadata: Self.cappedMetadata(metadata)
         )
     }
 
@@ -165,5 +192,33 @@ extension GeofenceApiRegion {
         guard let raw, !raw.isEmpty else { return defaults }
         let parsed = Set(raw.compactMap { GeofenceTransition(rawValue: $0.lowercased()) })
         return parsed.isEmpty ? defaults : parsed
+    }
+
+    /// Safety net so a runaway payload can't bloat a request in the short background wake: keeps
+    /// entries (sorted by key for determinism) until either the count cap or the total key+value byte
+    /// budget is hit. Per-value size is left to the server, which fully validates metadata.
+    private static func cappedMetadata(_ metadata: [String: GeofenceMetadataValue]?) -> [String: GeofenceMetadataValue] {
+        guard let metadata, !metadata.isEmpty else { return [:] }
+        var result: [String: GeofenceMetadataValue] = [:]
+        var totalBytes = 0
+        for (key, value) in metadata.sorted(by: { $0.key < $1.key }) {
+            guard result.count < GeofenceConstants.maxMetadataCount else { break }
+            totalBytes += key.utf8.count + value.byteCount
+            guard totalBytes <= GeofenceConstants.maxMetadataPayloadBytes else { break }
+            result[key] = value
+        }
+        return result
+    }
+}
+
+private extension GeofenceMetadataValue {
+    /// Serialized byte size for the payload budget: string UTF-8 length, or the numeric/bool text length.
+    var byteCount: Int {
+        switch self {
+        case .string(let value): return value.utf8.count
+        case .int(let value): return String(value).utf8.count
+        case .double(let value): return String(value).utf8.count
+        case .bool(let value): return value ? 4 : 5
+        }
     }
 }

--- a/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
@@ -172,14 +172,15 @@ private extension Comparable {
 extension GeofenceApiRegion {
     /// Empty / nil / all-unknown `transition_types` fall back to `[.enter, .exit]`; a mix of
     /// valid + unknown keeps just the valid subset. `lastUpdated` defaults to epoch when
-    /// missing so callers can compare without unwrapping; `name` defaults to the empty string.
+    /// missing so callers can compare without unwrapping. `name` is `nil` when the server omits it
+    /// (or sends an empty string), so the domain value is always either `nil` or non-empty.
     func toDomain() -> Geofence {
         Geofence(
             id: id,
             latitude: latitude,
             longitude: longitude,
             radius: radius,
-            name: name ?? "",
+            name: name.flatMap { $0.isEmpty ? nil : $0 },
             transitionTypes: Self.resolveTransitionTypes(transitionTypes),
             lastUpdated: lastUpdated.map { Date(timeIntervalSince1970: $0 / 1000) } ?? Date(timeIntervalSince1970: 0),
             geosetIds: geosetIds ?? [],

--- a/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
@@ -104,7 +104,9 @@ final class GeofenceEventTracker: @unchecked Sendable {
                 userId: stampedUserId,
                 name: geofenceName,
                 transitionId: transitionId,
-                geosetId: geosetId
+                geosetId: geosetId,
+                // Snapshot as the fallback for an evicted geofence; `deliver` prefers the live cache.
+                metadata: cachedGeofence?.metadata
             )
         }
         // Persist all rows in one atomic write: a per-row loop could save some and lose the rest on
@@ -157,17 +159,19 @@ final class GeofenceEventTracker: @unchecked Sendable {
         guard activeDeliveryKeys.mutating({ $0.insert(metric.key).inserted }) else { return }
         defer { activeDeliveryKeys.mutating { _ = $0.remove(metric.key) } }
 
+        let effective = await resolvingLiveValues(metric)
+
         // Rows without a stamped userId (anonymous capture or legacy pre-stamping)
         // route through EventBus instead — DataPipeline tracks anonymously under
         // whatever identity is current at consume time.
-        guard let stampedUserId = metric.userId, !stampedUserId.isEmpty else {
-            postEventBus(metric: metric)
+        guard let stampedUserId = effective.userId, !stampedUserId.isEmpty else {
+            postEventBus(metric: effective)
             _ = await pendingStore.remove(key: metric.key)
             return
         }
 
         let success = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
-            deliveryTracker.trackMetric(metric: metric, userId: stampedUserId) { result in
+            deliveryTracker.trackMetric(metric: effective, userId: stampedUserId) { result in
                 switch result {
                 case .success:
                     continuation.resume(returning: true)
@@ -179,9 +183,21 @@ final class GeofenceEventTracker: @unchecked Sendable {
 
         if success {
             _ = await pendingStore.remove(key: metric.key)
-            logger.geofenceEventTracked(geofenceId: metric.geofenceId, transition: metric.transition)
+            logger.geofenceEventTracked(geofenceId: effective.geofenceId, transition: effective.transition)
         }
         // HTTP failure: row stays for next flush.
+    }
+
+    /// Prefers the freshest cached `name`/`metadata` at send, falling back to the row snapshot when
+    /// the geofence has left the cache. All other fields — including the dedup key inputs — are
+    /// unchanged, so the returned copy addresses the same persisted row.
+    private func resolvingLiveValues(_ metric: PendingGeofenceMetric) async -> PendingGeofenceMetric {
+        guard let live = await storage.getCachedGeofences().first(where: { $0.id == metric.geofenceId }) else {
+            return metric
+        }
+        // Keep the snapshot name when the cached one is empty — don't regress a name we once had to blank.
+        let liveName = live.name.isEmpty ? metric.name : live.name
+        return metric.withResolved(name: liveName, metadata: live.metadata)
     }
 
     /// Anonymous-attribution fallback used when a row carries no stamped userId.
@@ -195,7 +211,8 @@ final class GeofenceEventTracker: @unchecked Sendable {
             timestamp: metric.timestamp,
             name: metric.name,
             transitionId: metric.transitionId,
-            geosetId: metric.geosetId
+            geosetId: metric.geosetId,
+            metadata: metric.metadata
         ))
         logger.geofenceEventTracked(geofenceId: metric.geofenceId, transition: metric.transition)
     }

--- a/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
@@ -81,11 +81,9 @@ final class GeofenceEventTracker: @unchecked Sendable {
         let liveUserId = contextStore.currentUserId
         let stampedUserId: String? = (liveUserId?.isEmpty == false) ? liveUserId : nil
         // Resolve the geofence name and geoset membership now and carry them on the metric;
-        // name is nil when unavailable so the event omits `geofenceName` rather than sending
-        // an empty value.
+        // name is nil when the geofence has none so the event omits `geofenceName`.
         let cachedGeofence = await storage.getCachedGeofences().first { $0.id == geofenceId }
-        let cachedName = cachedGeofence?.name
-        let geofenceName = (cachedName?.isEmpty == false) ? cachedName : nil
+        let geofenceName = cachedGeofence?.name
         // One event per geoset (scalar geosetId + geofence id/name as metadata) so matching needs no
         // joins; no geosets (or the fence left the cache) → one event without a geosetId.
         // Dedupe geoset ids, and drop blanks, so a fence listing the same one twice — or an empty
@@ -195,9 +193,8 @@ final class GeofenceEventTracker: @unchecked Sendable {
         guard let live = await storage.getCachedGeofences().first(where: { $0.id == metric.geofenceId }) else {
             return metric
         }
-        // Keep the snapshot name when the cached one is empty — don't regress a name we once had to blank.
-        let liveName = live.name.isEmpty ? metric.name : live.name
-        return metric.withResolved(name: liveName, metadata: live.metadata)
+        // Re-resolve name and metadata from the live cache; name is nil when the geofence has none.
+        return metric.withResolved(name: live.name, metadata: live.metadata)
     }
 
     /// Anonymous-attribution fallback used when a row carries no stamped userId.

--- a/Sources/LocationGeofence/GeofenceConstants.swift
+++ b/Sources/LocationGeofence/GeofenceConstants.swift
@@ -44,4 +44,11 @@ enum GeofenceConstants {
     static let maxRemoteFetchRefreshExpiry: TimeInterval = 7 * 24 * 60 * 60 // 7 days
     static let minDuplicateEventsExpiry: TimeInterval = 60 // 1 minute
     static let maxDuplicateEventsExpiry: TimeInterval = 24 * 60 * 60 // 24 hours
+
+    // Safety net on workspace-defined `metadata`: the server already validates them (they arrive
+    // pre-validated in the nearby response), so these only stop a runaway payload from bloating a
+    // background request. Set generously ahead of the server so a future increase can't make the SDK
+    // drop valid data; per-value size is left to the server.
+    static let maxMetadataCount = 100
+    static let maxMetadataPayloadBytes = 100 * 1024 // ~20× the server's 5 KB total
 }

--- a/Sources/LocationGeofence/Model/Geofence.swift
+++ b/Sources/LocationGeofence/Model/Geofence.swift
@@ -8,7 +8,8 @@ struct Geofence: Codable, Equatable, Sendable {
     let longitude: Double
     /// Radius in meters.
     let radius: Double
-    let name: String
+    /// Geofence name, or `nil` when the server didn't provide one.
+    let name: String?
     let transitionTypes: Set<GeofenceTransition>
     let lastUpdated: Date
     /// IDs of the geosets this geofence belongs to. Empty when the geofence is
@@ -23,7 +24,7 @@ struct Geofence: Codable, Equatable, Sendable {
         latitude: Double,
         longitude: Double,
         radius: Double,
-        name: String,
+        name: String?,
         transitionTypes: Set<GeofenceTransition>,
         lastUpdated: Date,
         geosetIds: [String] = [],
@@ -49,7 +50,7 @@ struct Geofence: Codable, Equatable, Sendable {
         self.latitude = try container.decode(Double.self, forKey: .latitude)
         self.longitude = try container.decode(Double.self, forKey: .longitude)
         self.radius = try container.decode(Double.self, forKey: .radius)
-        self.name = try container.decode(String.self, forKey: .name)
+        self.name = try container.decodeIfPresent(String.self, forKey: .name)
         self.transitionTypes = try container.decode(Set<GeofenceTransition>.self, forKey: .transitionTypes)
         self.lastUpdated = try container.decode(Date.self, forKey: .lastUpdated)
         self.geosetIds = try container.decodeIfPresent([String].self, forKey: .geosetIds) ?? []

--- a/Sources/LocationGeofence/Model/Geofence.swift
+++ b/Sources/LocationGeofence/Model/Geofence.swift
@@ -14,6 +14,9 @@ struct Geofence: Codable, Equatable, Sendable {
     /// IDs of the geosets this geofence belongs to. Empty when the geofence is
     /// in no geoset. Stamped onto transition events, one event per geoset.
     let geosetIds: [String]
+    /// Workspace-defined key/value metadata; empty when the geofence carries none.
+    /// Snapshotted onto transition events and preferred fresh from cache at send.
+    let metadata: [String: GeofenceMetadataValue]
 
     init(
         id: String,
@@ -23,7 +26,8 @@ struct Geofence: Codable, Equatable, Sendable {
         name: String,
         transitionTypes: Set<GeofenceTransition>,
         lastUpdated: Date,
-        geosetIds: [String] = []
+        geosetIds: [String] = [],
+        metadata: [String: GeofenceMetadataValue] = [:]
     ) {
         self.id = id
         self.latitude = latitude
@@ -33,10 +37,12 @@ struct Geofence: Codable, Equatable, Sendable {
         self.transitionTypes = transitionTypes
         self.lastUpdated = lastUpdated
         self.geosetIds = geosetIds
+        self.metadata = metadata
     }
 
-    /// Custom decode so geofences cached to disk by SDK versions that predate
-    /// `geosetIds` still decode (missing key means no geoset membership).
+    /// Custom decode so geofences cached by SDK versions predating `geosetIds` / `metadata` still
+    /// decode (missing key means none). Disk values come from our own encoder, so strict decode is
+    /// safe; the tolerant, null-dropping decode is at the API boundary in `GeofenceApiRegion`.
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.id = try container.decode(String.self, forKey: .id)
@@ -47,5 +53,6 @@ struct Geofence: Codable, Equatable, Sendable {
         self.transitionTypes = try container.decode(Set<GeofenceTransition>.self, forKey: .transitionTypes)
         self.lastUpdated = try container.decode(Date.self, forKey: .lastUpdated)
         self.geosetIds = try container.decodeIfPresent([String].self, forKey: .geosetIds) ?? []
+        self.metadata = try container.decodeIfPresent([String: GeofenceMetadataValue].self, forKey: .metadata) ?? [:]
     }
 }

--- a/Sources/LocationGeofence/Storage/PendingGeofenceMetric.swift
+++ b/Sources/LocationGeofence/Storage/PendingGeofenceMetric.swift
@@ -17,6 +17,9 @@ struct PendingGeofenceMetric: Codable, Equatable, Sendable, GeofenceMetric {
     /// One physical transition of a geofence in N geosets produces N rows, one per geoset.
     /// Optional so rows persisted by pre-geoset SDK versions still decode.
     let geosetId: String?
+    /// Snapshot of the geofence's metadata at transition, the fallback when `deliver` can't find
+    /// the geofence in cache. Optional so rows persisted before metadata still decode.
+    let metadata: [String: GeofenceMetadataValue]?
 
     /// Composite key over `(geofenceId, transition, timestamp_sec, geosetId)` used for
     /// storage-layer dedup. Matches Android's `PendingGeofenceDelivery.key`.
@@ -37,7 +40,8 @@ struct PendingGeofenceMetric: Codable, Equatable, Sendable, GeofenceMetric {
         userId: String?,
         name: String?,
         transitionId: String,
-        geosetId: String? = nil
+        geosetId: String? = nil,
+        metadata: [String: GeofenceMetadataValue]? = nil
     ) {
         self.geofenceId = geofenceId
         self.transition = transition
@@ -46,6 +50,7 @@ struct PendingGeofenceMetric: Codable, Equatable, Sendable, GeofenceMetric {
         self.name = name
         self.transitionId = transitionId
         self.geosetId = geosetId
+        self.metadata = metadata
     }
 
     enum CodingKeys: String, CodingKey {
@@ -56,5 +61,21 @@ struct PendingGeofenceMetric: Codable, Equatable, Sendable, GeofenceMetric {
         case name = "geofence_name"
         case transitionId = "transition_id"
         case geosetId = "geoset_id"
+        case metadata
+    }
+
+    /// Returns a copy with `name`/`metadata` replaced (used to prefer live cached values at send).
+    /// All other fields, including the dedup `key` inputs, are unchanged.
+    func withResolved(name: String?, metadata: [String: GeofenceMetadataValue]?) -> PendingGeofenceMetric {
+        PendingGeofenceMetric(
+            geofenceId: geofenceId,
+            transition: transition,
+            timestamp: timestamp,
+            userId: userId,
+            name: name,
+            transitionId: transitionId,
+            geosetId: geosetId,
+            metadata: metadata
+        )
     }
 }

--- a/Tests/Common/Service/BackgroundDeliveryHttpClientTests.swift
+++ b/Tests/Common/Service/BackgroundDeliveryHttpClientTests.swift
@@ -65,6 +65,41 @@ struct BackgroundDeliveryHttpClientTests {
     }
 
     @Test
+    func sendTrackEvent_givenTypedNumericProperties_expectSerializedWithTypesPreserved() async {
+        let (client, runner) = makeClient(store: makeStore())
+        runner.requestClosure = { _, _, onComplete in onComplete(Data(), makeOkResponse(), nil) }
+
+        // Mirrors GeofenceMetric.trackEventProperties: typed metadata surfaces as Int64/Double/Bool/
+        // String via `anyValue`. Int64 in particular must survive JSONSerialization on the real send
+        // path — the geofence delivery-tracker tests mock this client, so only this exercises the
+        // actual encode.
+        let metadata: [String: Any] = [
+            "priority": GeofenceMetadataValue.int(3).anyValue,
+            "score": GeofenceMetadataValue.double(1.5).anyValue,
+            "vip": GeofenceMetadataValue.bool(true).anyValue,
+            "brand": GeofenceMetadataValue.string("acme").anyValue
+        ]
+
+        let result: Result<Void, BackgroundDeliveryHttpError> = await withCheckedContinuation { continuation in
+            client.sendTrackEvent(
+                BackgroundTrackRequest(eventName: "Geofence Transition", userId: "user_42", properties: ["metadata": metadata])
+            ) { continuation.resume(returning: $0) }
+        }
+
+        // Encoding succeeded (not .invalidRequest) and the request was actually sent.
+        #expect(runner.requestCalled)
+        if case .failure(let error) = result { Issue.record("expected success, got \(error)") }
+
+        let body = runner.requestReceivedArguments?.params.body
+            .flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] }
+        let sentMetadata = (body?["properties"] as? [String: Any])?["metadata"] as? [String: Any]
+        #expect(sentMetadata?["priority"] as? Int64 == 3)
+        #expect(sentMetadata?["score"] as? Double == 1.5)
+        #expect(sentMetadata?["vip"] as? Bool == true)
+        #expect(sentMetadata?["brand"] as? String == "acme")
+    }
+
+    @Test
     func sendTrackEvent_givenNilTimestamp_expectTimestampOmittedFromBody() async {
         let (client, runner) = makeClient(store: makeStore())
         runner.requestClosure = { _, _, onComplete in onComplete(Data(), makeOkResponse(), nil) }

--- a/Tests/Common/Type/GeofenceMetadataValueTests.swift
+++ b/Tests/Common/Type/GeofenceMetadataValueTests.swift
@@ -1,0 +1,86 @@
+@testable import CioInternalCommon
+import Foundation
+import Testing
+
+@Suite("GeofenceMetadataValue")
+struct GeofenceMetadataValueTests {
+    // Wrapping in a dictionary avoids relying on top-level JSON fragment decoding.
+    private func decode(_ jsonValue: String) throws -> GeofenceMetadataValue {
+        let json = "{\"v\":\(jsonValue)}"
+        let map = try JSONDecoder().decode([String: GeofenceMetadataValue].self, from: Data(json.utf8))
+        return try #require(map["v"])
+    }
+
+    private func roundTrip(_ value: GeofenceMetadataValue) throws -> GeofenceMetadataValue {
+        let data = try JSONEncoder().encode(["v": value])
+        let map = try JSONDecoder().decode([String: GeofenceMetadataValue].self, from: data)
+        return try #require(map["v"])
+    }
+
+    // MARK: - Decoding by primitive type
+
+    @Test
+    func decode_givenString_expectStringCase() throws {
+        #expect(try decode("\"office\"") == .string("office"))
+    }
+
+    @Test
+    func decode_givenBool_expectBoolCaseNotNumber() throws {
+        // Bool must win over Int so `true` isn't coerced to 1.
+        #expect(try decode("true") == .bool(true))
+        #expect(try decode("false") == .bool(false))
+    }
+
+    @Test
+    func decode_givenInteger_expectIntCase() throws {
+        #expect(try decode("42") == .int(42))
+    }
+
+    @Test
+    func decode_givenLargeInteger_expectInt64Preserved() throws {
+        #expect(try decode("9007199254740993") == .int(9007199254740993))
+    }
+
+    @Test
+    func decode_givenDecimal_expectDoubleCase() throws {
+        #expect(try decode("3.5") == .double(3.5))
+    }
+
+    @Test
+    func decode_givenIntegerBeyondInt64_expectDoubleFallbackNoThrow() throws {
+        // A number larger than Int64.max must not crash; it falls back to a Double (lossy but safe).
+        guard case .double = try decode("99999999999999999999") else {
+            Issue.record("expected .double fallback for an over-Int64 integer")
+            return
+        }
+    }
+
+    @Test
+    func decode_givenNestedObject_expectThrows() {
+        #expect(throws: (any Error).self) { try decode("{\"a\":1}") }
+    }
+
+    @Test
+    func decode_givenArray_expectThrows() {
+        #expect(throws: (any Error).self) { try decode("[1,2]") }
+    }
+
+    // MARK: - Round-trip preserves primitive type
+
+    @Test
+    func encodeDecode_givenEachType_expectTypePreserved() throws {
+        for value: GeofenceMetadataValue in [.string("x"), .bool(true), .int(7), .double(1.25)] {
+            #expect(try roundTrip(value) == value)
+        }
+    }
+
+    // MARK: - anyValue
+
+    @Test
+    func anyValue_expectNativeTypes() {
+        #expect(GeofenceMetadataValue.string("a").anyValue as? String == "a")
+        #expect(GeofenceMetadataValue.bool(true).anyValue as? Bool == true)
+        #expect(GeofenceMetadataValue.int(3).anyValue as? Int64 == 3)
+        #expect(GeofenceMetadataValue.double(2.5).anyValue as? Double == 2.5)
+    }
+}

--- a/Tests/LocationGeofence/Geofence/Api/GeofenceApiResponseTests.swift
+++ b/Tests/LocationGeofence/Geofence/Api/GeofenceApiResponseTests.swift
@@ -195,7 +195,7 @@ struct GeofenceApiResponseTests {
         let region = response.toDomainRegions().first
 
         #expect(region?.id == "g1")
-        #expect(region?.name == "")
+        #expect(region?.name == nil)
         #expect(region?.transitionTypes == [.enter, .exit])
         #expect(region?.lastUpdated == Date(timeIntervalSince1970: 0))
     }

--- a/Tests/LocationGeofence/Geofence/Api/GeofenceApiResponseTests.swift
+++ b/Tests/LocationGeofence/Geofence/Api/GeofenceApiResponseTests.swift
@@ -296,4 +296,94 @@ struct GeofenceApiResponseTests {
         let response = try decode(json)
         #expect(response.toDomainRegions().first?.geosetIds == [])
     }
+
+    // MARK: - Metadata (server field `metadata`, type-preserved)
+
+    @Test
+    func toDomainRegions_givenScalarMetadata_expectTypesPreserved() throws {
+        let json = """
+        {"geofences":[{"id":"g1","latitude":1,"longitude":2,"radius":100,
+          "metadata":{"category":"office","priority":3,"score":1.5,"vip":true}}]}
+        """
+        let metadata = try #require(try decode(json).toDomainRegions().first?.metadata)
+        #expect(metadata["category"] == .string("office"))
+        #expect(metadata["priority"] == .int(3))
+        #expect(metadata["score"] == .double(1.5))
+        #expect(metadata["vip"] == .bool(true))
+    }
+
+    @Test
+    func toDomainRegions_givenMissingMetadata_expectEmpty() throws {
+        let json = """
+        {"geofences":[{"id":"g1","latitude":1,"longitude":2,"radius":100}]}
+        """
+        #expect(try decode(json).toDomainRegions().first?.metadata == [:])
+    }
+
+    @Test
+    func toDomainRegions_givenEmptyMetadata_expectEmpty() throws {
+        let json = """
+        {"geofences":[{"id":"g1","latitude":1,"longitude":2,"radius":100,"metadata":{}}]}
+        """
+        #expect(try decode(json).toDomainRegions().first?.metadata == [:])
+    }
+
+    @Test
+    func toDomainRegions_givenNullOrNonScalarMetadataValues_expectDroppedNotFailed() throws {
+        // A null, nested object, or array value must drop that single entry, not fail the region.
+        let json = """
+        {"geofences":[{"id":"g1","latitude":1,"longitude":2,"radius":100,
+          "metadata":{"good":"ok","bad":null,"nested":{"a":1},"list":[1,2]}}]}
+        """
+        #expect(try decode(json).toDomainRegions().first?.metadata == ["good": .string("ok")])
+    }
+
+    @Test
+    func toDomainRegions_givenMalformedMetadataType_expectEmptyMetadataAndRegionStillParses() throws {
+        // `metadata` sent as a non-object (here a string) must not fail the region/response decode —
+        // it degrades to empty metadata while every other field parses normally.
+        let json = """
+        {"geofences":[{"id":"g1","latitude":1.5,"longitude":2.5,"radius":100,"metadata":"oops"}]}
+        """
+        let region = try #require(try decode(json).toDomainRegions().first)
+        #expect(region.id == "g1")
+        #expect(region.latitude == 1.5)
+        #expect(region.metadata == [:])
+    }
+
+    @Test
+    func toDomainRegions_givenMetadataBeyondCountCap_expectCappedByKeyOrder() throws {
+        let entries = (0 ..< (GeofenceConstants.maxMetadataCount + 5))
+            .map { "\"k\(String(format: "%03d", $0))\":\"v\($0)\"" }
+            .joined(separator: ",")
+        let json = """
+        {"geofences":[{"id":"g1","latitude":1,"longitude":2,"radius":100,"metadata":{\(entries)}}]}
+        """
+        let metadata = try #require(try decode(json).toDomainRegions().first?.metadata)
+        #expect(metadata.count == GeofenceConstants.maxMetadataCount)
+        // Kept set is deterministic (sorted by key): k000 in, the overflow tail out.
+        #expect(metadata["k000"] == .string("v0"))
+        #expect(metadata["k\(String(format: "%03d", GeofenceConstants.maxMetadataCount + 2))"] == nil)
+    }
+
+    @Test
+    func toDomainRegions_givenTotalPayloadBeyondByteCap_expectStoppedAtByteBudget() throws {
+        // Umbrella guard: values are bounded by the total byte budget, independent of the count cap.
+        // Each value is ~1/4 of the budget, so 8 of them overrun it and only a few are kept.
+        let bigValue = String(repeating: "a", count: GeofenceConstants.maxMetadataPayloadBytes / 4)
+        let generated = 8
+        let entries = (0 ..< generated)
+            .map { "\"k\($0)\":\"\(bigValue)\"" }
+            .joined(separator: ",")
+        let json = """
+        {"geofences":[{"id":"g1","latitude":1,"longitude":2,"radius":100,"metadata":{\(entries)}}]}
+        """
+        let metadata = try #require(try decode(json).toDomainRegions().first?.metadata)
+        let totalBytes = metadata.reduce(0) { sum, entry in
+            guard case .string(let value) = entry.value else { return sum }
+            return sum + entry.key.utf8.count + value.utf8.count
+        }
+        #expect(totalBytes <= GeofenceConstants.maxMetadataPayloadBytes)
+        #expect(metadata.count < generated) // byte budget dropped some
+    }
 }

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -83,7 +83,8 @@ struct GeofenceSyncCoordinatorTests {
                 externalId: nil,
                 transitionTypes: region.transitionTypes.map(\.rawValue),
                 lastUpdated: region.lastUpdated.timeIntervalSince1970,
-                geosetIds: region.geosetIds.isEmpty ? nil : region.geosetIds
+                geosetIds: region.geosetIds.isEmpty ? nil : region.geosetIds,
+                metadata: region.metadata.isEmpty ? nil : region.metadata
             )
         }
         let apiConfig = config.map { config in

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceDeliveryTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceDeliveryTrackerTests.swift
@@ -20,7 +20,8 @@ struct GeofenceDeliveryTrackerTests {
         timestamp: Date = Date(timeIntervalSince1970: 1700000000),
         name: String? = nil,
         transitionId: String = "txn_abc",
-        geosetId: String? = nil
+        geosetId: String? = nil,
+        metadata: [String: GeofenceMetadataValue]? = nil
     ) -> PendingGeofenceMetric {
         PendingGeofenceMetric(
             geofenceId: geofenceId,
@@ -29,7 +30,8 @@ struct GeofenceDeliveryTrackerTests {
             userId: nil,
             name: name,
             transitionId: transitionId,
-            geosetId: geosetId
+            geosetId: geosetId,
+            metadata: metadata
         )
     }
 
@@ -126,6 +128,43 @@ struct GeofenceDeliveryTrackerTests {
         let properties = httpClient.sendTrackEventReceivedArguments?.request.properties ?? [:]
         #expect(properties["geosetId"] as? String == "123")
         #expect(properties["geosetId"] as? Int == nil)
+    }
+
+    @Test
+    func trackMetric_givenMetadata_expectNestedMetadataObjectWithPreservedTypes() async {
+        let (tracker, httpClient) = makeTracker()
+        httpClient.sendTrackEventClosure = { _, completion in completion(.success(())) }
+        let metadata: [String: GeofenceMetadataValue] = [
+            "category": .string("office"), "priority": .int(3), "vip": .bool(true)
+        ]
+
+        await withCheckedContinuation { continuation in
+            tracker.trackMetric(metric: makeMetric(metadata: metadata), userId: "user_42") { _ in
+                continuation.resume()
+            }
+        }
+
+        let properties = httpClient.sendTrackEventReceivedArguments?.request.properties ?? [:]
+        let nested = properties["metadata"] as? [String: Any]
+        #expect(nested?["category"] as? String == "office")
+        #expect(nested?["priority"] as? Int64 == 3)
+        #expect(nested?["vip"] as? Bool == true)
+    }
+
+    @Test
+    func trackMetric_givenNoMetadata_expectEmptyMetadataObject() async {
+        let (tracker, httpClient) = makeTracker()
+        httpClient.sendTrackEventClosure = { _, completion in completion(.success(())) }
+
+        await withCheckedContinuation { continuation in
+            tracker.trackMetric(metric: makeMetric(), userId: "user_42") { _ in
+                continuation.resume()
+            }
+        }
+
+        // Always present as an (empty) object rather than omitted/nil.
+        let properties = httpClient.sendTrackEventReceivedArguments?.request.properties ?? [:]
+        #expect((properties["metadata"] as? [String: Any])?.isEmpty == true)
     }
 
     // MARK: - Guard clauses

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -635,6 +635,149 @@ struct GeofenceEventTrackerTests {
         #expect(await pending.loadAll().first?.name == nil)
     }
 
+    // MARK: - Metadata (snapshot + prefer-live)
+
+    private func seedGeofence(_ storage: GeofenceStorage, id: String, name: String, metadata: [String: GeofenceMetadataValue]) async {
+        await storage.setCachedGeofences([
+            Geofence(
+                id: id, latitude: 1, longitude: 2, radius: 100,
+                name: name, transitionTypes: [.enter], lastUpdated: Date(timeIntervalSince1970: 0),
+                metadata: metadata
+            )
+        ])
+    }
+
+    @Test
+    func trackTransition_givenCachedGeofenceWithMetadata_expectMetricCarriesSnapshot() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        await seedGeofence(storage, id: "geo_1", name: "HQ", metadata: ["category": .string("office")])
+        let pending = makePendingStore(directory: dir)
+        let delivery = GeofenceDeliveryTrackerMock()
+        // Fail so the row survives on disk for inspection.
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.failure(.http(statusCode: 503))) }
+        let tracker = makeTracker(
+            storage: storage,
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_42")
+        )
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+
+        #expect(await pending.loadAll().first?.metadata == ["category": .string("office")])
+    }
+
+    @Test
+    func deliver_givenMetadataChangedAfterCapture_expectFreshMetadataSent() async {
+        // Prefer-live: an metadata edit between capture and a later flush goes out current.
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        await seedGeofence(storage, id: "geo_1", name: "HQ", metadata: ["tier": .string("gold")])
+        let pending = makePendingStore(directory: dir)
+        let failing = GeofenceDeliveryTrackerMock()
+        failing.trackMetricClosure = { _, _, onComplete in onComplete(.failure(.transport)) }
+        let priorTracker = makeTracker(
+            storage: storage, pendingStore: pending, deliveryTracker: failing,
+            contextStore: makeContextStore(userId: "user_42")
+        )
+        await priorTracker.trackTransition(geofenceId: "geo_1", transition: .enter) // snapshot gold, persisted
+
+        // Server updated the tier; the cache now reflects it.
+        await seedGeofence(storage, id: "geo_1", name: "HQ", metadata: ["tier": .string("platinum")])
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
+        let tracker = makeTracker(
+            storage: storage, pendingStore: pending, deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_42")
+        )
+
+        await tracker.flushPending()
+
+        #expect(delivery.trackMetricReceivedArguments?.metric.metadata == ["tier": .string("platinum")])
+    }
+
+    @Test
+    func deliver_givenGeofenceEvictedAfterCapture_expectSnapshotMetadataSent() async {
+        // Fallback: the geofence left the cache (e.g. a refetch) → the row snapshot is used.
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        await seedGeofence(storage, id: "geo_1", name: "HQ", metadata: ["tier": .string("gold")])
+        let pending = makePendingStore(directory: dir)
+        let failing = GeofenceDeliveryTrackerMock()
+        failing.trackMetricClosure = { _, _, onComplete in onComplete(.failure(.transport)) }
+        let priorTracker = makeTracker(
+            storage: storage, pendingStore: pending, deliveryTracker: failing,
+            contextStore: makeContextStore(userId: "user_42")
+        )
+        await priorTracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+
+        await storage.setCachedGeofences([]) // geofence evicted
+
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
+        let tracker = makeTracker(
+            storage: storage, pendingStore: pending, deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_42")
+        )
+
+        await tracker.flushPending()
+
+        #expect(delivery.trackMetricReceivedArguments?.metric.metadata == ["tier": .string("gold")])
+    }
+
+    @Test
+    func trackTransition_givenAnonymousAndCachedMetadata_expectEventBusEventCarriesMetadata() async {
+        // The EventBus (anonymous) path must carry metadata too, not just the HTTP path.
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        await seedGeofence(storage, id: "geo_1", name: "HQ", metadata: ["tier": .string("gold")])
+        let pending = makePendingStore(directory: dir)
+        let bus = EventBusHandlerMock()
+        let tracker = makeTracker(
+            storage: storage, pendingStore: pending,
+            deliveryTracker: GeofenceDeliveryTrackerMock(),
+            contextStore: makeContextStore(), eventBus: bus
+        )
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+
+        #expect(postedGeofenceEvents(from: bus).first?.metadata == ["tier": .string("gold")])
+    }
+
+    @Test
+    func deliver_givenNameChangedAfterCapture_expectFreshNameSent() async {
+        // Prefer-live applies to name too, not just metadata.
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        await seedGeofence(storage, id: "geo_1", name: "Old HQ", metadata: [:])
+        let pending = makePendingStore(directory: dir)
+        let failing = GeofenceDeliveryTrackerMock()
+        failing.trackMetricClosure = { _, _, onComplete in onComplete(.failure(.transport)) }
+        let priorTracker = makeTracker(
+            storage: storage, pendingStore: pending, deliveryTracker: failing,
+            contextStore: makeContextStore(userId: "user_42")
+        )
+        await priorTracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+
+        await seedGeofence(storage, id: "geo_1", name: "New HQ", metadata: [:])
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
+        let tracker = makeTracker(
+            storage: storage, pendingStore: pending, deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_42")
+        )
+
+        await tracker.flushPending()
+
+        #expect(delivery.trackMetricReceivedArguments?.metric.name == "New HQ")
+    }
+
     // MARK: - Geoset fan-out
 
     private func seedGeofence(_ storage: GeofenceStorage, id: String, name: String, geosetIds: [String]) async {

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -562,7 +562,7 @@ struct GeofenceEventTrackerTests {
 
     // MARK: - Geofence name resolution
 
-    private func seedGeofence(_ storage: GeofenceStorage, id: String, name: String) async {
+    private func seedGeofence(_ storage: GeofenceStorage, id: String, name: String?) async {
         await storage.setCachedGeofences([
             Geofence(
                 id: id, latitude: 1, longitude: 2, radius: 100,
@@ -613,13 +613,12 @@ struct GeofenceEventTrackerTests {
     }
 
     @Test
-    func trackTransition_givenCachedGeofenceWithEmptyName_expectNilName() async {
-        // The API maps an absent name to "". Empty must resolve to nil so the event omits
-        // `geofenceName` rather than sending an empty string.
+    func trackTransition_givenCachedGeofenceWithNoName_expectNilName() async {
+        // A geofence with no name (nil) must omit `geofenceName` rather than sending an empty value.
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let storage = makeStorage(directory: dir)
-        await seedGeofence(storage, id: "geo_1", name: "")
+        await seedGeofence(storage, id: "geo_1", name: nil)
         let pending = makePendingStore(directory: dir)
         let delivery = GeofenceDeliveryTrackerMock()
         delivery.trackMetricClosure = { _, _, onComplete in onComplete(.failure(.http(statusCode: 503))) }

--- a/Tests/LocationGeofence/Geofence/Storage/PendingGeofenceMetricStoreTests.swift
+++ b/Tests/LocationGeofence/Geofence/Storage/PendingGeofenceMetricStoreTests.swift
@@ -58,6 +58,34 @@ struct PendingGeofenceMetricStoreTests {
     }
 
     @Test
+    func appendLoad_givenMetadata_expectRoundTripPreserved() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let store = makeStore(directory: dir)
+        let metric = PendingGeofenceMetric(
+            geofenceId: "geo_1", transition: .enter,
+            timestamp: Date(timeIntervalSince1970: 1700000000),
+            userId: "user_42", name: "HQ", transitionId: "txn_1",
+            metadata: ["category": .string("office"), "priority": .int(3)]
+        )
+
+        _ = await store.append([metric])
+
+        #expect(await store.loadAll().first?.metadata == ["category": .string("office"), "priority": .int(3)])
+    }
+
+    @Test
+    func decode_givenLegacyRowWithoutMetadata_expectNilMetadata() throws {
+        // A row persisted before metadata existed must still decode (missing key → nil).
+        let legacy = """
+        {"geofence_id":"geo_1","transition":"enter","timestamp":1,"transition_id":"txn_1"}
+        """
+        let metric = try JSONDecoder().decode(PendingGeofenceMetric.self, from: Data(legacy.utf8))
+        #expect(metric.metadata == nil)
+        #expect(metric.geofenceId == "geo_1")
+    }
+
+    @Test
     func append_givenMultiple_expectAllPersistedInOrder() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -297,6 +297,11 @@ public interface CioInternalCommon.FileStorage {
 }
 public enum CioInternalCommon.FileType {
 }
+public enum CioInternalCommon.GeofenceMetadataValue {
+	public var anyValue: Any;
+	public fun init(from decoder: Decoder) throws;
+	public fun func encode(to encoder: Encoder) throws;
+}
 public interface CioInternalCommon.GeofenceMetric {
 	public var geofenceId: String;
 	public var transition: GeofenceTransition;
@@ -304,6 +309,7 @@ public interface CioInternalCommon.GeofenceMetric {
 	public var name: String?;
 	public var transitionId: String;
 	public var geosetId: String?;
+	public var metadata: List<String : GeofenceMetadataValue>?;
 }
 public enum CioInternalCommon.GeofenceTransition {
 }
@@ -613,7 +619,8 @@ public final class CioInternalCommon.TrackGeofenceMetricEvent {
 	public final val name: String?;
 	public final val transitionId: String;
 	public final val geosetId: String?;
-	public fun init(storageId: String = UUID().uuidString, geofenceId: String, transition: GeofenceTransition, timestamp: Date = Date(), name: String?, transitionId: String, geosetId: String? = nil, params: List<String: String> = List<:>);
+	public final val metadata: List<String : GeofenceMetadataValue>?;
+	public fun init(storageId: String = UUID().uuidString, geofenceId: String, transition: GeofenceTransition, timestamp: Date = Date(), name: String?, transitionId: String, geosetId: String? = nil, metadata: List<String: GeofenceMetadataValue>? = nil, params: List<String: String> = List<:>);
 }
 public final class CioInternalCommon.TrackInAppMetricEvent {
 	public final val storageId: String;


### PR DESCRIPTION
Enriches the "Geofence Transition" event with workspace-defined `metadata` so campaigns/segments can match on fence attributes (brand, category, promo, etc.) without a join at ingest. Values arrive on the nearby response and are stamped onto the event.

## What this does
- **`GeofenceMetadataValue`** (Common): a `Codable`/`Sendable` scalar enum — `string` / `int` (Int64) / `double` / `bool` — so a JSON primitive keeps its type all the way through decode → cache → persisted row → event payload (a number matches numerically, a bool matches as a bool).
- **Decode** (`GeofenceApiRegion`): tolerant at the API boundary — null/array/object values are dropped rather than failing the whole region; scalars keep their type. Disk decode stays strict (our own encoder).
- **Freshness — prefer-live-at-send**: each pending row snapshots the fence's `name` + `metadata` at crossing time; at send, `deliver` re-resolves both from the current cache and falls back to the snapshot only if the fence has left the cache. Name and metadata move together so they never mix points in time.
- **Always emitted**: `metadata` is a nested object on every event, empty `{}` when the fence carries none (never omitted/null). Flows through both delivery paths (direct-HTTP and EventBus).
- **Defensive caps** (`GeofenceConstants`): count (100) + total key+value byte budget (100 KB), applied sorted-by-key for determinism. The server fully validates metadata; these only stop a runaway payload from bloating a background request.

## Testing
New `GeofenceMetadataValueTests` (typed decode/encode, number-beyond-Int64 → double fallback). Added metadata coverage to `GeofenceApiResponseTests` (type-preservation, missing/empty → `[:]`, null/non-scalar dropped, count + byte caps), `GeofenceEventTrackerTests` (snapshot, prefer-live, evicted-fence fallback, EventBus carries metadata), `GeofenceDeliveryTrackerTests` (nested object, empty present), `PendingGeofenceMetricStoreTests` (round-trip + legacy rows without metadata decode to nil). api-docs baseline regenerated for the new public Common symbols.

## Android parity
Matches Android (`d3344112`): typed/type-preserved values, nested always-present `metadata`, prefer-live-at-send (`withFreshestEventData`), tolerant sanitize, identical caps (100 / 100 KB). iOS re-registers wholesale (no diff), so Android's `equalsForRegistration` has no iOS counterpart. (Android bundled the request-radius removal into this commit; on iOS that lives in #1148 — request-path cleanup — so this PR is metadata-only.)

## Stack
1. **This PR** (`mbl-2045-geofence-metadata`) → `chore/geofence-delivery-background-task`
2. #1149 (`chore/geofence-delivery-background-task`) → `mbl-2008-geoset-fanout`
3. #1148 (`chore/geofence-remove-fetchall`) → `mbl-2008-geoset-fanout` — sibling
4. #1146 (`mbl-2008-geoset-fanout`) → `feature/geofence-on-device`
5. #1130 (`feature/geofence-on-device`) → `main`

Merge order: #1146, then #1148 and #1149 (either order), then this, then #1130.

Linear: https://linear.app/customerio/issue/MBL-2045

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes geofence transition event shape and delivery paths (HTTP + EventBus) with backward-compatible persistence, but new always-present metadata and prefer-live resolution could affect downstream analytics expectations.
> 
> **Overview**
> **Geofence Transition** `/track` events now carry workspace **`metadata`** from the nearby API so ingest can match on fence attributes without joins.
> 
> Adds public **`GeofenceMetadataValue`** (string / int / double / bool) so primitives keep their JSON types through cache, pending rows, HTTP, and EventBus. **`GeofenceMetric.trackEventProperties`** always includes a nested **`metadata`** object (`{}` when none); empty **`geofenceName`** is omitted like legacy `""` names.
> 
> Metadata is decoded on **`GeofenceApiRegion`** with tolerant handling (bad types / non-scalars dropped, region still parses) and **count + byte caps** before it lands on **`Geofence`**. At delivery, **`GeofenceEventTracker`** snapshots metadata at crossing and **re-reads name + metadata from cache at send**, falling back to the persisted row if the fence was evicted. **`Geofence.name`** is now optional (`nil` when absent) instead of defaulting to `""`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e230acca2fa7c60644dd10ba57d51b3fa9c01982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

