### PR TITLE
chore(geofence): keep monitoring through empty areas and add off mode

### DIFF
--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+OsRegistration.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+OsRegistration.swift
@@ -37,8 +37,8 @@ extension GeofenceSyncCoordinatorImpl {
         // Register the movement trigger FIRST so it isn't starved when business regions fill the
         // shared 20-region OS budget (e.g. a host app that also monitors regions): losing it freezes
         // the set, since exiting the trigger is what re-ranks toward now-closer geofences. Kept even
-        // when the distance cap left the business set empty; skipped only when there's nothing to
-        // register toward (no geofences, or registration kill-switched).
+        // when the nearby set is empty (distance cap or an empty fetch) so the device keeps re-fetching
+        // as it moves back toward geofences; skipped only when kill-switched (`maxBusinessGeofences == 0`).
         if registerMovementTrigger {
             monitor.startMonitoring(
                 identifier: GeofenceConstants.movementTriggerIdentifier,

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
@@ -37,6 +37,7 @@ extension GeofenceSyncCoordinatorImpl {
         let effectiveConfig = parsedConfig ?? cachedConfig ?? .fallback
         let anchor = LocationData(latitude: latitude, longitude: longitude)
         let nearest = distanceFilter.nearest(regions, to: anchor, limit: effectiveConfig.maxBusinessGeofences, maxDistance: effectiveConfig.maxMonitoringDistance)
+        let registerMovementTrigger = effectiveConfig.maxBusinessGeofences > 0
         // Read before `recordRegistration` overwrites it — the diff decides which registrations are new.
         let previouslyRegisteredIds = await storage.getRegisteredBusinessIds()
         let osRegistration = await MainActor.run {
@@ -44,7 +45,7 @@ extension GeofenceSyncCoordinatorImpl {
                 businessRegions: nearest,
                 movementTriggerLocation: anchor,
                 movementTriggerRadius: effectiveConfig.localRefreshTriggerRadius,
-                registerMovementTrigger: effectiveConfig.maxBusinessGeofences > 0 && !regions.isEmpty
+                registerMovementTrigger: registerMovementTrigger
             )
         }
 
@@ -63,7 +64,7 @@ extension GeofenceSyncCoordinatorImpl {
             expectedUserId: expectedUserId,
             anchor: anchor
         )
-        logger.geofenceSyncCompleted(registeredCount: nearest.count)
+        logger.geofenceSyncCompleted(registeredCount: nearest.count, movementTriggerRegistered: registerMovementTrigger)
         return .success(())
     }
 
@@ -80,6 +81,7 @@ extension GeofenceSyncCoordinatorImpl {
     ) async -> Result<Void, GeofenceSyncError> {
         let anchor = LocationData(latitude: latitude, longitude: longitude)
         let nearest = distanceFilter.nearest(cachedRegions, to: anchor, limit: config.maxBusinessGeofences, maxDistance: config.maxMonitoringDistance)
+        let registerMovementTrigger = config.maxBusinessGeofences > 0
         // Read before `recordRegistration` overwrites it — the diff decides which registrations are new.
         let previouslyRegisteredIds = await storage.getRegisteredBusinessIds()
         let osRegistration = await MainActor.run {
@@ -87,7 +89,7 @@ extension GeofenceSyncCoordinatorImpl {
                 businessRegions: nearest,
                 movementTriggerLocation: anchor,
                 movementTriggerRadius: config.localRefreshTriggerRadius,
-                registerMovementTrigger: config.maxBusinessGeofences > 0 && !cachedRegions.isEmpty
+                registerMovementTrigger: registerMovementTrigger
             )
         }
         await storage.recordRegistration(center: anchor, businessIds: Set(nearest.map(\.id)))
@@ -98,7 +100,7 @@ extension GeofenceSyncCoordinatorImpl {
             expectedUserId: expectedUserId,
             anchor: anchor
         )
-        logger.geofenceSyncCompleted(registeredCount: nearest.count)
+        logger.geofenceSyncCompleted(registeredCount: nearest.count, movementTriggerRegistered: registerMovementTrigger)
         return .success(())
     }
 

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
@@ -212,10 +212,8 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
             logger.geofenceSyncSkipped(reason: "no identified user")
             return nil
         }
-        guard !cachedRegions.isEmpty else {
-            logger.geofenceSyncSkipped(reason: "no cached regions to restore")
-            return nil
-        }
+        // No early return on an empty cache: an empty nearby response clears it while the movement
+        // trigger stays armed, so this is what re-arms the trigger if the OS dropped our regions.
         // Need an anchor to distance-filter and to center the movement trigger. Skipping
         // when absent is safer than re-using an arbitrary location.
         guard let anchor else {
@@ -230,13 +228,14 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
 
         let effectiveConfig = config ?? .fallback
         let nearest = distanceFilter.nearest(cachedRegions, to: anchor, limit: effectiveConfig.maxBusinessGeofences, maxDistance: effectiveConfig.maxMonitoringDistance)
+        let registerMovementTrigger = effectiveConfig.maxBusinessGeofences > 0
         registerWithOsSync(
             businessRegions: nearest,
             movementTriggerLocation: anchor,
             movementTriggerRadius: effectiveConfig.localRefreshTriggerRadius,
-            registerMovementTrigger: effectiveConfig.maxBusinessGeofences > 0 && !cachedRegions.isEmpty
+            registerMovementTrigger: registerMovementTrigger
         )
-        logger.geofenceSyncCompleted(registeredCount: nearest.count)
+        logger.geofenceSyncCompleted(registeredCount: nearest.count, movementTriggerRegistered: registerMovementTrigger)
         // No initial-enter here: a cold-wake restore of the pre-kill set (not new registrations) off a
         // possibly-stale anchor. Genuinely-new fences come from a refresh fetch, which emits there.
         return GeofenceRegistration(center: anchor, businessIds: Set(nearest.map(\.id)))

--- a/Sources/LocationGeofence/CustomerIO+Geofence.swift
+++ b/Sources/LocationGeofence/CustomerIO+Geofence.swift
@@ -14,7 +14,8 @@ public protocol GeofenceServices {
     /// on its own and this is only needed to force an immediate refresh.
     ///
     /// In `.manual`, call this once a user has been identified — a refresh requested before any
-    /// identify is not retried automatically.
+    /// identify is not retried automatically. No-op when the module is configured with
+    /// `GeofenceLocationMode.off`.
     func refreshFromCurrentLocation()
 }
 
@@ -32,7 +33,7 @@ struct GeofenceServicesImplementation: GeofenceServices {
         // Arm first so the returning fix drives a sync even without a prior no-location skip,
         // then request a silent (no-analytics) fix. Safe when the Location module isn't
         // registered — `CustomerIO.location` returns a no-op that only logs.
-        GeofenceModuleState.shared.onRefreshRequested()
+        guard GeofenceModuleState.shared.onRefreshRequested() else { return }
         CustomerIO.location.requestLocationUpdateSilently()
     }
 }

--- a/Sources/LocationGeofence/GeofenceBootstrap.swift
+++ b/Sources/LocationGeofence/GeofenceBootstrap.swift
@@ -47,12 +47,15 @@ enum GeofenceBootstrap {
         let userId = di.backgroundDeliveryContextStore.currentUserId
 
         // The set we expect to still own: the business geofences registered last session plus the
-        // movement trigger registered alongside them. Empty on first launch or after the OS cleared
-        // everything. Compared against the OS-retained set below to decide adopt vs re-register.
+        // movement trigger registered alongside them. The trigger counts even when the business set
+        // is empty — a geofence-free area still arms it, and an unadopted trigger drops the EXIT
+        // that is the only path back to a re-rank or re-fetch. It is excluded under the kill switch
+        // for the same reason registration excludes it, leaving the set empty and monitoring off.
+        // Compared against the OS-retained set below to decide adopt vs re-register.
         let lastRegisteredBusinessIds = await di.geofenceStorage.getRegisteredBusinessIds()
-        let expectedOwnedRegions = lastRegisteredBusinessIds.isEmpty
-            ? Set<String>()
-            : lastRegisteredBusinessIds.union([GeofenceConstants.movementTriggerIdentifier])
+        let expectedOwnedRegions = (cachedConfig ?? .fallback).maxBusinessGeofences > 0
+            ? lastRegisteredBusinessIds.union([GeofenceConstants.movementTriggerIdentifier])
+            : lastRegisteredBusinessIds
 
         // Phase 2: synchronous on the main actor. No `await` between handler-bind and
         // `adoptExistingRegions` / `startMonitoring`, so `ownedRegionIdentifiers` is populated

--- a/Sources/LocationGeofence/GeofenceBootstrap.swift
+++ b/Sources/LocationGeofence/GeofenceBootstrap.swift
@@ -22,6 +22,35 @@ enum GeofenceBootstrap {
         await run.value
     }
 
+    /// Tears down monitoring for `GeofenceLocationMode.off`. Chained on the same run tail as
+    /// `wireMonitor` so a bootstrap running in the same launch (e.g. the host calls
+    /// `bootstrapForBackgroundDelivery` alongside an `.off` initialize) can't interleave: an
+    /// unserialized teardown could land between wireMonitor's state reads and its registration,
+    /// which would then re-register from the pre-teardown snapshot. Chained, either order
+    /// converges to off — teardown-last stops everything; teardown-first leaves wireMonitor
+    /// nothing to restore (no registered ids, no anchor).
+    static func tearDownMonitoring(di: DIGraphShared) async {
+        let previous = lastRun
+        let run = Task { @MainActor in
+            await previous?.value
+            // Read before constructing the monitor, per the no-await-after-construction rule below.
+            let businessIds = await di.geofenceStorage.getRegisteredBusinessIds()
+            let monitor = di.geofenceMonitor
+            // `stopMonitoringAll` reaches only the regions the monitor owns, and the classic monitor
+            // starts each process owning nothing — `.off` never runs `wireMonitor`, so without
+            // reclaiming first the stop is a no-op and last session's regions monitor forever. The
+            // CLMonitor path seeds ownership at init, where re-adopting would re-arm conditions we
+            // are about to remove.
+            if monitor.monitoredRegionIdentifiers.isEmpty {
+                monitor.adoptExistingRegions(matching: businessIds.union([GeofenceConstants.movementTriggerIdentifier]))
+            }
+            monitor.stopMonitoringAll()
+            await di.geofenceStorage.clearUserScopedState()
+        }
+        lastRun = run
+        await run.value
+    }
+
     private static func performWireMonitor(di: DIGraphShared) async {
         // iOS 18+ (CLMonitor): construct the monitor NOW. CLMonitor delivers events only while its
         // `events` sequence is iterated — the OS does not queue a crossing for a late consumer — and

--- a/Sources/LocationGeofence/GeofenceLocationMode.swift
+++ b/Sources/LocationGeofence/GeofenceLocationMode.swift
@@ -1,6 +1,7 @@
 import Foundation
 
-/// Controls how the geofence module acquires the device location it needs to sync nearby geofences.
+/// Controls how the geofence module acquires the device location it needs to sync nearby geofences,
+/// or disables geofencing entirely.
 ///
 /// Location acquired for geofencing is never sent as a `CIO Location Update` analytics event, cached,
 /// or added to identify context — it is used for geofencing only.
@@ -13,4 +14,13 @@ public enum GeofenceLocationMode {
     /// `CustomerIO.geofence.refreshFromCurrentLocation()` after granting location permission
     /// (movement transitions still work once geofences are registered).
     case manual
+
+    /// Geofencing is disabled: the SDK registers no geofences, acquires no location, and fires no
+    /// transitions. The local off switch for when the module is always linked (e.g. wrapper SDKs)
+    /// but the app wants to opt out. Applied at initialization — any monitoring left by a prior
+    /// session is torn down, so a build that ships `.off` disables itself on the next launch that
+    /// initializes the SDK. In wrapper SDKs that is the next foreground launch; a background wake
+    /// before then can still deliver transitions from the previous session's registrations.
+    /// Transitions captured before the switch are still delivered; only future ones stop.
+    case off
 }

--- a/Sources/LocationGeofence/GeofenceModuleState.swift
+++ b/Sources/LocationGeofence/GeofenceModuleState.swift
@@ -27,6 +27,13 @@ final class GeofenceModuleState {
     private let lock = NSLock()
     private var didSetup = false
 
+    /// True once `setup` has been told the host disabled geofencing. Set synchronously before the
+    /// teardown it schedules, so callers reached from a bootstrap earlier in the same launch stop
+    /// acting on the state that teardown is about to clear.
+    var isGeofencingDisabled: Bool {
+        locationMode.wrappedValue == .off
+    }
+
     /// Internal init lets tests build instances independent of `.shared`.
     init(
         locationServicesProvider: @escaping () -> LocationServices = { CustomerIO.location }
@@ -42,6 +49,22 @@ final class GeofenceModuleState {
         guard !didSetup else { return }
         didSetup = true
         self.locationMode.wrappedValue = locationMode
+
+        // `.off` disables geofencing locally. A prior session's OS registrations survive app updates
+        // and fire independently of these subscriptions, so tear them down rather than just skip
+        // wiring: stop OS monitoring and clear user-scoped state (registration ids, cooldowns,
+        // last-sync). Cached workspace regions/config are kept so re-enabling re-syncs without a
+        // fetch. Init-time only — a mode change takes effect at the next launch's initialize.
+        guard locationMode != .off else {
+            di.logger.geofenceModuleDisabled()
+            // Real crossings captured while the module was enabled, and the teardown below clears
+            // registration state but never the delivery queue — nothing else would drain them.
+            Task { await di.geofenceEventTracker.flushPending() }
+            Task { @MainActor in
+                await GeofenceBootstrap.tearDownMonitoring(di: di)
+            }
+            return
+        }
 
         registerEventSubscriptions(di: di)
         // Run the refresh decision once at app launch (SDK/module init) so time-staleness and any
@@ -78,9 +101,13 @@ final class GeofenceModuleState {
 
     /// Arms a host-initiated refresh so the next acquired fix drives a sync even without a prior
     /// no-location skip. Paired with `LocationServices.requestLocationUpdateSilently()` by the
-    /// `CustomerIO.geofence.refreshFromCurrentLocation()` facade.
-    func onRefreshRequested() {
+    /// `CustomerIO.geofence.refreshFromCurrentLocation()` facade. Returns `false` (without arming)
+    /// when geofencing is disabled (`.off`), so the facade can skip requesting a fix too.
+    @discardableResult
+    func onRefreshRequested() -> Bool {
+        guard locationMode.wrappedValue != .off else { return false }
         explicitRefreshRequested.wrappedValue = true
+        return true
     }
 
     /// Invoked at app launch and on identify. Picks the anchor to refresh from, arming the

--- a/Sources/LocationGeofence/GeofenceMonitorBinder.swift
+++ b/Sources/LocationGeofence/GeofenceMonitorBinder.swift
@@ -14,9 +14,15 @@ enum GeofenceMonitorBinder {
     static func bind(
         monitor: GeofenceRegionMonitoring,
         tracker: GeofenceEventTracker,
-        coordinator: GeofenceSyncCoordinator
+        coordinator: GeofenceSyncCoordinator,
+        isDisabled: @escaping @Sendable () -> Bool = { GeofenceModuleState.shared.isGeofencingDisabled }
     ) {
         monitor.setOnTransition { [weak tracker, weak coordinator] identifier, transition, location in
+            // A host that calls `bootstrapForBackgroundDelivery` from its AppDelegate has this bound
+            // and its regions registered before `initialize` reports `.off`, and the teardown that
+            // follows is asynchronous. Without this the crossings in between would deliver, and a
+            // movement EXIT would re-register everything off a cleared cache.
+            guard !isDisabled() else { return }
             // CLLocationManager delivers on main; both handlers below are async with their
             // own serialization (tracker active-delivery dedup, coordinator refresh gate),
             // so fire-and-forget Tasks are safe.

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -103,8 +103,11 @@ extension Logger {
         self.error("Sync fetch failed: \(error)", geofenceTag, nil)
     }
 
-    func geofenceSyncCompleted(registeredCount: Int) {
-        info("Sync completed: registered \(registeredCount) business geofences + 1 movement trigger", geofenceTag)
+    func geofenceSyncCompleted(registeredCount: Int, movementTriggerRegistered: Bool) {
+        let trigger = movementTriggerRegistered
+            ? " + 1 movement trigger"
+            : "; monitoring disabled (max business geofences is 0)"
+        info("Sync completed: registered \(registeredCount) business geofences\(trigger)", geofenceTag)
     }
 
     func geofenceMovementTrigger(tier: HandleMovementTier) {

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -37,6 +37,13 @@ extension Logger {
         )
     }
 
+    func geofenceModuleDisabled() {
+        info(
+            "Geofence module disabled (GeofenceLocationMode.off); no geofences will be monitored. Configure .automatic or .manual to enable.",
+            geofenceTag
+        )
+    }
+
     func geofencePermissionUnavailable(currentStatus: CLAuthorizationStatus) {
         info(
             "Geofence registration skipped: location permission not granted (current status: \(currentStatus.rawValue)). The host app controls when and which permission to request.",

--- a/Sources/LocationGeofence/Model/GeofenceConfig.swift
+++ b/Sources/LocationGeofence/Model/GeofenceConfig.swift
@@ -22,7 +22,8 @@ struct GeofenceConfig: Codable, Equatable, Sendable {
     /// Duplicate-transition suppression window keyed by "userId:geofenceId:transitionType".
     let duplicateEventsExpiry: TimeInterval
     /// Maximum number of business geofences to monitor. Always 0…19 on iOS (movement
-    /// trigger consumes the 20th OS slot).
+    /// trigger consumes the 20th OS slot). `0` is the server-driven kill switch: nothing
+    /// registers, not even the movement trigger.
     let maxBusinessGeofences: Int
     /// Maximum distance in meters from the device at which a geofence is registered with the OS.
     /// Geofences beyond it are skipped and re-added by a later re-rank as the device moves closer;

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -480,7 +480,7 @@ struct GeofenceSyncCoordinatorTests {
     }
 
     @Test
-    func refresh_givenEmptyBusinessRegions_expectNoMovementTriggerRegistered() async {
+    func refresh_givenEmptyServerResponse_expectMovementTriggerStillRegistered() async {
         let storage = makeStorage()
         let api = GeofenceApiServiceMock()
         api.fetchNearbyGeofencesClosure = { _, _, completion in
@@ -490,7 +490,34 @@ struct GeofenceSyncCoordinatorTests {
         let setup = makeCoordinator(api: api, storage: storage)
         _ = await setup.coordinator.refresh(latitude: 37.7749, longitude: -122.4194)
 
-        // No business regions ⇒ no movement trigger either; refetch-on-move would just hit the same empty result.
+        // Empty nearby response is a geofence-free area, not a stop signal: keep the movement trigger
+        // armed so a later EXIT re-fetches as the device moves back toward geofences. The trigger is
+        // the only region registered (no business geofences to add).
+        #expect(setup.monitor.startedRegions.map(\.identifier) == [GeofenceConstants.movementTriggerIdentifier])
+    }
+
+    @Test
+    func refresh_givenEmptyServerResponseButKillSwitch_expectNothingRegistered() async {
+        // maxBusinessGeofences == 0 is the runtime off switch: even with the "keep monitoring
+        // through empty areas" behavior, a kill-switched account registers nothing at all.
+        let storage = makeStorage()
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 750,
+            remoteFetchRefreshTriggerRadius: 3000,
+            remoteFetchRefreshExpiry: 86400,
+            duplicateEventsExpiry: 60,
+            maxBusinessGeofences: 0,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
+        )
+        await storage.setCachedConfig(config)
+        let api = GeofenceApiServiceMock()
+        api.fetchNearbyGeofencesClosure = { _, _, completion in
+            completion(.success(makeApiResponse(regions: [], config: config)))
+        }
+
+        let setup = makeCoordinator(api: api, storage: storage)
+        _ = await setup.coordinator.refresh(latitude: 37.7749, longitude: -122.4194)
+
         #expect(setup.monitor.startedRegions.isEmpty)
     }
 
@@ -650,13 +677,40 @@ struct GeofenceSyncCoordinatorTests {
     }
 
     @Test
-    func applyCachedRegistration_givenEmptyRegions_expectNoRegistration() {
+    func applyCachedRegistration_givenEmptyRegions_expectMovementTriggerRegistered() {
+        // An empty nearby response clears the cache but leaves the trigger armed. If the OS then
+        // drops our regions, this is the only path that re-arms it — the refresh decision skips on
+        // a cache that is fresh and empty.
+        let setup = makeCoordinator(storage: makeStorage())
+
+        let registration = setup.coordinator.applyCachedRegistration(
+            cachedRegions: [],
+            anchor: LocationData(latitude: 0, longitude: 0),
+            config: .fallback,
+            userId: "user-1"
+        )
+
+        #expect(setup.monitor.startedRegions.map(\.identifier) == [GeofenceConstants.movementTriggerIdentifier])
+        #expect(registration?.businessIds.isEmpty == true)
+    }
+
+    @Test
+    func applyCachedRegistration_givenEmptyRegionsAndKillSwitch_expectNothingRegistered() {
+        // The kill switch still wins over the empty-cache restore above.
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 750,
+            remoteFetchRefreshTriggerRadius: 3000,
+            remoteFetchRefreshExpiry: 86400,
+            duplicateEventsExpiry: 60,
+            maxBusinessGeofences: 0,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
+        )
         let setup = makeCoordinator(storage: makeStorage())
 
         _ = setup.coordinator.applyCachedRegistration(
             cachedRegions: [],
             anchor: LocationData(latitude: 0, longitude: 0),
-            config: .fallback,
+            config: config,
             userId: "user-1"
         )
 
@@ -944,6 +998,35 @@ struct GeofenceSyncCoordinatorTests {
         #expect(setup.api.fetchNearbyGeofencesCallsCount == 0)
         let businessRegistered = setup.monitor.startedRegions.filter { $0.identifier != GeofenceConstants.movementTriggerIdentifier }
         #expect(businessRegistered.map(\.identifier) == ["near", "far"])
+    }
+
+    @Test
+    func handleMovement_givenLocalRerankWithEmptyCache_expectMovementTriggerStillRegistered() async {
+        // After an empty nearby response wiped the cache, a within-threshold EXIT re-ranks an empty
+        // set. The movement trigger must stay armed (re-centered at the new location) so the device
+        // keeps moving toward the next refetch instead of going dark in a geofence-free area.
+        let storage = makeStorage()
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 5000,
+            remoteFetchRefreshExpiry: 3600,
+            duplicateEventsExpiry: 3600,
+            maxBusinessGeofences: 10,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
+        )
+        await storage.setCachedConfig(config)
+        await storage.recordSync(timestamp: Date(timeIntervalSince1970: 100), location: LocationData(latitude: 0, longitude: 0))
+        await storage.setCachedGeofences([]) // wiped by a prior empty response
+        let api = GeofenceApiServiceMock()
+        let setup = makeCoordinator(api: api, storage: storage)
+
+        // ~111 m from anchor — within the refetch radius, so it re-ranks locally, no fetch.
+        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
+
+        #expect(result.isSuccess)
+        #expect(setup.api.fetchNearbyGeofencesCallsCount == 0)
+        let trigger = setup.monitor.startedRegions.first { $0.identifier == GeofenceConstants.movementTriggerIdentifier }
+        #expect(trigger?.center == LocationData(latitude: 0, longitude: 0.001))
     }
 
     @Test

--- a/Tests/LocationGeofence/Geofence/GeofenceBootstrapTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceBootstrapTests.swift
@@ -85,6 +85,9 @@ struct GeofenceBootstrapTests {
 
         #expect(monitor.setOnTransitionCallsCount == 1)
         #expect(coordinator.applyCachedRegistrationCallsCount == 1)
+        // First launch: the expected-owned set is never empty (it always names the movement
+        // trigger), so the adopt branch has to be ruled out by the OS holding nothing.
+        #expect(monitor.adoptExistingRegionsCallsCount == 0)
         #expect(monitor.setOnAuthorizationChangedCallsCount == 1)
         #expect(monitor.onAuthorizationChanged != nil)
         #expect(monitor.reportPermissionTierCallsCount == 1)
@@ -283,6 +286,61 @@ struct GeofenceBootstrapTests {
 
         #expect(monitor.adoptedIdentifiers == ["g1", GeofenceConstants.movementTriggerIdentifier])
         #expect(coordinator.applyCachedRegistrationCallsCount == 0)
+    }
+
+    @Test
+    func wireMonitor_givenOnlyMovementTriggerRegistered_expectTriggerAdopted() async {
+        // Relaunch after an empty nearby response: the cache and the business set are empty, but the
+        // trigger stayed armed and the OS still holds it. Without adopting it the process owns
+        // nothing, so its EXIT is dropped at the ownership filter — and the refresh decision skips
+        // (fresh cache, no movement), leaving the device dark until the cache ages out.
+        let di = DIGraphShared.shared
+        let storage = GeofenceStorage(
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        await storage.recordRegistration(center: LocationData(latitude: 10, longitude: 20), businessIds: [])
+        di.override(value: storage, forType: GeofenceStorage.self)
+        let monitor = MockGeofenceRegionMonitor()
+        monitor.osMonitoredRegions = [GeofenceConstants.movementTriggerIdentifier]
+        di.override(value: monitor as GeofenceRegionMonitoring, forType: GeofenceRegionMonitoring.self)
+        let coordinator = GeofenceSyncCoordinatorMock()
+        di.override(value: coordinator as GeofenceSyncCoordinator, forType: GeofenceSyncCoordinator.self)
+        defer { di.reset() }
+
+        await GeofenceBootstrap.wireMonitor(di: di)
+
+        #expect(monitor.adoptedIdentifiers == [GeofenceConstants.movementTriggerIdentifier])
+        #expect(coordinator.applyCachedRegistrationCallsCount == 0)
+    }
+
+    @Test
+    func wireMonitor_givenKillSwitchedConfig_expectTriggerNotAdopted() async {
+        // Under the kill switch the trigger is not something we would register, so it is not
+        // something to reclaim either — expected-owned mirrors the register condition.
+        let di = DIGraphShared.shared
+        let storage = GeofenceStorage(
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        await storage.setCachedConfig(GeofenceConfig(
+            localRefreshTriggerRadius: 750,
+            remoteFetchRefreshTriggerRadius: 3000,
+            remoteFetchRefreshExpiry: 86400,
+            duplicateEventsExpiry: 60,
+            maxBusinessGeofences: 0,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
+        ))
+        await storage.recordRegistration(center: LocationData(latitude: 10, longitude: 20), businessIds: [])
+        di.override(value: storage, forType: GeofenceStorage.self)
+        let monitor = MockGeofenceRegionMonitor()
+        monitor.osMonitoredRegions = [GeofenceConstants.movementTriggerIdentifier]
+        di.override(value: monitor as GeofenceRegionMonitoring, forType: GeofenceRegionMonitoring.self)
+        let coordinator = GeofenceSyncCoordinatorMock()
+        di.override(value: coordinator as GeofenceSyncCoordinator, forType: GeofenceSyncCoordinator.self)
+        defer { di.reset() }
+
+        await GeofenceBootstrap.wireMonitor(di: di)
+
+        #expect(monitor.adoptExistingRegionsCallsCount == 0)
     }
 
     @Test

--- a/Tests/LocationGeofence/Geofence/GeofenceMonitorBinderTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceMonitorBinderTests.swift
@@ -71,6 +71,27 @@ struct GeofenceMonitorBinderTests {
         #expect(coordinator.handleMovementReceivedArguments?.longitude == -122.0)
     }
 
+    /// A bootstrap earlier in the same launch binds this and registers regions before `initialize`
+    /// reports `.off`, and the teardown that follows is asynchronous. Crossings arriving in between
+    /// must not deliver, and a movement EXIT must not re-register off the cache being cleared.
+    @Test
+    func bind_givenGeofencingDisabled_expectNeitherDispatchPathFires() async {
+        let monitor = MockGeofenceRegionMonitor()
+        let coordinator = makeCoordinatorMock()
+        let tracker = makeTracker(deliveryTracker: makeDeliveryMock())
+
+        GeofenceMonitorBinder.bind(monitor: monitor, tracker: tracker, coordinator: coordinator, isDisabled: { true })
+        monitor.simulateTransition(
+            identifier: GeofenceConstants.movementTriggerIdentifier,
+            transition: .exit,
+            location: LocationData(latitude: 37.0, longitude: -122.0)
+        )
+        monitor.simulateTransition(identifier: "biz-1", transition: .enter, location: nil)
+        await awaitDispatch(coordinator.handleMovementCallsCount > 0)
+
+        #expect(coordinator.handleMovementCallsCount == 0)
+    }
+
     /// We only register the movement trigger for `.exit`; an unexpected `.enter` on the
     /// reserved identifier must NOT fall through to either the tracker or the coordinator.
     @Test

--- a/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
+++ b/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
@@ -101,6 +101,9 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
 
     func stopMonitoringAll() {
         stopAllCallCount += 1
+        // Mirror the real monitor: only owned regions are handed to the OS for removal, so anything
+        // the OS still holds that this process never adopted survives the call.
+        osMonitoredRegions.subtract(activeIdentifiers)
         activeIdentifiers.removeAll()
         operationLog.append(.stopAll)
     }

--- a/Tests/LocationGeofence/GeofenceModuleSetupTests.swift
+++ b/Tests/LocationGeofence/GeofenceModuleSetupTests.swift
@@ -1,4 +1,5 @@
 @testable import CioInternalCommon
+@testable import CioInternalCommonMocks
 @_spi(Geofence) import CioLocation
 @testable import CioLocationGeofence
 @testable import CioLocationGeofenceMocks
@@ -80,6 +81,111 @@ struct GeofenceModuleSetupTests {
         #expect(f.bus.observers[ResetEvent.key] != nil, "ResetEvent observer must be registered")
         #expect(f.bus.observers[ProfileIdentifiedEvent.key] != nil, "ProfileIdentifiedEvent observer must be registered")
         #expect(f.bus.observers[LocationAcquiredEvent.key] != nil, "LocationAcquiredEvent observer must be registered")
+    }
+
+    @Test
+    @MainActor
+    func setup_givenOffMode_expectNoWiringAndNoRefreshOrAcquire() throws {
+        // `.off` is the local kill switch: no event observers, no launch refresh, no self-acquire.
+        // The off path spawns only the teardown task, which touches none of the state asserted
+        // here, so asserting right after `wire()` is deterministic.
+        let f = Fixture(cachedLocation: LocationData(latitude: 1, longitude: 2), locationMode: .off)
+        defer { f.cleanup() }
+
+        f.spyCoordinator.refreshClosure = { _, _ in .success(()) }
+
+        f.wire()
+
+        #expect(f.bus.observers[ResetEvent.key] == nil)
+        #expect(f.bus.observers[ProfileIdentifiedEvent.key] == nil)
+        #expect(f.bus.observers[LocationAcquiredEvent.key] == nil)
+        #expect(f.spyCoordinator.refreshCallsCount == 0)
+        #expect(f.stub.requestSilentlyCount.wrappedValue == 0)
+    }
+
+    @Test
+    @MainActor
+    func setup_givenOffMode_expectPriorMonitoringTornDown() async throws {
+        // A prior session's OS registrations survive independently of setup, so `.off` must tear them
+        // down — not just skip wiring: stop OS monitoring and clear user-scoped state. (cached
+        // regions/config are kept; that's covered by GeofenceStorage.clearUserScopedState tests.)
+        // `.off` never runs wireMonitor, so the monitor owns nothing at this point: teardown has to
+        // reclaim ownership from the persisted set first, or the stop reaches none of these regions.
+        let f = Fixture(locationMode: .off)
+        defer { f.cleanup() }
+
+        f.mockMonitor.osMonitoredRegions = ["g1", GeofenceConstants.movementTriggerIdentifier]
+        await f.di.geofenceStorage.recordRegistration(center: LocationData(latitude: 1, longitude: 2), businessIds: ["g1"])
+        await f.di.geofenceStorage.recordSync(timestamp: Date(timeIntervalSince1970: 100), location: LocationData(latitude: 1, longitude: 2))
+
+        f.wire()
+
+        // Teardown is a fire-and-forget Task; wait for it to land before asserting.
+        await waitUntil {
+            let registered = await f.di.geofenceStorage.getRegisteredBusinessIds()
+            return f.mockMonitor.osMonitoredRegions.isEmpty && registered.isEmpty
+        }
+
+        #expect(f.mockMonitor.osMonitoredRegions.isEmpty)
+        #expect(await f.di.geofenceStorage.getRegisteredBusinessIds().isEmpty)
+        #expect(await f.di.geofenceStorage.getLastSync() == nil)
+    }
+
+    @Test
+    @MainActor
+    func setup_givenOffModeAfterEmptyArea_expectMovementTriggerTornDown() async throws {
+        // Switched off while parked in a geofence-free area: no business geofences were registered,
+        // but the movement trigger was. Reclaiming only the persisted business ids would leave it
+        // running with the OS forever, waking the app for a module that is meant to be inert.
+        let f = Fixture(locationMode: .off)
+        defer { f.cleanup() }
+
+        f.mockMonitor.osMonitoredRegions = [GeofenceConstants.movementTriggerIdentifier]
+        await f.di.geofenceStorage.recordRegistration(center: LocationData(latitude: 1, longitude: 2), businessIds: [])
+
+        f.wire()
+
+        await waitUntil { f.mockMonitor.osMonitoredRegions.isEmpty }
+
+        #expect(f.mockMonitor.osMonitoredRegions.isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func setup_givenOffMode_expectQueuedDeliveriesStillFlushed() async throws {
+        // Transitions captured while the module was enabled are real crossings the SDK already
+        // accepted. `.off` stops future ones; it must not strand the backlog, which no other reader
+        // in a native app would ever drain.
+        let f = Fixture(locationMode: .off)
+        defer { f.cleanup() }
+
+        _ = await f.pendingStore.append([
+            PendingGeofenceMetric(
+                geofenceId: "geo_1", transition: .enter,
+                timestamp: Date(timeIntervalSince1970: 1),
+                userId: "test-user", name: nil, transitionId: "txn_1"
+            )
+        ])
+
+        f.wire()
+
+        await waitUntil { await f.pendingStore.loadAll().isEmpty }
+
+        #expect(await f.pendingStore.loadAll().isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func setup_givenOffMode_refreshFromCurrentLocationDoesNotArmOrAcquire() throws {
+        // The `refreshFromCurrentLocation()` facade must be inert in `.off`: arming returns false so
+        // the facade skips the location request.
+        let f = Fixture(locationMode: .off)
+        defer { f.cleanup() }
+
+        f.wire()
+
+        #expect(f.state.onRefreshRequested() == false)
+        #expect(f.stub.requestSilentlyCount.wrappedValue == 0)
     }
 
     @Test
@@ -291,6 +397,16 @@ struct GeofenceModuleSetupTests {
     }
 }
 
+/// Waits for a fire-and-forget `Task` to land. Bounded, so a genuine failure still ends the test
+/// with the assertion that follows rather than hanging.
+@MainActor
+private func waitUntil(_ condition: @MainActor () async -> Bool) async {
+    for _ in 0 ..< 200 {
+        if await condition() { return }
+        try? await Task.sleep(nanoseconds: 5000000)
+    }
+}
+
 /// Per-test setup: overrides the DI shared singleton with capturing/mocking deps and builds
 /// a fresh `GeofenceModuleState` with a stub `LocationServices`.
 @MainActor
@@ -303,6 +419,7 @@ private struct Fixture {
     let state: GeofenceModuleState
     let stub: StubLocationServices
     let locationMode: GeofenceLocationMode
+    let pendingStore: PendingGeofenceMetricStore
 
     init(cachedLocation: LocationData? = nil, locationMode: GeofenceLocationMode = .automatic, identifiedUserId: String? = "test-user") {
         self.locationMode = locationMode
@@ -325,6 +442,22 @@ private struct Fixture {
 
         let testStorage = GeofenceStorage(fileManager: .default, directoryURL: tempDir)
         di.override(value: testStorage, forType: GeofenceStorage.self)
+
+        // The real tracker is a process-wide singleton, so it must be overridden (not just its
+        // collaborators) to keep queued deliveries inside this fixture's temp directory.
+        let pending = PendingGeofenceMetricStore(fileManager: .default, directoryURL: tempDir)
+        self.pendingStore = pending
+        di.override(value: GeofenceEventTracker(
+            storage: testStorage,
+            pendingStore: pending,
+            deliveryTracker: GeofenceDeliveryTrackerMock(),
+            contextStore: contextStore,
+            eventBusHandler: bus,
+            dateUtil: DateUtilStub(),
+            logger: LoggerMock(),
+            cooldownInterval: 3600,
+            backgroundTaskRunner: NoBackgroundTaskRunner()
+        ), forType: GeofenceEventTracker.self)
 
         let stubServices = StubLocationServices(cachedLocation: cachedLocation)
         self.stub = stubServices


### PR DESCRIPTION
Two geofence robustness changes, plus the app-upgrade review outcome. Android parity for both.

## 1. Keep the movement trigger armed through geofence-free areas
`/geofences/nearest` is distance-capped, so an empty response means "none nearby right now," not "feature off." Previously an empty response (or an emptied cache) dropped the movement trigger, so driving through any fence-free corridor disarmed monitoring for the rest of the trip and it never re-fetched.

Now the trigger stays registered whenever `maxBusinessGeofences > 0`; only the server kill switch (`max_business_geofence = 0`) registers nothing. The device keeps re-fetching as it moves and repopulates on reaching geofences again.

Field-validated on a drive out of the cluster: registrations stepped 6 → 5 → 3 → 2 → 0, hit 0 in the background, and kept re-fetching (a second remote fetch after the first empty) instead of going silent.

Relaunching in such an area needed the same fix from the other side. The bootstrap's expected-owned set was empty whenever no business geofences were registered, so it never adopted the surviving trigger — and on iOS ≤17, where the monitor starts each process owning nothing, its EXIT was then dropped at the ownership filter. With the refresh decision skipping on a fresh cache, the device stayed dark until the cache aged out. That set now names the trigger under the same condition registration does, so the kill switch keeps leaving nothing to reclaim.

## 2. `GeofenceLocationMode.off`
A local off switch so a host that always links the module (e.g. wrapper SDKs) can keep geofencing inert without a backend change. Because a prior session's OS registrations survive app updates and fire independently of SDK subscriptions, `.off` **actively tears down** — stops OS monitoring and clears user-scoped state (registration ids, cooldowns, last-sync) — rather than just skipping setup. Cached workspace regions/config are kept so flipping back on re-syncs without a fetch. `refreshFromCurrentLocation()` is a no-op in `.off`. Applied at initialization.

Teardown reclaims ownership from the persisted registration set before stopping. `stopMonitoringAll` reaches only the regions the monitor owns, and the classic (iOS ≤17) monitor starts each process owning nothing — `.off` never runs `wireMonitor`, so without the reclaim the stop is a no-op and last session's regions keep monitoring, and waking the app, forever.

The teardown is asynchronous and serialized on the bootstrap run chain, so a same-launch `bootstrapForBackgroundDelivery` can't re-register from a pre-teardown snapshot. The transition handler that bootstrap binds is not on that chain, though: a host calling it from its AppDelegate has regions live from then until the teardown lands, and a crossing in between would deliver, or re-register everything off the cleared cache via `handleMovement`. The dispatch now checks the mode, which `setup` records synchronously before scheduling the teardown.

Queued deliveries are flushed before the teardown. They are real crossings captured while the module was enabled, the teardown never clears the delivery queue, and in a native app nothing else would drain it (the wrapper cold-wake entry already flushes on its own). Android does the same.

## App upgrades (MBL-2196)
No iOS code needed for geofence persistence across app updates. Unlike Android — where an update cancels the geofence `PendingIntent` (wiping OS registrations) and diff-based registration then skips re-upsert — iOS region monitoring persists across updates, and the SDK re-registers wholesale / adopts-else-reregisters on launch, so it self-heals. The only residual is CLMonitor re-arm latency, already handled by `rearmConditions()` at next launch.

Android's `osStateWiped()` guard against a synthesized ENTER after a wipe has no iOS counterpart. It compensates for losing the registration diff — once GMS state is gone, every fence re-registers and looks new. iOS never loses that diff (`monitoredGeofenceIds` is file-persisted and CL regions survive reboot and app update), so a wholesale re-register stays silent.

## Testing
Empty-response keeps the trigger; kill switch registers nothing and is not adopted on relaunch; local re-rank over an empty cache keeps the trigger; a relaunch holding only the trigger adopts it; a cached-restore with an empty cache re-arms it; `.off` tears down prior monitoring (including the trigger-only case), drops transition dispatch, still flushes queued deliveries, and the refresh facade is inert. Full LocationGeofence suite: 275 tests pass. Format + lint clean; api-docs unchanged; `-strict-concurrency=complete` clean.

## Parity
- Android keep-monitoring + app-update + synthesized-ENTER suppression: customerio/customerio-android@eb2be918
- Android off mode (teardown, flush, disabled-launch guards): customerio/customerio-android@be0c15fc

Android's restore-from-cache already gated only on user + anchor, never on an empty region list, so the empty-cache change above aligns iOS to it. The other two iOS fixes have no Android counterpart: its receiver has no in-process ownership filter, and `clearAll()` removes every geofence on the PendingIntent regardless of in-memory state.

Base branch: `feature/geofence-on-device`.

Ticket: https://linear.app/customerio/issue/MBL-2196/mobile-improve-geofence-persistence-across-app-upgrades

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core OS registration, cold-wake bootstrap/adopt, and lifecycle teardown with async races; wrong gating could leave regions monitoring forever or stop refetch in transit.
> 
> **Overview**
> **Geofence-free areas no longer disarm monitoring.** The movement trigger is registered whenever `maxBusinessGeofences > 0`, including empty nearby API responses, distance-capped empty sets, and empty cached restores—only the server kill switch (`maxBusinessGeofences == 0`) registers nothing. Bootstrap’s expected-owned set and cold-wake adopt logic now treat a trigger-only registration the same way, so relaunch in an empty area can reclaim the OS-persisted trigger instead of going dark.
> 
> **`GeofenceLocationMode.off` opts out locally at init.** Setup skips subscriptions and refresh wiring, flushes queued deliveries, and runs serialized `tearDownMonitoring` (reclaim persisted regions, `stopMonitoringAll`, clear user-scoped state while keeping cached regions/config). `refreshFromCurrentLocation()` and manual refresh arming are no-ops; `GeofenceMonitorBinder` drops transitions while disabled to close the race between early background bootstrap and async teardown.
> 
> Logging reflects whether a movement trigger was registered; tests cover empty-cache paths, kill switch, off-mode teardown, and binder suppression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 283e018eeebbf72696561a4e94adf3e488ef1dae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

