### PR TITLE
fix: preserve wrapped app delegate protocol conformance

### DIFF
--- a/Sources/MessagingPush/Integration/CioProviderAgnosticAppDelegate.swift
+++ b/Sources/MessagingPush/Integration/CioProviderAgnosticAppDelegate.swift
@@ -98,6 +98,11 @@ open class CioProviderAgnosticAppDelegate: CioAppDelegateType {
     // MARK: - method forwarding
 
     @objc
+    override public func conforms(to aProtocol: Protocol) -> Bool {
+        super.conforms(to: aProtocol) || wrappedAppDelegate?.conforms(to: aProtocol) == true
+    }
+
+    @objc
     override public func responds(to aSelector: Selector!) -> Bool {
         if implementedOptionalMethods.contains(aSelector), super.responds(to: aSelector) {
             return true

--- a/Tests/MessagingPush/Integration/CioProviderAgnosticAppDelegateTests.swift
+++ b/Tests/MessagingPush/Integration/CioProviderAgnosticAppDelegateTests.swift
@@ -7,6 +7,20 @@ import UIKit
 import UserNotifications
 import XCTest
 
+/// Test-only equivalent of framework lifecycle-provider protocols that are discovered at runtime.
+@objc(CioTestAppLifecycleProvider)
+private protocol TestAppLifecycleProvider: NSObjectProtocol {
+    func addApplicationLifeCycleDelegate(_ delegate: NSObject)
+}
+
+private final class LifecycleProviderAppDelegate: NSObject, UIApplicationDelegate, TestAppLifecycleProvider {
+    var addedLifecycleDelegate: NSObject?
+
+    func addApplicationLifeCycleDelegate(_ delegate: NSObject) {
+        addedLifecycleDelegate = delegate
+    }
+}
+
 class CioProviderAgnosticAppDelegateTests: XCTestCase {
     // Mock Classes
     var mockMessagingPush: MessagingPushInstanceMock!
@@ -137,6 +151,52 @@ class CioProviderAgnosticAppDelegateTests: XCTestCase {
     }
 
     // MARK: - Tests for method forwarding
+
+    func testConforms_whenWrappedDelegateConformsToProtocol_thenObjectiveCInvocationIsForwarded() throws {
+        let wrappedDelegate = LifecycleProviderAppDelegate()
+        appDelegate = CioProviderAgnosticAppDelegate(
+            messagingPush: mockMessagingPush,
+            appDelegate: wrappedDelegate,
+            config: { self.createMockConfig() },
+            logger: mockLogger
+        )
+        let lifecycleDelegate = NSObject()
+        let lifecycleProviderProtocol = try XCTUnwrap(NSProtocolFromString("CioTestAppLifecycleProvider"))
+        let addLifecycleDelegateSelector = #selector(TestAppLifecycleProvider.addApplicationLifeCycleDelegate(_:))
+
+        XCTAssertTrue(appDelegate.conforms(to: lifecycleProviderProtocol))
+        XCTAssertTrue(appDelegate.responds(to: addLifecycleDelegateSelector))
+        let forwardingTarget = appDelegate.forwardingTarget(for: addLifecycleDelegateSelector) as AnyObject?
+        XCTAssertTrue(forwardingTarget === wrappedDelegate)
+
+        appDelegate.perform(addLifecycleDelegateSelector, with: lifecycleDelegate)
+
+        XCTAssertTrue(wrappedDelegate.addedLifecycleDelegate === lifecycleDelegate)
+    }
+
+    func testConforms_whenProtocolIsImplementedByWrapperSuperclass_thenReturnsTrue() throws {
+        let applicationDelegateProtocol = try XCTUnwrap(NSProtocolFromString("UIApplicationDelegate"))
+
+        XCTAssertTrue(appDelegate.conforms(to: applicationDelegateProtocol))
+    }
+
+    func testConforms_whenWrappedDelegateIsNil_thenForeignProtocolReturnsFalse() throws {
+        appDelegate = CioProviderAgnosticAppDelegate(
+            messagingPush: mockMessagingPush,
+            appDelegate: nil,
+            config: { self.createMockConfig() },
+            logger: mockLogger
+        )
+        let tableViewDelegateProtocol = try XCTUnwrap(NSProtocolFromString("UITableViewDelegate"))
+
+        XCTAssertFalse(appDelegate.conforms(to: tableViewDelegateProtocol))
+    }
+
+    func testConforms_whenNeitherWrapperNorWrappedDelegateConforms_thenReturnsFalse() throws {
+        let tableViewDelegateProtocol = try XCTUnwrap(NSProtocolFromString("UITableViewDelegate"))
+
+        XCTAssertFalse(appDelegate.conforms(to: tableViewDelegateProtocol))
+    }
 
     func testResponds_whenSelectorIsProvided_thenItShouldCorrectlyDetectResponse() {
         // Test all implemented optional methods

--- a/Tests/MessagingPushFCM/Integration/CioAppDelegateFCMTests.swift
+++ b/Tests/MessagingPushFCM/Integration/CioAppDelegateFCMTests.swift
@@ -8,6 +8,26 @@ import UIKit
 import UserNotifications
 import XCTest
 
+@objc(CioTestFCMAppLifecycleProvider)
+private protocol TestFCMAppLifecycleProvider: NSObjectProtocol {
+    func addApplicationLifeCycleDelegate(_ delegate: NSObject)
+}
+
+private final class FlutterLikeAppDelegate: NSObject, UIApplicationDelegate, TestFCMAppLifecycleProvider {
+    weak static var latestInstance: FlutterLikeAppDelegate?
+
+    var addedLifecycleDelegate: NSObject?
+
+    override init() {
+        super.init()
+        Self.latestInstance = self
+    }
+
+    func addApplicationLifeCycleDelegate(_ delegate: NSObject) {
+        addedLifecycleDelegate = delegate
+    }
+}
+
 class CioAppDelegateFCMTests: XCTestCase {
     var appDelegateFCM: CioAppDelegate!
 
@@ -95,6 +115,20 @@ class CioAppDelegateFCMTests: XCTestCase {
         XCTAssertTrue(mockLogger.debugReceivedInvocations.contains {
             $0.message.contains("CIO: Registering for remote notifications")
         })
+    }
+
+    func testWrapperConforms_whenWrappedDelegateConforms_thenObjectiveCInvocationIsForwarded() throws {
+        let wrapper = CioAppDelegateWrapper<FlutterLikeAppDelegate>()
+        let lifecycleDelegate = NSObject()
+        let lifecycleProviderProtocol = try XCTUnwrap(NSProtocolFromString("CioTestFCMAppLifecycleProvider"))
+        let addLifecycleDelegateSelector = #selector(TestFCMAppLifecycleProvider.addApplicationLifeCycleDelegate(_:))
+
+        XCTAssertTrue(wrapper.conforms(to: lifecycleProviderProtocol))
+        XCTAssertTrue(wrapper.responds(to: addLifecycleDelegateSelector))
+
+        wrapper.perform(addLifecycleDelegateSelector, with: lifecycleDelegate)
+
+        XCTAssertTrue(FlutterLikeAppDelegate.latestInstance?.addedLifecycleDelegate === lifecycleDelegate)
     }
 
     func testDidFinishLaunching_whenCalled_thenFirebaseServiceDelegateIsSet() {


### PR DESCRIPTION
## Summary

- preserve Objective-C runtime protocol conformance exposed by the wrapped app delegate
- keep existing selector forwarding behavior unchanged
- cover the provider, nil-delegate, superclass, unrelated-protocol, and concrete FCM generic-wrapper paths

## Root cause

FlutterEngine checks whether the application delegate conforms to `FlutterAppLifeCycleProvider` before calling `addApplicationLifeCycleDelegate:`. `CioAppDelegateWrapper` forwarded selectors to the wrapped `FlutterAppDelegate`, but inherited `NSObject` protocol-conformance reporting, so FlutterEngine stopped before registration.

The wrapper now reports instance protocol conformance from either itself or the wrapped delegate. This follows the same composition model already used by `responds(to:)` and `forwardingTarget(for:)`.

## Impact

Flutter plugins that register application lifecycle delegates, including `quick_actions_ios`, can register and receive callbacks while Customer.io wraps the application delegate. The change is generic to wrapped Objective-C protocol conformance and is not Flutter-specific.

## Validation

- iOS package `build-for-testing`: passed
- affected provider and FCM wrapper suites: 22/22 passed
- MessagingPush + MessagingPushFCM suites: 119 passed, 5 skipped
- MessagingPushAPN suite: 4 passed, 4 platform-dependent tests skipped
- CocoaPods Flutter sample linked to this local native source:
  - terminated Home Screen quick action delivered callback 1
  - warm/backgrounded app delivered callback 2 with the same process
- SwiftPM Flutter sample linked to this local native source:
  - terminated Home Screen quick action delivered callback 1
  - warm/backgrounded app delivered callback 2 with the same process

## Ticket

[MBL-1583](https://linear.app/customerio/issue/MBL-1583/cioappdelegatewrapper-breaks-flutter-addapplicationdelegate-method)

The Flutter regression fixture is in [customerio-flutter#366](https://github.com/customerio/customerio-flutter/pull/366) and remains draft until this fix is released and its native pins are updated.

- [ ] Assign reviewers
- [ ] Wait for required status checks
- [ ] Obtain teammate approval
