### PR TITLE
chore(geofence): re-arm the movement trigger when a remote refresh fails

### DIFF
--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
@@ -161,12 +161,25 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         // otherwise refetch only once the device has moved beyond the cached nearby set.
         if anchor == nil || movedBeyondRefetchRadius(from: anchor, to: movement, config: effectiveConfig) {
             logger.geofenceMovementTrigger(tier: .remoteRefresh)
-            return await performRemoteRefresh(
+            let remote = await performRemoteRefresh(
                 expectedUserId: userId,
                 latitude: latitude,
                 longitude: longitude,
                 cachedConfig: cachedConfig
             )
+            if case .failure = remote {
+                // A failed pass never re-centers the trigger, leaving it on the circle the device
+                // just exited where no further EXIT can fire. Re-rank from cache to re-arm it.
+                logger.geofenceMovementRearmedAfterFailedRefresh()
+                _ = await performLocalRefresh(
+                    expectedUserId: userId,
+                    latitude: latitude,
+                    longitude: longitude,
+                    config: effectiveConfig,
+                    cachedRegions: await storage.getCachedGeofences()
+                )
+            }
+            return remote
         } else {
             logger.geofenceMovementTrigger(tier: .localRerank)
             let cachedRegions = await storage.getCachedGeofences()

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -118,6 +118,10 @@ extension Logger {
         debug("Movement trigger EXIT: \(tier.rawValue)", geofenceTag)
     }
 
+    func geofenceMovementRearmedAfterFailedRefresh() {
+        debug("Movement refresh failed; re-ranking from cache to re-arm the movement trigger", geofenceTag)
+    }
+
     func geofenceSyncSupersededByUserChange() {
         info("Sync result discarded: identified user changed during fetch", geofenceTag)
     }

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -1166,6 +1166,71 @@ struct GeofenceSyncCoordinatorTests {
         #expect(movementTrigger?.radius == config.localRefreshTriggerRadius)
     }
 
+    @Test
+    func handleMovement_givenRemoteFetchFails_expectMovementTriggerRearmedAtCurrentFix() async {
+        // A failed pass leaves the trigger on the circle the device just exited, so no further EXIT
+        // can fire and re-ranking stops until the next launch. Re-rank from cache to re-arm it.
+        let storage = makeStorage()
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 5000,
+            remoteFetchRefreshExpiry: 3600,
+            duplicateEventsExpiry: 3600,
+            maxBusinessGeofences: 10,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
+        )
+        await storage.setCachedConfig(config)
+        let fetchAnchor = LocationData(latitude: 0, longitude: 0)
+        await storage.recordSync(timestamp: Date(timeIntervalSince1970: 100), location: fetchAnchor)
+        let api = GeofenceApiServiceMock()
+        api.fetchNearbyGeofencesClosure = { _, _, completion in
+            completion(.failure(.transport))
+        }
+        let setup = makeCoordinator(api: api, storage: storage)
+
+        // ~157 km from the anchor — beyond the 5 km refetch radius, so this takes the remote tier.
+        let newLocation = LocationData(latitude: 1.0, longitude: 1.0)
+        let result = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude)
+
+        // The fetch failure is still what the caller sees.
+        #expect(result.errorOrNil == .fetchFailed(.transport))
+        #expect(setup.api.fetchNearbyGeofencesCallsCount == 1)
+        // ...but the trigger now sits on the device's current fix, so movement can fire again.
+        let movementTrigger = setup.monitor.startedRegions.last { $0.identifier == GeofenceConstants.movementTriggerIdentifier }
+        #expect(movementTrigger?.center == newLocation)
+        #expect(movementTrigger?.radius == config.localRefreshTriggerRadius)
+        // The fetch anchor stays put, so the next EXIT retries remotely instead of treating the
+        // re-arm as a successful sync.
+        #expect(await storage.getLastSync()?.location == fetchAnchor)
+    }
+
+    @Test
+    func handleMovement_givenRemoteFetchFailsUnderKillSwitch_expectTeardownNotRearm() async {
+        // The re-arm fallback must not resurrect the trigger the kill switch just tore down.
+        let storage = makeStorage()
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 5000,
+            remoteFetchRefreshExpiry: 3600,
+            duplicateEventsExpiry: 3600,
+            maxBusinessGeofences: 0,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
+        )
+        await storage.setCachedConfig(config)
+        await storage.recordSync(timestamp: Date(timeIntervalSince1970: 100), location: LocationData(latitude: 0, longitude: 0))
+        let api = GeofenceApiServiceMock()
+        api.fetchNearbyGeofencesClosure = { _, _, completion in
+            completion(.failure(.transport))
+        }
+        let setup = makeCoordinator(api: api, storage: storage)
+
+        let result = await setup.coordinator.handleMovement(latitude: 1.0, longitude: 1.0)
+
+        #expect(result.errorOrNil == .fetchFailed(.transport))
+        #expect(setup.monitor.monitoredRegionIdentifiers.isEmpty)
+        #expect(!setup.monitor.startedRegions.contains { $0.identifier == GeofenceConstants.movementTriggerIdentifier })
+    }
+
     // MARK: unchanged-set fast path (crossing absorption)
 
     /// Shared arrangement for the fast-path tests: an initial remote refresh registers `regions`


