### PR TITLE
fix(inbox): reset listener dedupe on logout and order callbacks after the store

### DIFF
--- a/Sources/MessagingInApp/Inbox/Data/Cache/InboxRenderAssetsCache.swift
+++ b/Sources/MessagingInApp/Inbox/Data/Cache/InboxRenderAssetsCache.swift
@@ -1,13 +1,18 @@
 import CioInternalCommon
 import Foundation
 
-/// Workspace-scoped persistent store for the visual-inbox render assets (templates JSON, branding
-/// JSON, and the enablement flag).
+/// Persistent store for the visual-inbox render assets (templates JSON, branding JSON, and the
+/// enablement flag).
 ///
 /// Backed by the same `SharedKeyValueStorage` the headless inbox uses to persist its queue response
 /// body, so render assets survive process restarts and reuse the existing storage mechanism rather
-/// than a bespoke in-memory store. Entries are workspace-scoped (the underlying UserDefaults file is
-/// keyed by site id), not per-user.
+/// than a bespoke in-memory store.
+///
+/// Scope: entries are **app-wide**, not per-user and not per-workspace. `SharedKeyValueStorage`
+/// resolves to a single shared UserDefaults suite with no site id in its name, unlike the
+/// site-scoped storage used elsewhere in the SDK. Cross-user carryover is handled by clearing on
+/// logout (see `clear()`); re-initializing the SDK with a different site id in one process would
+/// still read the previous workspace's assets until the next revalidation overwrites them.
 ///
 /// There is **no wall-clock TTL/expiry**: freshness is decided by once-per-session server
 /// revalidation in `VisualInboxRepository`, matching Android's model. This store's sole job is to

--- a/Sources/MessagingInApp/Inbox/Data/VisualInboxSPI.swift
+++ b/Sources/MessagingInApp/Inbox/Data/VisualInboxSPI.swift
@@ -275,8 +275,12 @@ final class VisualInboxProviderImpl: VisualInboxProvider, @unchecked Sendable {
             // permanently dedupe a mark that never applied.
             return false
         }
-        inbox.markMessageOpened(message: message)
-        eventDispatcher?.notifyMessageOpened(message: message)
+        if let eventDispatcher {
+            // Marks and notifies in order, so a host reading the inbox in the callback sees it opened.
+            await eventDispatcher.markOpenedAndNotify(message: message)
+        } else {
+            inbox.markMessageOpened(message: message)
+        }
         return true
     }
 
@@ -292,8 +296,12 @@ final class VisualInboxProviderImpl: VisualInboxProvider, @unchecked Sendable {
             // permanently dedupe a dismiss that never applied.
             return false
         }
-        inbox.markMessageDeleted(message: message)
-        eventDispatcher?.notifyMessageDismissed(message: message)
+        if let eventDispatcher {
+            // Marks and notifies in order, so a host reading the inbox in the callback sees it gone.
+            await eventDispatcher.markDismissedAndNotify(message: message)
+        } else {
+            inbox.markMessageDeleted(message: message)
+        }
         return true
     }
 

--- a/Sources/MessagingInApp/Inbox/DefaultNotificationInbox.swift
+++ b/Sources/MessagingInApp/Inbox/DefaultNotificationInbox.swift
@@ -31,13 +31,16 @@ class DefaultNotificationInbox: NotificationInbox, VisualInboxEventDispatching, 
     private var openedMessageIds: Set<String> = []
     private let openedMessageIdsLock = NSLock()
 
-    /// Last non-nil `userId` seen from the store, used to detect logout so the "once per session"
-    /// dedupe above does not leak across profiles. Guarded by `lastKnownUserIdLock`.
+    /// Last identity seen from the store — `userId` when identified, `anonymousId` otherwise — used
+    /// to detect a profile change so the "once per session" dedupe above does not leak across
+    /// profiles. Guarded by `lastKnownIdentityLock`.
     ///
-    /// Without this, a user who logs out and back in gets the same queue ids again and the host
-    /// silently stops receiving `messageShown` / `messageOpened` for them.
-    private var lastKnownUserId: String?
-    private let lastKnownUserIdLock = NSLock()
+    /// Without this, a profile that comes back gets the same queue ids again and the host silently
+    /// stops receiving `messageShown` / `messageOpened` for them. `anonymousId` is part of the
+    /// identity because an anonymous session keeps `userId` nil while still receiving messages (the
+    /// queue fetch accepts either), so its reset would otherwise look like no change at all.
+    private var lastKnownIdentity: String?
+    private let lastKnownIdentityLock = NSLock()
 
     /// Subscription task for inbox messages state changes
     private var subscriptionTask: Task<Void, Never>?
