### PR TITLE
fix(live-activities): address bugbot review findings

### DIFF
--- a/Apps/APN-UIKit/APN UIKit.xcodeproj/project.pbxproj
+++ b/Apps/APN-UIKit/APN UIKit.xcodeproj/project.pbxproj
@@ -632,7 +632,7 @@
 			mainGroup = 46D5D97429E459D600EAF40B;
 			packageReferences = (
 				30F117062D63531A00DB1E11 /* XCLocalSwiftPackageReference "../Common" */,
-				EEF4000F2FECEB85003FFED7 /* XCLocalSwiftPackageReference "../../../customerio-ios" */,
+				EEF4000F2FECEB85003FFED7 /* XCLocalSwiftPackageReference "../../" */,
 			);
 			productRefGroup = 46D5D97E29E459D600EAF40B /* Products */;
 			projectDirPath = "";
@@ -1301,9 +1301,9 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ../Common;
 		};
-		EEF4000F2FECEB85003FFED7 /* XCLocalSwiftPackageReference "../../../customerio-ios" */ = {
+		EEF4000F2FECEB85003FFED7 /* XCLocalSwiftPackageReference "../../" */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = "../../../customerio-ios";
+			relativePath = "../../";
 		};
 /* End XCLocalSwiftPackageReference section */
 

--- a/Sources/LiveActivities/LiveActivityHandle.swift
+++ b/Sources/LiveActivities/LiveActivityHandle.swift
@@ -68,16 +68,21 @@ public struct CIOLiveActivity<Attributes: ActivityAttributes> {
         // Mark before ending so the marker is set before ActivityKit emits any terminal state to
         // the observer, avoiding a race where `.dismissed` arrives first.
         markLocalEnd(id)
-        if let finalContentState {
-            await activity.end(ActivityContent(state: finalContentState, staleDate: nil), dismissalPolicy: dismissalPolicy)
-        } else {
-            await activity.end(nil, dismissalPolicy: dismissalPolicy)
-        }
+        // Report before awaiting ActivityKit. Reporting is identity-gated, so a logout landing
+        // during the await below would drop the `end` outright — and the observer stays silent
+        // too, because it suppresses its own report once the local-end marker is consumed.
+        // Reporting is decoupled from the local render by design (the app asked for the end, so
+        // Customer.io must record it), so ordering it first costs nothing.
         reporter.reportEnd(
             instanceUUID: id,
             notificationType: notificationType,
             contentState: finalContentState.flatMap(LiveActivityReporter.encode)
         )
+        if let finalContentState {
+            await activity.end(ActivityContent(state: finalContentState, staleDate: nil), dismissalPolicy: dismissalPolicy)
+        } else {
+            await activity.end(nil, dismissalPolicy: dismissalPolicy)
+        }
     }
 }
 #endif


### PR DESCRIPTION
Fixes the two automated-review findings on `feat/live-activities` that were worth acting on.

- **End event dropped after logout** — `CIOLiveActivity.end` now reports before awaiting ActivityKit. Reporting is identity-gated, so a logout landing inside that await dropped the `end` on both paths: the direct report was gated out, and the observer suppresses its own once the local-end marker is consumed.
- **Fragile sample package path** — the widget extension's local package reference is now `../../` instead of `../../../customerio-ios`, matching `Apps/Common/Package.swift`. The old path only resolved because it went up past the repo root and back down into a same-named directory, so it broke in any checkout not named `customerio-ios`.

## Verification

- `LiveActivitiesTests` — 114 tests across 22 suites, all passing
- APN-UIKit sample app builds with the new package path
- SwiftFormat and SwiftLint `--strict` clean

Note: `CIOLiveActivity` holds a concrete `Activity<Attributes>` with no seam, so the end-ordering change has no direct unit test — adding one would need a protocol abstraction larger than the fix itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)