### PR TITLE
fix(inbox): overlay QA fixes + dedicated CDP metric events

### DIFF
--- a/Sources/MessagingInApp/Inbox/Data/VisualInboxSPI.swift
+++ b/Sources/MessagingInApp/Inbox/Data/VisualInboxSPI.swift
@@ -240,6 +240,9 @@ final class VisualInboxProviderImpl: VisualInboxProvider, @unchecked Sendable {
     func brandingChrome() async -> VisualInboxChrome? {
         guard let branding = await repository.branding() else { return nil }
         let chrome = branding.chrome
+        // `unreadIndicator.text` is a raw token dictionary (`{ color, fontSize }`); pull out the badge
+        // count text color + size so the overlay can style the badge from branding (MBL-2126).
+        let badgeText = chrome.unreadIndicator?.text
         return VisualInboxChrome(
             bellBackground: chrome.floatingIcon.background,
             bellIconColor: chrome.floatingIcon.color,
@@ -247,6 +250,8 @@ final class VisualInboxProviderImpl: VisualInboxProvider, @unchecked Sendable {
             panelBackground: chrome.background,
             dividerColor: chrome.dividerColor ?? chrome.borderColor,
             badgeBackground: chrome.unreadIndicator?.background,
+            badgeTextColor: badgeText?["color"] as? String,
+            badgeTextSize: (badgeText?["fontSize"] as? NSNumber)?.doubleValue,
             cornerRadius: chrome.cornerRadius,
             position: chrome.position,
             showUnreadBadge: chrome.unreadIndicator?.showAlert,
@@ -295,8 +300,9 @@ final class VisualInboxProviderImpl: VisualInboxProvider, @unchecked Sendable {
         }
         // Track a "clicked" metric for the non-dismiss action via the existing headless
         // trackMessageClicked plumbing (dispatches the .trackClicked action). Always tracked,
-        // independent of whether the host intercepts the action below.
-        inbox.trackMessageClicked(message: message, actionName: actionName)
+        // independent of whether the host intercepts the action below. The action value is carried
+        // through so the `Report Delivery Event` (metric: clicked) includes it, matching web (MBL-2125).
+        inbox.trackMessageClicked(message: message, actionName: actionName, actionValue: actionValue)
         // Forward to the host listener on the main actor: this runs from an async Task off the main
         // thread, but the tap originated on the UI and hosts expect a main-thread callback. If it
         // handles the action, the overlay suppresses default navigation.

--- a/Sources/MessagingInApp/Inbox/Data/VisualInboxSPITypes.swift
+++ b/Sources/MessagingInApp/Inbox/Data/VisualInboxSPITypes.swift
@@ -86,6 +86,12 @@ public struct VisualInboxChrome: Equatable {
     public let dividerColor: String?
     /// `patterns.inbox.unreadIndicator.background` — the unread badge fill.
     public let badgeBackground: String?
+    /// `patterns.inbox.unreadIndicator.text.color` — the unread badge count text color (hex string).
+    /// nil when not configured; the overlay falls back to white.
+    public let badgeTextColor: String?
+    /// `patterns.inbox.unreadIndicator.text.fontSize` — the unread badge count text size (points).
+    /// nil when not configured; the overlay falls back to its caption size.
+    public let badgeTextSize: Double?
     /// `patterns.inbox.cornerRadius` — the panel corner radius (points).
     public let cornerRadius: Double?
     /// `patterns.inbox.position` — where the floating bell anchors (e.g. `bottom-right`, `bottom-left`,
@@ -106,6 +112,8 @@ public struct VisualInboxChrome: Equatable {
         panelBackground: String?,
         dividerColor: String?,
         badgeBackground: String?,
+        badgeTextColor: String?,
+        badgeTextSize: Double?,
         cornerRadius: Double?,
         position: String?,
         showUnreadBadge: Bool?,
@@ -117,6 +125,8 @@ public struct VisualInboxChrome: Equatable {
         self.panelBackground = panelBackground
         self.dividerColor = dividerColor
         self.badgeBackground = badgeBackground
+        self.badgeTextColor = badgeTextColor
+        self.badgeTextSize = badgeTextSize
         self.cornerRadius = cornerRadius
         self.position = position
         self.showUnreadBadge = showUnreadBadge
@@ -130,6 +140,8 @@ public struct VisualInboxChrome: Equatable {
             lhs.panelBackground == rhs.panelBackground &&
             lhs.dividerColor == rhs.dividerColor &&
             lhs.badgeBackground == rhs.badgeBackground &&
+            lhs.badgeTextColor == rhs.badgeTextColor &&
+            lhs.badgeTextSize == rhs.badgeTextSize &&
             lhs.cornerRadius == rhs.cornerRadius &&
             lhs.position == rhs.position &&
             lhs.showUnreadBadge == rhs.showUnreadBadge &&

--- a/Sources/MessagingInApp/Inbox/DefaultNotificationInbox.swift
+++ b/Sources/MessagingInApp/Inbox/DefaultNotificationInbox.swift
@@ -168,7 +168,11 @@ class DefaultNotificationInbox: NotificationInbox, @unchecked Sendable {
     }
 
     func trackMessageClicked(message: InboxMessage, actionName: String?) {
-        inAppMessageManager.dispatch(action: .inboxAction(action: .trackClicked(message: message, actionName: actionName)))
+        trackMessageClicked(message: message, actionName: actionName, actionValue: nil)
+    }
+
+    func trackMessageClicked(message: InboxMessage, actionName: String?, actionValue: String?) {
+        inAppMessageManager.dispatch(action: .inboxAction(action: .trackClicked(message: message, actionName: actionName, actionValue: actionValue)))
     }
 
     func setInboxEventListener(_ listener: InboxEventListener?) {

--- a/Sources/MessagingInApp/Inbox/NotificationInbox.swift
+++ b/Sources/MessagingInApp/Inbox/NotificationInbox.swift
@@ -64,6 +64,19 @@ public protocol NotificationInbox: Sendable {
     ///   - actionName: Optional name of the action clicked (e.g., "view_details", "dismiss")
     func trackMessageClicked(message: InboxMessage, actionName: String?)
 
+    /// Tracks a click event for an inbox message, carrying the action's value in addition to its name.
+    /// Both are included in the `Report Delivery Event` (metric: clicked) so they reach CDP, matching
+    /// web (which sends `actionName` + `actionValue`) — MBL-2125.
+    ///
+    /// A default implementation forwards to ``trackMessageClicked(message:actionName:)`` (dropping the
+    /// value), so existing conformers need not implement it.
+    ///
+    /// - Parameters:
+    ///   - message: The inbox message that was clicked
+    ///   - actionName: Optional name of the action clicked (e.g., "view_details", "dismiss")
+    ///   - actionValue: Optional value of the action clicked (e.g., the deep link / URL)
+    func trackMessageClicked(message: InboxMessage, actionName: String?, actionValue: String?)
+
     /// Registers (or clears, with `nil`) the host listener notified of inbox message actions.
     /// Used by `MessagingInApp.setInboxEventListener(_:)`; not intended for direct host use.
     func setInboxEventListener(_ listener: InboxEventListener?)
@@ -124,6 +137,12 @@ public extension NotificationInbox {
     /// - Parameter message: The inbox message that was clicked
     func trackMessageClicked(message: InboxMessage) {
         trackMessageClicked(message: message, actionName: nil)
+    }
+
+    /// Default implementation: forwards to ``trackMessageClicked(message:actionName:)``, dropping the
+    /// action value. Concrete conformers (e.g. the SDK's inbox) override to carry the value through.
+    func trackMessageClicked(message: InboxMessage, actionName: String?, actionValue: String?) {
+        trackMessageClicked(message: message, actionName: actionName)
     }
 
     /// Observes all inbox changes without topic filter.

--- a/Sources/MessagingInApp/State/InAppMessageAction.swift
+++ b/Sources/MessagingInApp/State/InAppMessageAction.swift
@@ -34,7 +34,7 @@ enum InAppMessageAction: Equatable {
     enum InboxAction: Equatable {
         case updateOpened(message: InboxMessage, opened: Bool)
         case deleteMessage(message: InboxMessage)
-        case trackClicked(message: InboxMessage, actionName: String?)
+        case trackClicked(message: InboxMessage, actionName: String?, actionValue: String?)
 
         /// The message associated with this inbox action
         var message: InboxMessage {
@@ -43,7 +43,7 @@ enum InAppMessageAction: Equatable {
                 return message
             case .deleteMessage(let message):
                 return message
-            case .trackClicked(let message, _):
+            case .trackClicked(let message, _, _):
                 return message
             }
         }

--- a/Sources/MessagingInApp/State/InAppMessageMiddleware.swift
+++ b/Sources/MessagingInApp/State/InAppMessageMiddleware.swift
@@ -285,6 +285,9 @@ private func handleUpdateOpened(
     if opened {
         logger.logWithModuleTag("Inbox message opened: \(message.describeForLogs)", level: .debug)
         if let deliveryId = message.deliveryId {
+            // Report the opened metric via the generic `Report Delivery Event` (metric: opened) —
+            // this matches web, where the CDP backend renders it as "Opened Inbox Message" for an
+            // inbox delivery. The server open-state PATCH above is separate and still fires.
             eventBusHandler.postEvent(TrackInAppMetricEvent(deliveryID: deliveryId, event: InAppMetric.opened.rawValue))
         }
     }
@@ -301,10 +304,17 @@ private func handleDeleteMessage(message: InboxMessage, state: InAppMessageState
     }
 }
 
-private func handleTrackClicked(message: InboxMessage, actionName: String?, logger: Logger, eventBusHandler: EventBusHandler) {
+private func handleTrackClicked(message: InboxMessage, actionName: String?, actionValue: String?, logger: Logger, eventBusHandler: EventBusHandler) {
     logger.logWithModuleTag("Inbox message clicked: \(message.describeForLogs)", level: .debug)
     if let deliveryId = message.deliveryId {
-        let params = actionName.map { ["actionName": $0] } ?? [:]
+        // Report the clicked metric via the generic `Report Delivery Event` (metric: clicked),
+        // carrying the action name AND value — matching web (the CDP backend renders it as
+        // "Clicked Inbox Message" for an inbox delivery) and mobile in-app clicks.
+        // Omit empty name/value so a value-less action doesn't emit `actionValue: ""` — web omits
+        // the field entirely when there is no value.
+        var params: [String: String] = [:]
+        if let actionName = actionName, !actionName.isEmpty { params["actionName"] = actionName }
+        if let actionValue = actionValue, !actionValue.isEmpty { params["actionValue"] = actionValue }
         eventBusHandler.postEvent(TrackInAppMetricEvent(deliveryID: deliveryId, event: InAppMetric.clicked.rawValue, params: params))
     }
 }
@@ -337,8 +347,8 @@ func inboxMessageMiddleware(logger: Logger, logManager: LogManager, eventBusHand
                     )
                 case .deleteMessage:
                     handleDeleteMessage(message: currentMessage, state: state, logger: logger, logManager: logManager)
-                case .trackClicked(_, let actionName):
-                    handleTrackClicked(message: currentMessage, actionName: actionName, logger: logger, eventBusHandler: eventBusHandler)
+                case .trackClicked(_, let actionName, let actionValue):
+                    handleTrackClicked(message: currentMessage, actionName: actionName, actionValue: actionValue, logger: logger, eventBusHandler: eventBusHandler)
                 }
             } else {
                 logger.logWithModuleTag("Skipping inbox action for \(inboxAction.message.describeForLogs) - message not found in state", level: .debug)

--- a/Sources/MessagingInbox/InboxBellIcon.swift
+++ b/Sources/MessagingInbox/InboxBellIcon.swift
@@ -15,33 +15,70 @@ import SwiftUI
 /// markup and combines the paths.
 @available(iOS 13.0, *)
 struct InboxBellGlyph {
-    let path: Path
+    /// One `<path>` element: its geometry (in viewBox coordinates) + the fill rule to apply to IT.
+    struct Subpath {
+        let path: Path
+        /// Even-odd fill for this path: its declared `fill-rule` (`evenodd` → true), else the root
+        /// `<svg>`'s, else nonzero (the SVG/CSS default). Resolved per-path so a glyph that mixes
+        /// rules renders each path correctly — matching how a browser fills each `<path>` (MBL-2123),
+        /// and matching Android which likewise honors the declared rule per path.
+        let usesEvenOddFill: Bool
+    }
+
+    /// One entry per `<path>` element, filled **independently**. Merging all `<path>`s into a single
+    /// `Path` and applying one fill rule flips winding parity where the paths overlap — punching
+    /// spurious holes/solids that read as a malformed/heavier glyph (MBL-2123). Browsers fill each
+    /// `<path>` on its own (with that path's own rule); stacking per-path fills with a uniform tint
+    /// matches that.
+    let subpaths: [Subpath]
     let viewBox: CGRect
 
     /// Builds a glyph from raw SVG markup (e.g. `<svg viewBox="0 0 24 25"><path d="…"/>…</svg>`), or
     /// nil when there is nothing renderable (no parseable `<path d>`) — the bell then falls back to
     /// the bundled default glyph. Malformed subpaths are skipped rather than failing the whole glyph.
     static func build(fromSVG svg: String) -> InboxBellGlyph? {
-        let pathData = pathData(from: svg)
-        guard !pathData.isEmpty else { return nil }
-        var combined = Path()
-        for data in pathData {
+        let elements = pathElements(from: svg)
+        guard !elements.isEmpty else { return nil }
+        // A `<path>` with no `fill-rule` inherits the root `<svg>`'s, else nonzero (SVG/CSS default).
+        let rootEvenOdd = rootSvgTag(from: svg).flatMap { fillRuleEvenOdd(in: $0) }
+        // Keep each `<path>` separate so it can be filled independently, with its own fill rule.
+        var subpaths: [Subpath] = []
+        for element in elements {
             // Vendored SVGPath (`Path(svgPath:)`); skip any malformed subpath rather than fail whole.
-            if let subpath = try? Path(svgPath: data) {
-                combined.addPath(subpath)
-            }
+            guard let data = pathDValue(in: element),
+                  let path = try? Path(svgPath: data), !path.isEmpty else { continue }
+            let usesEvenOdd = fillRuleEvenOdd(in: element) ?? rootEvenOdd ?? false
+            subpaths.append(Subpath(path: path, usesEvenOddFill: usesEvenOdd))
         }
-        guard !combined.isEmpty else { return nil }
-        // Prefer the declared viewBox; otherwise use the path's own bounds as the coordinate space.
-        return InboxBellGlyph(path: combined, viewBox: viewBox(from: svg) ?? combined.boundingRect)
+        guard !subpaths.isEmpty else { return nil }
+        // Prefer the declared viewBox; otherwise use the union of the paths' bounds as the space.
+        let fallbackBox = subpaths.reduce(CGRect.null) { $0.union($1.path.boundingRect) }
+        return InboxBellGlyph(subpaths: subpaths, viewBox: viewBox(from: svg) ?? fallbackBox)
     }
 
-    // MARK: - SVG extraction (path data + viewBox); parsing delegated to vendored SVGPath
+    // MARK: - SVG extraction (path elements + viewBox + fill-rule); parsing delegated to vendored SVGPath
 
-    /// Extracts every `<path … d="…">` value from the markup. Accepts single- OR double-quoted
-    /// attributes — branding markup (and captured fixtures) use single quotes.
-    private static func pathData(from svg: String) -> [String] {
-        matches(in: svg, pattern: #"<path[^>]*\bd\s*=\s*["']([^"']*)["']"#)
+    /// The full opening tag of every `<path …>` element, so per-path attributes (`d`, `fill-rule`)
+    /// can be read individually. Accepts single- OR double-quoted attributes.
+    private static func pathElements(from svg: String) -> [String] {
+        fullMatches(in: svg, pattern: #"<path\b[^>]*>"#)
+    }
+
+    /// The root `<svg …>` opening tag, if present (for a document-level `fill-rule` fallback).
+    private static func rootSvgTag(from svg: String) -> String? {
+        fullMatches(in: svg, pattern: #"<svg\b[^>]*>"#).first
+    }
+
+    /// The `d` attribute value within a single `<path>` element (single- or double-quoted).
+    private static func pathDValue(in element: String) -> String? {
+        matches(in: element, pattern: #"\bd\s*=\s*["']([^"']*)["']"#).first
+    }
+
+    /// Reads a `fill-rule` (attribute or CSS `style`) from a fragment: `evenodd` → true, `nonzero`
+    /// → false, absent → nil (so the caller falls back to the root rule, then nonzero — the default).
+    private static func fillRuleEvenOdd(in fragment: String) -> Bool? {
+        guard let raw = matches(in: fragment, pattern: #"fill-rule\s*[=:]\s*["']?\s*(evenodd|nonzero)"#).first else { return nil }
+        return raw.lowercased() == "evenodd"
     }
 
     /// Parses a `viewBox="minX minY width height"` attribute (single- or double-quoted), if present.
@@ -64,21 +101,37 @@ struct InboxBellGlyph {
         }
         return results
     }
+
+    /// Returns the whole matched substring of every match of `pattern` in `string` (e.g. a full
+    /// `<path …>` opening tag), used to read per-element attributes.
+    private static func fullMatches(in string: String, pattern: String) -> [String] {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { return [] }
+        let nsString = string as NSString
+        var results: [String] = []
+        regex.enumerateMatches(in: string, range: NSRange(location: 0, length: nsString.length)) { match, _, _ in
+            if let match = match {
+                results.append(nsString.substring(with: match.range))
+            }
+        }
+        return results
+    }
 }
 
 /// Renders a pre-built ``InboxBellGlyph`` as a tint-able SwiftUI `Shape`, fitting it into the target
 /// rect (centered, aspect-preserving). Parsing already happened in ``InboxBellGlyph/build(fromSVG:)``;
 /// `path(in:)` only applies the fit transform, so it stays cheap on every layout pass.
 ///
-/// Fill with `FillStyle(eoFill: true)`: CIO bell glyphs are authored with the even-odd rule (the bell
-/// body is an outlined ring), matching the source SVG's `fill-rule="evenodd"`.
+/// The caller fills each sub-path with `FillStyle(eoFill: subpath.usesEvenOddFill)` so the SVG's own
+/// declared `fill-rule` is honored per-path (MBL-2123) rather than assuming even-odd.
 @available(iOS 13.0, *)
 struct InboxBellIcon: Shape {
-    /// The pre-built glyph to render.
-    let glyph: InboxBellGlyph
+    /// One sub-path from the glyph (viewBox coordinates). Rendered as its own filled shape.
+    let subpath: Path
+    /// The glyph's viewBox — shared across all sub-paths so they fit + align identically.
+    let viewBox: CGRect
 
     func path(in rect: CGRect) -> Path {
-        let box = glyph.viewBox
+        let box = viewBox
         guard box.width > 0, box.height > 0 else { return Path() }
         // Fit the viewBox into rect, centered, preserving aspect ratio (scale then translate).
         let scale = min(rect.width / box.width, rect.height / box.height)
@@ -88,7 +141,7 @@ struct InboxBellIcon: Shape {
         let translateY = rect.minY + (rect.height - scaledHeight) / 2 - box.minY * scale
         let transform = CGAffineTransform(translationX: translateX, y: translateY)
             .scaledBy(x: scale, y: scale)
-        return glyph.path.applying(transform)
+        return subpath.applying(transform)
     }
 }
 #endif

--- a/Sources/MessagingInbox/InboxChromeColors.swift
+++ b/Sources/MessagingInbox/InboxChromeColors.swift
@@ -20,6 +20,11 @@ struct ResolvedInboxColors {
     let panelBackground: Color
     let divider: Color
     let badge: Color
+    /// Unread badge count text color (branding `unreadIndicator.text.color`, else white).
+    let badgeText: Color
+    /// Unread badge count text size in points (branding `unreadIndicator.text.fontSize`), or nil to
+    /// fall back to the caption font.
+    let badgeTextSize: CGFloat?
     let cornerRadius: CGFloat
 
     /// Resolves the chrome colors from the SPI `chrome` payload for the current color scheme.
@@ -54,6 +59,14 @@ struct ResolvedInboxColors {
         let badgeHex = darkInbox.childString("unreadIndicator", "background") ?? chrome?.badgeBackground
         let badge = InboxColorParser.color(from: badgeHex) ?? .red
 
+        // Badge count text color/size from branding `unreadIndicator.text` (MBL-2126). The dark
+        // override (when present) nests as `unreadIndicator.text.{color,fontSize}`; each falls back
+        // to the light chrome value, then to white / caption.
+        let badgeTextHex = darkInbox.grandchildString("unreadIndicator", "text", "color") ?? chrome?.badgeTextColor
+        let badgeText = InboxColorParser.color(from: badgeTextHex) ?? .white
+        let badgeTextSize = (darkInbox.grandchildDouble("unreadIndicator", "text", "fontSize") ?? chrome?.badgeTextSize)
+            .map { CGFloat($0) }
+
         let cornerRadius = CGFloat(chrome?.cornerRadius ?? 12)
 
         return ResolvedInboxColors(
@@ -62,6 +75,8 @@ struct ResolvedInboxColors {
             panelBackground: panelBackground,
             divider: divider,
             badge: badge,
+            badgeText: badgeText,
+            badgeTextSize: badgeTextSize,
             cornerRadius: cornerRadius
         )
     }
@@ -127,6 +142,20 @@ private extension Optional where Wrapped == [String: Any] {
     /// A String from a nested child object (e.g. `floatingIcon.background`), or nil.
     func childString(_ child: String, _ key: String) -> String? {
         (self?[child] as? [String: Any])?[key] as? String
+    }
+
+    /// A String from a doubly-nested object (e.g. `unreadIndicator.text.color`), or nil.
+    func grandchildString(_ child: String, _ grandchild: String, _ key: String) -> String? {
+        ((self?[child] as? [String: Any])?[grandchild] as? [String: Any])?[key] as? String
+    }
+
+    /// A Double from a doubly-nested object (e.g. `unreadIndicator.text.fontSize`), or nil.
+    /// Accepts an NSNumber (the usual JSON case) or a numeric String.
+    func grandchildDouble(_ child: String, _ grandchild: String, _ key: String) -> Double? {
+        let value = ((self?[child] as? [String: Any])?[grandchild] as? [String: Any])?[key]
+        if let number = value as? NSNumber { return number.doubleValue }
+        if let string = value as? String { return Double(string) }
+        return nil
     }
 }
 #endif

--- a/Sources/MessagingInbox/NotificationInboxBell.swift
+++ b/Sources/MessagingInbox/NotificationInboxBell.swift
@@ -76,9 +76,11 @@ public struct NotificationInboxBell: View {
                     .shadow(radius: 4)
 
                 if showsUnreadCount {
+                    // Badge count text color + size come from branding (`unreadIndicator.text`,
+                    // MBL-2126), falling back to white / the caption size when unset.
                     Text("\(model.unopenedCount)")
-                        .font(.caption)
-                        .foregroundColor(.white)
+                        .font(colors.badgeTextSize.map { Font.system(size: $0) } ?? .caption)
+                        .foregroundColor(colors.badgeText)
                         .padding(5)
                         .background(colors.badge)
                         .clipShape(Circle())
@@ -96,8 +98,15 @@ public struct NotificationInboxBell: View {
     @ViewBuilder
     private func bellGlyph(colors: ResolvedInboxColors) -> some View {
         if let glyph = model.bellGlyph {
-            // Even-odd fill matches CIO bell SVGs' `fill-rule="evenodd"` (outlined bell).
-            InboxBellIcon(glyph: glyph).fill(colors.bellIcon, style: FillStyle(eoFill: true))
+            // Fill each <path> INDEPENDENTLY (like the browser) with its OWN declared fill rule so
+            // overlapping paths don't flip each other's winding parity (MBL-2123). Uniform tint → the
+            // stack reads as one glyph.
+            ZStack {
+                ForEach(Array(glyph.subpaths.enumerated()), id: \.offset) { _, subpath in
+                    InboxBellIcon(subpath: subpath.path, viewBox: glyph.viewBox)
+                        .fill(colors.bellIcon, style: FillStyle(eoFill: subpath.usesEvenOddFill))
+                }
+            }
         } else {
             Image("cio-inbox-bell", bundle: .cioInboxResources)
                 .renderingMode(.template)

--- a/Sources/MessagingInbox/NotificationInboxView.swift
+++ b/Sources/MessagingInbox/NotificationInboxView.swift
@@ -108,6 +108,10 @@ public struct NotificationInboxView: View {
         }
     }
 
+    /// Top inset above the first message row so it doesn't hug the sheet grabber (MBL-2122), matching
+    /// the comfortable top margin of the web inbox. Single, easily-tunable value.
+    private static let listTopInset: CGFloat = 16
+
     private var messageList: some View {
         // Branding-first row divider (falls back to the system separator color).
         let colors = ResolvedInboxColors.resolve(chrome: model.chrome, isDark: colorScheme == .dark)
@@ -134,6 +138,7 @@ public struct NotificationInboxView: View {
                     colors.divider.frame(height: 1)
                 }
             }
+            .padding(.top, Self.listTopInset)
         }
     }
 

--- a/Tests/MessagingInApp/Inbox/Data/InboxBrandingTest.swift
+++ b/Tests/MessagingInApp/Inbox/Data/InboxBrandingTest.swift
@@ -74,6 +74,8 @@ class InboxBrandingTest: XCTestCase {
         XCTAssertEqual(chrome?.unreadIndicator?.showAlert, true)
         XCTAssertEqual(chrome?.unreadIndicator?.background, "#e00000")
         XCTAssertEqual(chrome?.unreadIndicator?.text?["fontSize"] as? Int, 8)
+        // Badge count text color travels in the same `unreadIndicator.text` token dict (MBL-2126).
+        XCTAssertEqual(chrome?.unreadIndicator?.text?["color"] as? String, "#ffffff")
     }
 
     func test_from_whenDarkModeAbsent_expectNilDarkModePattern() {

--- a/Tests/MessagingInApp/Inbox/Data/VisualInboxProviderTest.swift
+++ b/Tests/MessagingInApp/Inbox/Data/VisualInboxProviderTest.swift
@@ -27,6 +27,9 @@ final class VisualInboxProviderTest: XCTestCase {
         networkStub = InboxNetworkClientStub()
         inAppMessageManagerMock = InAppMessageManagerMock()
         inAppMessageManagerMock.subscribeReturnValue = Task {}
+        // `observe()` unsubscribes during stream teardown; stub the return value so the mock's
+        // implicitly-unwrapped `unsubscribeReturnValue` isn't nil (avoids a teardown-race crash).
+        inAppMessageManagerMock.unsubscribeReturnValue = Task {}
         keyValueStore = InMemorySharedKeyValueStorage()
         sleeperMock = SleeperMock()
         sleeperMock.sleepClosure = { _ in }
@@ -101,7 +104,11 @@ final class VisualInboxProviderTest: XCTestCase {
               "background": "#ffffff",
               "cornerRadius": 8,
               "position": "top-left",
-              "unreadIndicator": { "showAlert": false, "background": "#e00000" }
+              "unreadIndicator": {
+                "showAlert": false,
+                "background": "#e00000",
+                "text": { "color": "#00ff00", "fontSize": 11 }
+              }
             }
           }
         }
@@ -128,6 +135,9 @@ final class VisualInboxProviderTest: XCTestCase {
         XCTAssertEqual(chrome?.bellIconSvg, "<svg viewBox='0 0 24 25'><path d='M0 0Z'/></svg>")
         XCTAssertEqual(chrome?.position, "top-left")
         XCTAssertEqual(chrome?.showUnreadBadge, false)
+        // Badge count text color + size mapped from `unreadIndicator.text` (MBL-2126).
+        XCTAssertEqual(chrome?.badgeTextColor, "#00ff00")
+        XCTAssertEqual(chrome?.badgeTextSize, 11)
         // Sanity on the surrounding mapping so a field-order/name regression is also caught.
         XCTAssertEqual(chrome?.bellBackground, "#000000")
         XCTAssertEqual(chrome?.bellIconColor, "#ffffff")

--- a/Tests/MessagingInApp/Inbox/NotificationInboxTest.swift
+++ b/Tests/MessagingInApp/Inbox/NotificationInboxTest.swift
@@ -310,13 +310,46 @@ class NotificationInboxTest: UnitTest {
             XCTFail("Expected inboxAction, got different action")
             return
         }
-        guard case .trackClicked(let receivedMessage, let actionName) = inboxAction else {
+        guard case .trackClicked(let receivedMessage, let actionName, let actionValue) = inboxAction else {
             XCTFail("Expected trackClicked action")
             return
         }
         XCTAssertEqual(receivedMessage.queueId, message.queueId)
         XCTAssertEqual(receivedMessage.deliveryId, message.deliveryId)
         XCTAssertEqual(actionName, "view_details")
+        XCTAssertNil(actionValue)
+    }
+
+    func test_trackMessageClicked_withActionValue_expectDispatchesTrackClickedActionWithValue() {
+        // Setup mock to return empty task
+        inAppMessageManagerMock.dispatchReturnValue = Task {}
+
+        let message = InboxMessage(
+            queueId: "queue-1",
+            deliveryId: "delivery-1",
+            expiry: nil,
+            sentAt: Date(),
+            topics: [],
+            type: "",
+            opened: false,
+            priority: nil,
+            properties: [:]
+        )
+
+        notificationInbox.trackMessageClicked(message: message, actionName: "view_details", actionValue: "https://example.com")
+
+        XCTAssertEqual(inAppMessageManagerMock.dispatchCallsCount, 1)
+        guard case .inboxAction(let inboxAction) = inAppMessageManagerMock.dispatchReceivedArguments?.action else {
+            XCTFail("Expected inboxAction, got different action")
+            return
+        }
+        guard case .trackClicked(let receivedMessage, let actionName, let actionValue) = inboxAction else {
+            XCTFail("Expected trackClicked action")
+            return
+        }
+        XCTAssertEqual(receivedMessage.queueId, message.queueId)
+        XCTAssertEqual(actionName, "view_details")
+        XCTAssertEqual(actionValue, "https://example.com")
     }
 
     func test_trackMessageClicked_withoutActionName_expectDispatchesTrackClickedAction() {
@@ -342,7 +375,7 @@ class NotificationInboxTest: UnitTest {
             XCTFail("Expected inboxAction, got different action")
             return
         }
-        guard case .trackClicked(let receivedMessage, let actionName) = inboxAction else {
+        guard case .trackClicked(let receivedMessage, let actionName, _) = inboxAction else {
             XCTFail("Expected trackClicked action")
             return
         }

--- a/Tests/MessagingInApp/State/InAppMessageStateTests.swift
+++ b/Tests/MessagingInApp/State/InAppMessageStateTests.swift
@@ -1777,7 +1777,7 @@ class InAppMessageStateTests: IntegrationTest {
         let initialState = state
 
         // Track clicked
-        await inAppMessageManager.dispatchAsync(action: .inboxAction(action: .trackClicked(message: message, actionName: "view_details")))
+        await inAppMessageManager.dispatchAsync(action: .inboxAction(action: .trackClicked(message: message, actionName: "view_details", actionValue: nil)))
 
         state = await inAppMessageManager.state
         // State should remain unchanged
@@ -1808,7 +1808,7 @@ class InAppMessageStateTests: IntegrationTest {
         let initialState = state
 
         // Track clicked without actionName
-        await inAppMessageManager.dispatchAsync(action: .inboxAction(action: .trackClicked(message: message, actionName: nil)))
+        await inAppMessageManager.dispatchAsync(action: .inboxAction(action: .trackClicked(message: message, actionName: nil, actionValue: nil)))
 
         state = await inAppMessageManager.state
         // State should remain unchanged
@@ -1836,7 +1836,7 @@ class InAppMessageStateTests: IntegrationTest {
         XCTAssertTrue(state.inboxMessages.isEmpty)
 
         // Try to track click for non-existent message
-        await inAppMessageManager.dispatchAsync(action: .inboxAction(action: .trackClicked(message: nonExistentMessage, actionName: "test")))
+        await inAppMessageManager.dispatchAsync(action: .inboxAction(action: .trackClicked(message: nonExistentMessage, actionName: "test", actionValue: nil)))
 
         // State should remain empty
         let finalState = await inAppMessageManager.state

--- a/Tests/MessagingInApp/State/InAppMessageStateTests.swift
+++ b/Tests/MessagingInApp/State/InAppMessageStateTests.swift
@@ -1359,6 +1359,70 @@ class InAppMessageStateTests: IntegrationTest {
         XCTAssertTrue(state.inboxMessages.contains(message1))
     }
 
+    // MARK: - Inbox click metric: `.trackClicked` -> `TrackInAppMetricEvent` middleware mapping
+
+    /// Builds a store manager wired to [eventBusHandler] so a test can inspect the metric events the
+    /// inbox middleware posts. Mirrors the `setUp` wiring but with an injectable event bus.
+    private func makeManager(eventBusHandler: EventBusHandler) -> InAppMessageManager {
+        InAppMessageStoreManager(
+            logger: diGraphShared.logger,
+            threadUtil: diGraphShared.threadUtil,
+            logManager: diGraphShared.logManager,
+            gistDelegate: diGraphShared.gistDelegate,
+            anonymousMessageManager: diGraphShared.anonymousMessageManager,
+            eventBusHandler: eventBusHandler
+        )
+    }
+
+    private func inboxMessage(queueId: String, deliveryId: String?) -> InboxMessage {
+        InboxMessage(queueId: queueId, deliveryId: deliveryId, expiry: nil, sentAt: Date(), topics: [], type: "", opened: false, priority: 5, properties: [:])
+    }
+
+    /// Dispatching `.trackClicked` for a message in state maps to a single clicked
+    /// `TrackInAppMetricEvent` carrying the message's delivery id and BOTH actionName + actionValue.
+    /// Covers the middleware mapping between the action dispatch and the posted metric event (the API
+    /// dispatch and DataPipeline serialization are covered separately elsewhere).
+    func test_trackClickedMiddleware_givenActionNameAndValue_expectClickedMetricWithBoth() async {
+        let eventBus = EventBusHandlerMock()
+        let manager = makeManager(eventBusHandler: eventBus)
+        let message = inboxMessage(queueId: "queue-1", deliveryId: "delivery-1")
+
+        await manager.dispatchAsync(action: .setUserIdentifier(user: "test-user"))
+        await manager.dispatchAsync(action: .processInboxMessages(messages: [message]))
+        eventBus.resetMock() // ignore any events emitted while seeding state
+
+        await manager.dispatchAsync(action: .inboxAction(action: .trackClicked(message: message, actionName: "view_details", actionValue: "https://example.com")))
+
+        let metrics = eventBus.postEventReceivedInvocations.compactMap { $0 as? TrackInAppMetricEvent }
+        XCTAssertEqual(metrics.count, 1, "Expected exactly one clicked metric event")
+        let event = metrics.first
+        XCTAssertEqual(event?.deliveryID, "delivery-1")
+        XCTAssertEqual(event?.event, InAppMetric.clicked.rawValue)
+        XCTAssertEqual(event?.params["actionName"], "view_details")
+        XCTAssertEqual(event?.params["actionValue"], "https://example.com")
+    }
+
+    /// Empty actionName/actionValue are omitted from the metric params entirely (web parity — no
+    /// `actionValue: ""`), while the clicked event + delivery id are still reported.
+    func test_trackClickedMiddleware_givenEmptyActionNameAndValue_expectOmittedFromParams() async {
+        let eventBus = EventBusHandlerMock()
+        let manager = makeManager(eventBusHandler: eventBus)
+        let message = inboxMessage(queueId: "queue-1", deliveryId: "delivery-1")
+
+        await manager.dispatchAsync(action: .setUserIdentifier(user: "test-user"))
+        await manager.dispatchAsync(action: .processInboxMessages(messages: [message]))
+        eventBus.resetMock()
+
+        await manager.dispatchAsync(action: .inboxAction(action: .trackClicked(message: message, actionName: "", actionValue: "")))
+
+        let metrics = eventBus.postEventReceivedInvocations.compactMap { $0 as? TrackInAppMetricEvent }
+        XCTAssertEqual(metrics.count, 1)
+        let event = metrics.first
+        XCTAssertEqual(event?.deliveryID, "delivery-1")
+        XCTAssertEqual(event?.event, InAppMetric.clicked.rawValue)
+        XCTAssertTrue(event?.params.isEmpty ?? false, "Empty actionName/actionValue must be omitted from params")
+    }
+
     func test_inboxMessages_whenMessagePropertyChanges_expectStateChangeDetected() async {
         // Set user ID first to bypass auth middleware
         await inAppMessageManager.dispatchAsync(action: .setUserIdentifier(user: "test-user"))

--- a/Tests/MessagingInbox/InboxBellIconTests.swift
+++ b/Tests/MessagingInbox/InboxBellIconTests.swift
@@ -15,7 +15,8 @@ final class InboxBellIconTests: XCTestCase {
         let svg = #"<svg viewBox="0 0 24 25"><path d="M0 0 L24 0 L24 25 Z"/></svg>"#
         let rect = CGRect(x: 0, y: 0, width: 100, height: 100)
         let glyph = try XCTUnwrap(InboxBellGlyph.build(fromSVG: svg))
-        let path = InboxBellIcon(glyph: glyph).path(in: rect)
+        let subpath = try XCTUnwrap(glyph.subpaths.first).path
+        let path = InboxBellIcon(subpath: subpath, viewBox: glyph.viewBox).path(in: rect)
 
         XCTAssertFalse(path.isEmpty)
         let bounds = path.boundingRect
@@ -33,13 +34,17 @@ final class InboxBellIconTests: XCTestCase {
         // extractor must accept them, otherwise the overlay silently falls back to the bundled bell.
         let svg = "<svg viewBox='0 0 24 25'><path d='M0 0 L24 0 L24 25 Z'/></svg>"
         let glyph = try XCTUnwrap(InboxBellGlyph.build(fromSVG: svg))
-        XCTAssertFalse(InboxBellIcon(glyph: glyph).path(in: CGRect(x: 0, y: 0, width: 50, height: 50)).isEmpty)
+        let subpath = try XCTUnwrap(glyph.subpaths.first).path
+        XCTAssertFalse(InboxBellIcon(subpath: subpath, viewBox: glyph.viewBox).path(in: CGRect(x: 0, y: 0, width: 50, height: 50)).isEmpty)
     }
 
-    func test_bellIcon_givenMultiplePaths_thenParsesAll() throws {
+    func test_bellIcon_givenMultiplePaths_thenKeepsThemSeparate() throws {
         let svg = #"<svg viewBox="0 0 24 25"><path d="M0 0 L10 0 L10 10 Z"/><path d="M12 12 L20 12 L20 20 Z"/></svg>"#
         let glyph = try XCTUnwrap(InboxBellGlyph.build(fromSVG: svg))
-        XCTAssertFalse(InboxBellIcon(glyph: glyph).path(in: CGRect(x: 0, y: 0, width: 50, height: 50)).isEmpty)
+        // Each <path> is kept as its own entry so it can be filled independently (MBL-2123).
+        XCTAssertEqual(glyph.subpaths.count, 2)
+        let subpath = try XCTUnwrap(glyph.subpaths.first).path
+        XCTAssertFalse(InboxBellIcon(subpath: subpath, viewBox: glyph.viewBox).path(in: CGRect(x: 0, y: 0, width: 50, height: 50)).isEmpty)
     }
 
     func test_bellIcon_givenNoPathsOrGarbage_thenReturnsNil() {
@@ -52,6 +57,53 @@ final class InboxBellIconTests: XCTestCase {
         // A path lifted from the actual branding floatingIcon.svg (exponent + signed coords).
         let svg = #"<svg width="24" height="25" viewBox="0 0 24 25"><path fill-rule="evenodd" d="M9.05889 19.1249V19.9686C9.05889 21.3666 10.1922 22.4998 11.5901 22.4998C12.9881 22.4998 14.1214 21.3666 14.1214 19.9686V19.1249H15.8088V19.9686C15.8088 22.2986 13.9201 24.1873 11.5901 24.1873C9.26019 24.1873 7.3714 22.2986 7.3714 19.9686V19.1249H9.05889Z"/></svg>"#
         XCTAssertNotNil(InboxBellGlyph.build(fromSVG: svg))
+    }
+
+    // MARK: - Fill-rule (MBL-2123): honor the source SVG's declared rule instead of forcing even-odd
+
+    func test_bellIcon_givenEvenOddFillRule_thenUsesEvenOddFill() throws {
+        let svg = #"<svg viewBox="0 0 24 25"><path fill-rule="evenodd" d="M0 0 L24 0 L24 25 Z"/></svg>"#
+        let glyph = try XCTUnwrap(InboxBellGlyph.build(fromSVG: svg))
+        XCTAssertTrue(try XCTUnwrap(glyph.subpaths.first).usesEvenOddFill)
+    }
+
+    func test_bellIcon_givenSingleQuotedEvenOddFillRule_thenUsesEvenOddFill() throws {
+        let svg = "<svg viewBox='0 0 24 25'><path fill-rule='evenodd' d='M0 0 L24 0 L24 25 Z'/></svg>"
+        let glyph = try XCTUnwrap(InboxBellGlyph.build(fromSVG: svg))
+        XCTAssertTrue(try XCTUnwrap(glyph.subpaths.first).usesEvenOddFill)
+    }
+
+    func test_bellIcon_givenCssStyleEvenOddFillRule_thenUsesEvenOddFill() throws {
+        let svg = #"<svg viewBox="0 0 24 25"><path style="fill-rule: evenodd" d="M0 0 L24 0 L24 25 Z"/></svg>"#
+        let glyph = try XCTUnwrap(InboxBellGlyph.build(fromSVG: svg))
+        XCTAssertTrue(try XCTUnwrap(glyph.subpaths.first).usesEvenOddFill)
+    }
+
+    func test_bellIcon_givenNoFillRule_thenDefaultsToNonZero() throws {
+        // SVG/CSS default is nonzero — must NOT force even-odd (the pre-fix behavior).
+        let svg = #"<svg viewBox="0 0 24 25"><path d="M0 0 L24 0 L24 25 Z"/></svg>"#
+        let glyph = try XCTUnwrap(InboxBellGlyph.build(fromSVG: svg))
+        XCTAssertFalse(try XCTUnwrap(glyph.subpaths.first).usesEvenOddFill)
+    }
+
+    func test_bellIcon_givenExplicitNonZeroFillRule_thenUsesNonZero() throws {
+        let svg = #"<svg viewBox="0 0 24 25"><path fill-rule="nonzero" d="M0 0 L24 0 L24 25 Z"/></svg>"#
+        let glyph = try XCTUnwrap(InboxBellGlyph.build(fromSVG: svg))
+        XCTAssertFalse(try XCTUnwrap(glyph.subpaths.first).usesEvenOddFill)
+    }
+
+    func test_bellIcon_givenMixedFillRules_thenResolvesPerPath() throws {
+        // Each <path> keeps its OWN rule (not one rule for the whole SVG): first evenodd, second nonzero.
+        let svg = #"<svg viewBox="0 0 24 25"><path fill-rule="evenodd" d="M0 0 L10 0 L10 10 Z"/><path fill-rule="nonzero" d="M12 12 L20 12 L20 20 Z"/></svg>"#
+        let glyph = try XCTUnwrap(InboxBellGlyph.build(fromSVG: svg))
+        XCTAssertEqual(glyph.subpaths.map(\.usesEvenOddFill), [true, false])
+    }
+
+    func test_bellIcon_givenRootSvgFillRule_thenPathsInheritIt() throws {
+        // A <path> with no fill-rule inherits the root <svg>'s declared rule.
+        let svg = #"<svg fill-rule="evenodd" viewBox="0 0 24 25"><path d="M0 0 L24 0 L24 25 Z"/></svg>"#
+        let glyph = try XCTUnwrap(InboxBellGlyph.build(fromSVG: svg))
+        XCTAssertTrue(try XCTUnwrap(glyph.subpaths.first).usesEvenOddFill)
     }
 
     // MARK: - InboxBellPosition

--- a/api-docs/CioMessagingInApp.api
+++ b/api-docs/CioMessagingInApp.api
@@ -185,6 +185,7 @@ public interface CioMessagingInApp.NotificationInbox {
 	public fun func markMessageUnopened(message: InboxMessage);
 	public fun func markMessageDeleted(message: InboxMessage);
 	public fun func trackMessageClicked(message: InboxMessage, actionName: String?);
+	public fun func trackMessageClicked(message: InboxMessage, actionName: String?, actionValue: String?);
 	public fun func setInboxEventListener(_ listener: InboxEventListener?);
 	public fun func notifyMessageActionTaken(message: InboxMessage, actionValue: String, actionName: String) -> Boolean;
 	public fun func notifyMessageShown(message: InboxMessage);
@@ -210,11 +211,13 @@ public final class CioMessagingInApp.VisualInboxChrome {
 	public final val panelBackground: String?;
 	public final val dividerColor: String?;
 	public final val badgeBackground: String?;
+	public final val badgeTextColor: String?;
+	public final val badgeTextSize: Double?;
 	public final val cornerRadius: Double?;
 	public final val position: String?;
 	public final val showUnreadBadge: Boolean?;
 	public final val darkModePattern: Map<String, Any>?;
-	public fun init(bellBackground: String?, bellIconColor: String?, bellIconSvg: String?, panelBackground: String?, dividerColor: String?, badgeBackground: String?, cornerRadius: Double?, position: String?, showUnreadBadge: Boolean?, darkModePattern: List<String: Any>?);
+	public fun init(bellBackground: String?, bellIconColor: String?, bellIconSvg: String?, panelBackground: String?, dividerColor: String?, badgeBackground: String?, badgeTextColor: String?, badgeTextSize: Double?, cornerRadius: Double?, position: String?, showUnreadBadge: Boolean?, darkModePattern: List<String: Any>?);
 	public fun func == (lhs: VisualInboxChrome, rhs: VisualInboxChrome) -> Boolean;
 }
 public final class CioMessagingInApp.VisualInboxMessageSnapshot {


### PR DESCRIPTION
Visual Inbox overlay QA fixes surfaced during device testing, plus web-parity inbox metric reporting.

- **MBL-2123** — render the branding bell by filling each `<path>` independently (even-odd per path) so overlapping subpaths don't flip winding parity and malform the glyph.
- **MBL-2122** — add a top inset above the inbox list.
- **MBL-2126** — plumb badge text color/size from branding.
- **MBL-2125** — report inbox opened/clicked via the generic `Report Delivery Event` (`metric: opened|clicked`), matching the web SDK (`cdp-analytics-js` → `_analytics.track('Report Delivery Event', …)`). The CDP backend renders these as "Opened/Clicked Inbox Message" for an inbox delivery. Click carries `actionName` + `actionValue` (web parity). **No** separate named CDP events and **no** client-side "delivered" — the backend synthesizes delivered.

Pre-flight: `MessagingInboxTests`, `MessagingInAppTests`, `DataPipelineTests`, `CommonTests` green on simulator (2 unrelated flaky timing tests confirmed passing in isolation); `swiftformat --lint` and `swiftlint` clean; API-docs baseline regenerated.

> Sample-app (APN-UIKit) font demo scaffolding + `CustomerIOMessagingInbox.podspec`/`Package` Jist-dependency bumps are intentionally **excluded** here — they land in a follow-up once the Jist quote-stripping fix (#43) republishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect CDP delivery-event payloads and extend a public inbox API, but behavior is additive with web-parity defaults; remaining risk is mis-reported analytics if param mapping regresses.
> 
> **Overview**
> Visual Inbox overlay fixes from device QA, plus inbox **opened/clicked** reporting aligned with the web SDK via generic **`Report Delivery Event`** metrics (CDP renders these as opened/clicked inbox message events).
> 
> **Analytics (MBL-2125):** Click tracking now carries **`actionName` and `actionValue`** through `NotificationInbox.trackMessageClicked`, the `.trackClicked` inbox action, and inbox middleware into `TrackInAppMetricEvent` params (empty strings omitted). The visual inbox SPI forwards `actionValue` when handling row actions. Open-on-read posts the **opened** metric with the same delivery-event pattern (documented in middleware).
> 
> **UI / branding:** Branding bell SVGs (**MBL-2123**) fill each `<path>` separately with per-path **`fill-rule`** (root inheritance included) instead of one merged path forced to even-odd. Unread badge count **color and font size** come from `unreadIndicator.text` through `VisualInboxChrome` into resolved colors and the bell badge (**MBL-2126**). The message list gets a **16pt top inset** (**MBL-2122**).
> 
> Public API surface updates: `VisualInboxChrome` badge text fields and an overload of `trackMessageClicked` with `actionValue`; tests and API docs regenerated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49e6cda630fe7c9d144dfc665bf6189920ec06e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->