### PR TITLE
chore(geofence): flush queued transition events on each new crossing

### DIFF
--- a/Sources/Common/Store/BackgroundDeliveryContextStore.swift
+++ b/Sources/Common/Store/BackgroundDeliveryContextStore.swift
@@ -83,6 +83,13 @@ public final class BackgroundDeliveryContextStore: @unchecked Sendable {
         return cache.using { $0.cdpApiKey }
     }
 
+    /// Whether a registered provider is currently supplying a key — i.e. DataPipeline has
+    /// initialized in this process. Lets callers distinguish "SDK is up, hand work to it" from
+    /// "cold-wake, deliver directly off the persisted context".
+    public var hasLiveCdpApiKeyProvider: Bool {
+        providerRef.using { $0.provider?.cdpApiKey?.isEmpty == false }
+    }
+
     /// Registers a live source for `cdpApiKey`. Held weakly so the provider's lifecycle
     /// drives availability — when the provider is deallocated (or never registered, as on
     /// cold-wake), `currentCdpApiKey` falls back to the persisted value.

--- a/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
@@ -9,9 +9,11 @@ import Foundation
 /// transitionId:
 /// - Fresh transition → direct HTTP (`deliverFresh`): works before DataPipeline is up (cold-wake);
 ///   failure retains the row for the next flush.
-/// - Replay (`flushPending` → `deliverViaEventBus`) → EventBus → DataPipeline's durable queue.
+/// - Replay (`flushPending`) → EventBus when DataPipeline is live, else direct HTTP off the
+///   persisted context; routing rationale on the method.
 ///
-/// `flushPending()` runs on module init, cold-wake bootstrap, and `ProfileIdentifiedEvent`.
+/// `flushPending()` runs on module init, cold-wake bootstrap, `ProfileIdentifiedEvent`, and at the
+/// start of every tracked transition — so a backlog retries whenever a crossing wakes the device.
 /// Concurrent deliveries of the same row are deduped via the in-memory active-delivery set.
 ///
 /// `@unchecked Sendable`: all stored properties are `let`; mutable state is wrapped in `Synchronized`.
