### PR TITLE
chore(datapipeline): write background-delivery user id before publishing identify

### DIFF
--- a/Sources/DataPipeline/DataPipelineImplementation.swift
+++ b/Sources/DataPipeline/DataPipelineImplementation.swift
@@ -224,14 +224,17 @@ class DataPipelineImplementation: DataPipelineInstance, DataPipelineTracking, Ba
             deleteDeviceToken()
         }
 
+        // Mirror for cold-wake direct-HTTP callers. Must precede `analytics.identify`, which
+        // publishes `ProfileIdentifiedEvent` from a `.before` plugin — subscribers resolve the
+        // user from this store, and would otherwise read nil.
+        backgroundDeliveryContextStore.setUserId(userId)
+
         if let attributes = attributesCodable {
             analytics.identify(userId: userId, traits: attributes)
         } else {
             analytics.identify(userId: userId, traits: attributesDict)
         }
 
-        // Mirror to the background-delivery store for cold-wake direct-HTTP callers.
-        backgroundDeliveryContextStore.setUserId(userId)
         // Update session tracker so subsequent no-traits same-userId calls
         // within this session can dedup. Identify-with-traits passes through
         // but still refreshes the session tracker.

--- a/Tests/DataPipeline/DataPipelineImplementation+BackgroundDeliveryContextTests.swift
+++ b/Tests/DataPipeline/DataPipelineImplementation+BackgroundDeliveryContextTests.swift
@@ -1,3 +1,4 @@
+import CioAnalytics
 @testable import CioDataPipelines
 @testable import CioInternalCommon
 import Foundation
@@ -57,6 +58,25 @@ class BackgroundDeliveryContextWriteTests: IntegrationTest {
         XCTAssertEqual(testStore.currentUserId, "user_b")
     }
 
+    /// `ProfileIdentifiedEvent` is published by `DataPipelinePublishedEvents`, a `.before` plugin,
+    /// so subscribers can observe it while `analytics.identify` is still running. They resolve the
+    /// user from this store, so the id must already be written by the time the plugin timeline
+    /// runs — writing it afterwards let a subscriber read nil and silently skip its work for the
+    /// whole session (geofencing never registered).
+    ///
+    /// Snapshots the store from inside a `.before` plugin rather than from an EventBus observer:
+    /// the bus delivers asynchronously, so an observer always runs after `identify` returns and
+    /// would pass either way. This reads it at the instant the real publisher does.
+    func test_identify_expectStorePopulatedByTheTimeBeforePluginsRun() {
+        let givenIdentifier = String.random
+        let snapshotPlugin = StoreSnapshotPlugin(store: testStore)
+        analytics.add(plugin: snapshotPlugin)
+
+        customerIO.identify(userId: givenIdentifier)
+
+        XCTAssertEqual(snapshotPlugin.userIdDuringIdentify.wrappedValue, givenIdentifier)
+    }
+
     // MARK: - clearIdentify
 
     func test_clearIdentify_givenIdentifiedProfile_expectUserIdClearedFromStore() {
@@ -113,5 +133,24 @@ class BackgroundDeliveryContextWriteTests: IntegrationTest {
         // delivery still works — `currentCdpApiKey` returns the in-memory key.
         XCTAssertNil(reloadDiskState().currentCdpApiKey)
         XCTAssertEqual(testStore.currentCdpApiKey, dataPipelineConfigOptions.cdpApiKey)
+    }
+}
+
+/// Records what `BackgroundDeliveryContextStore` held at the moment the `.before` plugin timeline
+/// ran — the same point `DataPipelinePublishedEvents` publishes `ProfileIdentifiedEvent` from.
+private final class StoreSnapshotPlugin: EventPlugin {
+    var type: PluginType = .before
+    var analytics: Analytics?
+
+    let userIdDuringIdentify = Synchronized<String?>(nil)
+    private let store: BackgroundDeliveryContextStore
+
+    init(store: BackgroundDeliveryContextStore) {
+        self.store = store
+    }
+
+    func identify(event: IdentifyEvent) -> IdentifyEvent? {
+        userIdDuringIdentify.wrappedValue = store.currentUserId
+        return event
     }
 }


