### PR TITLE
fix(live-activities): report start when issued right after identify()

### DIFF
--- a/Sources/LiveActivities/ActivityTypeRegistration.swift
+++ b/Sources/LiveActivities/ActivityTypeRegistration.swift
@@ -56,6 +56,10 @@ struct ActivityTypeRegistration: Sendable {
     /// cancelling it stops all observation for this type.
     let startObserving: @Sendable (_ sinks: LiveActivityObservationSinks) -> Task<Void, Never>
 
-    /// Ends all currently-running activities of this type immediately (used on reset).
-    let endAllActivities: @Sendable () async -> Void
+    /// Ends all currently-running activities of this type immediately (used on reset). Each running
+    /// activity is passed to `prepareLocalEnd` (its system `activityId` + attributes instance id, if
+    /// the type carries one) *before* it is ended, so the caller can mark it as an SDK-initiated end.
+    /// The `.immediate` dismissal surfaces as a `.dismissed` terminal, which must not be reported as
+    /// a user swipe.
+    let endAllActivities: @Sendable (_ prepareLocalEnd: @Sendable (_ activityId: String, _ attributesInstanceId: String?) -> Void) async -> Void
 }

--- a/Sources/LiveActivities/CIOLiveActivitiesSDKProviding.swift
+++ b/Sources/LiveActivities/CIOLiveActivitiesSDKProviding.swift
@@ -8,6 +8,10 @@ import Foundation
 /// (`CustomerIO.shared`) is used in production.
 protocol CIOLiveActivitiesSDKProviding {
     var registeredDeviceToken: String? { get }
+    /// Whether a user is currently identified. Backed by the data pipeline, which updates it
+    /// synchronously during identify()/clearIdentify(), so it is accurate the instant those
+    /// return — used to gate lifecycle events without racing an async identify().
+    var isUserIdentified: Bool { get }
     var eventBusHandler: EventBusHandler { get }
     var logger: Logger { get }
     var sharedKeyValueStorage: SharedKeyValueStorage { get }
@@ -25,6 +29,13 @@ extension CustomerIO: CIOLiveActivitiesSDKProviding {
 
     var sharedKeyValueStorage: SharedKeyValueStorage {
         DIGraphShared.shared.sharedKeyValueStorage
+    }
+
+    // Reuses the DataPipelineTracking reverse-dependency (the same one the Location module
+    // consumes) rather than reading analytics directly. Returns false when DataPipeline isn't
+    // initialized. Its isUserIdentified is updated synchronously on identify()/clearIdentify().
+    var isUserIdentified: Bool {
+        DIGraphShared.shared.getOptional(DataPipelineTracking.self)?.isUserIdentified ?? false
     }
 
     // registeredDeviceToken is already declared on CustomerIO via CustomerIOInstance.

--- a/Sources/LiveActivities/LiveActivitiesModule.swift
+++ b/Sources/LiveActivities/LiveActivitiesModule.swift
@@ -37,7 +37,7 @@ public final class LiveActivitiesModule {
     private let tokenStorage: LiveActivityTokenStorage
 
     private let identity = LiveActivityIdentity()
-    private let localEndTracker = LiveActivityLocalEndTracker()
+    private let localEndTracker: LiveActivityLocalEndTracker
     private let reporter: LiveActivityReporter
     private let registrar: LiveActivityRegistrar
     private let deliveryTracker: LiveActivityDeliveryTracker
@@ -68,11 +68,13 @@ public final class LiveActivitiesModule {
     init(
         config: LiveActivityConfig,
         sdk: CIOLiveActivitiesSDKProviding,
-        tokenStorage: LiveActivityTokenStorage
+        tokenStorage: LiveActivityTokenStorage,
+        localEndTracker: LiveActivityLocalEndTracker = LiveActivityLocalEndTracker()
     ) {
         self.config = config
         self.sdk = sdk
         self.tokenStorage = tokenStorage
+        self.localEndTracker = localEndTracker
 
         let identity = self.identity
         let reporter = LiveActivityReporter(
@@ -310,19 +312,29 @@ public final class LiveActivitiesModule {
         }
     }
 
-    private func handleReset() async {
+    // Internal (not private) so the reset-suppression behavior can be driven directly in tests
+    // without routing through the async event bus.
+    func handleReset() async {
         // Reset is a logout: force-end every activity so one user's Live Activities never linger
         // into the next session. No `end` event is reported for these — the user is being
         // de-identified, so lifecycle events must not fire.
         //
-        // Clear the identified user *before* force-ending: gating the reporter off first ensures the
-        // terminal states these ends produce can't be misreported as user dismissals (the reporter
-        // drops events while anonymous).
+        // Each activity is marked as an SDK-initiated (local) end just before it is force-ended, so
+        // the `.dismissed` terminal its immediate dismissal produces is consumed by the observer and
+        // not reported as a user swipe. Identity-based gating can't suppress this on its own: an
+        // account switch — clearIdentify() then identify(B) — puts B into the synchronous identity
+        // store before this async reset runs, so A's forced ends would otherwise be reported under B.
         identity.userId = nil
         localEndTracker.clearAll()
         latestMetadata.wrappedValue = [:]
         for registration in config.registrations {
-            await registration.endAllActivities()
+            await registration.endAllActivities { [tokenStorage, localEndTracker] activityId, attributesInstanceId in
+                let instanceId = tokenStorage.resolveInstanceId(forActivityId: activityId) {
+                    if let attributesInstanceId, !attributesInstanceId.isEmpty { return attributesInstanceId }
+                    return ULID.generate()
+                }
+                localEndTracker.markEnded(instanceId)
+            }
         }
         registrar.handleReset()
         observer.restart()

--- a/Sources/LiveActivities/LiveActivitiesModule.swift
+++ b/Sources/LiveActivities/LiveActivitiesModule.swift
@@ -325,7 +325,11 @@ public final class LiveActivitiesModule {
         // account switch — clearIdentify() then identify(B) — puts B into the synchronous identity
         // store before this async reset runs, so A's forced ends would otherwise be reported under B.
         identity.userId = nil
-        localEndTracker.clearAll()
+        // Do NOT clear existing local-end markers here: an activity the app ended via
+        // CIOLiveActivity.end() just before logout is already gone from Activity.activities, so the
+        // force-end loop below won't re-mark it. Dropping its marker would let its late `.dismissed`
+        // terminal be misreported as a user swipe (under the next user). Markers are in-memory,
+        // one-shot, and ULID-keyed, so keeping them is inert for any other activity.
         latestMetadata.wrappedValue = [:]
         for registration in config.registrations {
             await registration.endAllActivities { [tokenStorage, localEndTracker] activityId, attributesInstanceId in

--- a/Sources/LiveActivities/LiveActivitiesModule.swift
+++ b/Sources/LiveActivities/LiveActivitiesModule.swift
@@ -77,7 +77,10 @@ public final class LiveActivitiesModule {
         let identity = self.identity
         let reporter = LiveActivityReporter(
             track: { name, properties in sdk.track(name: name, properties: properties) },
-            currentUserId: { identity.userId },
+            // Gate on the SDK's synchronous identified flag (backed by DataPipelineTracking),
+            // not the async event-bus-fed identity cache, so a start() right after identify()
+            // isn't dropped. Token registration still uses `identity` via the registrar.
+            isUserIdentified: { sdk.isUserIdentified },
             deviceToken: { identity.deviceToken },
             logger: sdk.logger
         )

--- a/Sources/LiveActivities/Observation/LiveActivityObserver.swift
+++ b/Sources/LiveActivities/Observation/LiveActivityObserver.swift
@@ -215,8 +215,12 @@ enum LiveActivityObservation {
                     }
                 }
             },
-            endAllActivities: {
+            endAllActivities: { prepareLocalEnd in
                 for activity in Activity<T>.activities {
+                    // Mark as an SDK-initiated end first: the `.immediate` dismissal below surfaces
+                    // as a `.dismissed` terminal, which the observer would otherwise report as a user
+                    // swipe. On reset no `end` may fire (the user is being de-identified).
+                    prepareLocalEnd(activity.id, attributesInstanceId(activity))
                     await activity.end(nil, dismissalPolicy: .immediate)
                 }
             }

--- a/Sources/LiveActivities/Reporting/LiveActivityReporter.swift
+++ b/Sources/LiveActivities/Reporting/LiveActivityReporter.swift
@@ -14,18 +14,18 @@ import Foundation
 /// is not duplicated into `properties`.
 final class LiveActivityReporter: @unchecked Sendable {
     private let track: (String, [String: Any]) -> Void
-    private let currentUserId: () -> String?
+    private let isUserIdentified: () -> Bool
     private let deviceToken: () -> String?
     private let logger: Logger
 
     init(
         track: @escaping (String, [String: Any]) -> Void,
-        currentUserId: @escaping () -> String?,
+        isUserIdentified: @escaping () -> Bool,
         deviceToken: @escaping () -> String?,
         logger: Logger
     ) {
         self.track = track
-        self.currentUserId = currentUserId
+        self.isUserIdentified = isUserIdentified
         self.deviceToken = deviceToken
         self.logger = logger
     }
@@ -127,7 +127,9 @@ final class LiveActivityReporter: @unchecked Sendable {
     /// Returns the device token when an identified user and a non-empty device token both
     /// exist; otherwise logs the reason and returns `nil` so the caller drops the event.
     private func gatedDeviceId(for what: String) -> String? {
-        guard currentUserId() != nil else {
+        // isUserIdentified is updated synchronously on identify(), so an identify() immediately
+        // followed by startLiveActivity() is reported rather than dropped by a stale flag.
+        guard isUserIdentified() else {
             logger.debug("Live Notifications require an identified user; dropping \(what).", "LiveActivities")
             return nil
         }

--- a/Tests/LiveActivities/LiveActivitiesRegistrarTests.swift
+++ b/Tests/LiveActivities/LiveActivitiesRegistrarTests.swift
@@ -17,7 +17,7 @@ struct LiveActivityRegistrarTests {
         let identity = LiveActivityIdentity()
         let reporter = LiveActivityReporter(
             track: { name, props in cap.record(name, props) },
-            currentUserId: { identity.userId },
+            isUserIdentified: { identity.userId != nil },
             deviceToken: { identity.deviceToken },
             logger: NoopLogger()
         )
@@ -149,7 +149,7 @@ struct LiveActivityRegistrarTests {
             identity.deviceToken = "dev"
             let reporter = LiveActivityReporter(
                 track: { name, props in cap.record(name, props) },
-                currentUserId: { identity.userId },
+                isUserIdentified: { identity.userId != nil },
                 deviceToken: { identity.deviceToken },
                 logger: NoopLogger()
             )
@@ -208,7 +208,7 @@ struct LiveActivityRegistrarTests {
         identity.deviceToken = "dev"
         let reporter = LiveActivityReporter(
             track: { name, props in cap.record(name, props) },
-            currentUserId: { identity.userId },
+            isUserIdentified: { identity.userId != nil },
             deviceToken: { identity.deviceToken },
             logger: NoopLogger()
         )
@@ -230,7 +230,7 @@ struct LiveActivityRegistrarTests {
         identity.deviceToken = "dev" // anonymous at launch
         let reporter = LiveActivityReporter(
             track: { name, props in cap.record(name, props) },
-            currentUserId: { identity.userId },
+            isUserIdentified: { identity.userId != nil },
             deviceToken: { identity.deviceToken },
             logger: NoopLogger()
         )

--- a/Tests/LiveActivities/LiveActivitiesResetTests.swift
+++ b/Tests/LiveActivities/LiveActivitiesResetTests.swift
@@ -1,0 +1,93 @@
+import CioInternalCommon
+import Foundation
+import Testing
+
+@testable import CioLiveActivities
+
+// MARK: - Fakes for driving the module directly (no ActivityKit / no event bus)
+
+final class NoopEventBusHandler: EventBusHandler, @unchecked Sendable {
+    func loadEventsFromStorage() async {}
+    func addObserver<E: EventRepresentable>(_ eventType: E.Type, action: @escaping (E) -> Void) {}
+    func removeObserver<E: EventRepresentable>(for eventType: E.Type) {}
+    func postEvent<E: EventRepresentable>(_ event: E) {}
+    func postEventAndWait<E: EventRepresentable>(_ event: E) async {}
+    func removeFromStorage<E: EventRepresentable>(_ event: E) async {}
+}
+
+final class FakeLiveActivitiesSDK: CIOLiveActivitiesSDKProviding, @unchecked Sendable {
+    let registeredDeviceToken: String?
+    let isUserIdentified: Bool
+    let eventBusHandler: EventBusHandler = NoopEventBusHandler()
+    let logger: Logger = NoopLogger()
+    let sharedKeyValueStorage: SharedKeyValueStorage = InMemoryKeyValueStorage()
+
+    init(registeredDeviceToken: String? = "device-token", isUserIdentified: Bool) {
+        self.registeredDeviceToken = registeredDeviceToken
+        self.isUserIdentified = isUserIdentified
+    }
+
+    func track(name: String, properties: [String: Any]?) {}
+}
+
+// MARK: - Reset suppression (account-switch regression)
+
+struct LiveActivitiesResetTests {
+    /// Regression: on reset (logout/account switch), every activity that reset force-ends must be
+    /// marked as an SDK-initiated (local) end. The `.immediate` dismissal surfaces as a `.dismissed`
+    /// terminal, which the observer would otherwise report as a user swipe — and, because the
+    /// reporter now gates on the *synchronous* identity, a `clearIdentify(); identify("B")` sequence
+    /// has already put B into the store by the time this async reset runs, so the stray `end` would
+    /// be attributed to B. Marking the local end makes the terminal classify as cleanupOnly instead.
+    @Test func reset_marksForceEndedActivitiesAsLocalEnds_evenWhenAnotherUserIsIdentified() async {
+        let tracker = LiveActivityLocalEndTracker()
+        let store = FakeTokenStore()
+        var config = LiveActivityConfig()
+        config.registrations = [
+            ActivityTypeRegistration(
+                activityIdentifier: "io.customer.livenotifications.segments",
+                attributesTypeName: "CIOSegmentsAttributes",
+                startObserving: { _ in Task {} },
+                endAllActivities: { prepareLocalEnd in
+                    // Simulate one running activity being force-ended by reset.
+                    prepareLocalEnd("activitykit-id-1", "inst-1")
+                }
+            )
+        ]
+        // isUserIdentified == true simulates the account switch: B is already identified in the
+        // synchronous store when this async reset runs.
+        let sdk = FakeLiveActivitiesSDK(isUserIdentified: true)
+        let module = LiveActivitiesModule(config: config, sdk: sdk, tokenStorage: store, localEndTracker: tracker)
+
+        await module.handleReset()
+
+        // The forced end was marked as a local end, so `liveActivityTerminalAction` classifies its
+        // `.dismissed` terminal as `.cleanupOnly` — no `end` reported under the new user.
+        #expect(tracker.consume("inst-1") == true)
+    }
+
+    /// Sanity: when the type carries no attributes instance id, reset still marks a (minted) local
+    /// end for the activity, keyed by the token store's resolved id.
+    @Test func reset_marksLocalEnd_whenNoAttributesInstanceId() async {
+        let tracker = LiveActivityLocalEndTracker()
+        let store = FakeTokenStore()
+        var config = LiveActivityConfig()
+        config.registrations = [
+            ActivityTypeRegistration(
+                activityIdentifier: "io.customer.livenotifications.custom",
+                attributesTypeName: "Custom",
+                startObserving: { _ in Task {} },
+                endAllActivities: { prepareLocalEnd in prepareLocalEnd("activitykit-id-2", nil) }
+            )
+        ]
+        let sdk = FakeLiveActivitiesSDK(isUserIdentified: true)
+        let module = LiveActivitiesModule(config: config, sdk: sdk, tokenStorage: store, localEndTracker: tracker)
+
+        await module.handleReset()
+
+        // The minted id is the one the store resolved for the activity; it must be marked local.
+        let resolved = store.resolveInstanceId(forActivityId: "activitykit-id-2") { "" }
+        #expect(!resolved.isEmpty)
+        #expect(tracker.consume(resolved) == true)
+    }
+}

--- a/Tests/LiveActivities/LiveActivitiesResetTests.swift
+++ b/Tests/LiveActivities/LiveActivitiesResetTests.swift
@@ -66,6 +66,31 @@ struct LiveActivitiesResetTests {
         #expect(tracker.consume("inst-1") == true)
     }
 
+    /// Regression: an activity the app ended via `CIOLiveActivity.end()` just before logout is
+    /// already marked local but no longer in `Activity.activities`, so the reset loop won't re-mark
+    /// it. Reset must NOT drop that marker — otherwise its late `.dismissed` terminal would be
+    /// reported as a user dismissal under the next user.
+    @Test func reset_preservesInFlightLocalEndMarks() async {
+        let tracker = LiveActivityLocalEndTracker()
+        tracker.markEnded("in-flight-1") // an app-initiated end already in flight at logout
+        let store = FakeTokenStore()
+        var config = LiveActivityConfig()
+        config.registrations = [
+            ActivityTypeRegistration(
+                activityIdentifier: "io.customer.livenotifications.segments",
+                attributesTypeName: "CIOSegmentsAttributes",
+                startObserving: { _ in Task {} },
+                endAllActivities: { _ in } // nothing currently listed to force-end
+            )
+        ]
+        let sdk = FakeLiveActivitiesSDK(isUserIdentified: true)
+        let module = LiveActivitiesModule(config: config, sdk: sdk, tokenStorage: store, localEndTracker: tracker)
+
+        await module.handleReset()
+
+        #expect(tracker.consume("in-flight-1") == true)
+    }
+
     /// Sanity: when the type carries no attributes instance id, reset still marks a (minted) local
     /// end for the activity, keyed by the token store's resolved id.
     @Test func reset_marksLocalEnd_whenNoAttributesInstanceId() async {

--- a/Tests/LiveActivities/Support/LiveActivitiesTestSupport.swift
+++ b/Tests/LiveActivities/Support/LiveActivitiesTestSupport.swift
@@ -29,7 +29,7 @@ final class TrackCapture: @unchecked Sendable {
     func makeReporter() -> LiveActivityReporter {
         LiveActivityReporter(
             track: { name, props in self.record(name, props) },
-            currentUserId: { self.userId },
+            isUserIdentified: { self.userId != nil },
             deviceToken: { self.deviceToken },
             logger: NoopLogger()
         )


### PR DESCRIPTION
Fixes the identify()→startLiveActivity() race.

The reporter gates lifecycle events on the SDK's synchronous identified flag (backed by the existing `DataPipelineTracking` reverse-dependency, updated on the caller thread during identify()/clearIdentify()) instead of the async event-bus-fed identity cache. A startLiveActivity() issued immediately after identify() is now reported rather than dropped by a stale flag. Token registration is unchanged (still event-driven via the registrar).

All 96 `LiveActivitiesTests` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Live Activities analytics gating and logout teardown paths where mis-reported `end` events or dropped `start` events would affect customer data; behavior is covered by new reset tests but touches identity timing and terminal classification.
> 
> **Overview**
> Fixes the **identify() → startLiveActivity()** race by having `LiveActivityReporter` gate lifecycle events on **`sdk.isUserIdentified`** (synchronous `DataPipelineTracking`) instead of the async event-bus `userId` cache, so a start right after `identify()` is no longer dropped.
> 
> **Logout / reset** no longer relies on clearing identity alone to hide force-ended activities: `endAllActivities` now takes a **`prepareLocalEnd`** callback so each activity is marked in `LiveActivityLocalEndTracker` before `.immediate` end, preventing `.dismissed` from being reported as a user swipe. Reset **stops calling `localEndTracker.clearAll()`** so in-flight app-initiated ends still suppress late terminals after account switch. `handleReset()` is exposed for tests; new **`LiveActivitiesResetTests`** cover account-switch and in-flight local-end cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 894c822bf42371af8df0bc5d41d3ebeb38f3725c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->