### PR TITLE
fix(inbox): unread badge web-parity (stadium) + sample dark-mode

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/Info.plist
+++ b/Apps/APN-UIKit/APN UIKit/Info.plist
@@ -4,8 +4,6 @@
 <dict>
     <key>CFBundleDisplayName</key>
     <string>Native iOS</string>
-    <key>UIUserInterfaceStyle</key>
-    <string>Light</string>
     <key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/Apps/APN-UIKit/APN UIKit/View/BaseViewController.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/BaseViewController.swift
@@ -7,7 +7,7 @@ class BaseViewController: UIViewController {
         super.viewDidLoad()
 
         dismissKeyboardOnTap()
-        overrideUserInterfaceStyle = .light
+        overrideUserInterfaceStyle = .unspecified
     }
 
     func getMetaData() -> String {

--- a/Sources/MessagingInbox/NotificationInboxBell.swift
+++ b/Sources/MessagingInbox/NotificationInboxBell.swift
@@ -78,12 +78,17 @@ public struct NotificationInboxBell: View {
                 if showsUnreadCount {
                     // Badge count text color + size come from branding (`unreadIndicator.text`,
                     // MBL-2126), falling back to white / the caption size when unset.
+                    // Geometry mirrors web (`#gist-inbox-badge`): a 20pt-tall stadium (Capsule,
+                    // radius = height/2) with min-width 20 and 6pt horizontal padding, so a single
+                    // digit is a circle and multi-digit counts grow horizontally rather than forcing
+                    // a full circle (MBL-2127). Offset (4, -4) matches web's top:-4/right:-4.
                     Text("\(model.unopenedCount)")
                         .font(colors.badgeTextSize.map { Font.system(size: $0) } ?? .caption)
                         .foregroundColor(colors.badgeText)
-                        .padding(5)
+                        .padding(.horizontal, 6)
+                        .frame(minWidth: 20, minHeight: 20)
                         .background(colors.badge)
-                        .clipShape(Circle())
+                        .clipShape(Capsule())
                         .offset(x: 4, y: -4)
                 }
             }


### PR DESCRIPTION
Aligns the Visual Inbox unread badge to web (`#gist-inbox-badge`): a 20pt-tall stadium (`Capsule`, min-width 20, 6pt horizontal padding) so multi-digit counts grow horizontally instead of forcing an oversized circle (MBL-2127); offset unchanged (`4,-4` = web `top:-4/right:-4`). Also drops the APN-UIKit sample's forced light appearance so inbox dark-mode theming is visible.

Verified on simulator: single-digit = circle, colors exact (`#ff6b00`/`#9fd8ff`), opened + clicked CDP metrics still fire as the generic `Report Delivery Event`. Multi-digit stadium proven on the Android device counterpart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized SwiftUI badge layout and sample-app appearance only; no auth, data, or API changes.
> 
> **Overview**
> **Visual Inbox unread badge** on `NotificationInboxBell` now matches web `#gist-inbox-badge`: **20pt** min height, **6pt** horizontal padding, **`Capsule`** clip (stadium) instead of a fixed **`Circle`**, so multi-digit counts widen horizontally while single digits stay circular (MBL-2127). Badge offset stays **(4, -4)**.
> 
> The **APN-UIKit** sample no longer forces light mode—**`UIUserInterfaceStyle`** was removed from **`Info.plist`** and **`BaseViewController`** uses **`.unspecified`**—so inbox dark-mode branding can be exercised in the demo app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 073df2a1f0fd1c7defd0496da60bd19a4eb97aaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->