### PR TITLE
chore(sample): align location mode default with SDK default

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
@@ -59,7 +59,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if settings.internalSettings.testMode {
             config.flushAt(1)
         }
-        let locationMode = settings.location?.trackingMode.toCIOMode() ?? .onAppStart
+        let locationMode = settings.location?.trackingMode.toCIOMode() ?? .manual
         config.addModule(LocationModule(config: LocationConfig(mode: locationMode)))
         config.addModule(GeofenceModule())
         CustomerIO.initialize(withConfig: config.build())

--- a/Apps/APN-UIKit/APN UIKit/Model/Settings.swift
+++ b/Apps/APN-UIKit/APN UIKit/Model/Settings.swift
@@ -8,7 +8,8 @@ struct Settings: Codable {
     var messaging: MessagingPushAPNSettings
     var inApp: MessagingInAppSettings
     /// Optional so existing serialized installs (which predate this field) still decode.
-    /// Callers fall back to `.manual`, the SDK's default mode.
+    /// Callers fall back to `.manual` to match the sample default the other SDKs use
+    /// (the Location module is opt-in, so the SDK has no runtime default mode of its own).
     var location: LocationSettings?
     var internalSettings: InternalSettings
 }

--- a/Apps/APN-UIKit/APN UIKit/Model/Settings.swift
+++ b/Apps/APN-UIKit/APN UIKit/Model/Settings.swift
@@ -8,7 +8,7 @@ struct Settings: Codable {
     var messaging: MessagingPushAPNSettings
     var inApp: MessagingInAppSettings
     /// Optional so existing serialized installs (which predate this field) still decode.
-    /// Callers fall back to `.onAppStart` to match the hardcoded behavior this replaced.
+    /// Callers fall back to `.manual`, the SDK's default mode.
     var location: LocationSettings?
     var internalSettings: InternalSettings
 }

--- a/Apps/APN-UIKit/APN UIKit/Service/SettingsService.swift
+++ b/Apps/APN-UIKit/APN UIKit/Service/SettingsService.swift
@@ -32,7 +32,7 @@ class SettingsService {
                 siteId: BuildEnvironment.CustomerIO.siteId,
                 region: .US
             ),
-            location: LocationSettings(trackingMode: .onAppStart),
+            location: LocationSettings(trackingMode: .manual),
             internalSettings: InternalSettings(
                 cdnHost: "cdp.customer.io/v1",
                 apiHost: "cdp.customer.io/v1",

--- a/Apps/APN-UIKit/APN UIKit/View/Settings/MainSettingsViewController+Location.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/Settings/MainSettingsViewController+Location.swift
@@ -46,7 +46,7 @@ extension MainSettingsViewController {
     }
 
     func setLocationInitialValues() {
-        let active = settingsViewModel.settings.location?.trackingMode ?? .onAppStart
+        let active = settingsViewModel.settings.location?.trackingMode ?? .manual
         for button in locationTrackingModeButtons {
             let mode = LocationTrackingModeSetting.allCases[button.tag]
             button.isSelected = mode == active

--- a/Apps/CocoaPods-FCM/src/AppDelegate.swift
+++ b/Apps/CocoaPods-FCM/src/AppDelegate.swift
@@ -53,7 +53,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         if let cdnHost = appSetSettings?.cdnHost, !cdnHost.isEmpty {
             config.cdnHost(cdnHost)
         }
-        config.addModule(LocationModule(config: LocationConfig(mode: .onAppStart)))
+        config.addModule(LocationModule(config: LocationConfig(mode: .manual)))
         config.addModule(GeofenceModule())
         CustomerIO.initialize(withConfig: config.build())
 


### PR DESCRIPTION
## What

Aligns the sample apps' location tracking mode with the SDK default (`.manual`), removing the `.onAppStart` override:

- **APN-UIKit**: settings fallback in `AppDelegate`, default settings seed, and settings-UI initial selection
- **CocoaPods-FCM**: hardcoded mode in `AppDelegate`

The mode remains selectable in the APN-UIKit settings screen; only the defaults changed. Installs with a saved location setting keep their saved value.

## Why

The samples overrode the mode to `.onAppStart`, diverging from the SDK default (`LocationTrackingMode.MANUAL` on Android; the Android sample sets no mode). Geofence auto-acquire on identify is unaffected — `requestLocationUpdateSilently` runs regardless of `LocationConfig.mode`.

Ticket: [MBL-2148](https://linear.app/customerio/issue/MBL-2148/mobile-align-sample-app-location-mode-with-sdk-defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sample-app default and comment-only changes; no production SDK or auth logic touched, and saved user settings are preserved.
> 
> **Overview**
> Sample apps now default **CioLocation** `trackingMode` to **`.manual`** instead of **`.onAppStart`**, matching other SDK samples and the documented opt-in behavior.
> 
> **APN-UIKit** updates the `LocationModule` fallback when `settings.location` is missing, seeds new installs with `.manual` in `SettingsService`, and shows **MANUAL** as the initial selection in the location settings UI. **CocoaPods-FCM** initializes `LocationConfig` with `.manual` in `AppDelegate`. Users can still pick **ON_APP_START** in APN-UIKit; persisted settings are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19380dce3b3e5aac1496e404ccd097116df0e219. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->