### PR TITLE
fix(in-app): stop corrupting escaped regex in page route rules

### DIFF
--- a/Sources/MessagingInApp/Gist/Managers/Models/Message.swift
+++ b/Sources/MessagingInApp/Gist/Managers/Models/Message.swift
@@ -153,10 +153,11 @@ extension Message {
     }
 
     var cleanPageRule: String? {
-        guard let routeRule = gistProperties.routeRule else {
-            return nil
-        }
-        return routeRule.replacingOccurrences(of: "\\", with: "/")
+        // The route rule arrives from the backend as a ready-to-use regex with any
+        // metacharacters already escaped (e.g. "\." for a literal dot). Return it
+        // unmodified. A previous "\" -> "/" replacement here corrupted those escapes
+        // (turning "\." into "/."), so any route containing a "." could never match.
+        gistProperties.routeRule
     }
 
     /*

--- a/Tests/MessagingInApp/Gist/Managers/Models/MessageTest.swift
+++ b/Tests/MessagingInApp/Gist/Managers/Models/MessageTest.swift
@@ -1,4 +1,5 @@
 @testable import CioMessagingInApp
+import Foundation
 import XCTest
 
 class MessageTest: XCTestCase {
@@ -70,8 +71,9 @@ class MessageTest: XCTestCase {
     // untouched so these escapes survive; corrupting "\" would make any dotted
     // route impossible to match.
     func test_doesPageRuleMatch_givenContainsRuleWithEscapedDots_expectMatchDottedRoute() {
-        // `#"\."#` in a raw string is a backslash followed by a dot, exactly as the
-        // route rule arrives over the wire for a "contains dashboard.account.settings" rule.
+        // `#"\."#` in a raw string is a single backslash followed by a dot: the pattern
+        // as it exists in memory after JSON decoding, for a "contains
+        // dashboard.account.settings" rule.
         let message = Message(pageRule: #"^(.*dashboard\.account\.settings.*)$"#)
         XCTAssertTrue(message.doesPageRuleMatch(route: "dashboard.account.settings"))
     }
@@ -81,6 +83,33 @@ class MessageTest: XCTestCase {
         XCTAssertTrue(message.doesPageRuleMatch(route: "dashboard.account.settings"))
     }
 
+    // MARK: - doesPageRuleMatch across the JSON transport boundary
+
+    // The tests above hand Message a Swift literal, which skips the step where the escape
+    // could be lost. The backend delivers the rule inside the message's `properties` JSON,
+    // where a literal dot is written `\\.` on the wire and decodes to `\.` in memory.
+    // Building the message from real JSON pins the whole path: wire escaping -> decoded
+    // pattern -> ICU literal-dot match.
+    func test_doesPageRuleMatch_givenRouteRuleDecodedFromJson_expectMatchDottedRoute() throws {
+        // Raw string, so `\\.` is the two characters JSON uses to encode one backslash.
+        let json = #"""
+        {
+          "gist": {
+            "campaignId": "test-campaign",
+            "routeRuleApple": "^(.*dashboard\\.account\\.settings.*)$"
+          }
+        }
+        """#
+        let properties = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+        let message = Message(messageId: .random, queueId: .random, priority: nil, properties: properties)
+
+        // Decoding leaves one backslash before each dot, so ICU treats the dots as literal.
+        XCTAssertEqual(message.cleanPageRule, #"^(.*dashboard\.account\.settings.*)$"#)
+        XCTAssertTrue(message.doesPageRuleMatch(route: "dashboard.account.settings"))
+        // The escaped dots must stay literal rather than acting as the "any character" wildcard.
+        XCTAssertFalse(message.doesPageRuleMatch(route: "dashboardXaccountXsettings"))
+    }
+
     // MARK: - cleanPageRule preserves escaped metacharacters
 
     func test_cleanPageRule_givenEscapedDots_expectDotsNotCorruptedToSlash() {
@@ -88,9 +117,10 @@ class MessageTest: XCTestCase {
         XCTAssertEqual(message.cleanPageRule, #"^(.*dashboard\.account\.settings.*)$"#)
     }
 
-    // Some rules arrive with the backslash itself escaped (two backslashes before
-    // each dot). cleanPageRule must still leave every backslash intact.
-    func test_cleanPageRule_givenDoubleEscapedDots_expectBackslashesNotCorruptedToSlash() {
+    // cleanPageRule is a pass-through: it must preserve every backslash, whatever follows it.
+    // This is an identity check on the property, not a claim that the backend sends
+    // consecutive backslashes.
+    func test_cleanPageRule_givenConsecutiveBackslashes_expectEveryBackslashPreserved() {
         let message = Message(pageRule: #"^(.*dashboard\\.account\\.settings.*)$"#)
         XCTAssertEqual(message.cleanPageRule, #"^(.*dashboard\\.account\\.settings.*)$"#)
     }

--- a/Tests/MessagingInApp/Gist/Managers/Models/MessageTest.swift
+++ b/Tests/MessagingInApp/Gist/Managers/Models/MessageTest.swift
@@ -62,4 +62,36 @@ class MessageTest: XCTestCase {
         let result = message.doesPageRuleMatch(route: "home")
         XCTAssertFalse(result)
     }
+
+    // MARK: - doesPageRuleMatch with escaped regex metacharacters
+
+    // A route target containing "." is delivered as a regex with the dots escaped
+    // (e.g. "\." for a literal dot). cleanPageRule must pass the regex through
+    // untouched so these escapes survive; corrupting "\" would make any dotted
+    // route impossible to match.
+    func test_doesPageRuleMatch_givenContainsRuleWithEscapedDots_expectMatchDottedRoute() {
+        // `#"\."#` in a raw string is a backslash followed by a dot, exactly as the
+        // route rule arrives over the wire for a "contains dashboard.account.settings" rule.
+        let message = Message(pageRule: #"^(.*dashboard\.account\.settings.*)$"#)
+        XCTAssertTrue(message.doesPageRuleMatch(route: "dashboard.account.settings"))
+    }
+
+    func test_doesPageRuleMatch_givenEqualsRuleWithEscapedDots_expectMatchExactDottedRoute() {
+        let message = Message(pageRule: #"^(dashboard\.account\.settings)$"#)
+        XCTAssertTrue(message.doesPageRuleMatch(route: "dashboard.account.settings"))
+    }
+
+    // MARK: - cleanPageRule preserves escaped metacharacters
+
+    func test_cleanPageRule_givenEscapedDots_expectDotsNotCorruptedToSlash() {
+        let message = Message(pageRule: #"^(.*dashboard\.account\.settings.*)$"#)
+        XCTAssertEqual(message.cleanPageRule, #"^(.*dashboard\.account\.settings.*)$"#)
+    }
+
+    // Some rules arrive with the backslash itself escaped (two backslashes before
+    // each dot). cleanPageRule must still leave every backslash intact.
+    func test_cleanPageRule_givenDoubleEscapedDots_expectBackslashesNotCorruptedToSlash() {
+        let message = Message(pageRule: #"^(.*dashboard\\.account\\.settings.*)$"#)
+        XCTAssertEqual(message.cleanPageRule, #"^(.*dashboard\\.account\\.settings.*)$"#)
+    }
 }


### PR DESCRIPTION
[MBL-2192: iOS SDK: dotted in-app page rules never match (cleanPageRule corrupts escaped regex)](https://linear.app/customerio/issue/MBL-2192/ios-sdk-dotted-in-app-page-rules-never-match-cleanpagerule-corrupts)

In-app page route rules arrive as a ready-to-use regex with metacharacters already escaped (e.g. `\.` for a literal dot). `cleanPageRule` was replacing every `\` with `/`, corrupting those escapes so any route containing a `.` could never match and the message was silently dropped. This returns the route rule unmodified and adds regression tests for single- and double-escaped dots (contains + equals forms).

Linear: MBL-2192

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix in page-rule string handling with targeted tests; restores intended regex matching without touching auth or data paths.
> 
> **Overview**
> Fixes in-app messages **silently failing to show** when page rules target routes that include dots (e.g. `dashboard.account.settings`).
> 
> **`cleanPageRule`** no longer replaces backslashes with slashes. Backend-supplied `routeRuleApple` regex already escapes metacharacters (`\.` for literal dots); the old transform turned `\.` into `/.`, breaking matching and dropping those messages.
> 
> Regression tests cover contains/equals patterns with escaped dots, JSON decode from `properties`, and identity checks that `cleanPageRule` preserves backslashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e60f67af082c7171f475daba68f70ab7057c9d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->