### PR TITLE
chore(live-activities): CocoaPods podspecs for LiveActivities modules

### DIFF
--- a/CustomerIO.podspec
+++ b/CustomerIO.podspec
@@ -54,4 +54,16 @@ Pod::Spec.new do |spec|
   spec.subspec "Location" do |ss|
     ss.dependency "CustomerIOLocation", "= #{spec.version.to_s}"
   end
+
+  spec.subspec "LiveActivities" do |ss|
+    ss.dependency "CustomerIOLiveActivities", "= #{spec.version.to_s}"
+  end
+
+  spec.subspec "LiveActivitiesAttributes" do |ss|
+    ss.dependency "CustomerIOLiveActivitiesAttributes", "= #{spec.version.to_s}"
+  end
+
+  spec.subspec "LiveActivitiesTemplates" do |ss|
+    ss.dependency "CustomerIOLiveActivitiesTemplates", "= #{spec.version.to_s}"
+  end
 end

--- a/CustomerIOLiveActivities.podspec
+++ b/CustomerIOLiveActivities.podspec
@@ -1,0 +1,26 @@
+Pod::Spec.new do |spec|
+  spec.name         = "CustomerIOLiveActivities"
+  spec.version      = "4.6.0" # Don't modify this line - it's automatically updated
+  spec.summary      = "Official Customer.io SDK for iOS."
+  spec.homepage     = "https://github.com/customerio/customerio-ios"
+  spec.documentation_url = 'https://customer.io/docs/sdk/ios/'
+  spec.changelog    = "https://github.com/customerio/customerio-ios/blob/#{spec.version.to_s}/CHANGELOG.md"
+  spec.license      = { :type => "MIT", :file => "LICENSE" }
+  spec.author       = { "CustomerIO Team" => "win@customer.io" }
+  spec.source       = { :git => 'https://github.com/customerio/customerio-ios.git', :tag => spec.version.to_s }
+
+  spec.swift_version = '5.9'
+  spec.cocoapods_version = '>= 1.11.0'
+
+  spec.platform = :ios
+  spec.ios.deployment_target = "13.0"
+
+  # Live Activities runtime (registration, lifecycle, delivery/token reporting). Import in the
+  # app target only. Live Activities APIs are @available(iOS 16.2, *)-gated in source.
+  path_to_source_for_module = "Sources/LiveActivities"
+  spec.source_files = "#{path_to_source_for_module}/**/*{.swift}"
+  spec.module_name = "CioLiveActivities" # the `import X` name when using SDK in Swift files
+
+  spec.dependency "CustomerIOCommon", "= #{spec.version.to_s}"
+  spec.dependency "CustomerIOLiveActivitiesAttributes", "= #{spec.version.to_s}"
+end

--- a/CustomerIOLiveActivitiesAttributes.podspec
+++ b/CustomerIOLiveActivitiesAttributes.podspec
@@ -1,0 +1,23 @@
+Pod::Spec.new do |spec|
+  spec.name         = "CustomerIOLiveActivitiesAttributes"
+  spec.version      = "4.6.0" # Don't modify this line - it's automatically updated
+  spec.summary      = "Official Customer.io SDK for iOS."
+  spec.homepage     = "https://github.com/customerio/customerio-ios"
+  spec.documentation_url = 'https://customer.io/docs/sdk/ios/'
+  spec.changelog    = "https://github.com/customerio/customerio-ios/blob/#{spec.version.to_s}/CHANGELOG.md"
+  spec.license      = { :type => "MIT", :file => "LICENSE" }
+  spec.author       = { "CustomerIO Team" => "win@customer.io" }
+  spec.source       = { :git => 'https://github.com/customerio/customerio-ios.git', :tag => spec.version.to_s }
+
+  spec.swift_version = '5.9'
+  spec.cocoapods_version = '>= 1.11.0'
+
+  spec.platform = :ios
+  spec.ios.deployment_target = "13.0"
+
+  # Protocols/models only, no SDK dependency. Safe to import in the app target and the
+  # widget extension. Live Activities APIs are @available(iOS 16.2, *)-gated in source.
+  path_to_source_for_module = "Sources/LiveActivities_Attributes"
+  spec.source_files = "#{path_to_source_for_module}/**/*{.swift}"
+  spec.module_name = "CioLiveActivities_Attributes" # the `import X` name when using SDK in Swift files
+end

--- a/CustomerIOLiveActivitiesTemplates.podspec
+++ b/CustomerIOLiveActivitiesTemplates.podspec
@@ -1,0 +1,25 @@
+Pod::Spec.new do |spec|
+  spec.name         = "CustomerIOLiveActivitiesTemplates"
+  spec.version      = "4.6.0" # Don't modify this line - it's automatically updated
+  spec.summary      = "Official Customer.io SDK for iOS."
+  spec.homepage     = "https://github.com/customerio/customerio-ios"
+  spec.documentation_url = 'https://customer.io/docs/sdk/ios/'
+  spec.changelog    = "https://github.com/customerio/customerio-ios/blob/#{spec.version.to_s}/CHANGELOG.md"
+  spec.license      = { :type => "MIT", :file => "LICENSE" }
+  spec.author       = { "CustomerIO Team" => "win@customer.io" }
+  spec.source       = { :git => 'https://github.com/customerio/customerio-ios.git', :tag => spec.version.to_s }
+
+  spec.swift_version = '5.9'
+  spec.cocoapods_version = '>= 1.11.0'
+
+  spec.platform = :ios
+  spec.ios.deployment_target = "13.0"
+
+  # Bundled SwiftUI/WidgetKit templates (Segments, Countdown Timer). Import in both the app
+  # target and the widget extension when using a built-in template.
+  path_to_source_for_module = "Sources/LiveActivities_Templates"
+  spec.source_files = "#{path_to_source_for_module}/**/*{.swift}"
+  spec.module_name = "CioLiveActivities_Templates" # the `import X` name when using SDK in Swift files
+
+  spec.dependency "CustomerIOLiveActivitiesAttributes", "= #{spec.version.to_s}"
+end


### PR DESCRIPTION
Adds CocoaPods podspecs for the three (currently SwiftPM-only) Live Activities modules plus `CustomerIO/*` subspec aliases, so the wrapper SDKs can consume Live Activities via CocoaPods. Unblocks end-to-end wrapper verification via `:git`/`:branch` ahead of a formal release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only changes (podspecs and umbrella subspecs); no runtime or SDK logic is modified in this diff.
> 
> **Overview**
> Adds **CocoaPods** distribution for the Live Activities stack that was previously **SwiftPM-only**, so wrapper SDKs and apps can pull it via `:git`/`:branch` before a formal release.
> 
> Three new pods mirror the existing source layout: **`CustomerIOLiveActivities`** (runtime in `Sources/LiveActivities`, depends on Common + Attributes), **`CustomerIOLiveActivitiesAttributes`** (shared protocols/models for app + widget extension, no SDK deps), and **`CustomerIOLiveActivitiesTemplates`** (bundled SwiftUI/WidgetKit templates, depends on Attributes). Each pod sets **`module_name`** to the same `CioLiveActivities*` imports used with SPM and pins **Swift 5.9** / iOS 13.0 with version-locked dependencies at **4.6.0**.
> 
> The umbrella **`CustomerIO`** podspec gains subspec aliases **`LiveActivities`**, **`LiveActivitiesAttributes`**, and **`LiveActivitiesTemplates`** so consumers can use the usual `CustomerIO/LiveActivities` style installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 723ba861d2fb6585f9cda4e0eaf0e0300bb9cd84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->