### PR TITLE
chore(geofence): address geoset PRs review feedback

### DIFF
--- a/Sources/Common/Communication/Event.swift
+++ b/Sources/Common/Communication/Event.swift
@@ -163,6 +163,9 @@ public struct TrackInAppMetricEvent: EventRepresentable {
     }
 }
 
+/// A geofence transition to be tracked by DataPipeline. Geofencing is identified-only, so `userId`
+/// is always present; DataPipeline pins the track to the identity captured when the transition fired,
+/// not the current one.
 public struct TrackGeofenceMetricEvent: EventRepresentable, GeofenceMetric {
     public let storageId: String
     public let params: [String: String]
@@ -171,11 +174,10 @@ public struct TrackGeofenceMetricEvent: EventRepresentable, GeofenceMetric {
     public let timestamp: Date
     public let name: String?
     public let transitionId: String
-    /// The geoset this event was fanned out for, or `nil` when the geofence is in no geoset.
-    /// Optional with a decode fallback so events persisted by pre-geoset SDK versions replay.
+    public let userId: String
+    /// The geoset this event was fanned out for; `nil` when the geofence is in no geoset.
     public let geosetId: String?
-    /// Workspace-defined geofence metadata, or `nil` when none. Optional so events persisted before
-    /// metadata still replay.
+    /// Workspace-defined geofence metadata; `nil` when none.
     public let metadata: [String: GeofenceMetadataValue]?
 
     public init(
@@ -185,6 +187,7 @@ public struct TrackGeofenceMetricEvent: EventRepresentable, GeofenceMetric {
         timestamp: Date = Date(),
         name: String?,
         transitionId: String,
+        userId: String,
         geosetId: String? = nil,
         metadata: [String: GeofenceMetadataValue]? = nil,
         params: [String: String] = [:]
@@ -196,6 +199,7 @@ public struct TrackGeofenceMetricEvent: EventRepresentable, GeofenceMetric {
         self.timestamp = timestamp
         self.name = name
         self.transitionId = transitionId
+        self.userId = userId
         self.geosetId = geosetId
         self.metadata = metadata
     }

--- a/Sources/DataPipeline/DataPipelineImplementation+GeofenceObserver.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation+GeofenceObserver.swift
@@ -2,16 +2,14 @@ import CioAnalytics
 import CioInternalCommon
 
 extension DataPipelineImplementation {
-    /// Tracks a geofence transition forwarded via EventBus from `GeofenceEventTracker`
-    /// when the row carries no stamped userId (anonymous capture path).
-    ///
-    /// Mirrors the property shape of the direct-HTTP path so both delivery channels
-    /// record the same set of fields. The `TrackEvent.timestamp` is set from
-    /// `metric.timestamp` so a flush replayed hours after capture still attributes
-    /// the transition to when it happened, not when it was sent.
+    /// Tracks a geofence transition forwarded via EventBus from `GeofenceEventTracker`'s flush.
+    /// `userId` and `timestamp` are pinned from the transition's snapshot so a delayed replay
+    /// attributes to the right person and time. `process(event:)` preserves both — `track` would
+    /// overwrite userId with the current identity.
     func processGeofenceMetricEvent(_ metric: TrackGeofenceMetricEvent) {
         var trackEvent = TrackEvent(event: metric.trackEventName, properties: try? JSON(metric.trackEventProperties))
         trackEvent.timestamp = metric.timestamp.string(format: .iso8601WithMilliseconds)
+        trackEvent.userId = metric.userId
         analytics.process(event: trackEvent)
     }
 }

--- a/Sources/Location/LocationServices.swift
+++ b/Sources/Location/LocationServices.swift
@@ -44,8 +44,9 @@ public protocol LocationServices: AnyObject {
     func requestLocationUpdate()
 
     /// Acquires a one-shot location fix for internal consumers (e.g. geofencing) with no analytics
-    /// side effects: no `CIO Location Update` track event, and the fix is **not** cached or persisted,
-    /// so it never reaches identify context enrichment and is not observable via `getLastKnownLocation`.
+    /// side effects: no `CIO Location Update` track event, and the fix is **not** persisted or used for
+    /// identify context enrichment. It does update the in-memory last-known fix, so it is observable via
+    /// `getLastKnownLocation` — geofencing anchors its refresh on that value.
     /// It posts `LocationAcquiredEvent` and runs regardless of `LocationConfig.mode` (geofencing needs
     /// a location even when location tracking is `.off`).
     /// Not part of the customer-facing API — other SDK modules call it via `@_spi(Geofence)`.

--- a/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
@@ -167,9 +167,10 @@ final class GeofenceEventTracker: @unchecked Sendable {
         // HTTP failure: row stays for next flush.
     }
 
-    /// Replay via EventBus → DataPipeline. Awaits the durable handoff (observer invoked, or the
-    /// event persisted to the EventBus cache when none exists yet) before removing our copy, so a
-    /// crash in between re-delivers on the next flush (deduped by transitionId) rather than dropping.
+    /// Replay via EventBus → DataPipeline, which then owns delivery and retry. We drop our copy once
+    /// the handoff resolves (observer invoked, or written to the EventBus cache when none exists yet).
+    /// That is not a durable-persistence ack — the strongest signal EventBus exposes today — so a
+    /// crash before DataPipeline persists re-delivers on the next flush (deduped by transitionId).
     private func deliverViaEventBus(metric: PendingGeofenceMetric) async {
         guard activeDeliveryKeys.mutating({ $0.insert(metric.key).inserted }) else { return }
         defer { activeDeliveryKeys.mutating { _ = $0.remove(metric.key) } }
@@ -192,8 +193,8 @@ final class GeofenceEventTracker: @unchecked Sendable {
 
     /// Hands a row to DataPipeline via EventBus, carrying the snapshot userId + timestamp so a
     /// delayed replay attributes to the right person and time, not the current identity/send time.
-    /// `postEventAndWait` (not `postEvent`) so the caller can drain the row only once the handoff is
-    /// durable — `postEvent` returns before its detached delivery/persist task runs.
+    /// `postEventAndWait` (not `postEvent`) so the caller drains the row only once the handoff has
+    /// resolved — `postEvent` returns before its detached delivery/persist task even runs.
     private func postEventBus(metric: PendingGeofenceMetric) async {
         await eventBusHandler.postEventAndWait(TrackGeofenceMetricEvent(
             geofenceId: metric.geofenceId,

--- a/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
@@ -3,24 +3,18 @@ import Foundation
 
 // sourcery: InjectRegisterShared = "GeofenceEventTracker"
 // sourcery: InjectCustomShared
-/// Sends geofence transition events through a three-layer delivery flow:
-/// 1. Cooldown-based deduplication (keyed by "geofenceId:transitionType")
-/// 2. Persist to `PendingGeofenceMetricStore` before any send attempt, stamping
-///    the currently-identified userId so A's transitions always attribute to A
-/// 3. Dispatch in `deliver`:
-///    - Stamped userId → direct-HTTP path with that userId; success drains the
-///      row, failure retains it for the next flush
-///    - No stamped userId → post to EventBus and drain; DataPipeline records
-///      the transition under its current identity (anonymous tracking when no
-///      one is identified). The captured timestamp flows through the event so
-///      both paths attribute the transition to when it happened
+/// Delivers geofence transition events. Anonymous crossings are dropped (geofencing is
+/// identified-only); survivors are deduped by a cooldown, fanned out per geoset, and persisted
+/// before any send. Two delivery channels drain the row, deduped server-side by the shared
+/// transitionId:
+/// - Fresh transition → direct HTTP (`deliverFresh`): works before DataPipeline is up (cold-wake);
+///   failure retains the row for the next flush.
+/// - Replay (`flushPending` → `deliverViaEventBus`) → EventBus → DataPipeline's durable queue.
 ///
-/// `flushPending()` replays queued rows on module init and on every `ProfileIdentifiedEvent`.
-/// Concurrent deliveries for the same row are deduplicated in-process via the active-delivery
-/// ID set; on app kill the row stays on disk and is retried in the next process.
+/// `flushPending()` runs on module init, cold-wake bootstrap, and `ProfileIdentifiedEvent`.
+/// Concurrent deliveries of the same row are deduped via the in-memory active-delivery set.
 ///
-/// `@unchecked Sendable`: all stored properties are `let`; mutable state is wrapped in
-/// `Synchronized`. Required for the weak capture in the `@Sendable` transition handler.
+/// `@unchecked Sendable`: all stored properties are `let`; mutable state is wrapped in `Synchronized`.
 final class GeofenceEventTracker: @unchecked Sendable {
     private let storage: GeofenceStorage
     private let pendingStore: PendingGeofenceMetricStore
@@ -57,13 +51,20 @@ final class GeofenceEventTracker: @unchecked Sendable {
 
     /// Tracks a geofence transition, suppressing duplicates within the cooldown window.
     /// Fans the transition out to one metric per geoset the geofence belongs to (a single
-    /// metric without a geosetId when it belongs to none), persists every row, then hands
-    /// each to `deliver`. The cooldown is evaluated once per geofence, before fan-out, so
-    /// all rows of one transition are suppressed or emitted together.
+    /// metric without a geosetId when it belongs to none), persists every row, then delivers.
+    /// The cooldown is evaluated once per geofence, before fan-out, so all rows of one
+    /// transition are suppressed or emitted together.
     func trackTransition(
         geofenceId: String,
         transition: GeofenceTransition
     ) async {
+        // Identified-only: the backend rejects anonymous geofence tracks, so drop before cooldown or
+        // persist. Snapshot the userId so a later sign-out/sign-in can't reattribute the row.
+        guard let stampedUserId = contextStore.currentUserId, !stampedUserId.isEmpty else {
+            logger.geofenceTransitionDroppedAnonymous(geofenceId: geofenceId, transition: transition)
+            return
+        }
+
         let cooldownKey = "\(geofenceId):\(transition.rawValue)"
         let now = dateUtil.now
         // Cached config wins when present so a workspace can tune the dedup window without
@@ -74,12 +75,6 @@ final class GeofenceEventTracker: @unchecked Sendable {
             logger.geofenceEventSuppressed(geofenceId: geofenceId, transition: transition)
             return
         }
-
-        // Stamp the current userId so a row captured under user A always delivers
-        // as A — even if B signs in before the flush replays it. Nil when no user
-        // is identified at capture time; `deliver` routes nil-stamped rows to EventBus.
-        let liveUserId = contextStore.currentUserId
-        let stampedUserId: String? = (liveUserId?.isEmpty == false) ? liveUserId : nil
         // Resolve the geofence name and geoset membership now and carry them on the metric;
         // name is nil when the geofence has none so the event omits `geofenceName`.
         let cachedGeofence = await storage.getCachedGeofences().first { $0.id == geofenceId }
@@ -103,7 +98,7 @@ final class GeofenceEventTracker: @unchecked Sendable {
                 name: geofenceName,
                 transitionId: transitionId,
                 geosetId: geosetId,
-                // Snapshot as the fallback for an evicted geofence; `deliver` prefers the live cache.
+                // Snapshot as the fallback for an evicted geofence; delivery prefers the live cache.
                 metadata: cachedGeofence?.metadata
             )
         }
@@ -128,48 +123,34 @@ final class GeofenceEventTracker: @unchecked Sendable {
         await backgroundTaskRunner.withBackgroundTime { [self] in
             await withTaskGroup(of: Void.self) { group in
                 for metric in metrics {
-                    group.addTask { await self.deliver(metric: metric) }
+                    group.addTask { await self.deliverFresh(metric: metric) }
                 }
             }
         }
         await storage.purgeExpiredCooldowns(now: now, interval: interval)
     }
 
-    /// Replays every queued metric through `deliver`. Runs on module init and cold-wake bootstrap,
-    /// so it holds a background-task assertion too — the backlog can be replaying in a short wake.
+    /// Replays every queued row via EventBus → DataPipeline, which owns delivery and its own
+    /// background handling from there — so no background-task assertion is needed (unlike the fresh
+    /// HTTP send). A row not handed off stays queued and retries on the next flush.
     func flushPending() async {
-        let pending = await pendingStore.loadAll()
-        guard !pending.isEmpty else { return }
-        await backgroundTaskRunner.withBackgroundTime { [self] in
-            for metric in pending {
-                await deliver(metric: metric)
-            }
+        for metric in await pendingStore.loadAll() {
+            await deliverViaEventBus(metric: metric)
         }
     }
 
     // MARK: - Private
 
-    private func deliver(metric: PendingGeofenceMetric) async {
-        // Claim before delivering so two concurrent callers (e.g. trackTransition and a
-        // ProfileIdentifiedEvent-triggered flush, or two flushes) can't both send the
-        // same row. The claim set is in-memory only — on app kill the row stays on
-        // disk and is retried by flushPending in the next process.
+    /// Fresh-transition delivery via direct HTTP. Failure leaves the row for `flushPending`.
+    private func deliverFresh(metric: PendingGeofenceMetric) async {
+        // Claim so a concurrent flush of the same row can't also send it.
         guard activeDeliveryKeys.mutating({ $0.insert(metric.key).inserted }) else { return }
         defer { activeDeliveryKeys.mutating { _ = $0.remove(metric.key) } }
 
         let effective = await resolvingLiveValues(metric)
 
-        // Rows without a stamped userId (anonymous capture or legacy pre-stamping)
-        // route through EventBus instead — DataPipeline tracks anonymously under
-        // whatever identity is current at consume time.
-        guard let stampedUserId = effective.userId, !stampedUserId.isEmpty else {
-            postEventBus(metric: effective)
-            _ = await pendingStore.remove(key: metric.key)
-            return
-        }
-
         let success = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
-            deliveryTracker.trackMetric(metric: effective, userId: stampedUserId) { result in
+            deliveryTracker.trackMetric(metric: effective, userId: effective.userId) { result in
                 switch result {
                 case .success:
                     continuation.resume(returning: true)
@@ -186,6 +167,18 @@ final class GeofenceEventTracker: @unchecked Sendable {
         // HTTP failure: row stays for next flush.
     }
 
+    /// Replay via EventBus → DataPipeline. Awaits the durable handoff (observer invoked, or the
+    /// event persisted to the EventBus cache when none exists yet) before removing our copy, so a
+    /// crash in between re-delivers on the next flush (deduped by transitionId) rather than dropping.
+    private func deliverViaEventBus(metric: PendingGeofenceMetric) async {
+        guard activeDeliveryKeys.mutating({ $0.insert(metric.key).inserted }) else { return }
+        defer { activeDeliveryKeys.mutating { _ = $0.remove(metric.key) } }
+
+        let effective = await resolvingLiveValues(metric)
+        await postEventBus(metric: effective)
+        _ = await pendingStore.remove(key: metric.key)
+    }
+
     /// Prefers the freshest cached `name`/`metadata` at send, falling back to the row snapshot when
     /// the geofence has left the cache. All other fields — including the dedup key inputs — are
     /// unchanged, so the returned copy addresses the same persisted row.
@@ -197,17 +190,18 @@ final class GeofenceEventTracker: @unchecked Sendable {
         return metric.withResolved(name: live.name, metadata: live.metadata)
     }
 
-    /// Anonymous-attribution fallback used when a row carries no stamped userId.
-    /// The captured `timestamp` flows through the event so DataPipeline can record
-    /// the transition under the moment it actually happened, not the moment the
-    /// flush ran.
-    private func postEventBus(metric: PendingGeofenceMetric) {
-        eventBusHandler.postEvent(TrackGeofenceMetricEvent(
+    /// Hands a row to DataPipeline via EventBus, carrying the snapshot userId + timestamp so a
+    /// delayed replay attributes to the right person and time, not the current identity/send time.
+    /// `postEventAndWait` (not `postEvent`) so the caller can drain the row only once the handoff is
+    /// durable — `postEvent` returns before its detached delivery/persist task runs.
+    private func postEventBus(metric: PendingGeofenceMetric) async {
+        await eventBusHandler.postEventAndWait(TrackGeofenceMetricEvent(
             geofenceId: metric.geofenceId,
             transition: metric.transition,
             timestamp: metric.timestamp,
             name: metric.name,
             transitionId: metric.transitionId,
+            userId: metric.userId,
             geosetId: metric.geosetId,
             metadata: metric.metadata
         ))

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -58,6 +58,13 @@ extension Logger {
         )
     }
 
+    func geofenceTransitionDroppedAnonymous(geofenceId: String, transition: GeofenceTransition) {
+        debug(
+            "Dropped \(transition.rawValue) event for geofence \(geofenceId): no identified user at transition time (geofencing is identified-only)",
+            geofenceTag
+        )
+    }
+
     func geofencePendingPersistFailed(geofenceId: String, transition: GeofenceTransition) {
         error(
             "Failed to persist \(transition.rawValue) event for geofence \(geofenceId) before send; cooldown released so the next crossing can retry",

--- a/Sources/LocationGeofence/Storage/PendingGeofenceMetric.swift
+++ b/Sources/LocationGeofence/Storage/PendingGeofenceMetric.swift
@@ -1,14 +1,15 @@
 import CioInternalCommon
 import Foundation
 
-/// A geofence transition queued for delivery (direct-HTTP when stamped with a
-/// userId, EventBus → DataPipeline anonymous when not).
+/// A geofence transition queued for delivery — fresh over direct HTTP, or replayed via
+/// EventBus → DataPipeline. Always carries the userId identified at capture; geofencing is
+/// identified-only, so anonymous crossings are dropped before a row is ever created.
 struct PendingGeofenceMetric: Codable, Equatable, Sendable, GeofenceMetric {
     let geofenceId: String
     let transition: GeofenceTransition
     let timestamp: Date
-    /// The userId identified at capture time, or `nil` if none was identified.
-    let userId: String?
+    /// The userId identified at capture time.
+    let userId: String
     /// The geofence's name, resolved at capture time, or `nil` when unavailable. Travels with the
     /// metric so a delayed flush still has it even after the geofence leaves the cache.
     let name: String?
@@ -17,8 +18,8 @@ struct PendingGeofenceMetric: Codable, Equatable, Sendable, GeofenceMetric {
     /// One physical transition of a geofence in N geosets produces N rows, one per geoset.
     /// Optional so rows persisted by pre-geoset SDK versions still decode.
     let geosetId: String?
-    /// Snapshot of the geofence's metadata at transition, the fallback when `deliver` can't find
-    /// the geofence in cache. Optional so rows persisted before metadata still decode.
+    /// Snapshot of the geofence's metadata at transition, the fallback when the geofence isn't in
+    /// cache at send. Optional so rows persisted before metadata still decode.
     let metadata: [String: GeofenceMetadataValue]?
 
     /// Composite key over `(geofenceId, transition, timestamp_sec, geosetId)` used for
@@ -37,7 +38,7 @@ struct PendingGeofenceMetric: Codable, Equatable, Sendable, GeofenceMetric {
         geofenceId: String,
         transition: GeofenceTransition,
         timestamp: Date,
-        userId: String?,
+        userId: String,
         name: String?,
         transitionId: String,
         geosetId: String? = nil,

--- a/Sources/LocationGeofence/Storage/PendingGeofenceMetricStore.swift
+++ b/Sources/LocationGeofence/Storage/PendingGeofenceMetricStore.swift
@@ -63,22 +63,6 @@ actor PendingGeofenceMetricStore {
         return saveToDisk(items)
     }
 
-    /// Removes entries whose keys are in `keys` in one read-modify-write.
-    /// Returns `true` when the file was updated, `false` when none of the keys were present.
-    func removeAll(keys: Set<String>) -> Bool {
-        guard !keys.isEmpty else { return true }
-        var items = loadFromDisk()
-        let originalCount = items.count
-        items.removeAll { keys.contains($0.key) }
-        guard items.count != originalCount else { return false }
-        return saveToDisk(items)
-    }
-
-    /// Wipes the queue. Used on sign-out to avoid sending one user's queued events with the next user's identifier.
-    func clearAll() {
-        _ = saveToDisk([])
-    }
-
     // MARK: - Private (file persistence)
 
     private func loadFromDisk() -> [PendingGeofenceMetric] {

--- a/Tests/DataPipeline/DataPipelineEventBustTests.swift
+++ b/Tests/DataPipeline/DataPipelineEventBustTests.swift
@@ -70,7 +70,8 @@ class DataPipelineEventBustTests: IntegrationTest {
                 transition: .enter,
                 timestamp: capturedAt,
                 name: "HQ",
-                transitionId: "txn_enter_1"
+                transitionId: "txn_enter_1",
+                userId: "user_1"
             )
         )
 
@@ -104,7 +105,8 @@ class DataPipelineEventBustTests: IntegrationTest {
                 transition: .exit,
                 timestamp: capturedAt,
                 name: nil,
-                transitionId: "txn_exit_1"
+                transitionId: "txn_exit_1",
+                userId: "user_1"
             )
         )
 
@@ -124,6 +126,29 @@ class DataPipelineEventBustTests: IntegrationTest {
         XCTAssertNil(properties["latitude"])
         XCTAssertNil(properties["longitude"])
         XCTAssertEqual(trackEvent.timestamp, capturedAt.string(format: .iso8601WithMilliseconds))
+    }
+
+    func testSubscribeToJourneyEvents_DataPipelineHandlesTrackGeofenceMetricEvent_pinsSnapshotUserId() async {
+        // The transition was captured under user_A; a different user is identified now. The event's
+        // snapshot userId must pin the track to user_A, not the current identity.
+        customerIO.identify(userId: "user_current")
+
+        await eventBusHandler.postEventAndWait(
+            TrackGeofenceMetricEvent(
+                geofenceId: String.random,
+                transition: .enter,
+                timestamp: Date(timeIntervalSince1970: 1700000000),
+                name: "HQ",
+                transitionId: "txn_pin_1",
+                userId: "user_A"
+            )
+        )
+
+        guard let trackEvent = outputReader.lastEvent as? TrackEvent else {
+            XCTFail("recorded event is not an instance of TrackEvent")
+            return
+        }
+        XCTAssertEqual(trackEvent.userId, "user_A")
     }
 
     func testSubscribeToJourneyEvents_DataPipelineHandlesRegisterDeviceEvent() async {

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceDeliveryTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceDeliveryTrackerTests.swift
@@ -27,7 +27,7 @@ struct GeofenceDeliveryTrackerTests {
             geofenceId: geofenceId,
             transition: transition,
             timestamp: timestamp,
-            userId: nil,
+            userId: "user_1",
             name: name,
             transitionId: transitionId,
             geosetId: geosetId,

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -66,17 +66,21 @@ struct GeofenceEventTrackerTests {
         let pending = makePendingStore(directory: dir)
         let delivery = GeofenceDeliveryTrackerMock()
         delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
+        let bus = EventBusHandlerMock()
         let tracker = makeTracker(
             storage: makeStorage(directory: dir),
             pendingStore: pending,
             deliveryTracker: delivery,
-            contextStore: makeContextStore(userId: "user_42")
+            contextStore: makeContextStore(userId: "user_42"),
+            eventBus: bus
         )
 
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
 
+        // Fresh transition goes out over HTTP only — the EventBus channel is for replay.
         #expect(delivery.trackMetricCallsCount == 1)
         #expect(delivery.trackMetricReceivedArguments?.userId == "user_42")
+        #expect(postedGeofenceEvents(from: bus).isEmpty)
         #expect(await pending.loadAll().isEmpty)
     }
 
@@ -142,54 +146,26 @@ struct GeofenceEventTrackerTests {
         let pending = makePendingStore(directory: dir)
         let delivery = GeofenceDeliveryTrackerMock()
         delivery.trackMetricClosure = { _, _, onComplete in onComplete(.failure(.transport)) }
-        let tracker = makeTracker(
-            storage: makeStorage(directory: dir),
-            pendingStore: pending,
-            deliveryTracker: delivery,
-            contextStore: makeContextStore(userId: "user_42")
-        )
-
-        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter) // attempt 1 fails → row persists
-        await tracker.flushPending() // attempt 2 replays the persisted row
-
-        let metrics = delivery.trackMetricReceivedInvocations.map(\.metric)
-        #expect(metrics.count == 2)
-        #expect(metrics.first?.transitionId.isEmpty == false) // minted at capture
-        #expect(metrics[0].transitionId == metrics[1].transitionId) // reloaded from disk, reused verbatim
-    }
-
-    @Test
-    func trackTransition_givenNoUserId_expectEventBusAndQueueDrained() async {
-        let dir = makeTempDirectory()
-        defer { try? FileManager.default.removeItem(at: dir) }
-        let pending = makePendingStore(directory: dir)
-        let delivery = GeofenceDeliveryTrackerMock()
         let bus = EventBusHandlerMock()
-        let dateUtil = DateUtilStub()
-        let captureTime = Date(timeIntervalSince1970: 1700000000)
-        dateUtil.givenNow = captureTime
         let tracker = makeTracker(
             storage: makeStorage(directory: dir),
             pendingStore: pending,
             deliveryTracker: delivery,
-            contextStore: makeContextStore(),
-            eventBus: bus,
-            dateUtil: dateUtil
+            contextStore: makeContextStore(userId: "user_42"),
+            eventBus: bus
         )
 
-        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter) // fresh HTTP fails → row persists
+        await tracker.flushPending() // replay hands the persisted row to EventBus
 
-        // Anonymous capture: stamped userId is nil. HTTP path can't attribute,
-        // so the row is handed off to EventBus → DataPipeline (anonymous track)
-        // and drained from disk.
-        #expect(delivery.trackMetricCallsCount == 0)
-        #expect(await pending.loadAll().isEmpty)
-
-        let posted = postedGeofenceEvents(from: bus)
-        #expect(posted.count == 1)
-        #expect(posted.first?.geofenceId == "geo_1")
-        #expect(posted.first?.transition == .enter)
-        #expect(posted.first?.timestamp == captureTime)
+        // Fresh delivery goes out over HTTP; the replay over EventBus. Both carry the same
+        // transitionId (minted at capture, reloaded from disk verbatim) so the server dedupes them.
+        let httpTransitionId = delivery.trackMetricReceivedInvocations.map(\.metric).first?.transitionId
+        let busTransitionId = postedGeofenceEvents(from: bus).first?.transitionId
+        #expect(delivery.trackMetricCallsCount == 1)
+        #expect(postedGeofenceEvents(from: bus).count == 1)
+        #expect(httpTransitionId?.isEmpty == false)
+        #expect(httpTransitionId == busTransitionId)
     }
 
     // MARK: - Cooldown
@@ -313,7 +289,7 @@ struct GeofenceEventTrackerTests {
     // MARK: - flushPending
 
     @Test
-    func flushPending_givenQueuedMetricsAndUserId_expectDeliveredAndDrained() async {
+    func flushPending_givenQueuedMetricsAndUserId_expectPostedToEventBusAndDrained() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let pending = makePendingStore(directory: dir)
@@ -332,51 +308,25 @@ struct GeofenceEventTrackerTests {
         #expect(await pending.loadAll().count == 2)
 
         let delivery = GeofenceDeliveryTrackerMock()
-        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
+        let bus = EventBusHandlerMock()
         let tracker = makeTracker(
             storage: makeStorage(directory: dir),
             pendingStore: pending,
             deliveryTracker: delivery,
-            contextStore: makeContextStore(userId: "user_42")
+            contextStore: makeContextStore(userId: "user_42"),
+            eventBus: bus
         )
 
         await tracker.flushPending()
 
-        #expect(delivery.trackMetricCallsCount == 2)
+        // Replay hands the backlog to EventBus → DataPipeline, not the direct-HTTP channel.
+        #expect(postedGeofenceEvents(from: bus).count == 2)
+        #expect(delivery.trackMetricCallsCount == 0)
         #expect(await pending.loadAll().isEmpty)
     }
 
     @Test
-    func flushPending_givenDeliveryFailure_expectQueueRetainedNoEventBus() async {
-        let dir = makeTempDirectory()
-        defer { try? FileManager.default.removeItem(at: dir) }
-        let pending = makePendingStore(directory: dir)
-        let failingDelivery = GeofenceDeliveryTrackerMock()
-        failingDelivery.trackMetricClosure = { _, _, onComplete in
-            onComplete(.failure(.http(statusCode: 503)))
-        }
-        let priorTracker = makeTracker(
-            storage: makeStorage(directory: dir),
-            pendingStore: pending,
-            deliveryTracker: failingDelivery,
-            contextStore: makeContextStore(userId: "user_42")
-        )
-        await priorTracker.trackTransition(geofenceId: "geo_1", transition: .enter)
-
-        let tracker = makeTracker(
-            storage: makeStorage(directory: dir),
-            pendingStore: pending,
-            deliveryTracker: failingDelivery,
-            contextStore: makeContextStore(userId: "user_42")
-        )
-
-        await tracker.flushPending()
-
-        #expect(await pending.loadAll().count == 1)
-    }
-
-    @Test
-    func concurrentFlushPending_expectEachMetricDeliveredOnce() async {
+    func concurrentFlushPending_expectDrainedAndEachMetricPostedAtLeastOnce() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let pending = makePendingStore(directory: dir)
@@ -393,30 +343,30 @@ struct GeofenceEventTrackerTests {
         await priorTracker.trackTransition(geofenceId: "geo_1", transition: .enter)
         await priorTracker.trackTransition(geofenceId: "geo_2", transition: .enter)
 
-        let delivery = GeofenceDeliveryTrackerMock()
-        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
+        let bus = EventBusHandlerMock()
         let tracker = makeTracker(
             storage: makeStorage(directory: dir),
             pendingStore: pending,
-            deliveryTracker: delivery,
-            contextStore: makeContextStore(userId: "user_42")
+            deliveryTracker: GeofenceDeliveryTrackerMock(),
+            contextStore: makeContextStore(userId: "user_42"),
+            eventBus: bus
         )
 
-        // Fire two flushPending calls in parallel; active-delivery dedup must prevent
-        // either metric from being delivered twice.
+        // Fire two flushPending calls in parallel. Delivery is at-least-once by design: two flushes
+        // reading the same snapshot may double-post a row (deduped downstream by transitionId).
+        // Both metrics are delivered and the store is drained.
         async let flush1: Void = tracker.flushPending()
         async let flush2: Void = tracker.flushPending()
         _ = await(flush1, flush2)
 
-        #expect(delivery.trackMetricCallsCount == 2)
+        #expect(Set(postedGeofenceEvents(from: bus).map(\.geofenceId)) == ["geo_1", "geo_2"])
         #expect(await pending.loadAll().isEmpty)
     }
 
     @Test
-    func flushPending_givenAnonymousCaptureThenIdentify_expectNoHttpBackfill() async {
-        // Regression: anonymous transitions must NOT auto-deliver as the next
-        // identified user via HTTP — they go through EventBus at capture time,
-        // not through HTTP after identify (which would mis-attribute).
+    func trackTransition_givenAnonymousCaptureThenIdentify_expectNoBackfill() async {
+        // Regression: an anonymous crossing is dropped at capture, so a later identify must NOT
+        // backfill it — there is no persisted row to attribute to the newly-identified user.
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let pending = makePendingStore(directory: dir)
@@ -433,16 +383,16 @@ struct GeofenceEventTrackerTests {
         )
 
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
-        // Anonymous capture posts to EventBus and drains the queue at capture time.
+        // Dropped at capture: nothing queued, nothing posted.
         #expect(await pending.loadAll().isEmpty)
-        #expect(postedGeofenceEvents(from: bus).count == 1)
+        #expect(postedGeofenceEvents(from: bus).isEmpty)
 
         contextStore.setUserId("user_42")
         await tracker.flushPending()
 
-        // No HTTP backfill, no second EventBus post — the row is already gone.
+        // Identify can't resurrect a crossing that was never persisted.
         #expect(delivery.trackMetricCallsCount == 0)
-        #expect(postedGeofenceEvents(from: bus).count == 1)
+        #expect(postedGeofenceEvents(from: bus).isEmpty)
     }
 
     // MARK: - userId stamping
@@ -471,7 +421,7 @@ struct GeofenceEventTrackerTests {
     }
 
     @Test
-    func flushPending_givenRowStampedDifferentFromCurrent_expectStampedUserIdUsed() async {
+    func flushPending_givenRowStampedDifferentFromCurrent_expectPinnedUserIdOnEvent() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let pending = makePendingStore(directory: dir)
@@ -483,23 +433,24 @@ struct GeofenceEventTrackerTests {
             name: nil,
             transitionId: "txn_a"
         )])
-        let delivery = GeofenceDeliveryTrackerMock()
-        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
+        let bus = EventBusHandlerMock()
         let tracker = makeTracker(
             storage: makeStorage(directory: dir),
             pendingStore: pending,
-            deliveryTracker: delivery,
-            contextStore: makeContextStore(userId: "user_B")
+            deliveryTracker: GeofenceDeliveryTrackerMock(),
+            contextStore: makeContextStore(userId: "user_B"),
+            eventBus: bus
         )
 
         await tracker.flushPending()
 
-        #expect(delivery.trackMetricCallsCount == 1)
-        #expect(delivery.trackMetricReceivedArguments?.userId == "user_A")
+        // The event carries the snapshot userId so DataPipeline pins the track to user_A, not the
+        // current user_B.
+        #expect(postedGeofenceEvents(from: bus).first?.userId == "user_A")
     }
 
     @Test
-    func flushPending_givenStampedUserId_andNoCurrent_expectDeliveredWithStamped() async {
+    func flushPending_givenStampedUserId_andNoCurrent_expectEventCarriesStamped() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let pending = makePendingStore(directory: dir)
@@ -510,54 +461,18 @@ struct GeofenceEventTrackerTests {
             name: nil,
             transitionId: "txn_a"
         )])
-        let delivery = GeofenceDeliveryTrackerMock()
-        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
-        let tracker = makeTracker(
-            storage: makeStorage(directory: dir),
-            pendingStore: pending,
-            deliveryTracker: delivery,
-            contextStore: makeContextStore()
-        )
-
-        await tracker.flushPending()
-
-        #expect(delivery.trackMetricReceivedArguments?.userId == "user_A")
-    }
-
-    @Test
-    func flushPending_givenNilUserIdOnRow_expectEventBusPostNoHttpCall() async {
-        let dir = makeTempDirectory()
-        defer { try? FileManager.default.removeItem(at: dir) }
-        let pending = makePendingStore(directory: dir)
-        // Row with no stamped userId (anonymous capture or legacy pre-upgrade).
-        let capturedAt = Date(timeIntervalSince1970: 1700000000)
-        _ = await pending.append([PendingGeofenceMetric(
-            geofenceId: "geo_1", transition: .enter,
-            timestamp: capturedAt,
-            userId: nil,
-            name: nil,
-            transitionId: "txn_a"
-        )])
-        let delivery = GeofenceDeliveryTrackerMock()
         let bus = EventBusHandlerMock()
         let tracker = makeTracker(
             storage: makeStorage(directory: dir),
             pendingStore: pending,
-            deliveryTracker: delivery,
-            // Current user is set — proving that the live userId is NOT used as a fallback;
-            // the row is anonymous-tracked via EventBus instead.
-            contextStore: makeContextStore(userId: "user_current"),
+            deliveryTracker: GeofenceDeliveryTrackerMock(),
+            contextStore: makeContextStore(),
             eventBus: bus
         )
 
         await tracker.flushPending()
 
-        #expect(delivery.trackMetricCallsCount == 0)
-        #expect(await pending.loadAll().isEmpty)
-
-        let posted = postedGeofenceEvents(from: bus)
-        #expect(posted.count == 1)
-        #expect(posted.first?.timestamp == capturedAt)
+        #expect(postedGeofenceEvents(from: bus).first?.userId == "user_A")
     }
 
     // MARK: - Geofence name resolution
@@ -686,16 +601,15 @@ struct GeofenceEventTrackerTests {
 
         // Server updated the tier; the cache now reflects it.
         await seedGeofence(storage, id: "geo_1", name: "HQ", metadata: ["tier": .string("platinum")])
-        let delivery = GeofenceDeliveryTrackerMock()
-        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
+        let bus = EventBusHandlerMock()
         let tracker = makeTracker(
-            storage: storage, pendingStore: pending, deliveryTracker: delivery,
-            contextStore: makeContextStore(userId: "user_42")
+            storage: storage, pendingStore: pending, deliveryTracker: GeofenceDeliveryTrackerMock(),
+            contextStore: makeContextStore(userId: "user_42"), eventBus: bus
         )
 
         await tracker.flushPending()
 
-        #expect(delivery.trackMetricReceivedArguments?.metric.metadata == ["tier": .string("platinum")])
+        #expect(postedGeofenceEvents(from: bus).first?.metadata == ["tier": .string("platinum")])
     }
 
     @Test
@@ -716,34 +630,13 @@ struct GeofenceEventTrackerTests {
 
         await storage.setCachedGeofences([]) // geofence evicted
 
-        let delivery = GeofenceDeliveryTrackerMock()
-        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
+        let bus = EventBusHandlerMock()
         let tracker = makeTracker(
-            storage: storage, pendingStore: pending, deliveryTracker: delivery,
-            contextStore: makeContextStore(userId: "user_42")
+            storage: storage, pendingStore: pending, deliveryTracker: GeofenceDeliveryTrackerMock(),
+            contextStore: makeContextStore(userId: "user_42"), eventBus: bus
         )
 
         await tracker.flushPending()
-
-        #expect(delivery.trackMetricReceivedArguments?.metric.metadata == ["tier": .string("gold")])
-    }
-
-    @Test
-    func trackTransition_givenAnonymousAndCachedMetadata_expectEventBusEventCarriesMetadata() async {
-        // The EventBus (anonymous) path must carry metadata too, not just the HTTP path.
-        let dir = makeTempDirectory()
-        defer { try? FileManager.default.removeItem(at: dir) }
-        let storage = makeStorage(directory: dir)
-        await seedGeofence(storage, id: "geo_1", name: "HQ", metadata: ["tier": .string("gold")])
-        let pending = makePendingStore(directory: dir)
-        let bus = EventBusHandlerMock()
-        let tracker = makeTracker(
-            storage: storage, pendingStore: pending,
-            deliveryTracker: GeofenceDeliveryTrackerMock(),
-            contextStore: makeContextStore(), eventBus: bus
-        )
-
-        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
 
         #expect(postedGeofenceEvents(from: bus).first?.metadata == ["tier": .string("gold")])
     }
@@ -765,16 +658,15 @@ struct GeofenceEventTrackerTests {
         await priorTracker.trackTransition(geofenceId: "geo_1", transition: .enter)
 
         await seedGeofence(storage, id: "geo_1", name: "New HQ", metadata: [:])
-        let delivery = GeofenceDeliveryTrackerMock()
-        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
+        let bus = EventBusHandlerMock()
         let tracker = makeTracker(
-            storage: storage, pendingStore: pending, deliveryTracker: delivery,
-            contextStore: makeContextStore(userId: "user_42")
+            storage: storage, pendingStore: pending, deliveryTracker: GeofenceDeliveryTrackerMock(),
+            contextStore: makeContextStore(userId: "user_42"), eventBus: bus
         )
 
         await tracker.flushPending()
 
-        #expect(delivery.trackMetricReceivedArguments?.metric.name == "New HQ")
+        #expect(postedGeofenceEvents(from: bus).first?.name == "New HQ")
     }
 
     // MARK: - Geoset fan-out
@@ -920,30 +812,38 @@ struct GeofenceEventTrackerTests {
     }
 
     @Test
-    func trackTransition_givenTwoGeosetsAnonymous_expectOneEventBusEventPerGeoset() async {
+    func flushPending_givenTwoGeosetRows_expectOneEventBusEventPerGeoset() async {
+        // The geoset fan-out survives the EventBus flush: two persisted rows → two posts, each with
+        // its own geosetId, all sharing the crossing's transitionId.
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let storage = makeStorage(directory: dir)
         await seedGeofence(storage, id: "geo_1", name: "HQ", geosetIds: ["set_y", "set_z"])
         let pending = makePendingStore(directory: dir)
-        let delivery = GeofenceDeliveryTrackerMock()
+        // Fail the fresh HTTP send so both fan-out rows persist for the flush to replay.
+        let failing = GeofenceDeliveryTrackerMock()
+        failing.trackMetricClosure = { _, _, onComplete in onComplete(.failure(.transport)) }
+        let priorTracker = makeTracker(
+            storage: storage, pendingStore: pending, deliveryTracker: failing,
+            contextStore: makeContextStore(userId: "user_42")
+        )
+        await priorTracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+
         let bus = EventBusHandlerMock()
         let tracker = makeTracker(
-            storage: storage,
-            pendingStore: pending,
-            deliveryTracker: delivery,
-            contextStore: makeContextStore(),
-            eventBus: bus
+            storage: storage, pendingStore: pending,
+            deliveryTracker: GeofenceDeliveryTrackerMock(),
+            contextStore: makeContextStore(userId: "user_42"), eventBus: bus
         )
 
-        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+        await tracker.flushPending()
 
-        #expect(delivery.trackMetricCallsCount == 0)
         #expect(await pending.loadAll().isEmpty)
         let posted = postedGeofenceEvents(from: bus)
         #expect(posted.count == 2)
         #expect(Set(posted.compactMap(\.geosetId)) == ["set_y", "set_z"]) // delivery order is not guaranteed (concurrent)
         #expect(posted.allSatisfy { $0.geofenceId == "geo_1" })
+        #expect(Set(posted.map(\.transitionId)).count == 1)
     }
 
     @Test
@@ -999,7 +899,7 @@ struct GeofenceEventTrackerTests {
     }
 
     @Test
-    func flushPending_givenQueuedRow_expectReplayRunsInsideBackgroundTask() async {
+    func flushPending_expectNoBackgroundTaskAndHandoffToEventBus() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let pending = makePendingStore(directory: dir)
@@ -1015,42 +915,23 @@ struct GeofenceEventTrackerTests {
             )
         ])
         let runner = SpyBackgroundTaskRunner()
-        let delivery = GeofenceDeliveryTrackerMock()
-        delivery.trackMetricClosure = { _, _, onComplete in
-            runner.record("deliver")
-            onComplete(.success(()))
-        }
+        let bus = EventBusHandlerMock()
         let tracker = makeTracker(
             storage: makeStorage(directory: dir),
             pendingStore: pending,
-            deliveryTracker: delivery,
-            contextStore: makeContextStore(userId: "user_42"),
-            backgroundTaskRunner: runner
-        )
-
-        await tracker.flushPending()
-
-        #expect(runner.callCount.wrappedValue == 1)
-        #expect(runner.events.wrappedValue == ["begin", "deliver", "end"])
-    }
-
-    @Test
-    func flushPending_givenEmptyQueue_expectNoBackgroundTaskRequested() async {
-        let dir = makeTempDirectory()
-        defer { try? FileManager.default.removeItem(at: dir) }
-        let runner = SpyBackgroundTaskRunner()
-        let tracker = makeTracker(
-            storage: makeStorage(directory: dir),
-            pendingStore: makePendingStore(directory: dir),
             deliveryTracker: GeofenceDeliveryTrackerMock(),
             contextStore: makeContextStore(userId: "user_42"),
+            eventBus: bus,
             backgroundTaskRunner: runner
         )
 
         await tracker.flushPending()
 
-        // Nothing to replay → no background time requested.
+        // The replay hands off to EventBus → DataPipeline, which owns delivery — so no background-task
+        // assertion is taken (that is only for the fresh HTTP send). The row is posted and drained.
         #expect(runner.callCount.wrappedValue == 0)
+        #expect(postedGeofenceEvents(from: bus).count == 1)
+        #expect(await pending.loadAll().isEmpty)
     }
 }
 

--- a/Tests/LocationGeofence/Geofence/Storage/PendingGeofenceMetricStoreTests.swift
+++ b/Tests/LocationGeofence/Geofence/Storage/PendingGeofenceMetricStoreTests.swift
@@ -23,7 +23,7 @@ struct PendingGeofenceMetricStoreTests {
             geofenceId: geofenceId,
             transition: transition,
             timestamp: Date(timeIntervalSince1970: 1700000000),
-            userId: nil,
+            userId: "user_store",
             name: nil,
             transitionId: transitionId
         )
@@ -78,7 +78,7 @@ struct PendingGeofenceMetricStoreTests {
     func decode_givenLegacyRowWithoutMetadata_expectNilMetadata() throws {
         // A row persisted before metadata existed must still decode (missing key → nil).
         let legacy = """
-        {"geofence_id":"geo_1","transition":"enter","timestamp":1,"transition_id":"txn_1"}
+        {"geofence_id":"geo_1","transition":"enter","timestamp":1,"user_id":"user_1","transition_id":"txn_1"}
         """
         let metric = try JSONDecoder().decode(PendingGeofenceMetric.self, from: Data(legacy.utf8))
         #expect(metric.metadata == nil)
@@ -189,56 +189,6 @@ struct PendingGeofenceMetricStoreTests {
         #expect(items.count == 1)
     }
 
-    // MARK: - RemoveAll
-
-    @Test
-    func removeAll_givenAllPresent_expectAllRemoved() async {
-        let dir = makeTempDirectory()
-        defer { try? FileManager.default.removeItem(at: dir) }
-        let store = makeStore(directory: dir)
-        let first = makeMetric(geofenceId: "geo_1")
-        let second = makeMetric(geofenceId: "geo_2")
-        _ = await store.append([first])
-        _ = await store.append([second])
-
-        let success = await store.removeAll(keys: [first.key, second.key])
-        let items = await store.loadAll()
-
-        #expect(success == true)
-        #expect(items.isEmpty)
-    }
-
-    @Test
-    func removeAll_givenPartialMatch_expectOnlyMatchingRemoved() async {
-        let dir = makeTempDirectory()
-        defer { try? FileManager.default.removeItem(at: dir) }
-        let store = makeStore(directory: dir)
-        let toKeep = makeMetric(geofenceId: "keep")
-        let toRemove = makeMetric(geofenceId: "remove")
-        _ = await store.append([toKeep])
-        _ = await store.append([toRemove])
-
-        let success = await store.removeAll(keys: [toRemove.key, "nonexistent_key"])
-        let items = await store.loadAll()
-
-        #expect(success == true)
-        #expect(items == [toKeep])
-    }
-
-    @Test
-    func removeAll_givenEmptySet_expectNoOp() async {
-        let dir = makeTempDirectory()
-        defer { try? FileManager.default.removeItem(at: dir) }
-        let store = makeStore(directory: dir)
-        _ = await store.append([makeMetric()])
-
-        let success = await store.removeAll(keys: [])
-        let items = await store.loadAll()
-
-        #expect(success == true)
-        #expect(items.count == 1)
-    }
-
     // MARK: - Append dedup + atomic fan-out
 
     @Test
@@ -270,11 +220,11 @@ struct PendingGeofenceMetricStoreTests {
         // (geofenceId, transition, timestamp), distinct geosetId suffixes. Persisted atomically.
         let rowY = PendingGeofenceMetric(
             geofenceId: "geo_1", transition: .enter, timestamp: timestamp,
-            userId: nil, name: nil, transitionId: "txn", geosetId: "set_y"
+            userId: "user_1", name: nil, transitionId: "txn", geosetId: "set_y"
         )
         let rowZ = PendingGeofenceMetric(
             geofenceId: "geo_1", transition: .enter, timestamp: timestamp,
-            userId: nil, name: nil, transitionId: "txn", geosetId: "set_z"
+            userId: "user_1", name: nil, transitionId: "txn", geosetId: "set_z"
         )
 
         let appended = await store.append([rowY, rowZ])
@@ -305,7 +255,7 @@ struct PendingGeofenceMetricStoreTests {
         // Rows persisted by pre-geoset SDK versions have no `geoset_id` field and
         // must keep decoding after an upgrade.
         let legacyJson = """
-        {"geofence_id":"geo_1","transition":"enter","timestamp":1700000000,"transition_id":"txn_legacy"}
+        {"geofence_id":"geo_1","transition":"enter","timestamp":1700000000,"user_id":"user_1","transition_id":"txn_legacy"}
         """
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .secondsSince1970
@@ -313,22 +263,6 @@ struct PendingGeofenceMetricStoreTests {
 
         #expect(metric.geosetId == nil)
         #expect(metric.key == "geo_1_enter_1700000000")
-    }
-
-    // MARK: - Clear
-
-    @Test
-    func clearAll_givenItems_expectEmpty() async {
-        let dir = makeTempDirectory()
-        defer { try? FileManager.default.removeItem(at: dir) }
-        let store = makeStore(directory: dir)
-        _ = await store.append([makeMetric(geofenceId: "geo_1")])
-        _ = await store.append([makeMetric(geofenceId: "geo_2")])
-
-        await store.clearAll()
-        let items = await store.loadAll()
-
-        #expect(items.isEmpty)
     }
 
     // MARK: - Persistence across instances
@@ -366,14 +300,14 @@ struct PendingGeofenceMetricStoreTests {
                                 geofenceId: "geo_\(i)_\(j)",
                                 transition: .enter,
                                 timestamp: Date(),
-                                userId: nil,
+                                userId: "user_1",
                                 name: nil,
                                 transitionId: "txn_\(i)_\(j)"
                             )])
                         case 1:
                             _ = await store.loadAll()
                         case 2:
-                            await store.clearAll()
+                            _ = await store.remove(key: "geo_\(i)_\(j)_enter_0")
                         default:
                             break
                         }

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -618,9 +618,10 @@ public final class CioInternalCommon.TrackGeofenceMetricEvent {
 	public final val timestamp: Date;
 	public final val name: String?;
 	public final val transitionId: String;
+	public final val userId: String;
 	public final val geosetId: String?;
 	public final val metadata: List<String : GeofenceMetadataValue>?;
-	public fun init(storageId: String = UUID().uuidString, geofenceId: String, transition: GeofenceTransition, timestamp: Date = Date(), name: String?, transitionId: String, geosetId: String? = nil, metadata: List<String: GeofenceMetadataValue>? = nil, params: List<String: String> = List<:>);
+	public fun init(storageId: String = UUID().uuidString, geofenceId: String, transition: GeofenceTransition, timestamp: Date = Date(), name: String?, transitionId: String, userId: String, geosetId: String? = nil, metadata: List<String: GeofenceMetadataValue>? = nil, params: List<String: String> = List<:>);
 }
 public final class CioInternalCommon.TrackInAppMetricEvent {
 	public final val storageId: String;


### PR DESCRIPTION
Addresses review feedback from the geoset delivery PRs.

Ticket: [MBL-2087](https://linear.app/customerio/issue/MBL-2087/mobile-address-geosets-prs-review-feedback)

## Fixes
- **Silent-location doc**: corrected — a silent fix *is* observable via `getLastKnownLocation` (unpersisted, no analytics/enrichment); geofencing anchors its refresh on it.
- **Removed unused pending-store APIs** (`removeAll(keys:)`, `clearAll`) whose only reference was their own tests; `clearAll`'s doc also implied a sign-out wipe that contradicts the retain-for-replay policy.
- **Drop anonymous transitions at capture** — geofencing is identified-only (the backend rejects anonymous geofence tracks), so an anonymous crossing is dropped before cooldown/persist instead of being sent anonymously and wrongly treated as delivered.
- **Split delivery by attempt** (Android parity): a fresh transition goes out over direct HTTP (works before DataPipeline is up on a cold-wake); the `flushPending` replay hands the backlog to EventBus → DataPipeline (publish-then-remove).
- **Pinned attribution on replay**: `TrackGeofenceMetricEvent` now carries the snapshot `userId`, which the DataPipeline observer pins onto the track (with timestamp) so a delayed replay attributes to the crossing's user and time, not the current identity/send time.

## Notes
- Base is `feature/geofence-on-device`; the umbrella feature→main PR is #1130.
- Verified against Android review-fix commit `f6747557` — full parity on everything this touches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes geofence delivery channels and identity attribution on replay; behavior is covered by extensive test updates but affects analytics correctness and cold-wake delivery paths.
> 
> **Overview**
> Geofence transitions are now **identified-only**: crossings with no user at capture are dropped before cooldown or persistence (backend rejects anonymous tracks), with a new debug log for that case.
> 
> **Delivery is split by attempt** (Android parity): a fresh transition still goes out over **direct HTTP** under a background task; **`flushPending` replays** the on-disk queue via **EventBus → DataPipeline** only (no HTTP retry on flush, no background assertion on replay).
> 
> **Attribution is pinned on replay**: `TrackGeofenceMetricEvent` and pending rows require a snapshot **`userId`**; DataPipeline sets `trackEvent.userId` from the event (with the existing timestamp pin) so delayed replay does not follow the current identity. EventBus posts use **`postEventAndWait`** so rows are removed only after handoff resolves.
> 
> Removes unused **`PendingGeofenceMetricStore.clearAll`** / **`removeAll(keys:)`**. Updates **`requestLocationUpdateSilently`** docs to note the in-memory last-known fix is visible via **`getLastKnownLocation`** for geofencing refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b561091a079dfdd220f2917301104ebd7662e8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->