### PR TITLE
feat(live-activities): stop reporting locally-triggered updates

### DIFF
--- a/Sources/LiveActivities/LiveActivitiesModule.swift
+++ b/Sources/LiveActivities/LiveActivitiesModule.swift
@@ -134,7 +134,8 @@ public final class LiveActivitiesModule {
     /// Works with any `ActivityAttributes` type — conforming to `CIOActivityAttribute` is only
     /// required for push-to-start.
     ///
-    /// - Returns: A handle whose `update`/`end` report the corresponding events.
+    /// - Returns: A handle whose `end` reports an `end` event; `update` applies the new
+    ///   content-state locally and is intentionally not reported.
     /// - Throws: `LiveActivityError.typeNotRegistered` if `Attributes` was not registered.
     @available(iOS 16.2, *)
     @discardableResult
@@ -216,8 +217,9 @@ public final class LiveActivitiesModule {
         )
     }
 
-    /// Wrap an activity your app created directly, so you can report `update`/`end` through the
-    /// returned handle. Does not report a `start` event (use `start` for that). Token capture for
+    /// Wrap an activity your app created directly, so you can drive `update`/`end` through the
+    /// returned handle — only `end` is reported; `update` applies locally and is not reported. Does
+    /// not report a `start` event (use `start` for that). Token capture for
     /// registered types happens automatically via observation regardless of `adopt`. Works with any
     /// `ActivityAttributes` type.
     @available(iOS 16.2, *)

--- a/Sources/LiveActivities/LiveActivityHandle.swift
+++ b/Sources/LiveActivities/LiveActivityHandle.swift
@@ -7,12 +7,14 @@ import ActivityKit
 
 /// A handle to a Live Activity the SDK is managing locally.
 ///
-/// Returned by `LiveActivitiesModule.start(...)` and `adopt(_:)`. Driving the activity through
-/// this handle's `update`/`end` is what emits the local `Live Notification Event`s — a backend
-/// push that changes or ends the activity is applied by the OS and is never reported.
+/// Returned by `LiveActivitiesModule.start(...)` and `adopt(_:)`. Starting and ending the activity
+/// through this handle is what emits the local `start`/`end` `Live Notification Event`s. A local
+/// `update` is applied to the activity but is intentionally not reported — only `start`/`end` emit a
+/// CDP event. A backend push that changes or ends the activity is applied by the OS and is never
+/// reported either.
 ///