@@ -259,7 +262,7 @@ class DefaultNotificationInbox: NotificationInbox, VisualInboxEventDispatching, 
         let subscriber = InAppMessageStoreSubscriber { [weak self] state in
             guard let self = self else { return }
 
-            self.handleUserChange(userId: state.userId)
+            self.handleIdentityChange(userId: state.userId, anonymousId: state.anonymousId)
 
             let messages = Array(state.inboxMessages)
             // Ensure all listener access happens on MainActor
@@ -272,31 +275,38 @@ class DefaultNotificationInbox: NotificationInbox, VisualInboxEventDispatching, 
         storeSubscriber = subscriber
 
         // Deliberately keyed on `inboxMessages` ALONE (array equality detects all property changes).
-        // Adding `userId` to a comparator here wakes this long-lived singleton on every identify and
-        // logout, spawning a MainActor notify hop each time — measurably enough extra work on userId
-        // mutations to destabilise unrelated timing tests. Logout is detected from the state this
-        // subscription already delivers instead.
+        // Adding the identity fields to a comparator here wakes this long-lived singleton on every
+        // identify and logout, spawning a MainActor notify hop each time — measurably enough extra
+        // work on those mutations to destabilise unrelated timing tests. A profile change is read
+        // from the state this subscription already delivers instead.
         //
-        // Residual gap, accepted: a reset while the store holds no messages does not fire, so the
-        // dedupe survives it. That can only strand ids whose messages were already dismissed, and a
-        // dismissed message does not come back.
+        // Residual gap, accepted: a profile change while the store holds no messages does not fire,
+        // so the dedupe survives it. That can only strand ids whose messages were already dismissed,
+        // and a dismissed message does not come back.
         subscriptionTask = inAppMessageManager.subscribe(
             keyPath: \.inboxMessages,
             subscriber: subscriber
         )
     }
 
-    /// Drops the per-session `messageShown` / `messageOpened` dedupe when a known user logs out.
+    /// Drops the per-session `messageShown` / `messageOpened` dedupe when the profile changes.
     ///
-    /// Only a transition away from a previously-known user clears: every cold launch starts with a
-    /// nil `userId` before identify runs, and clearing on that would be a no-op at best.
-    private func handleUserChange(userId: String?) {
-        lastKnownUserIdLock.lock()
-        let previous = lastKnownUserId
-        lastKnownUserId = userId
-        lastKnownUserIdLock.unlock()
+    /// Keyed on the identity that actually serves the queue — `userId` when identified,
+    /// `anonymousId` otherwise — and fires on ANY move away from a known identity, not just on
+    /// logout: `identify()` switches A → B directly without a reset, so A → B → A would otherwise
+    /// hand A back its own queue ids while they are still deduped.
+    ///
+    /// A first identity (`previous == nil`) never clears: every cold launch starts with no identity
+    /// before identify runs, and clearing on that would be a no-op at best.
+    private func handleIdentityChange(userId: String?, anonymousId: String?) {
+        let identity = userId ?? anonymousId
 
-        guard userId == nil, previous != nil else { return }
+        lastKnownIdentityLock.lock()
+        let previous = lastKnownIdentity
+        lastKnownIdentity = identity
+        lastKnownIdentityLock.unlock()
+
+        guard let previous, previous != identity else { return }
 
         shownMessageIdsLock.lock()
         shownMessageIds.removeAll()
@@ -306,7 +316,7 @@ class DefaultNotificationInbox: NotificationInbox, VisualInboxEventDispatching, 
         openedMessageIds.removeAll()
         openedMessageIdsLock.unlock()
 
-        logger.logWithModuleTag("[CIO-Inbox] logout: cleared shown/opened listener dedupe", level: .debug)
+        logger.logWithModuleTag("[CIO-Inbox] profile changed: cleared shown/opened listener dedupe", level: .debug)
     }
 
     /// Notify all registered listeners with filtered messages

--- a/Sources/MessagingInApp/Inbox/DefaultNotificationInbox.swift
+++ b/Sources/MessagingInApp/Inbox/DefaultNotificationInbox.swift
@@ -271,15 +271,17 @@ class DefaultNotificationInbox: NotificationInbox, VisualInboxEventDispatching, 
         // Keep strong reference to subscriber so store's weak reference remains valid
         storeSubscriber = subscriber
 
-        // One subscriber covering both fields rather than one per field: this is a long-lived
-        // singleton, so every extra subscriber adds a notification to every store mutation for the
-        // life of the process. `inboxMessages` drives listener delivery (array equality detects all
-        // property changes); `userId` catches logout, which a reset with no messages in the store
-        // would otherwise not surface.
+        // Deliberately keyed on `inboxMessages` ALONE (array equality detects all property changes).
+        // Adding `userId` to a comparator here wakes this long-lived singleton on every identify and
+        // logout, spawning a MainActor notify hop each time — measurably enough extra work on userId
+        // mutations to destabilise unrelated timing tests. Logout is detected from the state this
+        // subscription already delivers instead.
+        //
+        // Residual gap, accepted: a reset while the store holds no messages does not fire, so the
+        // dedupe survives it. That can only strand ids whose messages were already dismissed, and a
+        // dismissed message does not come back.
         subscriptionTask = inAppMessageManager.subscribe(
-            comparator: { old, new in
-                old.inboxMessages == new.inboxMessages && old.userId == new.userId
-            },
+            keyPath: \.inboxMessages,
             subscriber: subscriber
         )
     }