### PR DESCRIPTION
iOS port of Android [#798](https://github.com/customerio/customerio-android/pull/798). Same bug, same shape.

## The failure
On a movement-trigger EXIT that needs a refetch, `performMovement` returned the fetch result directly:

```swift
if anchor == nil || movedBeyondRefetchRadius(...) {
    return await performRemoteRefresh(...)   // nothing else runs
}
```

and `performRemoteRefresh` returns before `registerWithOsSync` when the fetch fails. So nothing re-registers, and the trigger stays centred on the circle the device **just exited**. CoreLocation only fires on transitions, and the device is now outside, so no further EXIT is possible — re-ranking is dead until an app launch or identify. For a background-only geofencing user that can be days.

Already-registered business fences keep firing; what is lost is adaptation, so the device stops discovering new nearby fences as it moves.

## The fix
On failure, fall through to a local re-rank purely to re-arm the trigger. Two properties matter:

- The **original fetch failure is still returned**, so callers and retry behaviour are unchanged.
- `performLocalRefresh` deliberately does not write `lastSync` — the API-fetch anchor is what the refetch decision compares against — so the next EXIT retries remotely rather than treating the re-arm as a successful sync. This mirrors Android's assertion that the fetch anchor and freshness stay untouched.

Worth noting this only works because #1177 removed the `!regions.isEmpty` guards: the `anchor == nil` first-EXIT-after-install case has an empty cache, and pre-#1177 the fallback would have registered nothing at all.

## Verification
Ran a state matrix over the failure path — `{anchor nil, beyond radius} × {cache empty, populated} × {maxBusinessGeofences 0, 10}`, 8 rows, printing real outcomes rather than reasoning about them:

- error propagates as `.fetchFailed(.transport)` in all 8
- `lastSync` never advances in any row
- with `maxBusinessGeofences > 0` the trigger re-centres on the current fix
- with the **kill switch** (`maxBusinessGeofences == 0`) it correctly tears down and does **not** re-arm

That last row is why there are two tests rather than one. A future "always re-arm on failure" simplification would silently defeat the kill switch on every failed fetch, so it is pinned:

- `handleMovement_givenRemoteFetchFails_expectMovementTriggerRearmedAtCurrentFix` — revert-verified: fails on the unfixed code, passes on the fix.
- `handleMovement_givenRemoteFetchFailsUnderKillSwitch_expectTeardownNotRearm`

`LocationGeofenceTests` 279, `LocationTests` 62, `DataPipelineTests` 142 (3 skipped) — all green. `make format` clean, `make lint` 0 violations. No public API change.

## Notes
- Concurrency unchanged: the fallback runs inside the same `acquireGate()` critical section as the remote pass, adds no captures or closures, and introduces no new Sendable surface.
- Base is `feature/geofence-on-device`; re-target to `main` if #1130 merges first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches background geofence sync and OS region registration on a failure path; behavior is narrow (fallback re-rank) but incorrect re-arm could affect monitoring or defeat the kill switch.
> 
> **Overview**
> Fixes a case where a **movement-trigger EXIT** that needs a **remote refetch** could leave geofence adaptation stuck until the next app launch.
> 
> When `performRemoteRefresh` fails, the movement trigger used to stay on the circle the device had just exited. With Core Location firing only on region transitions, no further EXIT could occur and re-ranking stopped even though existing business fences might still fire.
> 
> **`handleMovement`** now, on remote refresh failure, runs a **cache-only local re-rank** via `performLocalRefresh` to re-center the movement trigger at the current fix. The caller still receives the **original fetch failure**, and **`lastSync` is not advanced** so the next EXIT can retry remotely. When **`maxBusinessGeofences == 0`** (kill switch), teardown is unchanged and the fallback does **not** re-arm monitoring.
> 
> Adds **`geofenceMovementRearmedAfterFailedRefresh`** logging and unit tests for the re-arm path and the kill-switch exception.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa917e29ac4b5d160ca340cfa8f9bd6d8bf6e338. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->