-/// > Important: Ending or updating the underlying `activity` directly (bypassing this handle)
-/// > performs the ActivityKit operation but emits no Customer.io event.
+/// > Important: Ending the underlying `activity` directly (bypassing this handle) performs the
+/// > ActivityKit operation but emits no Customer.io event.
 @available(iOS 16.2, *)
 public struct CIOLiveActivity<Attributes: ActivityAttributes> {
     /// The stable correlation id (minted by the SDK for local starts, or carried in the
@@ -46,18 +48,16 @@ public struct CIOLiveActivity<Attributes: ActivityAttributes> {
         self.markLocalEnd = markLocalEnd
     }
 
-    /// Apply a local content-state update and report an `update` event.
+    /// Apply a local content-state update to the activity.
+    ///
+    /// The new content-state is applied locally via ActivityKit. This is intentionally **not**
+    /// reported to Customer.io — only `start` and `end` emit a `Live Notification Event`.
     public func update(
         _ contentState: Attributes.ContentState,
         staleDate: Date? = nil,
         alert: AlertConfiguration? = nil
     ) async {
         await activity.update(ActivityContent(state: contentState, staleDate: staleDate), alertConfiguration: alert)
-        reporter.reportUpdate(
-            instanceUUID: id,
-            notificationType: notificationType,
-            contentState: LiveActivityReporter.encode(contentState)
-        )
     }
 
     /// End the activity locally and report an `end` event with an optional final content-state.

--- a/Sources/LiveActivities/Observation/LiveActivityObserver.swift
+++ b/Sources/LiveActivities/Observation/LiveActivityObserver.swift
@@ -26,8 +26,8 @@ func liveActivityTerminalAction(firstTerminalIsDismissed: Bool, wasLocalEnd: Boo
 /// Starts one root task per registration, can `restart` after a reset, and cancels everything
 /// on `stop`/`deinit`. Observation only *captures tokens* (routed to the registrar) and surfaces
 /// appeared/ended signals — it never emits lifecycle events. Those come exclusively from the
-/// `start`/`update`/`end` API via `LiveActivityReporter`, so backend-initiated (push) changes
-/// are never echoed back.
+/// `start`/`end` API via `LiveActivityReporter` (a local `update` applies content but is not
+/// reported), so backend-initiated (push) changes are never echoed back.
 final class LiveActivityObserver: @unchecked Sendable {
     private let registrations: [ActivityTypeRegistration]
     private let registrar: LiveActivityRegistrar

--- a/Sources/LiveActivities/Reporting/LiveActivityContract.swift
+++ b/Sources/LiveActivities/Reporting/LiveActivityContract.swift
@@ -8,7 +8,7 @@ import Foundation
 enum LiveActivityContract {
     /// Track event names.
     enum Event {
-        /// Lifecycle event: start / update / end.
+        /// Lifecycle event: start / end.
         static let lifecycle = "Live Notification Event"
         /// Token registration event: push_to_start / instance.
         static let token = "Live Notification Token"
@@ -24,18 +24,18 @@ enum LiveActivityContract {
         static let notificationType = "notificationType"
         /// Static attributes object (encoded `Attributes`). Sent on `start` only.
         static let attributes = "attributes"
-        /// Dynamic content-state object (encoded `ContentState`). Sent on `start`/`update`,
-        /// and optionally on `end`.
+        /// Dynamic content-state object (encoded `ContentState`). Sent on `start`, and
+        /// optionally on `end`. Local updates are not reported.
         static let contentState = "contentState"
         static let pushToStartToken = "pushToStartToken"
         static let attributesType = "attributesType"
         static let instanceToken = "instanceToken"
     }
 
-    /// `eventType` values for the lifecycle event.
+    /// `eventType` values for the lifecycle event. Local updates are not reported, so only
+    /// `start`/`end` are emitted.
     enum EventType {
         static let start = "start"
-        static let update = "update"
         static let end = "end"
     }
 

--- a/Sources/LiveActivities/Reporting/LiveActivityReporter.swift
+++ b/Sources/LiveActivities/Reporting/LiveActivityReporter.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Maps Live Activities lifecycle and token registration to Customer.io CDP track events.
 ///
-/// Emits two events — `Live Notification Event` (start/update/end) and
+/// Emits two events — `Live Notification Event` (start/end) and
 /// `Live Notification Token` (push_to_start/instance) — carrying the contract fields under
 /// the event's `properties`. The data pipeline owns batching, retry and flush, so this type
 /// is a thin mapper.

--- a/Sources/LiveActivities/Reporting/LiveActivityReporter.swift
+++ b/Sources/LiveActivities/Reporting/LiveActivityReporter.swift
@@ -44,17 +44,6 @@ final class LiveActivityReporter: @unchecked Sendable {
         )
     }
 
-    /// Reports an `update`: sends the dynamic `contentState` object.
-    func reportUpdate(instanceUUID: String, notificationType: String, contentState: [String: Any]?) {
-        reportLifecycle(
-            eventType: LiveActivityContract.EventType.update,
-            instanceUUID: instanceUUID,
-            notificationType: notificationType,
-            attributes: nil,
-            contentState: contentState
-        )
-    }
-
     /// Reports an `end`: optionally sends a final `contentState` object (nil-omitted).
     func reportEnd(instanceUUID: String, notificationType: String, contentState: [String: Any]? = nil) {
         reportLifecycle(

--- a/Tests/LiveActivities/LiveActivitiesReporterTests.swift
+++ b/Tests/LiveActivities/LiveActivitiesReporterTests.swift
@@ -74,14 +74,6 @@ struct LiveActivityReporterShapeTests {
         #expect(contentState?["away"] as? Int == 2)
     }
 
-    @Test func reportUpdate_sendsContentStateOnly() {
-        let cap = identifiedCapture()
-        cap.makeReporter().reportUpdate(instanceUUID: "i1", notificationType: "type.a", contentState: ["home": 3])
-        #expect(cap.string(0, "eventType") == "update")
-        #expect(cap.events[0].properties["attributes"] == nil)
-        #expect(cap.events[0].properties["contentState"] != nil)
-    }
-
     @Test func reportEnd_withFinalContentState_sendsIt() {
         let cap = identifiedCapture()
         cap.makeReporter().reportEnd(instanceUUID: "i1", notificationType: "type.a", contentState: ["home": 5])


### PR DESCRIPTION
Local Live Activity updates driven by the host app now render/apply locally but no longer emit a `Live Notification Event` (`eventType=update`) to CDP — only `start` and `end` are reported. Removes the dead `reportUpdate` path and the `update` eventType from the wire contract. Public `update()` API is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shared CDP wire contract (`eventType` values) and analytics behavior for apps that relied on local update events; public `update()` API is unchanged so integration risk is mainly downstream data pipelines.
> 
> **Overview**
> **Local Live Activity updates no longer emit CDP lifecycle events.** `CIOLiveActivity.update()` still applies content via ActivityKit, but the SDK no longer calls `LiveActivityReporter` or sends `Live Notification Event` with `eventType=update`.
> 
> **Wire contract and reporter are trimmed to `start`/`end` only.** `LiveActivityContract.EventType.update` and `reportUpdate` are removed; docs on `LiveActivitiesModule`, `CIOLiveActivity`, and `LiveActivityObserver` state that only local `start`/`end` are reported (push-driven changes remain unreported). The `reportUpdate_sendsContentStateOnly` test is dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e786a7f1c830f4382fb9cf4843e1ec3dec0bbf06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->