### PR TITLE
chore(geofence): fix event-loss races and cross-user cooldown carryover

### DIFF
--- a/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
@@ -84,7 +84,9 @@ final class GeofenceEventTracker: @unchecked Sendable {
             return []
         }
 
-        let cooldownKey = "\(geofenceId):\(transition.rawValue)"
+        // Cooldown is scoped per user: a re-login must not be suppressed by the previous user's
+        // recent transition, even when a fast re-login skips the async sign-out cleanup.
+        let cooldownKey = "\(stampedUserId):\(geofenceId):\(transition.rawValue)"
         let now = dateUtil.now
         // Cached config wins when present so a workspace can tune the dedup window without
         // an SDK release; constructor default applies otherwise.

--- a/Sources/LocationGeofence/GeofenceBootstrap.swift
+++ b/Sources/LocationGeofence/GeofenceBootstrap.swift
@@ -81,13 +81,13 @@ enum GeofenceBootstrap {
         // regions dropped, e.g. a monitoring failure or only the trigger surviving) falls through to
         // re-register so the missing business geofences come back rather than staying unmonitored
         // until the next refresh.
-        if !expectedOwnedRegions.isEmpty, expectedOwnedRegions.isSubset(of: monitor.osMonitoredRegionIdentifiers) {
-            monitor.adoptExistingRegions(matching: expectedOwnedRegions)
-        } else if di.backgroundDeliveryContextStore.currentUserId != userId {
-            // Identity changed during the reads above: registering now could resurrect regions a
-            // sign-out reset just tore down, with no later reset to stop them. The next
-            // identify-driven refresh registers instead.
+        if di.backgroundDeliveryContextStore.currentUserId != userId {
+            // Identity changed during the reads above: adopting or registering now could resurrect
+            // regions a sign-out reset just tore down (adopt's FIFO'd re-adds land after the
+            // reset's queued removes). The next identify-driven refresh registers instead.
             di.logger.geofenceSyncSkipped(reason: "identified user changed during bootstrap")
+        } else if !expectedOwnedRegions.isEmpty, expectedOwnedRegions.isSubset(of: monitor.osMonitoredRegionIdentifiers) {
+            monitor.adoptExistingRegions(matching: expectedOwnedRegions)
         } else {
             // First launch after install, the OS dropped our regions (e.g. permission revoked then
             // re-granted, which clears `monitoredRegions`), or a partial drop. Register fresh from cache.

--- a/Sources/LocationGeofence/GeofenceBootstrap.swift
+++ b/Sources/LocationGeofence/GeofenceBootstrap.swift
@@ -83,6 +83,11 @@ enum GeofenceBootstrap {
         // until the next refresh.
         if !expectedOwnedRegions.isEmpty, expectedOwnedRegions.isSubset(of: monitor.osMonitoredRegionIdentifiers) {
             monitor.adoptExistingRegions(matching: expectedOwnedRegions)
+        } else if di.backgroundDeliveryContextStore.currentUserId != userId {
+            // Identity changed during the reads above: registering now could resurrect regions a
+            // sign-out reset just tore down, with no later reset to stop them. The next
+            // identify-driven refresh registers instead.
+            di.logger.geofenceSyncSkipped(reason: "identified user changed during bootstrap")
         } else {
             // First launch after install, the OS dropped our regions (e.g. permission revoked then
             // re-granted, which clears `monitoredRegions`), or a partial drop. Register fresh from cache.

--- a/Sources/LocationGeofence/Model/GeofenceConfig.swift
+++ b/Sources/LocationGeofence/Model/GeofenceConfig.swift
@@ -19,7 +19,7 @@ struct GeofenceConfig: Codable, Equatable, Sendable {
     /// Freshness window for cached sync. A successful sync within this interval suppresses
     /// redundant API calls from identify / app-launch triggers.
     let remoteFetchRefreshExpiry: TimeInterval
-    /// Duplicate-transition suppression window keyed by "geofenceId:transitionType".
+    /// Duplicate-transition suppression window keyed by "userId:geofenceId:transitionType".
     let duplicateEventsExpiry: TimeInterval
     /// Maximum number of business geofences to monitor. Always 0…19 on iOS (movement
     /// trigger consumes the 20th OS slot).

--- a/Sources/LocationGeofence/Model/GeofenceState.swift
+++ b/Sources/LocationGeofence/Model/GeofenceState.swift
@@ -14,7 +14,7 @@ struct GeofenceState: Codable, Equatable, Sendable {
     var monitoredGeofenceIds: Set<String>?
     /// Center of the current Movement Trigger Geofence.
     var movementTriggerCenter: LocationData?
-    /// Cooldown records for geofence transition events, keyed by "geofenceId:transitionType".
+    /// Cooldown records for geofence transition events, keyed by "userId:geofenceId:transitionType".
     var eventCooldowns: [String: Date]?
     /// Server-driven configuration from the last successful sync. `nil` when no sync has
     /// landed a `config` block yet — consumers fall back to `GeofenceConfig.fallback` or

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -207,9 +207,9 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
             return
         }
         guard case .deliver = await storage.recordMonitorEvent(transition, forIdentifier: identifier) else { return }
-        // The await hopped off the main actor; re-check ownership so a region removed during that
-        // window isn't delivered (parity with the classic delegate's synchronous ownership check).
-        guard ownedRegionIdentifiers.contains(identifier) else { return }
+        // No ownership re-check after the await: the baseline already advanced, so dropping here
+        // loses the transition permanently — a sync's stop-all + re-add swap would eat a genuine
+        // crossing that raced it. A region truly removed in that window delivers one last gated event.
         onTransition?(identifier, transition, currentLocationData())
     }
 

--- a/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
@@ -30,6 +30,16 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
     private var onAuthorizationChanged: GeofenceAuthorizationChangedHandler?
     private var lastLoggedPermissionTier: PermissionTier?
     private var ownedRegionIdentifiers: Set<String> = []
+    private struct PendingRegionEvent {
+        let identifier: String
+        let transition: GeofenceTransition
+        let location: LocationData?
+    }
+
+    /// Region events received before the bootstrap bound `onTransition` (see `handleRegionEvent`).
+    private var pendingEvents: [PendingRegionEvent] = []
+    private var isDrainingPendingEvents = false
+    private static let maxPendingEvents = 64
 
     init(logger: Logger) {
         self.manager = CLLocationManager()
@@ -59,6 +69,7 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
 
     func setOnTransition(_ handler: GeofenceTransitionHandler?) {
         onTransition = handler
+        drainPendingEventsIfReady()
     }
 
     func setOnAuthorizationChanged(_ handler: GeofenceAuthorizationChangedHandler?) {
@@ -104,17 +115,43 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
     // MARK: - CLLocationManagerDelegate
 
     func locationManager(_ manager: CLLocationManager, didEnterRegion region: CLRegion) {
-        guard let circularRegion = region as? CLCircularRegion,
-              ownedRegionIdentifiers.contains(circularRegion.identifier)
-        else { return }
-        onTransition?(circularRegion.identifier, .enter, currentLocationData())
+        handleRegionEvent(region, transition: .enter)
     }
 
     func locationManager(_ manager: CLLocationManager, didExitRegion region: CLRegion) {
-        guard let circularRegion = region as? CLCircularRegion,
-              ownedRegionIdentifiers.contains(circularRegion.identifier)
-        else { return }
-        onTransition?(circularRegion.identifier, .exit, currentLocationData())
+        handleRegionEvent(region, transition: .exit)
+    }
+
+    /// Delivers a region event, holding it until the bootstrap binds `onTransition`: on a cold wake
+    /// the delegate can go live before bind/adopt run (any DI path constructing the monitor), and a
+    /// crossing delivered then would be dropped with no re-emission. Ownership is checked at drain —
+    /// after adopt populated it — which still filters buffered host-app events. New arrivals queue
+    /// behind any backlog and behind an in-flight drain, so per-region order holds. Capped against a
+    /// process that never binds.
+    private func handleRegionEvent(_ region: CLRegion, transition: GeofenceTransition) {
+        guard region is CLCircularRegion else { return }
+        if onTransition == nil || !pendingEvents.isEmpty || isDrainingPendingEvents {
+            pendingEvents.append(PendingRegionEvent(identifier: region.identifier, transition: transition, location: currentLocationData()))
+            if pendingEvents.count > Self.maxPendingEvents { pendingEvents.removeFirst() }
+            drainPendingEventsIfReady()
+            return
+        }
+        guard ownedRegionIdentifiers.contains(region.identifier) else { return }
+        onTransition?(region.identifier, transition, currentLocationData())
+    }
+
+    private func drainPendingEventsIfReady() {
+        guard onTransition != nil, !isDrainingPendingEvents, !pendingEvents.isEmpty else { return }
+        isDrainingPendingEvents = true
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            while self.onTransition != nil, !self.pendingEvents.isEmpty {
+                let next = self.pendingEvents.removeFirst()
+                guard self.ownedRegionIdentifiers.contains(next.identifier) else { continue }
+                self.onTransition?(next.identifier, next.transition, next.location)
+            }
+            self.isDrainingPendingEvents = false
+        }
     }
 
     func locationManager(_ manager: CLLocationManager, monitoringDidFailFor region: CLRegion?, withError error: Error) {

--- a/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
@@ -127,7 +127,8 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
     /// crossing delivered then would be dropped with no re-emission. Ownership is checked at drain —
     /// after adopt populated it — which still filters buffered host-app events. New arrivals queue
     /// behind any backlog and behind an in-flight drain, so per-region order holds. Capped against a
-    /// process that never binds.
+    /// process that never binds; unlike CLMonitor there is no re-emission, but overflowing the cap
+    /// requires bind to never run, and then every buffered event is undeliverable anyway.
     private func handleRegionEvent(_ region: CLRegion, transition: GeofenceTransition) {
         guard region is CLCircularRegion else { return }
         if onTransition == nil || !pendingEvents.isEmpty || isDrainingPendingEvents {

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -136,7 +136,7 @@ struct GeofenceEventTrackerTests {
         #expect(delivery.trackMetricCallsCount == 0)
         // The cooldown claimed for this crossing was released, so the next crossing retries from a
         // clean state instead of being suppressed. A held cooldown would make this claim return false.
-        let canRetry = await storage.tryAcquireCooldown(key: "geo_1:enter", now: dateUtil.now, interval: cooldownInterval)
+        let canRetry = await storage.tryAcquireCooldown(key: "user_42:geo_1:enter", now: dateUtil.now, interval: cooldownInterval)
         #expect(canRetry)
     }
 
@@ -221,6 +221,50 @@ struct GeofenceEventTrackerTests {
         dateUtil.givenNow = baseTime.addingTimeInterval(cooldownInterval)
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
 
+        #expect(delivery.trackMetricCallsCount == 2)
+    }
+
+    @Test
+    func trackTransition_givenDifferentUserWithinCooldown_expectNotSuppressed() async {
+        // After A triggers a geofence, B (a fast re-login whose skipped sign-out cleanup left A's
+        // cooldown state in shared storage) crossing the same geofence within the window must
+        // not be suppressed.
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let pending = makePendingStore(directory: dir)
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
+        let dateUtil = DateUtilStub()
+        let baseTime = Date(timeIntervalSince1970: 1700000000)
+        dateUtil.givenNow = baseTime
+
+        let trackerA = makeTracker(
+            storage: storage,
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_A"),
+            dateUtil: dateUtil
+        )
+        await trackerA.trackTransition(geofenceId: "geo_1", transition: .enter)
+        #expect(delivery.trackMetricCallsCount == 1)
+
+        // Same geofence, halfway through the cooldown window, but user B now.
+        dateUtil.givenNow = baseTime.addingTimeInterval(cooldownInterval / 2)
+        let trackerB = makeTracker(
+            storage: storage,
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_B"),
+            dateUtil: dateUtil
+        )
+        await trackerB.trackTransition(geofenceId: "geo_1", transition: .enter)
+
+        #expect(delivery.trackMetricCallsCount == 2)
+        #expect(delivery.trackMetricReceivedArguments?.userId == "user_B")
+
+        // And the same user within the window stays suppressed.
+        await trackerA.trackTransition(geofenceId: "geo_1", transition: .enter)
         #expect(delivery.trackMetricCallsCount == 2)
     }
 


### PR DESCRIPTION
Fixes four event-loss and state-carryover defects surfaced by the #1130 review pass and a field-diagnosed missed transition. All are contained to `LocationGeofence`; one commit per fix.

Ticket: [MBL-2105](https://linear.app/customerio/issue/MBL-2105/ios-harden-geofence-background-delivery-on-ios-17)

## Fixes

**1. Per-user cooldown key** (`userId:geofenceId:transition`) — a fast re-login can skip the async sign-out cleanup, leaving the previous user's cooldown timestamps in shared storage and suppressing the new session's first crossings. Registration/freshness state deliberately stays user-agnostic (geofences are workspace-scoped); only the cooldown needed scoping.

**2. Bootstrap adopt/re-register skipped when the identified user changed mid-read** — bootstrap snapshots the userId, then awaits storage reads; a sign-out landing in that window ran the decision against a torn-down state: the restore re-registered regions the reset had just removed, and the adopt branch's re-arm re-added conditions after the reset's queued removes — with no later reset to stop either (the guard fronts both branches per review). Sign-in and user-switch paths are unaffected: `applyCachedRegistration` already skips a nil user, and a switch converges via reset-clears-state → `hasUnregisteredCache` → local re-register on the new user's identify refresh.

**3. Classic (≤17) cold-wake events buffered until the bootstrap binds the handler** — on a cold wake, any DI path constructing the monitor (e.g. the identify-replay refresh resolving the coordinator) puts the `CLLocationManager` delegate live before bind/adopt run; a queued crossing delivered in that window was dropped with no re-emission — losing the very crossing the OS woke the app for. The buffer is the classic twin of the CLMonitor path's pre-bind queue (drain-order guard included); ownership is checked at drain time, after adopt has populated it, so buffered host-app-region events are still filtered.

**4. CLMonitor events delivered when owned at observation time** — the post-await ownership re-check in `process()` dropped a transition whose dedup baseline had already advanced whenever a sync's stop-all + re-add swap raced the storage hop. The re-registration then preserved the advanced baseline and re-armed CLMonitor as agreeing, so the crossing was lost permanently. Field-diagnosed from a real missed enter: the state file showed the baseline traveling exit→enter→exit with no enter ever reaching the tracker — only this path can do that. A region genuinely removed in that window now delivers one last identity/cooldown-gated event instead, which is the right side of the trade.

## Testing
- Unit: cooldown scoping has a behavioral test (new user's crossing delivers mid-window, same user stays suppressed; fails against the old key); a latent vacuous assertion in the persist-fail test was fixed alongside. Full `LocationGeofenceTests` green at 260. Fixes 2–4 are structurally untestable at unit level (identity mutation mid-actor-read; simulator auth can't seed monitor ownership) — the monitors keep their established device-validated posture.
- Field (fix 3): forced-classic build, force-quit app, real drive — the first cold wake delivered two crossings **9ms before bind/adopt finished**; both were buffered, drained in FIFO order after adopt, and delivered within ~1s. iOS's duplicate re-callbacks a second later were cooldown-suppressed. Pre-fix, both crossings were silently lost.
- Field (fix 4): the failing case is reproduced from a real drive's state file (above); a confirmation drive on the fixed build is in progress and results will be posted here.

## Notes
- Base is `feature/geofence-on-device`; the umbrella feature→main PR is #1130.
- Deliberately out of scope, tracked separately: the privacy-manifest correction, and a sweep for classic regions orphaned by an iOS 17→18 upgrade (battery-only impact; id-collision question deserves its own look).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes race-sensitive background geofence delivery and identity timing; fixes reduce lost events but CLMonitor may emit an extra transition when ownership races sync teardown.
> 
> **Overview**
> Hardens **LocationGeofence** background delivery by fixing four defects that dropped or mis-attributed transitions.
> 
> **Duplicate suppression** now keys cooldowns as `userId:geofenceId:transition` so a fast re-login is not blocked by the prior user’s recent crossing when sign-out cleanup did not run.
> 
> **Bootstrap** skips adopt/re-register if `currentUserId` changes during the async storage reads after the snapshot, avoiding resurrecting regions torn down by sign-out; the next identify refresh registers instead.
> 
> **Classic `CLLocationManager` monitor** buffers region callbacks until `onTransition` is bound (and drains with ownership checks), matching the CLMonitor pre-bind queue so cold-wake crossings before bind/adopt are not lost.
> 
> **CLMonitor `process`** no longer re-checks ownership after `recordMonitorEvent`’s await, so a genuine crossing is not permanently dropped when sync’s stop-all/re-add races the storage hop (may deliver one last gated event if a region was removed in that window).
> 
> Adds a unit test for per-user cooldown behavior and updates cooldown key expectations in existing tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f1d575c0d0eb585c7088de78bb947ce779b0117. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

