### PR TITLE
chore(geofence): align privacy manifest linkage with identified-only delivery

### DIFF
--- a/Sources/LocationGeofence/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/LocationGeofence/Resources/PrivacyInfo.xcprivacy
@@ -9,10 +9,7 @@
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array>
 		<!-- The nearby-geofence fetch sends the device's exact coordinates so the server can
-		     return the fences around it. The request carries no user identifier, but the
-		     coordinates currently persist in server request logs, so the ephemeral
-		     real-time-servicing exemption does not apply. Drop this entry once the
-		     endpoint's logs redact coordinates. -->
+		     return the fences around it. The request carries no user identifier. -->
 		<dict>
 			<key>NSPrivacyCollectedDataType</key>
 			<string>NSPrivacyCollectedDataTypePreciseLocation</string>

--- a/Sources/LocationGeofence/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/LocationGeofence/Resources/PrivacyInfo.xcprivacy
@@ -9,9 +9,10 @@
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array>
 		<!-- The nearby-geofence fetch sends the device's exact coordinates so the server can
-		     return the fences around it. The request carries no user identifier, so the
-		     location is not attributable to a person. Transition events themselves carry
-		     geofence ids, never coordinates. -->
+		     return the fences around it. The request carries no user identifier, but the
+		     coordinates currently persist in server request logs, so the ephemeral
+		     real-time-servicing exemption does not apply. Drop this entry once the
+		     endpoint's logs redact coordinates. -->
 		<dict>
 			<key>NSPrivacyCollectedDataType</key>
 			<string>NSPrivacyCollectedDataTypePreciseLocation</string>
@@ -24,11 +25,13 @@
 				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
 			</array>
 		</dict>
+		<!-- Retained Geofence Transition events identify a geographic region (by id and
+		     name, never coordinates) and are associated with the identified user. -->
 		<dict>
 			<key>NSPrivacyCollectedDataType</key>
-			<string>NSPrivacyCollectedDataTypeProductInteraction</string>
+			<string>NSPrivacyCollectedDataTypeCoarseLocation</string>
 			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/> <!-- anonymous profiles make person-linkage optional -->
+			<true/>
 			<key>NSPrivacyCollectedDataTypeTracking</key>
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
@@ -38,11 +41,12 @@
 				<string>NSPrivacyCollectedDataTypePurposeProductPersonalization</string>
 			</array>
 		</dict>
+		<!-- Geofence delivery is identified-only; every event carries the user id. -->
 		<dict>
 			<key>NSPrivacyCollectedDataType</key>
 			<string>NSPrivacyCollectedDataTypeUserID</string>
 			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
+			<true/>
 			<key>NSPrivacyCollectedDataTypeTracking</key>
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>


### PR DESCRIPTION
Follow-up to #1168, adopting the manifest shape proposed by @Shahroz16 in [its review thread](https://github.com/customerio/customerio-ios/pull/1168#discussion_r3636052783) — with one fact-driven divergence explained below. Apologies for needing a second PR; #1168 was merged before the thread was addressed.

Ticket: [MBL-2158](https://linear.app/customerio/issue/MBL-2158/ios-review-and-update-geofence-privacyinfo)

## Changes (matching the review-thread proposal)
- **Retained Geofence Transition events → `CoarseLocation`, `Linked=true`** (was `ProductInteraction`, `Linked=false`): they identify a geographic region (id/name, never coordinates) associated with the identified user — the proposal's classification is the accurate one.
- **`UserID` → `Linked=true`**: the inherited "anonymous profiles make person-linkage optional" rationale no longer holds for this module — geofence delivery is identified-only since #1156, every event carries a userId.
- `ProductInteraction` entry removed (its content is now correctly covered by the CoarseLocation entry; also keeps the manifest minimal for host apps, which can't remove SDK declarations).

## PreciseLocation
Stays declared for now as the conservative posture, `Linked=false` (the request carries no user identifier). Per review, the endpoint does not persist coordinates in server request logs (an earlier assumption to the contrary was corrected in review and removed from the manifest comment) — which means Apple's ephemeral real-time-servicing exemption is available, and dropping this entry entirely (the review proposal's shape) is a one-line follow-up if the team prefers the minimal manifest.

## Testing
- `plutil -lint` passes; resource-only change, no code affected.

## Notes
- Base is `feature/geofence-on-device`; the umbrella feature→main PR is #1130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Plist-only privacy manifest updates with no code paths or data-handling logic changed; affects App Store disclosure accuracy for host apps.
> 
> **Overview**
> Updates **LocationGeofence** `PrivacyInfo.xcprivacy` so declared data types match identified-only geofence delivery and how transition events are categorized.
> 
> **Geofence transition events** move from `ProductInteraction` with `Linked=false` to **`CoarseLocation` with `Linked=true`**, reflecting region id/name tied to the identified user (not coordinates). **`UserID`** is now **`Linked=true`** because every geofence event carries a user id. **`PreciseLocation`** stays declared with **`Linked=false`** for the nearby-fence lookup request (no user id on that call); plist comments were tightened to document that and why precise location is still listed.
> 
> Resource-only change; no SDK runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b425e8205a1a41ff345b836718f9d984fbba8a08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
