### PR TITLE
chore(location): preserve tracked intent when requests race the single-request gate

### DIFF
--- a/Sources/Location/LocationServices.swift
+++ b/Sources/Location/LocationServices.swift
@@ -221,7 +221,12 @@ actor LocationServicesImplementation: LocationServices {
     }
 
     private func clearTaskIfCurrent(_ task: Task<Void, Never>) async {
-        if currentTask == task { currentTask = nil }
+        guard currentTask == task else { return }
+        currentTask = nil
+        // A tracked request can arrive after `runLocationRequest`'s `defer` cleared the latch but
+        // while `currentTask` still looks busy. It is dropped either way; clearing here stops its
+        // intent from being consumed by an unrelated later fix.
+        pendingTrackUpgrade = false
     }
 
     /// - Parameters:

--- a/Sources/Location/LocationServices.swift
+++ b/Sources/Location/LocationServices.swift
@@ -98,6 +98,10 @@ actor LocationServicesImplementation: LocationServices {
     private let lifecycleNotifying: AppLifecycleNotifying
     private let applicationStateProvider: ApplicationStateProvider
     private var currentTask: Task<Void, Never>?
+    /// Set when a tracked request arrives while another request is in flight, so the tracked
+    /// intent survives the single-request gate (the lifecycle's tracked request and geofence's
+    /// silent auto-acquire race at first identified launch).
+    private var pendingTrackUpgrade = false
     /// Owned by this implementation; calls requestLocationUpdate/stopLocationUpdates when lifecycle events fire. Set in setUpLifecycleObserver() (after init so we can capture self).
     private var locationLifecycleObserver: LocationLifecycleObserver?
 
@@ -199,7 +203,13 @@ actor LocationServicesImplementation: LocationServices {
     }
 
     private func startRequestIfNeeded(track: Bool, respectMode: Bool) async {
-        guard currentTask == nil else { return }
+        guard currentTask == nil else {
+            // A dropped tracked request never retries this process (the lifecycle gate is
+            // one-shot), so latch the intent instead; the `.off` gate is re-applied when
+            // the in-flight request consumes it.
+            if track { pendingTrackUpgrade = true }
+            return
+        }
 
         var task: Task<Void, Never>!
         task = Task { [weak self] in
@@ -219,6 +229,9 @@ actor LocationServicesImplementation: LocationServices {
     ///   - respectMode: when true, honors the `.off` tracking mode (public path); geofence-initiated
     ///     fixes pass false so a location can be acquired even when location tracking is off.
     private func runLocationRequest(track: Bool, respectMode: Bool) async {
+        // A latched upgrade that found no fix is dropped, matching what the tracked request
+        // would have done itself (same provider, same failure; the gate retries neither).
+        defer { pendingTrackUpgrade = false }
         if respectMode {
             guard config.mode != .off else {
                 logger.trackingDisabledIgnoringRequestLocationUpdate()
@@ -228,7 +241,10 @@ actor LocationServicesImplementation: LocationServices {
         if let result = await locationProvider.requestLocationOnce() {
             switch result {
             case .success(let snapshot):
-                await postLocation(snapshot, track: track)
+                // The upgrade must not emit a track the public request itself would have
+                // refused under `.off` (silent requests run regardless of mode).
+                let upgraded = pendingTrackUpgrade && config.mode != .off
+                await postLocation(snapshot, track: track || upgraded)
             case .failure(.cancelled):
                 logger.locationRequestCancelled()
             case .failure(let error):

--- a/Sources/LocationGeofence/GeofenceConstants.swift
+++ b/Sources/LocationGeofence/GeofenceConstants.swift
@@ -11,11 +11,11 @@ enum GeofenceConstants {
 
     /// Fallback for `localRefreshTriggerRadius` (meters) — the movement-trigger geofence radius and
     /// the ranking-staleness threshold. Server config overrides it.
-    static let movementTriggerRadius: Double = 3000
+    static let movementTriggerRadius: Double = 1000
 
     /// Fallback for `remoteFetchRefreshTriggerRadius` (meters): how far the device must move from the
     /// last fetch anchor before the SDK refetches a fresh nearby set.
-    static let serverFetchDistance: Double = 20000
+    static let serverFetchDistance: Double = 5000
 
     /// Default `maxMonitoringDistance` (meters) applied when the server omits the field — which it
     /// does today. A finite cap (not "unlimited") so a device far from a workspace's geofences (e.g.

--- a/Tests/Location/LocationServicesImplementationTest.swift
+++ b/Tests/Location/LocationServicesImplementationTest.swift
@@ -209,6 +209,108 @@ struct LocationServicesImplementationTests {
         #expect(await service.getLastKnownLocation()?.latitude == 37.7749)
     }
 
+    // MARK: - In-flight request upgrade
+
+    /// Yields until the provider has an in-flight request (bounded), so a second request in the
+    /// test reliably arrives while the first one is actually running.
+    private func waitUntilRequestInFlight(_ provider: MockLocationProvider) async {
+        for _ in 0 ..< 200 {
+            if await provider.requestLocationCallCount >= 1 { return }
+            await Task.yield()
+        }
+    }
+
+    private var validSnapshot: LocationSnapshot {
+        LocationSnapshot(latitude: 37.7749, longitude: -122.4194, timestamp: Date(), horizontalAccuracy: 100, altitude: nil)
+    }
+
+    @Test
+    func requestLocationUpdate_givenSilentRequestInFlight_expectTrackedIntentUpgradesIt() async {
+        let mockProvider = MockLocationProvider()
+        await mockProvider.setResult(.success(validSnapshot))
+        await mockProvider.holdNextRequest()
+        let pipelineMock = DataPipelineTrackingMock()
+        let service = makeImplementation(mode: .manual, dataPipeline: pipelineMock, locationProvider: mockProvider)
+
+        service.requestLocationUpdateSilently()
+        await waitUntilRequestInFlight(mockProvider)
+        service.requestLocationUpdate()
+        await yieldForLocationTask()
+        await mockProvider.releaseHeldRequest()
+        await yieldForLocationTask()
+
+        // One acquisition serves both callers: the silent fix is promoted to a tracked one
+        // instead of the tracked request being dropped by the single-request gate.
+        #expect(await mockProvider.requestLocationCallCount == 1)
+        #expect(pipelineMock.trackCallsCount == 1)
+        #expect(pipelineMock.trackInvocations.first?.name == "CIO Location Update")
+    }
+
+    @Test
+    func requestLocationUpdateSilently_givenTrackedRequestInFlight_expectSingleTrackedResult() async {
+        let mockProvider = MockLocationProvider()
+        await mockProvider.setResult(.success(validSnapshot))
+        await mockProvider.holdNextRequest()
+        let pipelineMock = DataPipelineTrackingMock()
+        let service = makeImplementation(mode: .manual, dataPipeline: pipelineMock, locationProvider: mockProvider)
+
+        service.requestLocationUpdate()
+        await waitUntilRequestInFlight(mockProvider)
+        service.requestLocationUpdateSilently()
+        await yieldForLocationTask()
+        await mockProvider.releaseHeldRequest()
+        await yieldForLocationTask()
+
+        // The reverse overlap needs no upgrade: the tracked result feeds silent consumers too.
+        #expect(await mockProvider.requestLocationCallCount == 1)
+        #expect(pipelineMock.trackCallsCount == 1)
+    }
+
+    @Test
+    func requestLocationUpdate_givenSilentInFlightAndTrackingDisabled_expectNoTrackUpgrade() async {
+        let mockProvider = MockLocationProvider()
+        await mockProvider.setResult(.success(validSnapshot))
+        await mockProvider.holdNextRequest()
+        let pipelineMock = DataPipelineTrackingMock()
+        let service = makeImplementation(mode: .off, dataPipeline: pipelineMock, locationProvider: mockProvider)
+
+        service.requestLocationUpdateSilently()
+        await waitUntilRequestInFlight(mockProvider)
+        service.requestLocationUpdate()
+        await yieldForLocationTask()
+        await mockProvider.releaseHeldRequest()
+        await yieldForLocationTask()
+
+        // Under `.off` the tracked request would have been refused outright, so the latched
+        // intent must not smuggle a track through the silent request either.
+        #expect(pipelineMock.trackCallsCount == 0)
+    }
+
+    @Test
+    func requestLocationUpdate_givenSilentInFlightFails_expectUpgradeDroppedNotCarriedToNextRequest() async {
+        let mockProvider = MockLocationProvider()
+        await mockProvider.setResult(.failure(.permissionDenied))
+        await mockProvider.holdNextRequest()
+        let pipelineMock = DataPipelineTrackingMock()
+        let service = makeImplementation(mode: .manual, dataPipeline: pipelineMock, locationProvider: mockProvider)
+
+        service.requestLocationUpdateSilently()
+        await waitUntilRequestInFlight(mockProvider)
+        service.requestLocationUpdate()
+        await yieldForLocationTask()
+        await mockProvider.releaseHeldRequest()
+        await yieldForLocationTask()
+
+        // A later silent request must start from a clean slate: the failed request dropped the
+        // latched intent (the tracked request would have failed identically).
+        await mockProvider.setResult(.success(validSnapshot))
+        service.requestLocationUpdateSilently()
+        await yieldForLocationTask()
+
+        #expect(await mockProvider.requestLocationCallCount == 2)
+        #expect(pipelineMock.trackCallsCount == 0)
+    }
+
     @Test
     func stopLocationUpdates_expectCancelCalledOnProvider() async {
         let mockProvider = MockLocationProvider()

--- a/Tests/Location/Mocks/MockLocationProvider.swift
+++ b/Tests/Location/Mocks/MockLocationProvider.swift
@@ -8,12 +8,30 @@ actor MockLocationProvider: LocationProviding {
     private(set) var requestLocationCallCount = 0
     private(set) var cancelCallCount = 0
 
+    private var isHolding = false
+    private var holdContinuation: CheckedContinuation<Void, Never>?
+
     func setResult(_ result: LocationResult) {
         nextResult = result
     }
 
+    /// The next `requestLocationOnce` suspends until `releaseHeldRequest()`, letting tests keep
+    /// a request in flight while another arrives.
+    func holdNextRequest() {
+        isHolding = true
+    }
+
+    func releaseHeldRequest() {
+        isHolding = false
+        holdContinuation?.resume()
+        holdContinuation = nil
+    }
+
     func requestLocationOnce() async -> LocationResult? {
         requestLocationCallCount += 1
+        if isHolding {
+            await withCheckedContinuation { holdContinuation = $0 }
+        }
         return nextResult
     }
 


### PR DESCRIPTION
Fixes the launch-time race flagged by @Shahroz16 in [#1130 review](https://github.com/customerio/customerio-ios/pull/1130#discussion_r3626299936) (and independently by Bugbot on its latest pass): a tracked location request that loses the single-request gate to geofence's silent auto-acquire was dropped for the whole process.

Ticket: [MBL-2191](https://linear.app/customerio/issue/MBL-2191/mobile-prevent-location-request-race-during-app-launch)

## The failure
On launch, the `.onAppStart` lifecycle request (`track: true`) and geofence `.automatic`'s silent acquire (`track: false`) race into `startRequestIfNeeded`'s `guard currentTask == nil` — the loser is silently dropped, intent included. When the silent request wins: no `CIO Location Update`, no cached location for identify enrichment, and the one-shot lifecycle gate never retries — until the next cold launch, which can be days away for an app living in background. The race condition (geofence has no anchor while a user is identified at launch) is true exactly once per user — but for the entire upgrade cohort: every existing identified user's first launch on a geofence-enabled build, plus every post-sign-out re-login. That's why this is in the release rather than a fast-follow: the fix arriving after the cohort's first launches would miss most of its purpose.

## The fix (the `wantsTracking` latch shape suggested in the review)
- `pendingTrackUpgrade` latch on the service actor: a tracked request arriving while another is in flight latches the intent instead of vanishing.
- The in-flight request consumes it at result time and posts a **tracked** result — one GPS fix serves both consumers (also one fewer acquisition than the no-race case would run).
- The `.off` mode gate is re-applied at consumption, so the upgrade can't smuggle a track the public request itself would have refused; silent-only behavior under `.off` is unchanged.
- A request that ends without a fix (failure/cancel) drops the latch via `defer` — matching what the tracked request would have done itself (same provider, same failure, no retry either way).
- The owning task also clears the latch when it clears `currentTask`, one actor turn later. Without that, a tracked request arriving in that turn latches an intent with no request left to consume it, and the next acquisition — often a geofence fix much later — would post it as a tracked update.

## Interleavings
- Silent in flight → tracked arrives: upgraded, tracked result (the bug).
- Tracked in flight → silent arrives: dropped as before — harmless, a tracked result feeds geofence via `LocationAcquiredEvent` regardless.
- Overlap under mode `.off`: no track emitted.
- Everything non-overlapping: byte-for-byte the previous code path; the latch stays false and the `defer` clear is a no-op.
- Residual: a tracked request arriving in the single actor-turn between the in-flight result posting and the task clearing is still dropped — identical to today's behavior, with the window shrunk from seconds to microseconds.

All state is actor-isolated alongside `currentTask` — no locks, no new Sendable surface.

## Testing
- 4 new tests pin each interleaving (upgrade delivers one tracked result from one provider call; reverse order unchanged; `.off` refuses the upgrade; a failed request drops the latch so the next silent request stays silent). `MockLocationProvider` gained a hold/release gate so tests keep a request genuinely in flight.
- Full `LocationTests` suite green (63), format + lint clean, no public API change.

## Also included: fallback config constants aligned with live server defaults
`movementTriggerRadius` 3000 → 1000 and `serverFetchDistance` 20000 → 5000, matching what the config endpoint serves today. Fallbacks only govern the pre-first-fetch window (and per-field decode failures); the previous values were deliberately more conservative, so this is a tuning alignment, not a behavior fix. Full `LocationGeofenceTests` green (265). Android has the same 3000/20000 fallbacks — aligning it is tracked separately.

## Notes
- Merge order: if reviewed before the feature→main merge, this lands into `feature/geofence-on-device` first; otherwise it re-targets `main` afterwards.
- Base is `feature/geofence-on-device`; the umbrella feature→main PR is #1130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes launch-time location analytics and geofence pre-config refresh thresholds; behavior is actor-isolated and covered by new tests with no public API change.
> 
> **Overview**
> Fixes a **launch-time race** where a tracked `requestLocationUpdate()` (e.g. `.onAppStart`) could lose to geofence’s silent acquire on the single in-flight gate and never retry—dropping `CIO Location Update` and identify enrichment until the next cold launch.
> 
> `LocationServicesImplementation` now **latches** `pendingTrackUpgrade` when a tracked call arrives while another request is running; the in-flight fix can be **promoted** to a tracked post on success (still blocked under `.off`, cleared on failure/cancel and when the owning task finishes). Non-overlapping paths stay the same.
> 
> **Geofence fallbacks** (pre-server-config only): `movementTriggerRadius` **3000 → 1000** m and `serverFetchDistance` **20000 → 5000** m to match live server defaults.
> 
> Tests add **hold/release** on `MockLocationProvider` and four cases for upgrade, reverse overlap, `.off`, and failed-request latch cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ff08b0c319452f09a7871d48c4f95cb5b34be3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