### PR DESCRIPTION
Geofencing could silently never start for an entire app session. Found while running the post-merge simulator validation for #1177 / #1173.

## The failure
`ProfileIdentifiedEvent` is published by `DataPipelinePublishedEvents`, a `.before` analytics plugin — so it reaches subscribers *from inside* `analytics.identify(...)`. `backgroundDeliveryContextStore.setUserId(userId)` ran **after** that call returned.

Geofencing resolves the identified user from that store:

```swift
guard di.backgroundDeliveryContextStore.currentUserId?.isEmpty == false else { return }
```

Lose the race and it reads `nil`, returns before doing anything — and, because the guard precedes every log statement, emits nothing at all. That silence is why this went unnoticed: it looks identical to geofencing not being configured.

Impact when lost: no geofences registered for the session. It self-heals on the next cold launch, so the blast radius is one session — but it fires on **every login**, including the first launch after install.

## Evidence
Reproduced on simulator against the merged feature branch. Two of three sign-ins registered nothing:

```
17:39:23  [Location] Tracking location: …
17:41:52  ProfileIdentifiedEvent posted
          (nothing — no sync, no "Sync skipped", no geofenceState.json)
```

A relaunch immediately registered `6 business geofences + 1 movement trigger`, confirming state and permissions were fine and only the ordering was at fault.

## The fix
Move the store write above `analytics.identify`, restoring the invariant that the store is populated before identification is announced.

Checked for collateral:
- `isChangingIdentifiedProfile` / `isFirstTimeIdentifying` derive from `registeredUserId`, which reads `analytics.userId` — not this store.
- `deleteDeviceToken()` still runs before the new write, so token cleanup still targets the previous profile.
- Nothing between the function entry and the insertion point reads the store.

## Test
`test_identify_expectStorePopulatedByTheTimeBeforePluginsRun` snapshots the store from inside a `.before` plugin — the same point the real publisher fires.

My first attempt observed the EventBus instead and was **vacuous**: the bus delivers asynchronously, so the observer always ran after `identify` returned and the test passed with or without the fix. The plugin-based version is revert-verified — it fails on the unfixed code and passes on the fix.

## Verification
- `DataPipelineTests` 142 (3 skipped), `LocationGeofenceTests` 277, `LocationTests` 62 — all green
- `make format` clean, `make lint` 0 violations in 617 files
- No public API change

## Not included
Two findings from the same validation session, both pre-existing and deliberately out of scope:
- **Transition loss on set change** — a crossing detected inside the ~1s teardown of a set-changing re-registration is absorbed. Measured 1 loss in 5 crossings at 140 km/h, but **0 in 8 at 90 km/h**, so the realistic rate is low. Real fix is diff-based registration, which touches the ≤17 ownership model and warrants its own PR with a state matrix.
- **`wireMonitor` runs twice per launch** — `performWireMonitor` re-triggers itself from the reconcile path and the chain serializes without deduping. Adoption is idempotent so there is no correctness impact, but it doubles work in the cold-wake window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core identify ordering used by background delivery and geofencing; fix is narrow but identity timing is security- and correctness-sensitive.
> 
> **Overview**
> Fixes a **session-long geofencing skip** on login: `ProfileIdentifiedEvent` fires from a `.before` analytics plugin *during* `analytics.identify`, while geofencing reads the user from `BackgroundDeliveryContextStore`. The store write used to run **after** identify returned, so subscribers often saw `nil` and exited silently (no geofences for that session until the next cold launch).
> 
> **`backgroundDeliveryContextStore.setUserId(userId)`** is now called **immediately before** `analytics.identify`, with comments documenting the ordering invariant. Token cleanup on profile change is unchanged (still before the write).
> 
> Adds **`test_identify_expectStorePopulatedByTheTimeBeforePluginsRun`**, which snapshots the store from a `.before` plugin (not EventBus observers, which run too late to catch the bug).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04ac73f930a55d8e65eb9272bcce7d4c70853516. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->