@@ -58,6 +60,10 @@ final class GeofenceEventTracker: @unchecked Sendable {
         geofenceId: String,
         transition: GeofenceTransition
     ) async {
+        // Retry any backlog first: a crossing proves the device is awake, and queued rows are
+        // self-contained (stamped userId) — this crossing's identity/cooldown gates don't apply.
+        await flushPending()
+
         // Identified-only: the backend rejects anonymous geofence tracks, so drop before cooldown or
         // persist. Snapshot the userId so a later sign-out/sign-in can't reattribute the row.
         guard let stampedUserId = contextStore.currentUserId, !stampedUserId.isEmpty else {
@@ -130,12 +136,28 @@ final class GeofenceEventTracker: @unchecked Sendable {
         await storage.purgeExpiredCooldowns(now: now, interval: interval)
     }
 
-    /// Replays every queued row via EventBus → DataPipeline, which owns delivery and its own
-    /// background handling from there — so no background-task assertion is needed (unlike the fresh
-    /// HTTP send). A row not handed off stays queued and retries on the next flush.
+    /// Replays every queued row, routed by who owns delivery best right now:
+    /// - DataPipeline live → EventBus: its durable queue retries on its own cadence and batches the rows.
+    /// - Else persisted key → direct HTTP: an uninitialized cold-wake (wrapper before JS/Dart init)
+    ///   ships the backlog in the wake window; failed rows stay queued for the next trigger.
+    /// - Neither → EventBus persists to disk; DataPipeline replays at next init.
     func flushPending() async {
-        for metric in await pendingStore.loadAll() {
-            await deliverViaEventBus(metric: metric)
+        let metrics = await pendingStore.loadAll()
+        guard !metrics.isEmpty else { return }
+        let persistedKey = contextStore.currentCdpApiKey
+        if !contextStore.hasLiveCdpApiKeyProvider, let persistedKey, !persistedKey.isEmpty {
+            // Same assertion + concurrent fan-out rationale as the fresh send in `trackTransition`.
+            await backgroundTaskRunner.withBackgroundTime { [self] in
+                await withTaskGroup(of: Void.self) { group in
+                    for metric in metrics {
+                        group.addTask { await self.deliverFresh(metric: metric) }
+                    }
+                }
+            }
+        } else {
+            for metric in metrics {
+                await deliverViaEventBus(metric: metric)
+            }
         }
     }
 
@@ -167,10 +189,11 @@ final class GeofenceEventTracker: @unchecked Sendable {
         // HTTP failure: row stays for next flush.
     }
 
-    /// Replay via EventBus → DataPipeline, which then owns delivery and retry. We drop our copy once
-    /// the handoff resolves (observer invoked, or written to the EventBus cache when none exists yet).
-    /// That is not a durable-persistence ack — the strongest signal EventBus exposes today — so a
-    /// crash before DataPipeline persists re-delivers on the next flush (deduped by transitionId).
+    /// Replay via EventBus → DataPipeline, which then owns delivery and retry. We drop our copy
+    /// once the handoff resolves (observer invoked, or written to the EventBus cache when none
+    /// exists yet). That is not a durable-persistence ack — the strongest signal EventBus exposes
+    /// today — so a crash before DataPipeline persists re-delivers on the next flush (deduped by
+    /// transitionId).
     private func deliverViaEventBus(metric: PendingGeofenceMetric) async {
         guard activeDeliveryKeys.mutating({ $0.insert(metric.key).inserted }) else { return }
         defer { activeDeliveryKeys.mutating { _ = $0.remove(metric.key) } }

--- a/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
@@ -12,8 +12,9 @@ import Foundation
 /// - Replay (`flushPending`) → EventBus when DataPipeline is live, else direct HTTP off the
 ///   persisted context; routing rationale on the method.
 ///
-/// `flushPending()` runs on module init, cold-wake bootstrap, `ProfileIdentifiedEvent`, and at the
-/// start of every tracked transition — so a backlog retries whenever a crossing wakes the device.
+/// `flushPending()` runs on module init, cold-wake bootstrap, `ProfileIdentifiedEvent`, and after
+/// every tracked transition (once its own rows are persisted and sent) — so a backlog retries
+/// whenever a crossing wakes the device, without the fresh crossing's durability waiting on it.
 /// Concurrent deliveries of the same row are deduped via the in-memory active-delivery set.
 ///
 /// `@unchecked Sendable`: all stored properties are `let`; mutable state is wrapped in `Synchronized`.
@@ -60,15 +61,27 @@ final class GeofenceEventTracker: @unchecked Sendable {
         geofenceId: String,
         transition: GeofenceTransition
     ) async {
-        // Retry any backlog first: a crossing proves the device is awake, and queued rows are
-        // self-contained (stamped userId) — this crossing's identity/cooldown gates don't apply.
-        await flushPending()
+        // Persist and send the current crossing before any backlog work: the monitor's dedup
+        // baseline has already advanced, so a crossing suspended away un-persisted can never
+        // re-emit — its durability must not wait on a slow replay.
+        let freshKeys = await deliverCurrentCrossing(geofenceId: geofenceId, transition: transition)
+        // Then retry the backlog: queued rows are self-contained (stamped userId), so this
+        // crossing's gates don't apply. Excluding the rows just written keeps a failed fresh
+        // send on disk for the next trigger instead of re-attempting it on the same network.
+        await flushPending(excluding: freshKeys)
+    }
 
+    /// Gates, fans out, persists, and sends the crossing's rows over direct HTTP; returns the
+    /// persisted keys (empty when gated) so the caller can exclude them from the backlog flush.
+    private func deliverCurrentCrossing(
+        geofenceId: String,
+        transition: GeofenceTransition
+    ) async -> Set<String> {
         // Identified-only: the backend rejects anonymous geofence tracks, so drop before cooldown or
         // persist. Snapshot the userId so a later sign-out/sign-in can't reattribute the row.
         guard let stampedUserId = contextStore.currentUserId, !stampedUserId.isEmpty else {
             logger.geofenceTransitionDroppedAnonymous(geofenceId: geofenceId, transition: transition)
-            return
+            return []
         }
 
         let cooldownKey = "\(geofenceId):\(transition.rawValue)"
@@ -79,7 +92,7 @@ final class GeofenceEventTracker: @unchecked Sendable {
 
         guard await storage.tryAcquireCooldown(key: cooldownKey, now: now, interval: interval) else {
             logger.geofenceEventSuppressed(geofenceId: geofenceId, transition: transition)
-            return
+            return []
         }
         // Resolve the geofence name and geoset membership now and carry them on the metric;
         // name is nil when the geofence has none so the event omits `geofenceName`.
@@ -119,7 +132,7 @@ final class GeofenceEventTracker: @unchecked Sendable {
             // success-path remove(key:) drop a later same-second crossing's row (keys omit transitionId).
             logger.geofencePendingPersistFailed(geofenceId: geofenceId, transition: transition)
             await storage.releaseCooldown(key: cooldownKey)
-            return
+            return []
         }
 
         // Hold a background-task assertion across delivery so the OS doesn't suspend us mid-send when
@@ -134,6 +147,7 @@ final class GeofenceEventTracker: @unchecked Sendable {
             }
         }
         await storage.purgeExpiredCooldowns(now: now, interval: interval)
+        return Set(metrics.map(\.key))
     }
 
     /// Replays every queued row, routed by who owns delivery best right now:
@@ -141,8 +155,10 @@ final class GeofenceEventTracker: @unchecked Sendable {
     /// - Else persisted key → direct HTTP: an uninitialized cold-wake (wrapper before JS/Dart init)
     ///   ships the backlog in the wake window; failed rows stay queued for the next trigger.
     /// - Neither → EventBus persists to disk; DataPipeline replays at next init.
-    func flushPending() async {
-        let metrics = await pendingStore.loadAll()
+    ///
+    /// `excluding` skips rows the caller just persisted and already attempted itself.
+    func flushPending(excluding excludedKeys: Set<String> = []) async {
+        let metrics = await pendingStore.loadAll().filter { !excludedKeys.contains($0.key) }
         guard !metrics.isEmpty else { return }
         let persistedKey = contextStore.currentCdpApiKey
         if !contextStore.hasLiveCdpApiKeyProvider, let persistedKey, !persistedKey.isEmpty {

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -22,12 +22,13 @@ struct GeofenceEventTrackerTests {
         PendingGeofenceMetricStore(fileManager: .default, directoryURL: directory)
     }
 
-    private func makeContextStore(userId: String? = nil) -> BackgroundDeliveryContextStore {
+    private func makeContextStore(userId: String? = nil, cdpApiKey: String? = nil) -> BackgroundDeliveryContextStore {
         let store = BackgroundDeliveryContextStore(
             fileManager: .default,
             directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         )
         if let userId { store.setUserId(userId) }
+        if let cdpApiKey { store.setCdpApiKey(cdpApiKey) }
         return store
     }
 
@@ -289,22 +290,24 @@ struct GeofenceEventTrackerTests {
     // MARK: - flushPending
 
     @Test
-    func flushPending_givenQueuedMetricsAndUserId_expectPostedToEventBusAndDrained() async {
+    func flushPending_givenNoHttpContext_expectPostedToEventBusAndDrained() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let pending = makePendingStore(directory: dir)
-        let failingDelivery = GeofenceDeliveryTrackerMock()
-        failingDelivery.trackMetricClosure = { _, _, onComplete in
-            onComplete(.failure(.http(statusCode: 503)))
-        }
-        let priorTracker = makeTracker(
-            storage: makeStorage(directory: dir),
-            pendingStore: pending,
-            deliveryTracker: failingDelivery,
-            contextStore: makeContextStore(userId: "user_42")
-        )
-        await priorTracker.trackTransition(geofenceId: "geo_1", transition: .enter)
-        await priorTracker.trackTransition(geofenceId: "geo_2", transition: .enter)
+        // Rows from earlier failed sends, seeded directly — tracking a second transition would
+        // itself replay the first row's backlog before the store could be inspected.
+        _ = await pending.append([
+            PendingGeofenceMetric(
+                geofenceId: "geo_1", transition: .enter,
+                timestamp: Date(timeIntervalSince1970: 1),
+                userId: "user_42", name: nil, transitionId: "txn_1"
+            ),
+            PendingGeofenceMetric(
+                geofenceId: "geo_2", transition: .enter,
+                timestamp: Date(timeIntervalSince1970: 2),
+                userId: "user_42", name: nil, transitionId: "txn_2"
+            )
+        ])
         #expect(await pending.loadAll().count == 2)
 
         let delivery = GeofenceDeliveryTrackerMock()
@@ -319,9 +322,170 @@ struct GeofenceEventTrackerTests {
 
         await tracker.flushPending()
 
-        // Replay hands the backlog to EventBus → DataPipeline, not the direct-HTTP channel.
+        // Without an HTTP context (no cdpApiKey), replay falls back to EventBus → DataPipeline.
         #expect(postedGeofenceEvents(from: bus).count == 2)
         #expect(delivery.trackMetricCallsCount == 0)
+        #expect(await pending.loadAll().isEmpty)
+    }
+
+    @Test
+    func flushPending_givenColdWakeWithPersistedKey_expectDeliveredOverHttpAndDrained() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pending = makePendingStore(directory: dir)
+        _ = await pending.append([
+            PendingGeofenceMetric(
+                geofenceId: "geo_1", transition: .enter,
+                timestamp: Date(timeIntervalSince1970: 1),
+                userId: "user_42", name: nil, transitionId: "txn_1"
+            ),
+            PendingGeofenceMetric(
+                geofenceId: "geo_2", transition: .enter,
+                timestamp: Date(timeIntervalSince1970: 2),
+                userId: "user_42", name: nil, transitionId: "txn_2"
+            )
+        ])
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
+        let bus = EventBusHandlerMock()
+        let tracker = makeTracker(
+            storage: makeStorage(directory: dir),
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_42", cdpApiKey: "key_123"),
+            eventBus: bus
+        )
+
+        await tracker.flushPending()
+
+        // Persisted key and no live DataPipeline = uninitialized cold-wake (the wrapper case):
+        // replay ships over the direct channel instead of waiting for the next launch.
+        #expect(Set(delivery.trackMetricReceivedInvocations.map(\.metric.geofenceId)) == ["geo_1", "geo_2"])
+        #expect(postedGeofenceEvents(from: bus).isEmpty)
+        #expect(await pending.loadAll().isEmpty)
+    }
+
+    @Test
+    func flushPending_givenColdWakeHttpFailure_expectRowRetainedNoEventBus() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pending = makePendingStore(directory: dir)
+        _ = await pending.append([PendingGeofenceMetric(
+            geofenceId: "geo_1", transition: .enter,
+            timestamp: Date(timeIntervalSince1970: 1),
+            userId: "user_42", name: nil, transitionId: "txn_1"
+        )])
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in
+            onComplete(.failure(.http(statusCode: 503)))
+        }
+        let bus = EventBusHandlerMock()
+        let tracker = makeTracker(
+            storage: makeStorage(directory: dir),
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_42", cdpApiKey: "key_123"),
+            eventBus: bus
+        )
+
+        await tracker.flushPending()
+
+        // An HTTP failure keeps the row queued for the next trigger; it must not silently switch
+        // channels — EventBus is the no-context fallback, not the failure fallback.
+        #expect(await pending.loadAll().count == 1)
+        #expect(postedGeofenceEvents(from: bus).isEmpty)
+    }
+
+    @Test
+    func flushPending_givenColdWakeRowStampedDifferentUser_expectStampedUserIdSent() async {
+        // Same pinned-attribution contract the EventBus fallback has (tests below): a row captured
+        // under user_A ships as user_A even though user_B is signed in at flush time.
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pending = makePendingStore(directory: dir)
+        _ = await pending.append([PendingGeofenceMetric(
+            geofenceId: "geo_1", transition: .enter,
+            timestamp: Date(timeIntervalSince1970: 1),
+            userId: "user_A",
+            name: nil,
+            transitionId: "txn_a"
+        )])
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
+        let tracker = makeTracker(
+            storage: makeStorage(directory: dir),
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_B", cdpApiKey: "key_123")
+        )
+
+        await tracker.flushPending()
+
+        #expect(delivery.trackMetricReceivedArguments?.userId == "user_A")
+        #expect(delivery.trackMetricReceivedArguments?.metric.userId == "user_A")
+    }
+
+    @Test
+    func flushPending_givenLiveDataPipeline_expectEventBusPreferredOverHttp() async {
+        // With DataPipeline live in-process, replay hands off over EventBus — its durable queue
+        // owns retry and batches the rows — even though a persisted key would allow direct HTTP.
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pending = makePendingStore(directory: dir)
+        _ = await pending.append([PendingGeofenceMetric(
+            geofenceId: "geo_1", transition: .enter,
+            timestamp: Date(timeIntervalSince1970: 1),
+            userId: "user_42", name: nil, transitionId: "txn_1"
+        )])
+        let contextStore = makeContextStore(userId: "user_42", cdpApiKey: "persisted_key")
+        let liveProvider = StubCdpApiKeyProvider(cdpApiKey: "live_key")
+        contextStore.setCdpApiKeyProvider(liveProvider)
+        let delivery = GeofenceDeliveryTrackerMock()
+        let bus = EventBusHandlerMock()
+        let tracker = makeTracker(
+            storage: makeStorage(directory: dir),
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: contextStore,
+            eventBus: bus
+        )
+
+        await tracker.flushPending()
+
+        #expect(postedGeofenceEvents(from: bus).count == 1)
+        #expect(delivery.trackMetricCallsCount == 0)
+        #expect(await pending.loadAll().isEmpty)
+        // The store holds the provider weakly; keep it alive through the flush above.
+        withExtendedLifetime(liveProvider) {}
+    }
+
+    @Test
+    func trackTransition_givenColdWakeBacklog_expectBacklogShippedOverHttpWithCrossing() async {
+        // The wrapper cold-wake story end-to-end: a crossing arrives with a backlog queued and no
+        // DataPipeline — both the backlog row and the fresh crossing go out over direct HTTP.
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pending = makePendingStore(directory: dir)
+        _ = await pending.append([PendingGeofenceMetric(
+            geofenceId: "geo_old", transition: .exit,
+            timestamp: Date(timeIntervalSince1970: 1),
+            userId: "user_42", name: nil, transitionId: "txn_old"
+        )])
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
+        let bus = EventBusHandlerMock()
+        let tracker = makeTracker(
+            storage: makeStorage(directory: dir),
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_42", cdpApiKey: "key_123"),
+            eventBus: bus
+        )
+
+        await tracker.trackTransition(geofenceId: "geo_new", transition: .enter)
+
+        #expect(Set(delivery.trackMetricReceivedInvocations.map(\.metric.geofenceId)) == ["geo_old", "geo_new"])
+        #expect(postedGeofenceEvents(from: bus).isEmpty)
         #expect(await pending.loadAll().isEmpty)
     }
 
@@ -330,18 +494,19 @@ struct GeofenceEventTrackerTests {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
         let pending = makePendingStore(directory: dir)
-        let failingDelivery = GeofenceDeliveryTrackerMock()
-        failingDelivery.trackMetricClosure = { _, _, onComplete in
-            onComplete(.failure(.http(statusCode: 503)))
-        }
-        let priorTracker = makeTracker(
-            storage: makeStorage(directory: dir),
-            pendingStore: pending,
-            deliveryTracker: failingDelivery,
-            contextStore: makeContextStore(userId: "user_42")
-        )
-        await priorTracker.trackTransition(geofenceId: "geo_1", transition: .enter)
-        await priorTracker.trackTransition(geofenceId: "geo_2", transition: .enter)
+        // Seeded directly for the same reason as the test above.
+        _ = await pending.append([
+            PendingGeofenceMetric(
+                geofenceId: "geo_1", transition: .enter,
+                timestamp: Date(timeIntervalSince1970: 1),
+                userId: "user_42", name: nil, transitionId: "txn_1"
+            ),
+            PendingGeofenceMetric(
+                geofenceId: "geo_2", transition: .enter,
+                timestamp: Date(timeIntervalSince1970: 2),
+                userId: "user_42", name: nil, transitionId: "txn_2"
+            )
+        ])
 
         let bus = EventBusHandlerMock()
         let tracker = makeTracker(
@@ -360,6 +525,66 @@ struct GeofenceEventTrackerTests {
         _ = await(flush1, flush2)
 
         #expect(Set(postedGeofenceEvents(from: bus).map(\.geofenceId)) == ["geo_1", "geo_2"])
+        #expect(await pending.loadAll().isEmpty)
+    }
+
+    @Test
+    func trackTransition_givenBacklogFromEarlierFailure_expectBacklogReplayedOnCrossing() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pending = makePendingStore(directory: dir)
+        _ = await pending.append([PendingGeofenceMetric(
+            geofenceId: "geo_old", transition: .exit,
+            timestamp: Date(timeIntervalSince1970: 1),
+            userId: "user_42", name: nil, transitionId: "txn_old"
+        )])
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
+        let bus = EventBusHandlerMock()
+        let tracker = makeTracker(
+            storage: makeStorage(directory: dir),
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_42"),
+            eventBus: bus
+        )
+
+        await tracker.trackTransition(geofenceId: "geo_new", transition: .enter)
+
+        // The crossing replays the backlog over EventBus, then delivers itself over HTTP.
+        #expect(postedGeofenceEvents(from: bus).map(\.geofenceId) == ["geo_old"])
+        #expect(delivery.trackMetricReceivedInvocations.map(\.metric.geofenceId) == ["geo_new"])
+        #expect(await pending.loadAll().isEmpty)
+    }
+
+    @Test
+    func trackTransition_givenAnonymousCrossingWithBacklog_expectBacklogStillReplayed() async {
+        // The backlog replay runs before the identified-only gate: queued rows carry their own
+        // stamped userId, so a crossing the gate drops is still a wake-up worth using.
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pending = makePendingStore(directory: dir)
+        _ = await pending.append([PendingGeofenceMetric(
+            geofenceId: "geo_old", transition: .exit,
+            timestamp: Date(timeIntervalSince1970: 1),
+            userId: "user_A", name: nil, transitionId: "txn_old"
+        )])
+        let delivery = GeofenceDeliveryTrackerMock()
+        let bus = EventBusHandlerMock()
+        let tracker = makeTracker(
+            storage: makeStorage(directory: dir),
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(),
+            eventBus: bus
+        )
+
+        await tracker.trackTransition(geofenceId: "geo_new", transition: .enter)
+
+        // The anonymous crossing itself is dropped (no HTTP, nothing new queued)...
+        #expect(delivery.trackMetricCallsCount == 0)
+        // ...but the stamped backlog row still went out.
+        #expect(postedGeofenceEvents(from: bus).map(\.transitionId) == ["txn_old"])
         #expect(await pending.loadAll().isEmpty)
     }
 
@@ -950,5 +1175,14 @@ private final class SpyBackgroundTaskRunner: BackgroundTaskRunner, @unchecked Se
         record("begin")
         await work()
         record("end")
+    }
+}
+
+/// Stands in for DataPipeline's live key registration, so tests can put the store into the
+/// "initialized in this process" state.
+private final class StubCdpApiKeyProvider: BackgroundDeliveryCdpApiKeyProvider {
+    let cdpApiKey: String?
+    init(cdpApiKey: String?) {
+        self.cdpApiKey = cdpApiKey
     }
 }

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -529,6 +529,57 @@ struct GeofenceEventTrackerTests {
     }
 
     @Test
+    func trackTransition_givenSlowBacklogReplay_expectFreshRowDurableBeforeBacklogCompletes() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pending = makePendingStore(directory: dir)
+        _ = await pending.append([PendingGeofenceMetric(
+            geofenceId: "geo_old", transition: .exit,
+            timestamp: Date(timeIntervalSince1970: 1),
+            userId: "user_42", name: nil, transitionId: "txn_old"
+        )])
+        let delivery = GeofenceDeliveryTrackerMock()
+        // Backlog row: signal when its send starts, then hold completion so the replay stays in
+        // flight. Fresh row: fail, so its persisted row must survive on disk.
+        let backlogStarted = AsyncStream.makeStream(of: Void.self)
+        let backlogRelease = AsyncStream.makeStream(of: Void.self)
+        delivery.trackMetricClosure = { metric, _, onComplete in
+            if metric.geofenceId == "geo_old" {
+                backlogStarted.continuation.yield()
+                Task {
+                    for await _ in backlogRelease.stream {
+                        break
+                    }
+                    onComplete(.success(()))
+                }
+            } else {
+                onComplete(.failure(.transport))
+            }
+        }
+        // Cold-wake HTTP route: persisted key, no live provider.
+        let tracker = makeTracker(
+            storage: makeStorage(directory: dir),
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_42", cdpApiKey: "key_123")
+        )
+
+        let tracking = Task { await tracker.trackTransition(geofenceId: "geo_new", transition: .enter) }
+        for await _ in backlogStarted.stream {
+            break
+        }
+        // The replay is mid-flight; a suspension here must not lose the crossing — it is on disk.
+        #expect(await pending.loadAll().map(\.geofenceId).contains("geo_new"))
+        backlogRelease.continuation.yield()
+        await tracking.value
+
+        // Backlog delivered and removed; the failed fresh row stays for the next trigger, attempted
+        // exactly once — the flush excluded it instead of re-sending on the same network.
+        #expect(await pending.loadAll().map(\.geofenceId) == ["geo_new"])
+        #expect(delivery.trackMetricReceivedInvocations.filter { $0.metric.geofenceId == "geo_new" }.count == 1)
+    }
+
+    @Test
     func trackTransition_givenBacklogFromEarlierFailure_expectBacklogReplayedOnCrossing() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -42,6 +42,7 @@ public final class CioInternalCommon.BackgroundDeliveryContextStore {
 	public var currentUserId: String?;
 	public var currentApiHost: String?;
 	public var currentCdpApiKey: String?;
+	public var hasLiveCdpApiKeyProvider: Boolean;
 	public fun convenience init();
 	public fun func setCdpApiKeyProvider(_ provider: BackgroundDeliveryCdpApiKeyProvider?);
 	public fun func setUserId(_ userId: String?);


### PR DESCRIPTION
Retries queued geofence transition events on every new crossing instead of waiting for the next launch or identify. Contained to `GeofenceEventTracker.trackTransition`/`flushPending` plus one read-only accessor on `BackgroundDeliveryContextStore`.

Ticket: [MBL-2105](https://linear.app/customerio/issue/MBL-2105)

## Why
A row that fails its fresh HTTP send (offline, timeout) stays in the pending store, but the store was only flushed on module init, cold-wake bootstrap, and identify. A process that stays alive in the background and keeps receiving crossings never retried its backlog — each crossing delivered only its own rows. Field-observed on a real drive: an offline background wake queued a crossing at 18:39, and later crossings at 19:00 in the same process delivered themselves while the 18:39 rows sat untouched until the next relaunch. Android already converges per crossing (WorkManager network-aware retry); this closes that gap.

## Approach
`trackTransition` persists and sends the current crossing **first**: the monitor's dedup baseline has already advanced by the time the tracker sees a crossing, so a process suspended during a slow backlog replay must not be able to lose an un-persisted crossing (it would never re-emit); attribution (user, timestamp) is captured at crossing time for the same reason. The backlog flush then runs on every crossing — anonymous and cooldown-suppressed ones included, since backlog rows are self-contained (stamped userId) — **excluding the rows just written**, so a failed fresh send stays on disk for the next trigger instead of re-attempting on the network that just failed. The flush routes by who owns delivery best:

- **DataPipeline live in-process** (`hasLiveCdpApiKeyProvider`) → EventBus: durable queue, its own retry cadence, batches with other traffic.
- **Not live but persisted API key** (wrapper cold-wake) → direct HTTP inside the background-time window, so the backlog ships during the wake instead of deferring to the next JS/Dart launch.
- **Neither** → EventBus persistent event, replayed by DataPipeline at the next initialized launch.

No fallback-on-failure between channels: a failed row stays queued for the next flush. Duplicate handoffs are absorbed by the active-delivery claims and server-side `transitionId` dedup (at-least-once contract, unchanged).

## Testing
- Tracker suite extended to 38 tests: routing per channel (live provider / persisted-key cold-wake / neither), backlog replay on gated crossings, stamped-userId over HTTP, failed-row retention, concurrent flush dedup, and fresh-row durability while a blocked backlog replay is mid-flight (attempted exactly once — the flush excludes it). Full `LocationGeofenceTests` + `CommonTests` green.
- `api-docs/internal/CioInternalCommon.api` regenerated for the new public accessor.

## Notes
- Base is `feature/geofence-on-device` (independent of #1158; umbrella feature→main PR is #1130).
- Known accepted trade: an initialized-but-backgrounded backlog rides DataPipeline's flush cadence rather than sending immediately — the backlog is already late by definition, and the fresh path stays direct HTTP for real-time delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes background geofence delivery ordering and flush routing; behavior is localized to `GeofenceEventTracker` with broad new tests, but mis-routing could affect metric delivery in cold-wake vs foreground SDK states.
> 
> **Overview**
> Fixes **stuck pending geofence metrics** in long-lived background processes by **replaying the backlog after every crossing**, not only on init, identify, or cold-wake bootstrap.
> 
> **`trackTransition`** now **persists and sends the current crossing first** (`deliverCurrentCrossing`), then calls **`flushPending(excluding:)`** so a slow backlog replay cannot block durability of the new crossing and a just-failed fresh send is not immediately retried on the same flush.
> 
> **`flushPending`** chooses the replay channel: **EventBus when DataPipeline is live** (`hasLiveCdpApiKeyProvider` on `BackgroundDeliveryContextStore`); **direct HTTP with a background task** when only a **persisted CDP key** exists (wrapper cold-wake); otherwise **EventBus** for disk persistence until the next init. HTTP failures keep rows queued without falling back to EventBus.
> 
> Tests cover routing, stamped user attribution, anonymous crossings still flushing backlog, and ordering under slow replay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b292e736b1ee3fad892937e09cd54acd1c2780fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

