### PR TITLE
chore(geofence): drop regions the OS would reject before ranking and registration

### DIFF
--- a/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
@@ -1,4 +1,5 @@
 import CioInternalCommon
+import CoreLocation
 import Foundation
 
 /// Wire shape of the nearby geofence fetch response. Every field on `config` and per-region
@@ -112,8 +113,16 @@ extension GeofenceApiResponse {
         config?.toDomain()
     }
 
-    func toDomainRegions() -> [Geofence] {
-        geofences.map { $0.toDomain() }
+    /// Regions the OS would reject (non-positive radius, out-of-range coordinates) are dropped
+    /// here so one bad server region costs itself, not a nearest-selection slot or the whole sync.
+    func toDomainRegions(onInvalidRegion: (String) -> Void = { _ in }) -> [Geofence] {
+        geofences.compactMap { region in
+            guard let domain = region.toDomain() else {
+                onInvalidRegion(region.id)
+                return nil
+            }
+            return domain
+        }
     }
 }
 
@@ -170,12 +179,17 @@ private extension Comparable {
 }
 
 extension GeofenceApiRegion {
-    /// Empty / nil / all-unknown `transition_types` fall back to `[.enter, .exit]`; a mix of
-    /// valid + unknown keeps just the valid subset. `lastUpdated` defaults to epoch when
-    /// missing so callers can compare without unwrapping. `name` is `nil` when the server omits it
-    /// (or sends an empty string), so the domain value is always either `nil` or non-empty.
-    func toDomain() -> Geofence {
-        Geofence(
+    /// `nil` when the region violates the monitors' registration preconditions (radius must be
+    /// positive, coordinates in range). Empty / nil / all-unknown `transition_types` fall back to
+    /// `[.enter, .exit]`; a mix of valid + unknown keeps just the valid subset. `lastUpdated`
+    /// defaults to epoch when missing so callers can compare without unwrapping. `name` is `nil`
+    /// when the server omits it (or sends an empty string), so the domain value is always either
+    /// `nil` or non-empty.
+    func toDomain() -> Geofence? {
+        guard radius > 0,
+              CLLocationCoordinate2DIsValid(CLLocationCoordinate2D(latitude: latitude, longitude: longitude))
+        else { return nil }
+        return Geofence(
             id: id,
             latitude: latitude,
             longitude: longitude,

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
@@ -33,7 +33,7 @@ extension GeofenceSyncCoordinatorImpl {
         }
 
         let parsedConfig = response.toDomainConfig()
-        let regions = response.toDomainRegions()
+        let regions = response.toDomainRegions(onInvalidRegion: { logger.geofenceInvalidRegionDropped($0) })
         let effectiveConfig = parsedConfig ?? cachedConfig ?? .fallback
         let anchor = LocationData(latitude: latitude, longitude: longitude)
         let nearest = distanceFilter.nearest(regions, to: anchor, limit: effectiveConfig.maxBusinessGeofences, maxDistance: effectiveConfig.maxMonitoringDistance)

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -5,6 +5,14 @@ import Foundation
 private let geofenceTag = "Geofence"
 
 extension Logger {
+    func geofenceInvalidRegionDropped(_ identifier: String) {
+        error(
+            "Geofence '\(identifier)' dropped — invalid coordinates or radius, not registerable with the OS",
+            geofenceTag,
+            nil
+        )
+    }
+
     func geofenceInvalidCoordinatesForRegion(_ identifier: String) {
         error(
             "Invalid coordinates for region \(identifier), skipping",

--- a/Tests/LocationGeofence/Geofence/Api/GeofenceApiResponseTests.swift
+++ b/Tests/LocationGeofence/Geofence/Api/GeofenceApiResponseTests.swift
@@ -228,6 +228,59 @@ struct GeofenceApiResponseTests {
     }
 
     @Test
+    func toDomainRegions_givenNonPositiveRadius_expectDropped() throws {
+        let json = """
+        {"geofences":[
+          {"id":"g0","latitude":1,"longitude":2,"radius":0},
+          {"id":"g-neg","latitude":1,"longitude":2,"radius":-50}
+        ]}
+        """
+        let response = try decode(json)
+        #expect(response.toDomainRegions().isEmpty)
+    }
+
+    @Test
+    func toDomainRegions_givenOutOfRangeCoordinates_expectDropped() throws {
+        let json = """
+        {"geofences":[
+          {"id":"lat-high","latitude":90.1,"longitude":2,"radius":100},
+          {"id":"lat-low","latitude":-90.1,"longitude":2,"radius":100},
+          {"id":"lon-high","latitude":1,"longitude":180.1,"radius":100},
+          {"id":"lon-low","latitude":1,"longitude":-180.1,"radius":100}
+        ]}
+        """
+        let response = try decode(json)
+        #expect(response.toDomainRegions().isEmpty)
+    }
+
+    @Test
+    func toDomainRegions_givenMixedValidAndInvalidRegions_expectValidKeptAndInvalidReported() throws {
+        // One bad server region must cost itself, not the rest of the sync.
+        let json = """
+        {"geofences":[
+          {"id":"good","latitude":1,"longitude":2,"radius":100},
+          {"id":"bad","latitude":91,"longitude":2,"radius":100}
+        ]}
+        """
+        let response = try decode(json)
+        var droppedIds: [String] = []
+        let regions = response.toDomainRegions(onInvalidRegion: { droppedIds.append($0) })
+
+        #expect(regions.map(\.id) == ["good"])
+        #expect(droppedIds == ["bad"])
+    }
+
+    @Test
+    func toDomainRegions_givenBoundaryCoordinates_expectKept() throws {
+        // The exact poles/antimeridian are valid registerable coordinates.
+        let json = """
+        {"geofences":[{"id":"edge","latitude":90,"longitude":-180,"radius":100}]}
+        """
+        let response = try decode(json)
+        #expect(response.toDomainRegions().first?.id == "edge")
+    }
+
+    @Test
     func toDomainRegions_givenLastUpdatedMillis_expectConvertedToSeconds() throws {
         // Wire value is epoch milliseconds; the domain `Date` is seconds.
         let json = """


### PR DESCRIPTION
Validates server geofence data at the API-mapping layer, dropping regions the OS would reject (non-positive radius, out-of-range coordinates) instead of carrying them into ranking and registration.

Ticket: [MBL-2157](https://linear.app/customerio/issue/MBL-2157/mobile-validate-geofence-data-before-registering-with-the-os)
Android counterpart: customerio-android `a2b8213c` (merged)

## Why
On Android the same data crashes GMS at request build, so validation there is crash-prevention. iOS cannot crash on it (CoreLocation registration doesn't throw, and both monitors already skip invalid coordinates), but two real costs remained:
- An invalid region consumed one of the ≤19 nearest-selection slots, displacing a valid fence.
- A region with radius ≤ 0 passed the monitors' coordinate-only guard and occupied one of the 20 OS region slots while never being able to fire.

Validating at the mapping also keeps the monitored set identical across platforms for the same server payload.

## Changes
- `GeofenceApiRegion.toDomain()` returns `nil` when radius ≤ 0 or `CLLocationCoordinate2DIsValid` fails — the same precondition the monitors enforce.
- `toDomainRegions(onInvalidRegion:)` compact-maps and reports each dropped id; the refresh path logs it (`error` level, matching the module's existing invalid-coordinates log).
- Android's two exception nets (`runCatching` per region, try/catch at the OS request build) are deliberately omitted: Swift's mapping can't throw and CoreLocation registration doesn't crash, so both would be dead code here.

## Crash-surface check (invalid data end to end)
Response decode is wrapped (`.decoding` failure); `JSONDecoder` rejects non-finite number literals outright (verified empirically), so no NaN/Infinity can reach the guards; a giant-but-finite radius is clamped to `maximumRegionMonitoringDistance` before any OS call; runtime monitoring failures arrive via `monitoringDidFailFor`, which already removes ownership and logs.

## Testing
- 4 new `GeofenceApiResponseTests`: radius 0/negative dropped; all four coordinate range violations dropped; mixed payload keeps the valid region and reports the invalid id (exact-array assertions); poles/antimeridian boundary coordinates kept.
- Full run green: `GeofenceApiResponseTests` + `GeofenceSyncCoordinatorTests` + `GeofenceApiServiceTests`, 107/107. Format + lint clean. No public API change.

## Notes
- Base is `feature/geofence-on-device`; the umbrella feature→main PR is #1130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive validation at the mapping layer before ranking/registration; no public API change and behavior aligns with existing monitor guards.
> 
> **Overview**
> Server geofences are now **filtered at API-to-domain mapping** so regions Core Location would not accept never enter nearest-selection or OS registration.
> 
> **`GeofenceApiRegion.toDomain()`** returns `nil` when radius is not positive or coordinates fail `CLLocationCoordinate2DIsValid`. **`toDomainRegions(onInvalidRegion:)`** compact-maps with an optional callback per dropped id. The remote refresh path wires that callback to a new **`geofenceInvalidRegionDropped`** error log.
> 
> Invalid payloads no longer steal one of the limited nearest slots or occupy a monitored region slot with zero/negative radius. Four unit tests cover radius, coordinate bounds, mixed valid/invalid with callback reporting, and boundary coordinates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 805f26adc78095312e00cc2cb0106f42c6511be2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->