--- a/Sources/MessagingInApp/Inbox/DefaultNotificationInbox.swift
+++ b/Sources/MessagingInApp/Inbox/DefaultNotificationInbox.swift
@@ -31,6 +31,14 @@ class DefaultNotificationInbox: NotificationInbox, VisualInboxEventDispatching, 
     private var openedMessageIds: Set<String> = []
     private let openedMessageIdsLock = NSLock()
 
+    /// Last non-nil `userId` seen from the store, used to detect logout so the "once per session"
+    /// dedupe above does not leak across profiles. Guarded by `lastKnownUserIdLock`.
+    ///
+    /// Without this, a user who logs out and back in gets the same queue ids again and the host
+    /// silently stops receiving `messageShown` / `messageOpened` for them.
+    private var lastKnownUserId: String?
+    private let lastKnownUserIdLock = NSLock()
+
     /// Subscription task for inbox messages state changes
     private var subscriptionTask: Task<Void, Never>?
 
@@ -184,17 +192,28 @@ class DefaultNotificationInbox: NotificationInbox, VisualInboxEventDispatching, 
         deliverOnMain { listener?.messageShown(message: message) }
     }
 
-    func notifyMessageOpened(message: InboxMessage) {
+    func markOpenedAndNotify(message: InboxMessage) async {
+        // Dedupe BEFORE the store round-trip so two concurrent opens of the same message can't both
+        // pass the check while the first is still awaiting.
         openedMessageIdsLock.lock()
         let alreadyOpened = openedMessageIds.contains(message.queueId)
         if !alreadyOpened { openedMessageIds.insert(message.queueId) }
         openedMessageIdsLock.unlock()
+
+        await inAppMessageManager.dispatch(
+            action: .inboxAction(action: .updateOpened(message: message, opened: true))
+        ).value
+
         guard !alreadyOpened else { return }
         let listener = currentInboxEventListener()
         deliverOnMain { listener?.messageOpened(message: message.copy(opened: true)) }
     }
 
-    func notifyMessageDismissed(message: InboxMessage) {
+    func markDismissedAndNotify(message: InboxMessage) async {
+        await inAppMessageManager.dispatch(
+            action: .inboxAction(action: .deleteMessage(message: message))
+        ).value
+
         let listener = currentInboxEventListener()
         deliverOnMain { listener?.messageDismissed(message: message) }
     }
@@ -240,6 +259,8 @@ class DefaultNotificationInbox: NotificationInbox, VisualInboxEventDispatching, 
         let subscriber = InAppMessageStoreSubscriber { [weak self] state in
             guard let self = self else { return }
 
+            self.handleUserChange(userId: state.userId)
+
             let messages = Array(state.inboxMessages)
             // Ensure all listener access happens on MainActor
             Task { @MainActor in
@@ -250,11 +271,40 @@ class DefaultNotificationInbox: NotificationInbox, VisualInboxEventDispatching, 
         // Keep strong reference to subscriber so store's weak reference remains valid
         storeSubscriber = subscriber
 
-        // Subscribe to inbox messages - Array equality detects all property changes
+        // One subscriber covering both fields rather than one per field: this is a long-lived
+        // singleton, so every extra subscriber adds a notification to every store mutation for the
+        // life of the process. `inboxMessages` drives listener delivery (array equality detects all
+        // property changes); `userId` catches logout, which a reset with no messages in the store
+        // would otherwise not surface.
         subscriptionTask = inAppMessageManager.subscribe(
-            keyPath: \.inboxMessages,
+            comparator: { old, new in
+                old.inboxMessages == new.inboxMessages && old.userId == new.userId
+            },
             subscriber: subscriber
         )
+    }
+
+    /// Drops the per-session `messageShown` / `messageOpened` dedupe when a known user logs out.
+    ///
+    /// Only a transition away from a previously-known user clears: every cold launch starts with a
+    /// nil `userId` before identify runs, and clearing on that would be a no-op at best.
+    private func handleUserChange(userId: String?) {
+        lastKnownUserIdLock.lock()
+        let previous = lastKnownUserId
+        lastKnownUserId = userId
+        lastKnownUserIdLock.unlock()
+
+        guard userId == nil, previous != nil else { return }
+
+        shownMessageIdsLock.lock()
+        shownMessageIds.removeAll()
+        shownMessageIdsLock.unlock()
+
+        openedMessageIdsLock.lock()
+        openedMessageIds.removeAll()
+        openedMessageIdsLock.unlock()
+
+        logger.logWithModuleTag("[CIO-Inbox] logout: cleared shown/opened listener dedupe", level: .debug)
     }
 
     /// Notify all registered listeners with filtered messages

--- a/Sources/MessagingInApp/Inbox/NotificationInbox.swift
+++ b/Sources/MessagingInApp/Inbox/NotificationInbox.swift
@@ -164,10 +164,15 @@ public extension NotificationInbox {
 /// visual-inbox SPI dispatches through a conditional cast, so a conformer without this (the no-op
 /// inbox) simply does not fire callbacks.
 protocol VisualInboxEventDispatching: Sendable {
-    /// Notifies the registered `InboxEventListener` that a message was opened in the visual inbox.
-    /// Deduped by the SDK so it fires at most once per message per app session.
-    func notifyMessageOpened(message: InboxMessage)
+    /// Marks the message opened, waits for the store to apply it, then notifies the registered
+    /// `InboxEventListener`. Deduped by the SDK so the callback fires at most once per message per
+    /// app session.
+    ///
+    /// The wait is the point: the mark is dispatched asynchronously, so notifying straight after it
+    /// would let a host that reads the inbox inside the callback still see the message unopened.
+    func markOpenedAndNotify(message: InboxMessage) async
 
-    /// Notifies the registered `InboxEventListener` that a message was dismissed in the visual inbox.
-    func notifyMessageDismissed(message: InboxMessage)
+    /// Marks the message deleted, waits for the store to apply it, then notifies the registered
+    /// `InboxEventListener`. Ordered for the same reason as ``markOpenedAndNotify(message:)``.
+    func markDismissedAndNotify(message: InboxMessage) async
 }

--- a/Tests/MessagingInApp/Inbox/NotificationInboxTest.swift
+++ b/Tests/MessagingInApp/Inbox/NotificationInboxTest.swift
@@ -554,6 +554,121 @@ class NotificationInboxTest: UnitTest {
         XCTAssertEqual(listener.messageShownCallsCount, 2)
     }
 
+    // MARK: - profile change dedupe reset
+
+    /// Delivers a store state through the subscription the inbox already owns, standing in for what
+    /// the reducer produces after an identify, a logout, or a reset.
+    ///
+    /// Builds the state with the initialiser rather than `copy`, because `copy` coalesces with
+    /// `??` and so cannot express clearing an identity back to nil — which is the case under test.
+    private func deliverStoreState(userId: String?, anonymousId: String? = nil) async {
+        await waitUntil({ self.inAppMessageManagerMock.subscribeReceivedArguments != nil },
+            "the inbox subscribed to the store"
+        )
+        inAppMessageManagerMock.subscribeReceivedArguments?.subscriber.newState(
+            state: InAppMessageState(userId: userId, anonymousId: anonymousId)
+        )
+    }
+
+    func test_profileChange_whenUserLogsOut_expectShownDedupeCleared() async {
+        let listener = InboxEventListenerMock()
+        notificationInbox.setInboxEventListener(listener)
+        let message = makeInboxMessage(queueId: "q-1")
+
+        await deliverStoreState(userId: "user-a")
+        notificationInbox.notifyMessageShown(message: message)
+        await flushMainQueue()
+        XCTAssertEqual(listener.messageShownCallsCount, 1)
+
+        await deliverStoreState(userId: nil)
+        notificationInbox.notifyMessageShown(message: message)
+        await flushMainQueue()
+
+        XCTAssertEqual(listener.messageShownCallsCount, 2, "logout did not clear the shown dedupe")
+    }
+
+    func test_profileChange_whenUserLogsOut_expectOpenedDedupeCleared() async {
+        inAppMessageManagerMock.dispatchReturnValue = Task {}
+        let listener = InboxEventListenerMock()
+        notificationInbox.setInboxEventListener(listener)
+        let message = makeInboxMessage(queueId: "q-1")
+
+        await deliverStoreState(userId: "user-a")
+        await notificationInbox.markOpenedAndNotify(message: message)
+        await flushMainQueue()
+        XCTAssertEqual(listener.messageOpenedCallsCount, 1)
+
+        await deliverStoreState(userId: nil)
+        await notificationInbox.markOpenedAndNotify(message: message)
+        await flushMainQueue()
+
+        XCTAssertEqual(listener.messageOpenedCallsCount, 2, "logout did not clear the opened dedupe")
+    }
+
+    // `identify()` switches A → B directly, with no reset on the path, so the switch itself has to
+    // clear. Otherwise A → B → A hands A back its own queue ids while they are still deduped and the
+    // host silently stops seeing them.
+    func test_profileChange_whenProfileSwitchesDirectlyAndBack_expectDedupeClearedEachTime() async {
+        let listener = InboxEventListenerMock()
+        notificationInbox.setInboxEventListener(listener)
+        let message = makeInboxMessage(queueId: "q-1")
+
+        await deliverStoreState(userId: "user-a")
+        notificationInbox.notifyMessageShown(message: message)
+        await flushMainQueue()
+        XCTAssertEqual(listener.messageShownCallsCount, 1)
+
+        // Direct identify A → B, no logout in between.
+        await deliverStoreState(userId: "user-b")
+        notificationInbox.notifyMessageShown(message: message)
+        await flushMainQueue()
+        XCTAssertEqual(listener.messageShownCallsCount, 2, "a direct profile switch did not clear the dedupe")
+
+        // ...and back to A, whose ids were last seen two states ago.
+        await deliverStoreState(userId: "user-a")
+        notificationInbox.notifyMessageShown(message: message)
+        await flushMainQueue()
+        XCTAssertEqual(listener.messageShownCallsCount, 3, "switching back to a previous profile did not clear the dedupe")
+    }
+
+    // An anonymous session never sets `userId`, yet still receives messages (the queue fetch accepts
+    // either identity). Its reset is therefore only visible through `anonymousId`.
+    func test_profileChange_whenAnonymousSessionResets_expectDedupeCleared() async {
+        let listener = InboxEventListenerMock()
+        notificationInbox.setInboxEventListener(listener)
+        let message = makeInboxMessage(queueId: "q-1")
+
+        await deliverStoreState(userId: nil, anonymousId: "anon-a")
+        notificationInbox.notifyMessageShown(message: message)
+        await flushMainQueue()
+        XCTAssertEqual(listener.messageShownCallsCount, 1)
+
+        await deliverStoreState(userId: nil, anonymousId: nil)
+        notificationInbox.notifyMessageShown(message: message)
+        await flushMainQueue()
+
+        XCTAssertEqual(listener.messageShownCallsCount, 2, "an anonymous reset did not clear the shown dedupe")
+    }
+
+    // The counterpart to the tests above: arriving at a FIRST identity is not a profile change. Every
+    // cold launch starts with no identity before identify runs, so clearing there would erase a
+    // dedupe that is still valid — and would make the tests above pass for the wrong reason.
+    func test_profileChange_whenFirstIdentityArrives_expectDedupeRetained() async {
+        let listener = InboxEventListenerMock()
+        notificationInbox.setInboxEventListener(listener)
+        let message = makeInboxMessage(queueId: "q-1")
+
+        notificationInbox.notifyMessageShown(message: message)
+        await flushMainQueue()
+        XCTAssertEqual(listener.messageShownCallsCount, 1)
+
+        await deliverStoreState(userId: "user-a")
+        notificationInbox.notifyMessageShown(message: message)
+        await flushMainQueue()
+
+        XCTAssertEqual(listener.messageShownCallsCount, 1, "the first identify cleared a still-valid dedupe")
+    }
+
     /// Drains the main queue so a listener callback the SDK enqueued via `deliverOnMain` has run
     /// before we assert on it.
     ///

--- a/Tests/MessagingInApp/Inbox/NotificationInboxTest.swift
+++ b/Tests/MessagingInApp/Inbox/NotificationInboxTest.swift
@@ -432,38 +432,90 @@ class NotificationInboxTest: UnitTest {
 
     // MARK: - observe-only listener callbacks (shown / opened / dismissed)
 
-    func test_notifyMessageOpened_whenListenerSet_expectInboxMessageOpenedFired() {
+    func test_markOpenedAndNotify_whenListenerSet_expectInboxMessageOpenedFired() async {
         inAppMessageManagerMock.dispatchReturnValue = Task {}
         let listener = InboxEventListenerMock()
         notificationInbox.setInboxEventListener(listener)
 
-        notificationInbox.notifyMessageOpened(message: makeInboxMessage(queueId: "q-1"))
+        await notificationInbox.markOpenedAndNotify(message: makeInboxMessage(queueId: "q-1"))
+        await flushMainQueue()
 
         XCTAssertEqual(listener.messageOpenedCallsCount, 1)
         XCTAssertEqual(listener.messageOpenedReceivedArguments?.queueId, "q-1")
         XCTAssertEqual(listener.messageOpenedReceivedArguments?.opened, true)
     }
 
-    func test_notifyMessageOpened_whenCalledTwiceForSameId_expectFiredOnce() {
+    func test_markOpenedAndNotify_whenCalledTwiceForSameId_expectFiredOnce() async {
         inAppMessageManagerMock.dispatchReturnValue = Task {}
         let listener = InboxEventListenerMock()
         notificationInbox.setInboxEventListener(listener)
 
-        notificationInbox.notifyMessageOpened(message: makeInboxMessage(queueId: "q-1"))
-        notificationInbox.notifyMessageOpened(message: makeInboxMessage(queueId: "q-1"))
+        await notificationInbox.markOpenedAndNotify(message: makeInboxMessage(queueId: "q-1"))
+        await notificationInbox.markOpenedAndNotify(message: makeInboxMessage(queueId: "q-1"))
+        await flushMainQueue()
 
         XCTAssertEqual(listener.messageOpenedCallsCount, 1)
     }
 
-    func test_notifyMessageDismissed_whenListenerSet_expectInboxMessageDismissedFired() {
+    // The store mutation must COMPLETE before the host callback, so a host reading the inbox inside
+    // messageOpened/messageDismissed never observes the pre-mutation state. Asserting only that a
+    // dispatch happened would not catch a regression — the callback hops to main either way, so it
+    // always lands after. Gating the dispatch is what makes this discriminating: while the store
+    // work is parked, the listener must not have fired.
+    func test_markOpenedAndNotify_expectListenerWaitsForStoreMutation() async {
+        let gate = AsyncGate()
+        inAppMessageManagerMock.dispatchReturnValue = Task { await gate.wait() }
+        let listener = InboxEventListenerMock()
+        notificationInbox.setInboxEventListener(listener)
+
+        let call = Task { [notificationInbox, message = makeInboxMessage(queueId: "q-1")] in
+            await notificationInbox!.markOpenedAndNotify(message: message)
+        }
+
+        // Wait until the store call is parked on the gate. Without this the assertion below could
+        // pass simply because the task had not started yet, rather than because of ordering.
+        await waitUntil({ self.inAppMessageManagerMock.dispatchCallsCount == 1 }, "the store mark was dispatched")
+        await flushMainQueue()
+        XCTAssertEqual(listener.messageOpenedCallsCount, 0, "listener fired before the store applied the mark")
+
+        gate.open()
+        await call.value
+        await flushMainQueue()
+        XCTAssertEqual(listener.messageOpenedCallsCount, 1)
+    }
+
+    func test_markDismissedAndNotify_whenListenerSet_expectInboxMessageDismissedFired() async {
         inAppMessageManagerMock.dispatchReturnValue = Task {}
         let listener = InboxEventListenerMock()
         notificationInbox.setInboxEventListener(listener)
 
-        notificationInbox.notifyMessageDismissed(message: makeInboxMessage(queueId: "q-1"))
+        await notificationInbox.markDismissedAndNotify(message: makeInboxMessage(queueId: "q-1"))
+        await flushMainQueue()
 
         XCTAssertEqual(listener.messageDismissedCallsCount, 1)
         XCTAssertEqual(listener.messageDismissedReceivedArguments?.queueId, "q-1")
+    }
+
+    func test_markDismissedAndNotify_expectListenerWaitsForStoreMutation() async {
+        let gate = AsyncGate()
+        inAppMessageManagerMock.dispatchReturnValue = Task { await gate.wait() }
+        let listener = InboxEventListenerMock()
+        notificationInbox.setInboxEventListener(listener)
+
+        let call = Task { [notificationInbox, message = makeInboxMessage(queueId: "q-1")] in
+            await notificationInbox!.markDismissedAndNotify(message: message)
+        }
+
+        // Wait until the store call is parked on the gate. Without this the assertion below could
+        // pass simply because the task had not started yet, rather than because of ordering.
+        await waitUntil({ self.inAppMessageManagerMock.dispatchCallsCount == 1 }, "the store delete was dispatched")
+        await flushMainQueue()
+        XCTAssertEqual(listener.messageDismissedCallsCount, 0, "listener fired before the store applied the delete")
+
+        gate.open()
+        await call.value
+        await flushMainQueue()
+        XCTAssertEqual(listener.messageDismissedCallsCount, 1)
     }
 
     // The headless mutation API must NOT fire the visual-inbox listener: a host with no overlay
@@ -500,6 +552,32 @@ class NotificationInboxTest: UnitTest {
         notificationInbox.notifyMessageShown(message: makeInboxMessage(queueId: "q-2"))
 
         XCTAssertEqual(listener.messageShownCallsCount, 2)
+    }
+
+    /// Drains the main queue so a listener callback the SDK enqueued via `deliverOnMain` has run
+    /// before we assert on it.
+    ///
+    /// `deliverOnMain` only runs inline when already on the main thread; an `async` test body is not,
+    /// so the callback is enqueued instead. Hopping to the main actor lands FIFO behind it, which
+    /// makes this deterministic rather than a sleep.
+    private func flushMainQueue() async {
+        await MainActor.run {}
+    }
+
+    /// Polls `condition` until it holds, so a test can wait for work to reach a known point instead of
+    /// sleeping for a guessed duration. Fails rather than hanging if it never becomes true.
+    private func waitUntil(
+        _ condition: () -> Bool,
+        _ message: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        for _ in 0 ..< 500 {
+            if condition() { return }
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 1000000) // 1ms
+        }
+        XCTFail("timed out waiting until \(message)", file: file, line: line)
     }
 
     private func makeInboxMessage(queueId: String) -> InboxMessage {
@@ -1088,5 +1166,25 @@ private class TestNotificationInboxChangeListener: NotificationInboxChangeListen
 
     func onMessagesChanged(messages: [InboxMessage]) {
         onMessagesChangedClosure?(messages)
+    }
+}
+
+/// Lets a test hold an awaited operation open, so it can assert on the state of the world while that
+/// operation is still in flight. Mirrors `GatedInboxNetworkClientStub`'s approach.
+private final class AsyncGate: @unchecked Sendable {
+    private let semaphore = DispatchSemaphore(value: 0)
+
+    func open() {
+        semaphore.signal()
+    }
+
+    /// Suspends (without blocking the caller's thread) until `open()` is called.
+    func wait() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            DispatchQueue.global().async { [semaphore] in
+                semaphore.wait()
+                continuation.resume()
+            }
+        }
     }
 }


### PR DESCRIPTION
Follow-up to the review of #1141, addressing the Bugbot findings that survived an audit of the whole backlog on that PR. Five of the twelve open findings turned out to be already fixed and four were not worth acting on; these are the three that were live and real.

## 1. Listener dedupe survived a profile reset (Medium)

`shownMessageIds` / `openedMessageIds` were never cleared — the only `removeAll` calls in the file are on `listeners`. A user who logs out and back in gets the same queue ids again, so the host silently stops receiving `messageShown` / `messageOpened` for them.

Logout now clears both. It is detected through the store subscriber `DefaultNotificationInbox` **already owns**: its `keyPath: \.inboxMessages` becomes a comparator over `inboxMessages` and `userId`. Deliberately not a second subscription — this is a long-lived singleton, and an extra subscriber taxes every store mutation for the life of the process (that is what destabilised unrelated timing tests earlier in this stack).

## 2. Host callbacks fired before the store applied the mutation (Low)

The visual-inbox open and dismiss paths called `markMessageOpened` / `markMessageDeleted`, which dispatch asynchronously, then notified the host immediately. A host reading `MessagingInApp.shared.inbox` inside `messageOpened` / `messageDismissed` could still see the message unopened or still present.

The internal `VisualInboxEventDispatching` now exposes ordered `markOpenedAndNotify` / `markDismissedAndNotify` that await the store before the callback fires. The opened dedupe is claimed *before* the round-trip so two concurrent opens cannot both pass while the first is in flight.

## 3. The assets cache claimed a scope it does not have (Medium)

`InboxRenderAssetsCache` documented entries as workspace-scoped, "the underlying UserDefaults file is keyed by site id". That is false — `SharedKeyValueStorage` resolves to a single app-wide suite with no site id in its name; the site-scoped initialiser is a different one. The comment now states the real scope, and what logout does and does not cover.

Only the comment is corrected here. Actually re-scoping the storage is a larger change with migration implications, and since logout clears the cache the residual exposure is re-initialising the SDK with a different site id in one process — worth its own issue.

## Tests

`markOpenedAndNotify` / `markDismissedAndNotify` each get a happy path plus an ordering test that gates the store dispatch and asserts the listener has **not** fired while it is parked.

Worth calling out: the first two versions of those ordering tests could not fail. Asserting "a dispatch happened before the callback" always holds, because the callback hops to the main queue either way; and gating alone was not enough, because the assertion could run before the task under test had even started. Both were confirmed by injecting the regression and watching the test still pass. The committed version waits until the dispatch is parked on the gate before asserting, and was verified to fail when the notify is moved ahead of the store write.

463 tests, 0 failures; swiftlint clean; API baseline unchanged (all additions are internal).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches long-lived inbox singleton behavior (identity dedupe reset and async listener ordering) that hosts rely on for `messageShown` / `messageOpened`; changes are well-tested but affect multi-profile and callback-timing contracts.
> 
> **Overview**
> Fixes three inbox issues: **per-session listener dedupe leaking across profiles**, **host callbacks racing the store**, and **misdocumented render-assets cache scope**.
> 
> **Profile / dedupe:** `DefaultNotificationInbox` tracks `userId ?? anonymousId` and clears `shownMessageIds` / `openedMessageIds` when identity changes (logout, direct A→B identify, anonymous reset)—not on the first identity after launch. Detection runs inside the existing `inboxMessages` store subscriber so identity is not added to the subscription key path.
> 
> **Visual inbox ordering:** `VisualInboxEventDispatching` replaces fire-and-forget `notifyMessageOpened` / `notifyMessageDismissed` with async `markOpenedAndNotify` / `markDismissedAndNotify` that **await** store dispatch before `InboxEventListener` callbacks; open dedupe is claimed before the await. `VisualInboxSPI` routes `markOpened` / `dismiss` through these when the inbox conforms.
> 
> **Docs:** `InboxRenderAssetsCache` comments now describe **app-wide** (not workspace-scoped) storage and residual cross-site exposure until revalidation.
> 
> Tests add ordering gates, profile-change dedupe cases, and `AsyncGate` / `flushMainQueue` helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 796cffa96f67b887e9b3d3df28363bf9b3a1323a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->