### PR TITLE
chore(geofence): declare collected location and UserDefaults use in privacy manifest

### DIFF
--- a/Sources/LocationGeofence/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/LocationGeofence/Resources/PrivacyInfo.xcprivacy
@@ -2,10 +2,28 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<!-- Geofence transitions are sent via /track with the user id; the device's
-	     coordinates are never sent, so no location data type is declared. -->
+	<!--
+	Docs for this section: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests
+	This section is describing what information our SDK collects about the app user.
+	-->
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array>
+		<!-- The nearby-geofence fetch sends the device's exact coordinates so the server can
+		     return the fences around it. The request carries no user identifier, so the
+		     location is not attributable to a person. Transition events themselves carry
+		     geofence ids, never coordinates. -->
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePreciseLocation</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/> <!-- the request that carries coordinates has no user identity attached -->
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
 		<dict>
 			<key>NSPrivacyCollectedDataType</key>
 			<string>NSPrivacyCollectedDataTypeProductInteraction</string>
@@ -36,8 +54,22 @@
 		</dict>
 	</array>
 
+	<!--
+	Docs: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api
+	Documents if our SDK uses certain system calls and why.
+	-->
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
+		<!-- CLMonitorGeofenceMonitor mirrors its monitored-condition identifiers in
+		     UserDefaults; data is written and read only by this SDK inside the app. -->
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
 	</array>
 
 	<key>NSPrivacyTracking</key>


### PR DESCRIPTION
Corrects the CioLocationGeofence privacy manifest, which understated what the module does ([review thread](https://github.com/customerio/customerio-ios/pull/1130#discussion_r3575202269)).

Ticket: [MBL-2158](https://linear.app/customerio/issue/MBL-2158/ios-review-and-update-geofence-privacyinfo)

## Changes
- **Declares `PreciseLocation`** (Linked=false, Tracking=false, purpose: app functionality). The manifest claimed coordinates are never sent, but the nearby-geofence fetch posts exact latitude/longitude to `/geofences/nearest`. Apple's ephemeral exemption ("accessible no longer than necessary to service the request in real time") does not apply because the coordinates end up in unredacted server logs. `Linked=false` because the request carries no user identifier, so the location is not attributable to a person. Transition events themselves carry geofence ids, never coordinates.
- **Declares the UserDefaults required-reason API** (`CA92.1`) for the CLMonitor condition mirror — the accessed-API list was wrongly empty.

## Open for team discussion (deliberately unchanged here)
- **Linked flags on UserID/ProductInteraction**: the inherited "anonymous profiles make person-linkage optional" rationale is stale for this module — geofence delivery is identified-only, so every transition carries a userId. Arguably `Linked=true` here, but that diverges from DataPipeline's stance; needs a Legal/consistency call.
- **CoarseLocation for transitions**: an identified event saying a user entered a named geofence communicates presence at a place without coordinates. Conservative reading declares `CoarseLocation` (Linked=true); current reading covers it as ProductInteraction.
- **Future slim-down path**: if the backend redacts coordinates from `/geofences/nearest` logs, the `PreciseLocation` entry can be dropped in a follow-up under the real-time-servicing basis.

## Testing
- `plutil -lint` passes; resource-only change, no code affected.

## Notes
- Base is `feature/geofence-on-device`; the umbrella feature→main PR is #1130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Resource-only privacy manifest and comment updates; no runtime code or API behavior changes.
> 
> **Overview**
> Updates **CioLocationGeofence** `PrivacyInfo.xcprivacy` so it matches what the module actually does, instead of stating that device coordinates are never sent.
> 
> **Adds `NSPrivacyCollectedDataTypePreciseLocation`** (not linked, not used for tracking, app functionality) for the nearby-geofence **`/geofences/nearest`** request that posts exact latitude/longitude, with inline rationale that the call carries no user id. Existing **ProductInteraction** and **UserID** entries are unchanged.
> 
> **Fills in `NSPrivacyAccessedAPITypes`** with **UserDefaults** and reason **CA92.1** for the CLMonitor condition-id mirror that was previously missing from an empty list. Section-level Apple doc links and comments were added for maintainers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f28578dac011cc10932e2a5f54f861506a3a2ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->