### PR TITLE
chore(geofence): keep monitoring through geofence-free areas

### DIFF
--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+OsRegistration.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+OsRegistration.swift
@@ -19,6 +19,36 @@ extension GeofenceSyncCoordinatorImpl {
         }
     }
 
+    /// True when re-registering would be a no-op: same ids as recorded, all owned by this process
+    /// and still held by the OS. Re-adding re-seeds each region's assumed state from the live fix,
+    /// absorbing any crossing the OS hasn't delivered yet — a recurring loss window at driving
+    /// speed, since re-ranks fire once per trigger radius. Any doubt falls through to the wholesale
+    /// path (re-establishes ownership, heals dropped regions, tears down under the kill switch).
+    @MainActor
+    func canSkipReregistration(
+        nearestIds: Set<String>,
+        previouslyRegisteredIds: Set<String>,
+        registerMovementTrigger: Bool
+    ) -> Bool {
+        guard registerMovementTrigger, nearestIds == previouslyRegisteredIds else { return false }
+        let expected = nearestIds.union([GeofenceConstants.movementTriggerIdentifier])
+        return expected.isSubset(of: monitor.monitoredRegionIdentifiers)
+            && expected.isSubset(of: monitor.osMonitoredRegionIdentifiers)
+    }
+
+    /// Moves only the trigger. Explicit stop-then-start (both monitors serialize the pair); no
+    /// pending event to lose — the EXIT that brought us here was already consumed.
+    @MainActor
+    func recenterMovementTrigger(at location: LocationData, radius: Double) {
+        monitor.stopMonitoring(identifier: GeofenceConstants.movementTriggerIdentifier)
+        monitor.startMonitoring(
+            identifier: GeofenceConstants.movementTriggerIdentifier,
+            center: location,
+            radius: radius,
+            transitionTypes: [.exit]
+        )
+    }
+
     /// Stops all monitored regions, then starts the new business set + movement trigger. Returns the
     /// OS-accepted identifiers (a region the monitor dropped for blocked permission / invalid
     /// coordinates is absent) plus the radius cap, so `emitInitialEnters` won't fire an unbalanced

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+OsRegistration.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+OsRegistration.swift
@@ -37,8 +37,8 @@ extension GeofenceSyncCoordinatorImpl {
         // Register the movement trigger FIRST so it isn't starved when business regions fill the
         // shared 20-region OS budget (e.g. a host app that also monitors regions): losing it freezes
         // the set, since exiting the trigger is what re-ranks toward now-closer geofences. Kept even
-        // when the distance cap left the business set empty; skipped only when there's nothing to
-        // register toward (no geofences, or registration kill-switched).
+        // when the nearby set is empty (distance cap or an empty fetch) so the device keeps re-fetching
+        // as it moves back toward geofences; skipped only when kill-switched (`maxBusinessGeofences == 0`).
         if registerMovementTrigger {
             monitor.startMonitoring(
                 identifier: GeofenceConstants.movementTriggerIdentifier,

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+OsRegistration.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+OsRegistration.swift
@@ -21,9 +21,10 @@ extension GeofenceSyncCoordinatorImpl {
 
     /// True when re-registering would be a no-op: same ids as recorded, all owned by this process
     /// and still held by the OS. Re-adding re-seeds each region's assumed state from the live fix,
-    /// absorbing any crossing the OS hasn't delivered yet — a recurring loss window at driving
-    /// speed, since re-ranks fire once per trigger radius. Any doubt falls through to the wholesale
-    /// path (re-establishes ownership, heals dropped regions, tears down under the kill switch).
+    /// absorbing any crossing the OS hasn't delivered yet — once per trigger radius at driving
+    /// speed. Any doubt falls through to the wholesale path, which re-establishes ownership, heals
+    /// dropped regions, and tears down under the kill switch (a geofence-free area leaves the
+    /// trigger owned with no business ids, so the ids alone would otherwise match).
     @MainActor
     func canSkipReregistration(
         nearestIds: Set<String>,
@@ -36,8 +37,9 @@ extension GeofenceSyncCoordinatorImpl {
             && expected.isSubset(of: monitor.osMonitoredRegionIdentifiers)
     }
 
-    /// Moves only the trigger. Explicit stop-then-start (both monitors serialize the pair); no
-    /// pending event to lose — the EXIT that brought us here was already consumed.
+    /// Moves only the trigger. Explicit stop-then-start, which both monitors serialize. Nothing is
+    /// lost by re-seeding this one region: it is being re-centered precisely because the device
+    /// left the old circle.
     @MainActor
     func recenterMovementTrigger(at location: LocationData, radius: Double) {
         monitor.stopMonitoring(identifier: GeofenceConstants.movementTriggerIdentifier)

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
@@ -37,6 +37,7 @@ extension GeofenceSyncCoordinatorImpl {
         let effectiveConfig = parsedConfig ?? cachedConfig ?? .fallback
         let anchor = LocationData(latitude: latitude, longitude: longitude)
         let nearest = distanceFilter.nearest(regions, to: anchor, limit: effectiveConfig.maxBusinessGeofences, maxDistance: effectiveConfig.maxMonitoringDistance)
+        let registerMovementTrigger = effectiveConfig.maxBusinessGeofences > 0
         // Read before `recordRegistration` overwrites it — the diff decides which registrations are new.
         let previouslyRegisteredIds = await storage.getRegisteredBusinessIds()
         let osRegistration = await MainActor.run {
@@ -44,7 +45,7 @@ extension GeofenceSyncCoordinatorImpl {
                 businessRegions: nearest,
                 movementTriggerLocation: anchor,
                 movementTriggerRadius: effectiveConfig.localRefreshTriggerRadius,
-                registerMovementTrigger: effectiveConfig.maxBusinessGeofences > 0 && !regions.isEmpty
+                registerMovementTrigger: registerMovementTrigger
             )
         }
 
@@ -63,7 +64,7 @@ extension GeofenceSyncCoordinatorImpl {
             expectedUserId: expectedUserId,
             anchor: anchor
         )
-        logger.geofenceSyncCompleted(registeredCount: nearest.count)
+        logger.geofenceSyncCompleted(registeredCount: nearest.count, movementTriggerRegistered: registerMovementTrigger)
         return .success(())
     }
 
@@ -80,6 +81,7 @@ extension GeofenceSyncCoordinatorImpl {
     ) async -> Result<Void, GeofenceSyncError> {
         let anchor = LocationData(latitude: latitude, longitude: longitude)
         let nearest = distanceFilter.nearest(cachedRegions, to: anchor, limit: config.maxBusinessGeofences, maxDistance: config.maxMonitoringDistance)
+        let registerMovementTrigger = config.maxBusinessGeofences > 0
         // Read before `recordRegistration` overwrites it — the diff decides which registrations are new.
         let previouslyRegisteredIds = await storage.getRegisteredBusinessIds()
         let osRegistration = await MainActor.run {
@@ -87,7 +89,7 @@ extension GeofenceSyncCoordinatorImpl {
                 businessRegions: nearest,
                 movementTriggerLocation: anchor,
                 movementTriggerRadius: config.localRefreshTriggerRadius,
-                registerMovementTrigger: config.maxBusinessGeofences > 0 && !cachedRegions.isEmpty
+                registerMovementTrigger: registerMovementTrigger
             )
         }
         await storage.recordRegistration(center: anchor, businessIds: Set(nearest.map(\.id)))
@@ -98,7 +100,7 @@ extension GeofenceSyncCoordinatorImpl {
             expectedUserId: expectedUserId,
             anchor: anchor
         )
-        logger.geofenceSyncCompleted(registeredCount: nearest.count)
+        logger.geofenceSyncCompleted(registeredCount: nearest.count, movementTriggerRegistered: registerMovementTrigger)
         return .success(())
     }
 

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
@@ -40,6 +40,10 @@ extension GeofenceSyncCoordinatorImpl {
         let registerMovementTrigger = effectiveConfig.maxBusinessGeofences > 0
         // Read before `recordRegistration` overwrites it — the diff decides which registrations are new.
         let previouslyRegisteredIds = await storage.getRegisteredBusinessIds()
+        let nearestIds = Set(nearest.map(\.id))
+        if await appliedUnchangedRemoteSync(regions: regions, nearestIds: nearestIds, parsedConfig: parsedConfig, effectiveConfig: effectiveConfig, anchor: anchor) {
+            return .success(())
+        }
         let osRegistration = await MainActor.run {
             registerWithOsSync(
                 businessRegions: nearest,
@@ -56,7 +60,7 @@ extension GeofenceSyncCoordinatorImpl {
             await storage.setCachedConfig(parsedConfig)
         }
         await storage.recordSync(timestamp: dateUtil.now, location: anchor)
-        await storage.recordRegistration(center: anchor, businessIds: Set(nearest.map(\.id)))
+        await storage.recordRegistration(center: anchor, businessIds: nearestIds)
         emitInitialEnters(
             candidates: nearest,
             osRegistration: osRegistration,
@@ -84,6 +88,18 @@ extension GeofenceSyncCoordinatorImpl {
         let registerMovementTrigger = config.maxBusinessGeofences > 0
         // Read before `recordRegistration` overwrites it — the diff decides which registrations are new.
         let previouslyRegisteredIds = await storage.getRegisteredBusinessIds()
+        let nearestIds = Set(nearest.map(\.id))
+        // Adjacent trigger EXITs usually re-rank onto the same nearest set — leave the OS
+        // registrations alone (see `canSkipReregistration`; geometry can't differ on matching
+        // ids here, ranking re-reads the same cache) and walk only the trigger + anchor.
+        if await canSkipReregistration(
+            nearestIds: nearestIds,
+            previouslyRegisteredIds: previouslyRegisteredIds,
+            registerMovementTrigger: registerMovementTrigger
+        ) {
+            await applyUnchangedRegistration(anchor: anchor, nearestIds: nearestIds, triggerRadius: config.localRefreshTriggerRadius)
+            return .success(())
+        }
         let osRegistration = await MainActor.run {
             registerWithOsSync(
                 businessRegions: nearest,
@@ -92,7 +108,7 @@ extension GeofenceSyncCoordinatorImpl {
                 registerMovementTrigger: registerMovementTrigger
             )
         }
-        await storage.recordRegistration(center: anchor, businessIds: Set(nearest.map(\.id)))
+        await storage.recordRegistration(center: anchor, businessIds: nearestIds)
         emitInitialEnters(
             candidates: nearest,
             osRegistration: osRegistration,
@@ -102,6 +118,45 @@ extension GeofenceSyncCoordinatorImpl {
         )
         logger.geofenceSyncCompleted(registeredCount: nearest.count, movementTriggerRegistered: registerMovementTrigger)
         return .success(())
+    }
+
+    /// Order-insensitive: server ordering isn't contractual, and `lastUpdated` in `Equatable`
+    /// makes any server-side edit force the wholesale path that applies it.
+    func regionsUnchanged(_ fetched: [Geofence], _ cached: [Geofence]) -> Bool {
+        fetched.sorted { $0.id < $1.id } == cached.sorted { $0.id < $1.id }
+    }
+
+    /// The unchanged-set fast path's shared effects: re-center the trigger and walk the
+    /// ranking-staleness anchor forward, leaving business regions untouched.
+    func applyUnchangedRegistration(anchor: LocationData, nearestIds: Set<String>, triggerRadius: Double) async {
+        await recenterMovementTrigger(at: anchor, radius: triggerRadius)
+        await storage.recordRegistration(center: anchor, businessIds: nearestIds)
+        logger.geofenceRerankUnchanged(keptCount: nearestIds.count)
+    }
+
+    /// Remote fast path: identical payload + unchanged registration (see `canSkipReregistration`)
+    /// ⇒ apply config, advance the refetch anchor, walk the trigger, and return true.
+    /// False = register wholesale.
+    func appliedUnchangedRemoteSync(
+        regions: [Geofence],
+        nearestIds: Set<String>,
+        parsedConfig: GeofenceConfig?,
+        effectiveConfig: GeofenceConfig,
+        anchor: LocationData
+    ) async -> Bool {
+        guard regionsUnchanged(regions, await storage.getCachedGeofences()),
+              await canSkipReregistration(
+                  nearestIds: nearestIds,
+                  previouslyRegisteredIds: storage.getRegisteredBusinessIds(),
+                  registerMovementTrigger: effectiveConfig.maxBusinessGeofences > 0
+              )
+        else { return false }
+        if let parsedConfig {
+            await storage.setCachedConfig(parsedConfig)
+        }
+        await storage.recordSync(timestamp: dateUtil.now, location: anchor)
+        await applyUnchangedRegistration(anchor: anchor, nearestIds: nearestIds, triggerRadius: effectiveConfig.localRefreshTriggerRadius)
+        return true
     }
 
     /// A sign-out/switch can land anywhere inside a gated operation, and the `reset()` it triggers

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
@@ -212,10 +212,8 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
             logger.geofenceSyncSkipped(reason: "no identified user")
             return nil
         }
-        guard !cachedRegions.isEmpty else {
-            logger.geofenceSyncSkipped(reason: "no cached regions to restore")
-            return nil
-        }
+        // No early return on an empty cache: an empty nearby response clears it while the movement
+        // trigger stays armed, so this is what re-arms the trigger if the OS dropped our regions.
         // Need an anchor to distance-filter and to center the movement trigger. Skipping
         // when absent is safer than re-using an arbitrary location.
         guard let anchor else {
@@ -230,13 +228,14 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
 
         let effectiveConfig = config ?? .fallback
         let nearest = distanceFilter.nearest(cachedRegions, to: anchor, limit: effectiveConfig.maxBusinessGeofences, maxDistance: effectiveConfig.maxMonitoringDistance)
+        let registerMovementTrigger = effectiveConfig.maxBusinessGeofences > 0
         registerWithOsSync(
             businessRegions: nearest,
             movementTriggerLocation: anchor,
             movementTriggerRadius: effectiveConfig.localRefreshTriggerRadius,
-            registerMovementTrigger: effectiveConfig.maxBusinessGeofences > 0 && !cachedRegions.isEmpty
+            registerMovementTrigger: registerMovementTrigger
         )
-        logger.geofenceSyncCompleted(registeredCount: nearest.count)
+        logger.geofenceSyncCompleted(registeredCount: nearest.count, movementTriggerRegistered: registerMovementTrigger)
         // No initial-enter here: a cold-wake restore of the pre-kill set (not new registrations) off a
         // possibly-stale anchor. Genuinely-new fences come from a refresh fetch, which emits there.
         return GeofenceRegistration(center: anchor, businessIds: Set(nearest.map(\.id)))

--- a/Sources/LocationGeofence/GeofenceBootstrap.swift
+++ b/Sources/LocationGeofence/GeofenceBootstrap.swift
@@ -47,12 +47,13 @@ enum GeofenceBootstrap {
         let userId = di.backgroundDeliveryContextStore.currentUserId
 
         // The set we expect to still own: the business geofences registered last session plus the
-        // movement trigger registered alongside them. Empty on first launch or after the OS cleared
-        // everything. Compared against the OS-retained set below to decide adopt vs re-register.
+        // movement trigger, which stays armed when that set is empty but not under the kill switch
+        // — expected-owned mirrors the register condition, so a kill-switched account reclaims
+        // nothing. Compared against the OS-retained set below.
         let lastRegisteredBusinessIds = await di.geofenceStorage.getRegisteredBusinessIds()
-        let expectedOwnedRegions = lastRegisteredBusinessIds.isEmpty
-            ? Set<String>()
-            : lastRegisteredBusinessIds.union([GeofenceConstants.movementTriggerIdentifier])
+        let expectedOwnedRegions = (cachedConfig ?? .fallback).maxBusinessGeofences > 0
+            ? lastRegisteredBusinessIds.union([GeofenceConstants.movementTriggerIdentifier])
+            : []
 
         // Phase 2: synchronous on the main actor. No `await` between handler-bind and
         // `adoptExistingRegions` / `startMonitoring`, so `ownedRegionIdentifiers` is populated

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -110,6 +110,10 @@ extension Logger {
         info("Sync completed: registered \(registeredCount) business geofences\(trigger)", geofenceTag)
     }
 
+    func geofenceRerankUnchanged(keptCount: Int) {
+        debug("Re-rank: nearest set unchanged, kept \(keptCount) business geofences monitored; movement trigger re-centered", geofenceTag)
+    }
+
     func geofenceMovementTrigger(tier: HandleMovementTier) {
         debug("Movement trigger EXIT: \(tier.rawValue)", geofenceTag)
     }

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -103,8 +103,11 @@ extension Logger {
         self.error("Sync fetch failed: \(error)", geofenceTag, nil)
     }
 
-    func geofenceSyncCompleted(registeredCount: Int) {
-        info("Sync completed: registered \(registeredCount) business geofences + 1 movement trigger", geofenceTag)
+    func geofenceSyncCompleted(registeredCount: Int, movementTriggerRegistered: Bool) {
+        let trigger = movementTriggerRegistered
+            ? " + 1 movement trigger"
+            : "; monitoring disabled (max business geofences is 0)"
+        info("Sync completed: registered \(registeredCount) business geofences\(trigger)", geofenceTag)
     }
 
     func geofenceMovementTrigger(tier: HandleMovementTier) {

--- a/Sources/LocationGeofence/Model/GeofenceConfig.swift
+++ b/Sources/LocationGeofence/Model/GeofenceConfig.swift
@@ -22,7 +22,8 @@ struct GeofenceConfig: Codable, Equatable, Sendable {
     /// Duplicate-transition suppression window keyed by "userId:geofenceId:transitionType".
     let duplicateEventsExpiry: TimeInterval
     /// Maximum number of business geofences to monitor. Always 0…19 on iOS (movement
-    /// trigger consumes the 20th OS slot).
+    /// trigger consumes the 20th OS slot). `0` is the server-driven kill switch: nothing
+    /// registers, not even the movement trigger.
     let maxBusinessGeofences: Int
     /// Maximum distance in meters from the device at which a geofence is registered with the OS.
     /// Geofences beyond it are skipped and re-added by a later re-rank as the device moves closer;

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -1166,6 +1166,182 @@ struct GeofenceSyncCoordinatorTests {
         #expect(movementTrigger?.radius == config.localRefreshTriggerRadius)
     }
 
+    // MARK: unchanged-set fast path (crossing absorption)
+
+    /// Shared arrangement for the fast-path tests: an initial remote refresh registers `regions`
+    /// (wholesale, stopAll #1), so the monitor owns them and the OS holds them — the steady state
+    /// every subsequent re-rank runs against.
+    private func makeRegisteredSetup(
+        regions: [Geofence],
+        config: GeofenceConfig,
+        storage: GeofenceStorage
+    ) async -> Setup {
+        let api = GeofenceApiServiceMock()
+        api.fetchNearbyGeofencesClosure = { _, _, completion in
+            completion(.success(makeApiResponse(regions: regions, config: config)))
+        }
+        let setup = makeCoordinator(api: api, storage: storage)
+        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+        return setup
+    }
+
+    private var fastPathConfig: GeofenceConfig {
+        GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 5000,
+            remoteFetchRefreshExpiry: 3600,
+            duplicateEventsExpiry: 3600,
+            maxBusinessGeofences: 10,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
+        )
+    }
+
+    @Test
+    func handleMovement_givenRerankLandsOnSameNearestSet_expectBusinessRegionsUntouched() async {
+        // Steady-state drive: adjacent trigger EXITs mostly re-rank onto the identical nearest set.
+        // Re-registering re-seeds the OS's assumed state and absorbs an undelivered crossing, so the
+        // business regions must be left alone — only the trigger re-centers and the ranking anchor walks.
+        let region = makeRegion(id: "g1", latitude: 0.5, longitude: 0.5)
+        let storage = makeStorage()
+        let setup = await makeRegisteredSetup(regions: [region], config: fastPathConfig, storage: storage)
+
+        // ~111 m: within the refetch radius → local re-rank, same nearest set.
+        let newLocation = LocationData(latitude: 0, longitude: 0.001)
+        let result = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude)
+
+        #expect(result.isSuccess)
+        #expect(setup.monitor.stopAllCallCount == 1) // the initial registration only
+        #expect(setup.monitor.startedRegions.filter { $0.identifier == "g1" }.count == 1) // never re-added
+        #expect(setup.monitor.stoppedIdentifiers == [GeofenceConstants.movementTriggerIdentifier])
+        let triggerStarts = setup.monitor.startedRegions.filter { $0.identifier == GeofenceConstants.movementTriggerIdentifier }
+        #expect(triggerStarts.count == 2)
+        #expect(triggerStarts.last?.center == newLocation)
+        #expect(await storage.getLastRegistrationCenter() == newLocation)
+    }
+
+    @Test
+    func handleMovement_givenRerankChangesNearestSet_expectFullReregistration() async {
+        // Membership actually changed (budget of 1, a closer fence took the slot) — the wholesale
+        // path must run so the OS set matches the new ranking.
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 5000,
+            remoteFetchRefreshExpiry: 3600,
+            duplicateEventsExpiry: 3600,
+            maxBusinessGeofences: 1,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
+        )
+        let nearStart = makeRegion(id: "near-start", latitude: 0, longitude: 0.001)
+        let nearEnd = makeRegion(id: "near-end", latitude: 0, longitude: 0.021)
+        let setup = await makeRegisteredSetup(regions: [nearStart, nearEnd], config: config, storage: makeStorage())
+
+        // ~2.2 km: still a local re-rank, but the single budget slot now belongs to near-end.
+        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.02)
+
+        #expect(result.isSuccess)
+        #expect(setup.monitor.stopAllCallCount == 2)
+        #expect(setup.monitor.startedRegions.contains { $0.identifier == "near-end" })
+    }
+
+    @Test
+    func handleMovement_givenUnchangedSetButOsDroppedRegion_expectFullReregistration() async {
+        // The set compare alone would skip, but the OS silently dropped a region (monitoring
+        // failure). Wholesale re-registration is what heals that — the fast path must step aside.
+        let region = makeRegion(id: "g1", latitude: 0.5, longitude: 0.5)
+        let setup = await makeRegisteredSetup(regions: [region], config: fastPathConfig, storage: makeStorage())
+        setup.monitor.osMonitoredRegions.remove("g1")
+
+        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
+
+        #expect(result.isSuccess)
+        #expect(setup.monitor.stopAllCallCount == 2)
+        #expect(setup.monitor.startedRegions.filter { $0.identifier == "g1" }.count == 2)
+    }
+
+    @Test
+    func refresh_givenFreshProcessWithMatchingStorage_expectFullReregistration() async {
+        // Fresh process: storage says the same set is registered and the OS still holds it, but this
+        // process owns nothing yet (bootstrap hasn't adopted). Skipping would leave OS events with no
+        // owner — the wholesale path must run to re-establish in-process ownership.
+        let storage = makeStorage()
+        let dateUtil = DateUtilStub()
+        await storage.setCachedConfig(fastPathConfig)
+        await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-100), location: LocationData(latitude: 0, longitude: 0))
+        await storage.recordRegistration(center: LocationData(latitude: 0, longitude: 0), businessIds: ["g1"])
+        await storage.setCachedGeofences([makeRegion(id: "g1", latitude: 0.5, longitude: 0.5)])
+        let setup = makeCoordinator(storage: storage, dateUtil: dateUtil)
+        setup.monitor.osMonitoredRegions = ["g1", GeofenceConstants.movementTriggerIdentifier]
+
+        // ~2.2 km from the registration center → ranking stale → local re-rank, same nearest set.
+        let result = await setup.coordinator.refresh(latitude: 0.02, longitude: 0)
+
+        #expect(result.isSuccess)
+        #expect(setup.monitor.stopAllCallCount == 1)
+        #expect(setup.monitor.startedRegions.contains { $0.identifier == "g1" })
+    }
+
+    @Test
+    func handleMovement_givenRemoteRefreshReturnsIdenticalPayload_expectBusinessRegionsUntouched() async {
+        // The 5 km refetch fired but the server returned byte-identical data and the ranking didn't
+        // change — same absorption risk as the local case. The trigger and both anchors must still
+        // walk forward so the next refetch threshold measures from here.
+        let region = makeRegion(id: "g1", latitude: 0.5, longitude: 0.5)
+        let storage = makeStorage()
+        let setup = await makeRegisteredSetup(regions: [region], config: fastPathConfig, storage: storage)
+
+        // ~5.5 km from the fetch anchor → remote tier.
+        let newLocation = LocationData(latitude: 0, longitude: 0.05)
+        let result = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude)
+
+        #expect(result.isSuccess)
+        #expect(setup.api.fetchNearbyGeofencesCallsCount == 2)
+        #expect(setup.monitor.stopAllCallCount == 1)
+        #expect(setup.monitor.startedRegions.filter { $0.identifier == "g1" }.count == 1)
+        let triggerStarts = setup.monitor.startedRegions.filter { $0.identifier == GeofenceConstants.movementTriggerIdentifier }
+        #expect(triggerStarts.last?.center == newLocation)
+        #expect(await storage.getLastSync()?.location == newLocation)
+        #expect(await storage.getLastRegistrationCenter() == newLocation)
+    }
+
+    @Test
+    func handleMovement_givenRemoteRefreshChangesGeometry_expectFullReregistration() async {
+        // Same ids, but the server edited the fence (radius change bumps `lastUpdated`/geometry) —
+        // wholesale re-registration is what applies the new circle to the OS.
+        let original = makeRegion(id: "g1", latitude: 0.5, longitude: 0.5, radius: 100)
+        let resized = makeRegion(id: "g1", latitude: 0.5, longitude: 0.5, radius: 250)
+        let config = fastPathConfig
+        let api = GeofenceApiServiceMock()
+        var responses = [[original], [resized]]
+        api.fetchNearbyGeofencesClosure = { _, _, completion in
+            completion(.success(makeApiResponse(regions: responses.removeFirst(), config: config)))
+        }
+        let setup = makeCoordinator(api: api, storage: makeStorage())
+        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+
+        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.05)
+
+        #expect(result.isSuccess)
+        #expect(setup.monitor.stopAllCallCount == 2)
+        #expect(setup.monitor.startedRegions.last { $0.identifier == "g1" }?.radius == 250)
+    }
+
+    @Test
+    func handleMovement_givenEmptyAreaLoop_expectTriggerWalksWithoutChurn() async {
+        // The geofence-free corridor: empty response, empty cache, trigger armed. Every 5 km refetch
+        // comes back empty again — the trigger must keep walking forward without a stop-all cycle.
+        let setup = await makeRegisteredSetup(regions: [], config: fastPathConfig, storage: makeStorage())
+
+        let newLocation = LocationData(latitude: 0, longitude: 0.05)
+        let result = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude)
+
+        #expect(result.isSuccess)
+        #expect(setup.api.fetchNearbyGeofencesCallsCount == 2)
+        #expect(setup.monitor.stopAllCallCount == 1)
+        let triggerStarts = setup.monitor.startedRegions.filter { $0.identifier == GeofenceConstants.movementTriggerIdentifier }
+        #expect(triggerStarts.count == 2)
+        #expect(triggerStarts.last?.center == newLocation)
+    }
+
     @Test
     func handleMovement_givenInFlightRefresh_expectAlreadyInProgress() async {
         // Shared `refreshInProgress` gate — a refresh holding it must short-circuit

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -480,7 +480,7 @@ struct GeofenceSyncCoordinatorTests {
     }
 
     @Test
-    func refresh_givenEmptyBusinessRegions_expectNoMovementTriggerRegistered() async {
+    func refresh_givenEmptyServerResponse_expectMovementTriggerStillRegistered() async {
         let storage = makeStorage()
         let api = GeofenceApiServiceMock()
         api.fetchNearbyGeofencesClosure = { _, _, completion in
@@ -490,7 +490,34 @@ struct GeofenceSyncCoordinatorTests {
         let setup = makeCoordinator(api: api, storage: storage)
         _ = await setup.coordinator.refresh(latitude: 37.7749, longitude: -122.4194)
 
-        // No business regions ⇒ no movement trigger either; refetch-on-move would just hit the same empty result.
+        // Empty nearby response is a geofence-free area, not a stop signal: keep the movement trigger
+        // armed so a later EXIT re-fetches as the device moves back toward geofences. The trigger is
+        // the only region registered (no business geofences to add).
+        #expect(setup.monitor.startedRegions.map(\.identifier) == [GeofenceConstants.movementTriggerIdentifier])
+    }
+
+    @Test
+    func refresh_givenEmptyServerResponseButKillSwitch_expectNothingRegistered() async {
+        // maxBusinessGeofences == 0 is the runtime off switch: even with the "keep monitoring
+        // through empty areas" behavior, a kill-switched account registers nothing at all.
+        let storage = makeStorage()
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 750,
+            remoteFetchRefreshTriggerRadius: 3000,
+            remoteFetchRefreshExpiry: 86400,
+            duplicateEventsExpiry: 60,
+            maxBusinessGeofences: 0,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
+        )
+        await storage.setCachedConfig(config)
+        let api = GeofenceApiServiceMock()
+        api.fetchNearbyGeofencesClosure = { _, _, completion in
+            completion(.success(makeApiResponse(regions: [], config: config)))
+        }
+
+        let setup = makeCoordinator(api: api, storage: storage)
+        _ = await setup.coordinator.refresh(latitude: 37.7749, longitude: -122.4194)
+
         #expect(setup.monitor.startedRegions.isEmpty)
     }
 
@@ -650,13 +677,40 @@ struct GeofenceSyncCoordinatorTests {
     }
 
     @Test
-    func applyCachedRegistration_givenEmptyRegions_expectNoRegistration() {
+    func applyCachedRegistration_givenEmptyRegions_expectMovementTriggerRegistered() {
+        // An empty nearby response clears the cache but leaves the trigger armed. If the OS then
+        // drops our regions, this is the only path that re-arms it — the refresh decision skips on
+        // a cache that is fresh and empty.
+        let setup = makeCoordinator(storage: makeStorage())
+
+        let registration = setup.coordinator.applyCachedRegistration(
+            cachedRegions: [],
+            anchor: LocationData(latitude: 0, longitude: 0),
+            config: .fallback,
+            userId: "user-1"
+        )
+
+        #expect(setup.monitor.startedRegions.map(\.identifier) == [GeofenceConstants.movementTriggerIdentifier])
+        #expect(registration?.businessIds.isEmpty == true)
+    }
+
+    @Test
+    func applyCachedRegistration_givenEmptyRegionsAndKillSwitch_expectNothingRegistered() {
+        // The kill switch still wins over the empty-cache restore above.
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 750,
+            remoteFetchRefreshTriggerRadius: 3000,
+            remoteFetchRefreshExpiry: 86400,
+            duplicateEventsExpiry: 60,
+            maxBusinessGeofences: 0,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
+        )
         let setup = makeCoordinator(storage: makeStorage())
 
         _ = setup.coordinator.applyCachedRegistration(
             cachedRegions: [],
             anchor: LocationData(latitude: 0, longitude: 0),
-            config: .fallback,
+            config: config,
             userId: "user-1"
         )
 
@@ -944,6 +998,35 @@ struct GeofenceSyncCoordinatorTests {
         #expect(setup.api.fetchNearbyGeofencesCallsCount == 0)
         let businessRegistered = setup.monitor.startedRegions.filter { $0.identifier != GeofenceConstants.movementTriggerIdentifier }
         #expect(businessRegistered.map(\.identifier) == ["near", "far"])
+    }
+
+    @Test
+    func handleMovement_givenLocalRerankWithEmptyCache_expectMovementTriggerStillRegistered() async {
+        // After an empty nearby response wiped the cache, a within-threshold EXIT re-ranks an empty
+        // set. The movement trigger must stay armed (re-centered at the new location) so the device
+        // keeps moving toward the next refetch instead of going dark in a geofence-free area.
+        let storage = makeStorage()
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 5000,
+            remoteFetchRefreshExpiry: 3600,
+            duplicateEventsExpiry: 3600,
+            maxBusinessGeofences: 10,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
+        )
+        await storage.setCachedConfig(config)
+        await storage.recordSync(timestamp: Date(timeIntervalSince1970: 100), location: LocationData(latitude: 0, longitude: 0))
+        await storage.setCachedGeofences([]) // wiped by a prior empty response
+        let api = GeofenceApiServiceMock()
+        let setup = makeCoordinator(api: api, storage: storage)
+
+        // ~111 m from anchor — within the refetch radius, so it re-ranks locally, no fetch.
+        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
+
+        #expect(result.isSuccess)
+        #expect(setup.api.fetchNearbyGeofencesCallsCount == 0)
+        let trigger = setup.monitor.startedRegions.first { $0.identifier == GeofenceConstants.movementTriggerIdentifier }
+        #expect(trigger?.center == LocationData(latitude: 0, longitude: 0.001))
     }
 
     @Test

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -1220,6 +1220,32 @@ struct GeofenceSyncCoordinatorTests {
     }
 
     @Test
+    func handleMovement_givenEmptyAreaThenKillSwitch_expectTeardownNotTriggerRecenter() async {
+        // The one state where the ids match but skipping would be wrong: a geofence-free area leaves
+        // the trigger armed with no business regions, so a later kill-switched config re-ranks onto
+        // the same (empty) set while the trigger is still owned. Skipping there would re-center a
+        // trigger the kill switch is supposed to remove.
+        let storage = makeStorage()
+        let setup = await makeRegisteredSetup(regions: [], config: fastPathConfig, storage: storage)
+        #expect(setup.monitor.monitoredRegionIdentifiers == [GeofenceConstants.movementTriggerIdentifier])
+
+        await storage.setCachedConfig(GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 5000,
+            remoteFetchRefreshExpiry: 3600,
+            duplicateEventsExpiry: 3600,
+            maxBusinessGeofences: 0,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
+        ))
+
+        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
+
+        #expect(result.isSuccess)
+        #expect(setup.monitor.stopAllCallCount == 2) // wholesale teardown ran, not the fast path
+        #expect(setup.monitor.monitoredRegionIdentifiers.isEmpty)
+    }
+
+    @Test
     func handleMovement_givenRerankChangesNearestSet_expectFullReregistration() async {
         // Membership actually changed (budget of 1, a closer fence took the slot) — the wholesale
         // path must run so the OS set matches the new ranking.

--- a/Tests/LocationGeofence/Geofence/GeofenceBootstrapTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceBootstrapTests.swift
@@ -85,6 +85,9 @@ struct GeofenceBootstrapTests {
 
         #expect(monitor.setOnTransitionCallsCount == 1)
         #expect(coordinator.applyCachedRegistrationCallsCount == 1)
+        // First launch: the expected-owned set is never empty (it always names the movement
+        // trigger), so the adopt branch has to be ruled out by the OS holding nothing.
+        #expect(monitor.adoptExistingRegionsCallsCount == 0)
         #expect(monitor.setOnAuthorizationChangedCallsCount == 1)
         #expect(monitor.onAuthorizationChanged != nil)
         #expect(monitor.reportPermissionTierCallsCount == 1)
@@ -283,6 +286,61 @@ struct GeofenceBootstrapTests {
 
         #expect(monitor.adoptedIdentifiers == ["g1", GeofenceConstants.movementTriggerIdentifier])
         #expect(coordinator.applyCachedRegistrationCallsCount == 0)
+    }
+
+    @Test
+    func wireMonitor_givenOnlyMovementTriggerRegistered_expectTriggerAdopted() async {
+        // Relaunch after an empty nearby response: the cache and the business set are empty, but the
+        // trigger stayed armed and the OS still holds it. Without adopting it the process owns
+        // nothing, so its EXIT is dropped at the ownership filter — and the refresh decision skips
+        // (fresh cache, no movement), leaving the device dark until the cache ages out.
+        let di = DIGraphShared.shared
+        let storage = GeofenceStorage(
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        await storage.recordRegistration(center: LocationData(latitude: 10, longitude: 20), businessIds: [])
+        di.override(value: storage, forType: GeofenceStorage.self)
+        let monitor = MockGeofenceRegionMonitor()
+        monitor.osMonitoredRegions = [GeofenceConstants.movementTriggerIdentifier]
+        di.override(value: monitor as GeofenceRegionMonitoring, forType: GeofenceRegionMonitoring.self)
+        let coordinator = GeofenceSyncCoordinatorMock()
+        di.override(value: coordinator as GeofenceSyncCoordinator, forType: GeofenceSyncCoordinator.self)
+        defer { di.reset() }
+
+        await GeofenceBootstrap.wireMonitor(di: di)
+
+        #expect(monitor.adoptedIdentifiers == [GeofenceConstants.movementTriggerIdentifier])
+        #expect(coordinator.applyCachedRegistrationCallsCount == 0)
+    }
+
+    @Test
+    func wireMonitor_givenKillSwitchedConfig_expectTriggerNotAdopted() async {
+        // Under the kill switch the trigger is not something we would register, so it is not
+        // something to reclaim either — expected-owned mirrors the register condition.
+        let di = DIGraphShared.shared
+        let storage = GeofenceStorage(
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        await storage.setCachedConfig(GeofenceConfig(
+            localRefreshTriggerRadius: 750,
+            remoteFetchRefreshTriggerRadius: 3000,
+            remoteFetchRefreshExpiry: 86400,
+            duplicateEventsExpiry: 60,
+            maxBusinessGeofences: 0,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
+        ))
+        await storage.recordRegistration(center: LocationData(latitude: 10, longitude: 20), businessIds: [])
+        di.override(value: storage, forType: GeofenceStorage.self)
+        let monitor = MockGeofenceRegionMonitor()
+        monitor.osMonitoredRegions = [GeofenceConstants.movementTriggerIdentifier]
+        di.override(value: monitor as GeofenceRegionMonitoring, forType: GeofenceRegionMonitoring.self)
+        let coordinator = GeofenceSyncCoordinatorMock()
+        di.override(value: coordinator as GeofenceSyncCoordinator, forType: GeofenceSyncCoordinator.self)
+        defer { di.reset() }
+
+        await GeofenceBootstrap.wireMonitor(di: di)
+
+        #expect(monitor.adoptExistingRegionsCallsCount == 0)
     }
 
     @Test

--- a/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
+++ b/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
@@ -101,6 +101,9 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
 
     func stopMonitoringAll() {
         stopAllCallCount += 1
+        // Mirror the real monitor: only owned regions are handed to the OS for removal, so anything
+        // the OS still holds that this process never adopted survives the call.
+        osMonitoredRegions.subtract(activeIdentifiers)
         activeIdentifiers.removeAll()
         operationLog.append(.stopAll)
     }

--- a/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
+++ b/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
@@ -90,12 +90,16 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
             transitionTypes: transitionTypes
         ))
         activeIdentifiers.insert(identifier)
+        // Mirror the real monitors: a successful add is reflected in the OS-persisted set too
+        // (classic's `monitoredRegions`, CLMonitor's condition mirror).
+        osMonitoredRegions.insert(identifier)
         operationLog.append(.start(identifier: identifier))
     }
 
     func stopMonitoring(identifier: String) {
         stoppedIdentifiers.append(identifier)
         activeIdentifiers.remove(identifier)
+        osMonitoredRegions.remove(identifier)
         operationLog.append(.stop(identifier: identifier))
     }
 


### PR DESCRIPTION
Geofencing could go silent for the rest of a trip after passing through an area with no nearby geofences, and stay silent across a relaunch — and at driving speed, its own re-registration churn could silently eat crossings. Four fixes across those two failure modes.

Replaces #1176, which also carried `GeofenceLocationMode.off`. That mode has to interpose on every lifecycle entry point and kept turning up gaps in review, so it is split out into its own PR rather than holding this up.

## 1. An empty nearby response is not a kill switch
`/geofences/nearest` is distance-capped, so an empty response means "none nearby right now," not "feature off." Registration tied the movement trigger to a non-empty business set, so an empty response (or an emptied cache) dropped the trigger — and the trigger's EXIT is the only thing that drives a re-fetch. Driving through any fence-free corridor disarmed monitoring for the rest of the journey.

The trigger now stays registered whenever `maxBusinessGeofences > 0`. Only the server kill switch (`max_business_geofence = 0`) registers nothing.

Field-validated on a drive out of the cluster: registrations stepped 6 → 5 → 3 → 2 → 0, hit 0 in the background, and kept re-fetching instead of going silent.

## 2. A relaunch in such an area never reclaimed the trigger
The bootstrap's expected-owned set was empty whenever no business geofences were registered, so it never adopted the trigger the OS had kept. On iOS ≤17 the monitor starts each process owning nothing, so that trigger's EXIT was dropped at the ownership filter — and with a cache that is fresh and empty the refresh decision returns `.skip`, so nothing re-registered either. The device stayed dark until the cache aged out (24h default).

The trigger is now part of that set under the same condition registration uses, so a kill-switched account still reclaims nothing.

## 3. Cached restore bailed on an empty cache
`applyCachedRegistration` returned early when `cachedRegions` was empty. After an empty response cleared the cache, if the OS then dropped our regions — permission revoked then re-granted, or a monitoring failure — that early return was the last thing between the device and no trigger at all. The guard is gone; the anchor guard below it still rules out the genuinely nothing-to-restore cases (first launch, post-sign-out).

## 4. Re-registering an unchanged set absorbed crossings at speed
Every movement-trigger EXIT re-registered all regions wholesale, and each re-add re-seeds the OS's assumed state from the live fix — so a crossing the OS had detected but not yet delivered was silently re-baselined instead of firing. Re-ranks fire once per trigger radius (every ~35–45 s at highway speed), making that a recurring loss window. Sim-reproduced: a fence exit was eaten exactly between two adjacent re-registers, leaving its stored state stuck at "inside" permanently — dwell time never recovers an eaten event.

When the freshly ranked set matches what this process already has live with the OS, business regions are now left untouched: only the trigger re-centers and the ranking/refetch anchors walk forward. Any doubt still takes the wholesale path — fresh process (ownership not yet adopted), a region the OS silently dropped, a changed payload (`lastUpdated` participates in equality, so any server-side edit forces the re-register that applies it), or the kill switch (wholesale is the teardown).

## Verification
Every behavioural change has a test confirmed to fail without its fix (for fix 4: the three fast-path tests fail with the skip neutered, and four more pin each fall-through guard — set changed, OS-dropped region, fresh process, geometry edit). Beyond those, both bootstrap decision points were checked exhaustively rather than by inspection:

- `applyCachedRegistration` across all 16 combinations of (cache empty/full) × (anchor nil/present) × (kill switch on/off) × (user id nil/present) — only the intended cell changed.
- `wireMonitor`'s adopt-vs-re-register decision across 36 combinations of (registered business ids) × (what the OS still holds) × (cached config) × (cache empty/full) — every kill-switch row registers nothing, first launch always re-registers, partial drops never partially adopt.

277 LocationGeofence tests pass. Format + lint clean, api-docs unchanged, `-strict-concurrency=complete` clean for the module.

**Not covered:** none of the iOS ≤17 ownership behaviour has run against a real `CLLocationManager` — it is verified by source reading plus a mock made faithful to it. Worth one device pass before release: relaunch in a geofence-free area and confirm the trigger is adopted and the next EXIT re-fetches, rather than silence. Fix 4 likewise hasn't been re-driven yet; a route re-run should show `Re-rank: nearest set unchanged` lines replacing the per-EXIT re-register churn, with previously-absorbed crossings delivering.

## Parity
Android's equivalent is customerio/customerio-android@eb2be918 (`monitoringEnabled = maxBusinessGeofences > 0`, same kill-switch semantics, same sync-completed logging).

Fixes 2 and 3 have no Android counterpart and none is needed: its receiver has no in-process ownership filter, and its restore path already gated only on user + anchor, never on an empty region list — this aligns iOS to what Android already did.

Fix 4 also lands iOS where Android already sits: Android's registration is diff-based (a wholesale re-add would spam `INITIAL_TRIGGER_ENTER`), so an unchanged set is already left alone there; the absorption mechanism being fixed is specific to iOS re-seeding assumed state on re-add.

Base branch: `feature/geofence-on-device`.

Ticket: https://linear.app/customerio/issue/MBL-2196/mobile-improve-geofence-persistence-across-app-upgrades

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core geofence OS registration, bootstrap adoption, and re-rank behavior where missed transitions or silent monitoring are user-visible; scope is well covered by new tests but remains location-critical infrastructure.
> 
> **Overview**
> Keeps iOS geofencing active in fence-free corridors and on relaunch, and cuts OS re-registration churn that could swallow crossings at driving speed.
> 
> **Movement trigger when the nearby set is empty.** Registration no longer ties the movement trigger to a non-empty business list; it stays on whenever `maxBusinessGeofences > 0`, with only `maxBusinessGeofences == 0` registering nothing. Bootstrap’s expected-owned set and cached restore follow the same rule so a relaunch can adopt or re-arm a trigger-only registration after an empty fetch.
> 
> **Unchanged-set fast path.** Local re-ranks and identical remote syncs can skip wholesale `stopAll` + re-add when business IDs match, the process owns the regions, and the OS still holds them—only **re-centering the movement trigger** and advancing registration/sync anchors. Wholesale registration still runs when the set changes, geometry changes, the OS dropped a region, the process hasn’t adopted yet, or the kill switch applies.
> 
> Logging reflects whether the trigger was registered; tests and the region monitor mock were extended for these paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e92335b95e835d2326300c9348791828c2faef8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


