### PR TITLE
fix(inbox): backfill on SSE connect confirmation and own the inbox view models

### DIFF
--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -152,9 +152,16 @@ class Gist: GistProvider {
             // User became identified and SSE is enabled - stop polling (SSE will take over)
             logger.logWithModuleTag("Gist: User identified with SSE enabled - stopping polling (SSE will handle messages)", level: .info)
             invalidateTimer()
-            // The backfill for messages that predate the stream is driven by the server's `connected`
-            // event in SseLifecycleManager, not from here: issued at this point it would race the
-            // connection and could overwrite a newer SSE update with an older snapshot.
+            // Fetch here as well as from the `connected` hook, because this transition fires on ANY
+            // `userId` change — including one identified user replacing another. In that case SSE is
+            // already connected, so `startConnection()` no-ops, no `connected` event follows, and the
+            // new user's existing inbox would never load until an unrelated reconnect.
+            //
+            // Accepted cost: on anonymous → identified, where SSE was not yet connected, this fetches
+            // once here and again from `connected`. And being fire-and-forget it is not ordered
+            // against SSE, so this path keeps the overwrite window the `connected` hook removes for
+            // the others. Guaranteeing the new user sees their inbox is worth both.
+            fetchUserQueue(state: state)
         } else if !state.isUserIdentified, state.useSse {
             // User became anonymous but SSE flag is still enabled - start polling
             // (SSE won't be used for anonymous users)

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -51,9 +51,9 @@ class Gist: GistProvider {
 
         // Start the SSE lifecycle manager to observe app foreground/background events
         Task {
-            await sseLifecycleManager.start { [weak self] state in
+            await sseLifecycleManager.start(queueFetchHandler: { [weak self] state in
                 self?.fetchUserQueue(state: state)
-            }
+            })
         }
     }
 
@@ -126,11 +126,9 @@ class Gist: GistProvider {
             // SSE is now active - stop polling
             logger.logWithModuleTag("Gist: SSE enabled for identified user - stopping polling timer", level: .info)
             invalidateTimer()
-            // SSE does not deliver pending messages on connect. Backfill any messages that already
-            // exist for the user (mirrors SseLifecycleManager's foreground fetch); otherwise a fresh
-            // login shows an empty inbox until the next foreground. Calls fetchUserQueue directly
-            // because fetchUserMessages() no-ops when shouldUseSse is true.
-            fetchUserQueue(state: state)
+            // The backfill for messages that predate the stream is driven by the server's `connected`
+            // event in SseLifecycleManager, not from here: issued at this point it would race the
+            // connection and could overwrite a newer SSE update with an older snapshot.
         } else if !state.useSse {
             // SSE disabled - start polling
             logger.logWithModuleTag("Gist: SSE disabled - starting polling with interval: \(state.pollInterval)s", level: .info)
@@ -154,11 +152,9 @@ class Gist: GistProvider {
             // User became identified and SSE is enabled - stop polling (SSE will take over)
             logger.logWithModuleTag("Gist: User identified with SSE enabled - stopping polling (SSE will handle messages)", level: .info)
             invalidateTimer()
-            // SSE does not deliver pending messages on connect. Backfill the messages that already
-            // exist for the now-identified user (mirrors SseLifecycleManager's foreground fetch);
-            // otherwise a fresh login shows an empty inbox until the next foreground. Calls
-            // fetchUserQueue directly because fetchUserMessages() no-ops when shouldUseSse is true.
-            fetchUserQueue(state: state)
+            // The backfill for messages that predate the stream is driven by the server's `connected`
+            // event in SseLifecycleManager, not from here: issued at this point it would race the
+            // connection and could overwrite a newer SSE update with an older snapshot.
         } else if !state.isUserIdentified, state.useSse {
             // User became anonymous but SSE flag is still enabled - start polling
             // (SSE won't be used for anonymous users)

--- a/Sources/MessagingInApp/Gist/Network/SSE/SseConnectionManager.swift
+++ b/Sources/MessagingInApp/Gist/Network/SSE/SseConnectionManager.swift
@@ -9,6 +9,16 @@ protocol SseConnectionManagerProtocol: AutoMockable {
 
     /// Stops the current SSE connection.
     func stopConnection() async
+
+    /// Registers the hook invoked when the server confirms the connection (its `connected` event),
+    /// which is the only transition into `.connected`.
+    ///
+    /// Exists so the owner can sync state SSE will not deliver: the stream only carries messages
+    /// that arrive AFTER the connection is established, so whatever already exists for the user has
+    /// to be fetched over HTTP. Driving that from here rather than alongside `startConnection()`
+    /// means the fetch cannot race an SSE update that lands first (mirrors gist-web, which fetches
+    /// from its `connected` listener).
+    func setOnConnectionConfirmed(_ handler: @escaping @Sendable () -> Void) async
 }
 
 // sourcery: InjectRegisterShared = "SseConnectionManagerProtocol"
@@ -63,6 +73,9 @@ actor SseConnectionManager: SseConnectionManagerProtocol {
     private var activeConnectionGeneration: UInt64 = 0
 
     private var connectionState: SseConnectionState = .disconnected
+
+    /// Hook invoked from `setupSuccessfulConnection`. See `setOnConnectionConfirmed`.
+    private var onConnectionConfirmed: (@Sendable () -> Void)?
     private var streamTask: Task<Void, Never>?
     private var retryTask: Task<Void, Never>?
 
@@ -157,6 +170,10 @@ actor SseConnectionManager: SseConnectionManagerProtocol {
     /// The cleanup operations include the connection generation, so they only affect
     /// the connection that was active when stopConnection() was called. If a new connection
     /// starts during the await points, it won't be affected by this cleanup.
+    func setOnConnectionConfirmed(_ handler: @escaping @Sendable () -> Void) {
+        onConnectionConfirmed = handler
+    }
+
     func stopConnection() async {
         // Capture the generation we're stopping BEFORE any state changes
         let stoppingGeneration = activeConnectionGeneration
@@ -544,6 +561,8 @@ actor SseConnectionManager: SseConnectionManagerProtocol {
 
         // Start heartbeat timer with initial timeout (default + buffer)
         await heartbeatTimer.startTimer(timeoutSeconds: HeartbeatTimer.initialTimeoutSeconds, generation: generation)
+
+        onConnectionConfirmed?()
     }
 
     // MARK: - State Management

--- a/Sources/MessagingInApp/Gist/Network/SSE/SseConnectionManager.swift
+++ b/Sources/MessagingInApp/Gist/Network/SSE/SseConnectionManager.swift
@@ -10,14 +10,19 @@ protocol SseConnectionManagerProtocol: AutoMockable {
     /// Stops the current SSE connection.
     func stopConnection() async
 
-    /// Registers the hook invoked when the server confirms the connection (its `connected` event),
-    /// which is the only transition into `.connected`.
+    /// Registers the hook invoked when the SERVER confirms the connection with its `connected`
+    /// event — not on the transport-level `.connectionOpen`, which arrives first.
     ///
     /// Exists so the owner can sync state SSE will not deliver: the stream only carries messages
     /// that arrive AFTER the connection is established, so whatever already exists for the user has
-    /// to be fetched over HTTP. Driving that from here rather than alongside `startConnection()`
-    /// means the fetch cannot race an SSE update that lands first (mirrors gist-web, which fetches
-    /// from its `connected` listener).
+    /// to be fetched over HTTP. Waiting for confirmation rather than firing alongside
+    /// `startConnection()` means the fetch starts against a live stream, and is skipped entirely when
+    /// a connection never establishes (mirrors gist-web, which fetches from its `connected` listener).
+    ///
+    /// NOTE: this does not fully order the HTTP response against SSE. An `inbox_messages` event that
+    /// arrives while the fetch is in flight can still be overwritten by the older HTTP snapshot,
+    /// because both publish a full-state write. Closing that needs the two writes versioned or
+    /// merged; tracked separately.
     func setOnConnectionConfirmed(_ handler: @escaping @Sendable () -> Void) async
 }
 
@@ -74,7 +79,7 @@ actor SseConnectionManager: SseConnectionManagerProtocol {
 
     private var connectionState: SseConnectionState = .disconnected
 
-    /// Hook invoked from `setupSuccessfulConnection`. See `setOnConnectionConfirmed`.
+    /// Hook invoked from the server `connected` event branch only. See `setOnConnectionConfirmed`.
     private var onConnectionConfirmed: (@Sendable () -> Void)?
     private var streamTask: Task<Void, Never>?
     private var retryTask: Task<Void, Never>?
@@ -164,16 +169,16 @@ actor SseConnectionManager: SseConnectionManagerProtocol {
         streamTask = newTask
     }
 
+    func setOnConnectionConfirmed(_ handler: @escaping @Sendable () -> Void) {
+        onConnectionConfirmed = handler
+    }
+
     /// Stops the active SSE connection.
     /// This method is idempotent - calling it multiple times is safe.
     ///
     /// The cleanup operations include the connection generation, so they only affect
     /// the connection that was active when stopConnection() was called. If a new connection
     /// starts during the await points, it won't be affected by this cleanup.
-    func setOnConnectionConfirmed(_ handler: @escaping @Sendable () -> Void) {
-        onConnectionConfirmed = handler
-    }
-
     func stopConnection() async {
         // Capture the generation we're stopping BEFORE any state changes
         let stoppingGeneration = activeConnectionGeneration
@@ -357,6 +362,11 @@ actor SseConnectionManager: SseConnectionManagerProtocol {
         case .connected:
             logger.logWithModuleTag("SSE Manager: ✓ Server acknowledged connection", level: .info)
             await setupSuccessfulConnection(generation: generation)
+            // Only here, not in setupSuccessfulConnection: that also runs for the transport
+            // `.connectionOpen` event, which fires first and before the server has confirmed
+            // anything — so hooking it there would both double-invoke and start the backfill at the
+            // same point as the pre-connect fetch this replaced.
+            onConnectionConfirmed?()
 
         case .heartbeat:
             await handleHeartbeatEvent(event, generation: generation)
@@ -561,8 +571,6 @@ actor SseConnectionManager: SseConnectionManagerProtocol {
 
         // Start heartbeat timer with initial timeout (default + buffer)
         await heartbeatTimer.startTimer(timeoutSeconds: HeartbeatTimer.initialTimeoutSeconds, generation: generation)
-
-        onConnectionConfirmed?()
     }
 
     // MARK: - State Management

--- a/Sources/MessagingInApp/Gist/Utilities/SseLifecycleManager.swift
+++ b/Sources/MessagingInApp/Gist/Utilities/SseLifecycleManager.swift
@@ -115,10 +115,13 @@ actor CioSseLifecycleManager: SseLifecycleManager {
     ///
     /// SSE only delivers events that arrive AFTER the connection is established, so a fresh login
     /// would otherwise show an empty inbox until the next foreground. Keyed off the server's
-    /// `connected` event rather than the transition that decides to connect, because the fetch is
-    /// fire-and-forget: issued alongside `startConnection()` its response could land after an SSE
-    /// update and overwrite the newer list with an older snapshot. Waiting for confirmation also
-    /// means nothing is fetched when a connection never establishes.
+    /// `connected` event rather than the transition that decides to connect, so the fetch starts
+    /// against a stream that is already live and is skipped when a connection never establishes.
+    ///
+    /// This narrows the overwrite window but does not close it: the fetch is fire-and-forget, so an
+    /// `inbox_messages` event arriving while it is in flight can still be overwritten by the older
+    /// HTTP snapshot, since both publish a full-state write. Ordering them properly needs the two
+    /// writes versioned or merged; tracked separately.
     private func backfillOnConnectionConfirmed() async {
         let state = await inAppMessageManager.state
         logger.logWithModuleTag(

--- a/Sources/MessagingInApp/Gist/Utilities/SseLifecycleManager.swift
+++ b/Sources/MessagingInApp/Gist/Utilities/SseLifecycleManager.swift
@@ -122,6 +122,9 @@ actor CioSseLifecycleManager: SseLifecycleManager {
     /// `inbox_messages` event arriving while it is in flight can still be overwritten by the older
     /// HTTP snapshot, since both publish a full-state write. Ordering them properly needs the two
     /// writes versioned or merged; tracked separately.
+    ///
+    /// Not the only backfill trigger: `Gist.handleUserIdentificationChange` also fetches, because a
+    /// `userId` change while SSE is already connected produces no `connected` event to hook.
     private func backfillOnConnectionConfirmed() async {
         let state = await inAppMessageManager.state
         logger.logWithModuleTag(

--- a/Sources/MessagingInApp/Gist/Utilities/SseLifecycleManager.swift
+++ b/Sources/MessagingInApp/Gist/Utilities/SseLifecycleManager.swift
@@ -19,8 +19,9 @@ import UIKit
 /// Corresponds to Android's `SseLifecycleManager` class.
 protocol SseLifecycleManager: AutoMockable {
     /// Starts the lifecycle manager. Must be called after initialization.
-    /// - Parameter foregroundFetchHandler: Called to fetch missed messages when app returns to foreground while SSE is active.
-    func start(foregroundFetchHandler: @escaping (InAppMessageState) -> Void) async
+    /// - Parameter queueFetchHandler: Called to fetch the messages SSE will not deliver — those that
+    ///   already existed before the stream opened. Invoked once per confirmed SSE connection.
+    func start(queueFetchHandler: @escaping (InAppMessageState) -> Void) async
 }
 
 // sourcery: InjectRegisterShared = "SseLifecycleManager"
@@ -36,7 +37,7 @@ actor CioSseLifecycleManager: SseLifecycleManager {
     private var userIdSubscriber: InAppMessageStoreSubscriber?
 
     private var isForegrounded: Bool = false
-    private var foregroundFetchHandler: ((InAppMessageState) -> Void)?
+    private var queueFetchHandler: ((InAppMessageState) -> Void)?
 
     init(
         logger: Logger,
@@ -50,9 +51,14 @@ actor CioSseLifecycleManager: SseLifecycleManager {
         self.applicationStateProvider = applicationStateProvider
     }
 
-    func start(foregroundFetchHandler: @escaping (InAppMessageState) -> Void) async {
-        self.foregroundFetchHandler = foregroundFetchHandler
+    func start(queueFetchHandler: @escaping (InAppMessageState) -> Void) async {
+        self.queueFetchHandler = queueFetchHandler
         logger.logWithModuleTag("SseLifecycleManager: Starting lifecycle manager", level: .debug)
+
+        // Backfill once the server confirms a connection, rather than alongside startConnection().
+        await sseConnectionManager.setOnConnectionConfirmed { [weak self] in
+            Task { await self?.backfillOnConnectionConfirmed() }
+        }
 
         // Register observers FIRST to ensure no state transitions are missed
         await setupNotificationObservers()
@@ -102,6 +108,24 @@ actor CioSseLifecycleManager: SseLifecycleManager {
         } else {
             logger.logWithModuleTag("SseLifecycleManager: App backgrounded at init - SSE will start when foregrounded", level: .debug)
         }
+    }
+
+    /// Fetches the messages that already existed before the stream opened, once the server has
+    /// confirmed the connection.
+    ///
+    /// SSE only delivers events that arrive AFTER the connection is established, so a fresh login
+    /// would otherwise show an empty inbox until the next foreground. Keyed off the server's
+    /// `connected` event rather than the transition that decides to connect, because the fetch is
+    /// fire-and-forget: issued alongside `startConnection()` its response could land after an SSE
+    /// update and overwrite the newer list with an older snapshot. Waiting for confirmation also
+    /// means nothing is fetched when a connection never establishes.
+    private func backfillOnConnectionConfirmed() async {
+        let state = await inAppMessageManager.state
+        logger.logWithModuleTag(
+            "SseLifecycleManager: Connection confirmed - backfilling messages that predate the stream",
+            level: .info
+        )
+        queueFetchHandler?(state)
     }
 
     // MARK: - SSE Eligibility
@@ -208,9 +232,12 @@ actor CioSseLifecycleManager: SseLifecycleManager {
 
         // Check all 3 conditions: foregrounded + SSE enabled + user identified
         if state.shouldUseSse {
-            // SSE only delivers new events after reconnecting, so perform a one-time
-            // HTTP fetch to retrieve any messages sent while the app was backgrounded.
-            foregroundFetchHandler?(state)
+            // The catch-up HTTP fetch is NOT issued here. SSE only delivers events that arrive after
+            // the connection is established, so the messages that already exist still have to be
+            // fetched — but that now happens from the server's `connected` event (see
+            // `backfillOnConnectionConfirmed`). Issuing it here as well would both double-fetch and
+            // race: the fetch is fire-and-forget, so its response could land after an SSE update and
+            // overwrite the newer list with an older snapshot.
             await sseConnectionManager.startConnection()
         } else {
             logger.logWithModuleTag(

--- a/Sources/MessagingInbox/NotificationInboxBell.swift
+++ b/Sources/MessagingInbox/NotificationInboxBell.swift
@@ -19,6 +19,28 @@ import SwiftUI
 /// ```
 @available(iOS 13.0, *)
 public struct NotificationInboxBell: View {
+    /// Owns the model for standalone use. `@State` rather than `@ObservedObject` so SwiftUI keeps the
+    /// instance across view reconstruction; `@StateObject` is iOS 14+ and this view is public on
+    /// iOS 13. See ``NotificationInboxView`` for the full rationale.
+    @State private var model = VisualInboxModel()
+
+    private let onTap: () -> Void
+
+    /// Creates a standalone inbox bell backed by the SDK's shared Visual Inbox data layer.
+    /// - Parameter onTap: invoked when the user taps the bell.
+    public init(onTap: @escaping () -> Void) {
+        self.onTap = onTap
+    }
+
+    public var body: some View {
+        InboxBellView(model: model, ownsModelLifecycle: true, onTap: onTap)
+    }
+}
+
+/// Renders the bell for a model it does not own. Always constructed with an explicit model — either
+/// the shared one from ``NotificationInboxOverlay`` or the one ``NotificationInboxBell`` owns.
+@available(iOS 13.0, *)
+struct InboxBellView: View {
     @ObservedObject private var model: VisualInboxModel
 
     /// Drives dark-mode branding resolution for the bell chrome.
@@ -31,20 +53,12 @@ public struct NotificationInboxBell: View {
     /// Called when the user taps the bell.
     private let onTap: () -> Void
 
-    /// Creates a standalone inbox bell backed by the SDK's shared Visual Inbox data layer.
-    /// - Parameter onTap: invoked when the user taps the bell.
-    public init(onTap: @escaping () -> Void) {
-        _model = ObservedObject(wrappedValue: VisualInboxModel())
-        self.ownsModelLifecycle = true
-        self.onTap = onTap
-    }
-
     /// Creates a bell observing a shared model (used by ``NotificationInboxOverlay`` so the bell,
     /// panel, and overlay all observe the same state). The shared model's lifecycle is driven by the
     /// owner, so this view does not start/stop it.
-    init(model: VisualInboxModel, onTap: @escaping () -> Void) {
+    init(model: VisualInboxModel, ownsModelLifecycle: Bool = false, onTap: @escaping () -> Void) {
         _model = ObservedObject(wrappedValue: model)
-        self.ownsModelLifecycle = false
+        self.ownsModelLifecycle = ownsModelLifecycle
         self.onTap = onTap
     }
 

--- a/Sources/MessagingInbox/NotificationInboxOverlay.swift
+++ b/Sources/MessagingInbox/NotificationInboxOverlay.swift
@@ -58,7 +58,7 @@ public struct NotificationInboxOverlay: View {
         return ZStack(alignment: bellPosition.alignment) {
             Color.clear
                 .allowsHitTesting(false)
-            NotificationInboxBell(model: model) {
+            InboxBellView(model: model) {
                 isInboxPresented = true
             }
             .padding(16)
@@ -87,7 +87,7 @@ public struct NotificationInboxOverlay: View {
             let colors = ResolvedInboxColors.resolve(chrome: model.chrome, isDark: colorScheme == .dark)
             // Dismiss the sheet after a navigation action so the opened screen (deep link / URL) isn't
             // left behind the inbox.
-            NotificationInboxView(model: model, onNavigate: { isInboxPresented = false })
+            InboxListView(model: model, onNavigate: { isInboxPresented = false })
                 .presentationDetents([.medium, .large])
                 .presentationDragIndicator(.visible)
                 .modifier(BrandedInboxSheetStyle(background: colors.panelBackground, cornerRadius: colors.cornerRadius))

--- a/Sources/MessagingInbox/NotificationInboxView.swift
+++ b/Sources/MessagingInbox/NotificationInboxView.swift
@@ -22,6 +22,27 @@ import UIKit
 /// ```
 @available(iOS 13.0, *)
 public struct NotificationInboxView: View {
+    /// Owns the model for standalone embedding.
+    ///
+    /// `@State` rather than `@ObservedObject`: `@ObservedObject` does not own its value, so a parent
+    /// update could hand the view a brand-new model after the original had already started its
+    /// lifecycle — losing load state, dedupe guards, and in-flight work. `@StateObject` would be the
+    /// natural owner but is iOS 14+, and this view is public on iOS 13. `VisualInboxModel.init` has no
+    /// side effects (work begins in `start()`), so the instances SwiftUI discards are inert.
+    @State private var model = VisualInboxModel()
+
+    /// Creates a standalone inbox list backed by the SDK's shared Visual Inbox data layer.
+    public init() {}
+
+    public var body: some View {
+        InboxListView(model: model, ownsModelLifecycle: true, marksOpenedOnAppear: true)
+    }
+}
+
+/// Renders the inbox list for a model it does not own. Always constructed with an explicit model —
+/// either the shared one from ``NotificationInboxOverlay`` or the one ``NotificationInboxView`` owns.
+@available(iOS 13.0, *)
+struct InboxListView: View {
     @ObservedObject private var model: VisualInboxModel
 
     /// Drives dark-mode branding resolution for the row divider.
@@ -45,22 +66,19 @@ public struct NotificationInboxView: View {
     /// rather than reaching into `DIGraphShared.shared` inline, so navigation is testable.
     private let navigator: InboxActionNavigating
 
-    /// Creates a standalone inbox list backed by the SDK's shared Visual Inbox data layer.
-    public init() {
-        _model = ObservedObject(wrappedValue: VisualInboxModel())
-        self.ownsModelLifecycle = true
-        self.marksOpenedOnAppear = true
-        self.onNavigate = nil
-        self.navigator = DefaultInboxActionNavigator()
-    }
-
     /// Creates a list observing a shared model (used by ``NotificationInboxOverlay`` so the bell,
     /// panel, and overlay all observe the same state). The overlay drives lifecycle + mark-opened and
     /// passes `onNavigate` to close its sheet after a navigation action.
-    init(model: VisualInboxModel, onNavigate: (() -> Void)? = nil, navigator: InboxActionNavigating = DefaultInboxActionNavigator()) {
+    init(
+        model: VisualInboxModel,
+        ownsModelLifecycle: Bool = false,
+        marksOpenedOnAppear: Bool = false,
+        onNavigate: (() -> Void)? = nil,
+        navigator: InboxActionNavigating = DefaultInboxActionNavigator()
+    ) {
         _model = ObservedObject(wrappedValue: model)
-        self.ownsModelLifecycle = false
-        self.marksOpenedOnAppear = false
+        self.ownsModelLifecycle = ownsModelLifecycle
+        self.marksOpenedOnAppear = marksOpenedOnAppear
         self.onNavigate = onNavigate
         self.navigator = navigator
     }

--- a/Tests/MessagingInApp/Gist/Network/SSE/SseConnectionManagerTest.swift
+++ b/Tests/MessagingInApp/Gist/Network/SSE/SseConnectionManagerTest.swift
@@ -2,6 +2,7 @@
 @testable import CioInternalCommonMocks
 @testable import CioMessagingInAppMocks
 @testable import CioMessagingInApp
+import Foundation
 import SharedTests
 import XCTest
 
@@ -168,6 +169,41 @@ class SseConnectionManagerTest: XCTestCase {
 
         // Assert
         XCTAssertTrue(heartbeatTimerMock.startTimerCalled)
+    }
+
+    // The hook must fire on the SERVER's `connected` event only. setupSuccessfulConnection also runs
+    // for the transport `.connectionOpen`, which arrives first, so hooking it there would fire twice
+    // and start the first backfill before the server had confirmed anything.
+    func test_openThenConnected_expectConnectionConfirmedExactlyOnce() async {
+        let (stream, continuation) = AsyncStreamBackport.makeStream(of: SseEvent.self)
+        sseServiceMock.connectReturnValue = stream
+
+        let counter = ConfirmationCounter()
+        await sut.setOnConnectionConfirmed { counter.increment() }
+
+        await sut.startConnection()
+        continuation.yield(.connectionOpen)
+        continuation.yield(.serverEvent(ServerEvent(id: nil, type: "connected", data: "")))
+        try? await Task.sleep(nanoseconds: 200000000) // 0.2 seconds
+        continuation.finish()
+
+        XCTAssertEqual(counter.value, 1)
+    }
+
+    func test_transportOpenOnly_expectNoConnectionConfirmed() async {
+        let (stream, continuation) = AsyncStreamBackport.makeStream(of: SseEvent.self)
+        sseServiceMock.connectReturnValue = stream
+
+        let counter = ConfirmationCounter()
+        await sut.setOnConnectionConfirmed { counter.increment() }
+
+        await sut.startConnection()
+        continuation.yield(.connectionOpen)
+        try? await Task.sleep(nanoseconds: 200000000) // 0.2 seconds
+        continuation.finish()
+
+        // Transport open alone is not confirmation: nothing should be backfilled yet.
+        XCTAssertEqual(counter.value, 0)
     }
 
     func test_connectionOpen_expectRetryStateReset() async {
@@ -391,5 +427,23 @@ class SseConnectionManagerTest: XCTestCase {
             return false
         }
         XCTAssertEqual(sseDisabledActions.count, 1)
+    }
+}
+
+/// Counts hook invocations from a `@Sendable` closure. A plain captured `var` is not usable there.
+private final class ConfirmationCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+
+    func increment() {
+        lock.lock()
+        defer { lock.unlock() }
+        count += 1
     }
 }

--- a/Tests/MessagingInApp/Gist/Utilities/SseLifecycleManagerTest.swift
+++ b/Tests/MessagingInApp/Gist/Utilities/SseLifecycleManagerTest.swift
@@ -14,7 +14,8 @@ class SseLifecycleManagerTest: XCTestCase {
     private var applicationStateProviderMock: ApplicationStateProviderMock!
 
     private var sut: CioSseLifecycleManager!
-    private var foregroundFetchCallsCount = 0
+    private var queueFetchCallsCount = 0
+    private var connectionConfirmedHandler: (() -> Void)?
 
     override func setUp() {
         super.setUp()
@@ -22,7 +23,8 @@ class SseLifecycleManagerTest: XCTestCase {
         inAppMessageManagerMock = InAppMessageManagerMock()
         sseConnectionManagerMock = SseConnectionManagerProtocolMock()
         applicationStateProviderMock = ApplicationStateProviderMock()
-        foregroundFetchCallsCount = 0
+        queueFetchCallsCount = 0
+        connectionConfirmedHandler = nil
 
         // Default to foreground state for most tests (explicit control)
         applicationStateProviderMock.underlyingApplicationState = .active
@@ -49,9 +51,23 @@ class SseLifecycleManagerTest: XCTestCase {
     }
 
     private func startLifecycleManager(_ manager: CioSseLifecycleManager) async {
-        await manager.start { [weak self] _ in
-            self?.foregroundFetchCallsCount += 1
+        await manager.start(queueFetchHandler: { [weak self] _ in
+            self?.queueFetchCallsCount += 1
+        })
+        // Captured here rather than read from the mock later: several tests call resetMock(), which
+        // clears its recorded arguments, and the hook is only registered once at start.
+        connectionConfirmedHandler = sseConnectionManagerMock.setOnConnectionConfirmedReceivedArguments
+    }
+
+    /// Invokes the backfill hook the manager registered, standing in for the server's `connected`
+    /// event. The fetch is keyed off that event, not off the transition that opens the connection.
+    private func simulateConnectionConfirmed() async {
+        guard let handler = connectionConfirmedHandler else {
+            XCTFail("lifecycle manager never registered a connection-confirmed hook")
+            return
         }
+        handler()
+        try? await Task.sleep(nanoseconds: 100000000)
     }
 
     /// Sets up the default state for the InAppMessageManager mock
@@ -194,7 +210,7 @@ class SseLifecycleManagerTest: XCTestCase {
         await startLifecycleManager(sut)
 
         sseConnectionManagerMock.resetMock()
-        foregroundFetchCallsCount = 0
+        queueFetchCallsCount = 0
 
         NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
         try? await Task.sleep(nanoseconds: 100000000)
@@ -205,7 +221,11 @@ class SseLifecycleManagerTest: XCTestCase {
 
         XCTAssertTrue(sseConnectionManagerMock.startConnectionCalled)
         XCTAssertEqual(sseConnectionManagerMock.startConnectionCallsCount, 1)
-        XCTAssertEqual(foregroundFetchCallsCount, 1)
+        // Foregrounding opens the connection; the backfill waits for the server to confirm it.
+        XCTAssertEqual(queueFetchCallsCount, 0)
+
+        await simulateConnectionConfirmed()
+        XCTAssertEqual(queueFetchCallsCount, 1)
     }
 
     func test_foregroundNotification_givenSseDisabled_expectNoConnection() async {
@@ -216,13 +236,13 @@ class SseLifecycleManagerTest: XCTestCase {
         NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
         try? await Task.sleep(nanoseconds: 100000000)
         sseConnectionManagerMock.resetMock()
-        foregroundFetchCallsCount = 0
+        queueFetchCallsCount = 0
 
         NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
         try? await Task.sleep(nanoseconds: 100000000)
 
         XCTAssertFalse(sseConnectionManagerMock.startConnectionCalled)
-        XCTAssertEqual(foregroundFetchCallsCount, 0)
+        XCTAssertEqual(queueFetchCallsCount, 0)
     }
 
     func test_foregroundNotification_givenAlreadyForegrounded_expectSkipped() async {
@@ -385,7 +405,7 @@ class SseLifecycleManagerTest: XCTestCase {
 
         XCTAssertEqual(sseConnectionManagerMock.startConnectionCallsCount, 1)
         XCTAssertEqual(sseConnectionManagerMock.stopConnectionCallsCount, 0)
-        XCTAssertEqual(foregroundFetchCallsCount, 0)
+        XCTAssertEqual(queueFetchCallsCount, 0)
 
         NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
         try? await Task.sleep(nanoseconds: 100000000)
@@ -398,7 +418,11 @@ class SseLifecycleManagerTest: XCTestCase {
 
         XCTAssertEqual(sseConnectionManagerMock.startConnectionCallsCount, 2)
         XCTAssertEqual(sseConnectionManagerMock.stopConnectionCallsCount, 1)
-        XCTAssertEqual(foregroundFetchCallsCount, 1)
+        // Reconnecting opens the connection; the backfill waits for the server to confirm it.
+        XCTAssertEqual(queueFetchCallsCount, 0)
+
+        await simulateConnectionConfirmed()
+        XCTAssertEqual(queueFetchCallsCount, 1)
     }
 
     // MARK: - Anonymous User Tests (SSE requires identified user)
@@ -426,13 +450,13 @@ class SseLifecycleManagerTest: XCTestCase {
         NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
         try? await Task.sleep(nanoseconds: 100000000)
         sseConnectionManagerMock.resetMock()
-        foregroundFetchCallsCount = 0
+        queueFetchCallsCount = 0
 
         NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
         try? await Task.sleep(nanoseconds: 100000000)
 
         XCTAssertFalse(sseConnectionManagerMock.startConnectionCalled)
-        XCTAssertEqual(foregroundFetchCallsCount, 0)
+        XCTAssertEqual(queueFetchCallsCount, 0)
     }
 
     func test_sseFlagChangedToTrue_givenAnonymousUser_expectNoConnection() async {

--- a/Tests/Mocks/MessagingInApp/AutoMockable.generated.swift
+++ b/Tests/Mocks/MessagingInApp/AutoMockable.generated.swift
@@ -2352,6 +2352,11 @@ class SseConnectionManagerProtocolMock: @unchecked Sendable, SseConnectionManage
         _stopConnectionCallsCount.wrappedValue = 0
 
         mockCalled = false // do last as resetting properties above can make this true
+        _setOnConnectionConfirmedCallsCount.wrappedValue = 0
+        _setOnConnectionConfirmedReceivedArguments.wrappedValue = nil
+        _setOnConnectionConfirmedReceivedInvocations.wrappedValue = []
+
+        mockCalled = false // do last as resetting properties above can make this true
     }
 
     // MARK: - startConnection
@@ -2402,6 +2407,45 @@ class SseConnectionManagerProtocolMock: @unchecked Sendable, SseConnectionManage
         mockCalled = true
         _stopConnectionCallsCount += 1
         stopConnectionClosure?()
+    }
+
+    // MARK: - setOnConnectionConfirmed
+
+    /// Number of times the function was called.
+    private let _setOnConnectionConfirmedCallsCount: CioInternalCommon.Synchronized<Int> = .init(0)
+    var setOnConnectionConfirmedCallsCount: Int {
+        _setOnConnectionConfirmedCallsCount.wrappedValue
+    }
+
+    /// `true` if the function was ever called.
+    var setOnConnectionConfirmedCalled: Bool {
+        setOnConnectionConfirmedCallsCount > 0
+    }
+
+    /// The arguments from the *last* time the function was called.
+    private let _setOnConnectionConfirmedReceivedArguments: CioInternalCommon.Synchronized<(() -> Void)?> = .init(nil)
+    var setOnConnectionConfirmedReceivedArguments: (() -> Void)? {
+        _setOnConnectionConfirmedReceivedArguments.wrappedValue
+    }
+
+    /// Arguments from *all* of the times that the function was called.
+    private let _setOnConnectionConfirmedReceivedInvocations: CioInternalCommon.Synchronized<[() -> Void]> = .init([])
+    var setOnConnectionConfirmedReceivedInvocations: [() -> Void] {
+        _setOnConnectionConfirmedReceivedInvocations.wrappedValue
+    }
+
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     */
+    var setOnConnectionConfirmedClosure: ((@escaping () -> Void) -> Void)?
+
+    /// Mocked function for `setOnConnectionConfirmed(_ handler: @Sendable @escaping () -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
+    func setOnConnectionConfirmed(_ handler: @Sendable @escaping () -> Void) {
+        mockCalled = true
+        _setOnConnectionConfirmedCallsCount += 1
+        _setOnConnectionConfirmedReceivedArguments.wrappedValue = handler
+        _setOnConnectionConfirmedReceivedInvocations.append(handler)
+        setOnConnectionConfirmedClosure?(handler)
     }
 }
 
@@ -2460,13 +2504,13 @@ class SseLifecycleManagerMock: @unchecked Sendable, SseLifecycleManager, Mock {
      */
     var startClosure: ((@escaping (InAppMessageState) -> Void) -> Void)?
 
-    /// Mocked function for `start(foregroundFetchHandler: @escaping (InAppMessageState) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
-    func start(foregroundFetchHandler: @escaping (InAppMessageState) -> Void) {
+    /// Mocked function for `start(queueFetchHandler: @escaping (InAppMessageState) -> Void)`. Your opportunity to return a mocked value and check result of mock in test code.
+    func start(queueFetchHandler: @escaping (InAppMessageState) -> Void) {
         mockCalled = true
         _startCallsCount += 1
-        _startReceivedArguments.wrappedValue = foregroundFetchHandler
-        _startReceivedInvocations.append(foregroundFetchHandler)
-        startClosure?(foregroundFetchHandler)
+        _startReceivedArguments.wrappedValue = queueFetchHandler
+        _startReceivedInvocations.append(queueFetchHandler)
+        startClosure?(queueFetchHandler)
     }
 }
 

--- a/api-docs/CioMessagingInbox.api
+++ b/api-docs/CioMessagingInbox.api
@@ -1,0 +1,12 @@
+public final class CioMessagingInbox.NotificationInboxBell {
+	public var body: some View;
+	public fun init(onTap: @escaping () -> Unit);
+}
+public final class CioMessagingInbox.NotificationInboxOverlay {
+	public var body: some View;
+	public fun init();
+}
+public final class CioMessagingInbox.NotificationInboxView {
+	public var body: some View;
+	public fun init();
+}


### PR DESCRIPTION
The two live findings from the #1141 review, plus the api-docs baseline that is currently failing `check-api-breaking-changes` on the base branch. Paired with customerio-android#802 for the SSE half.

## 1. SSE backfill ordering (Shahroz16 + Bugbot, independently)

We introduced this in #1143 while fixing the fresh-login empty inbox. `fetchUserQueue` is fire-and-forget (`threadUtil.runBackground`), so issuing it alongside `startConnection()` left the two unordered: the HTTP response could land after an SSE `inbox_messages` update and replace the newer list with an older snapshot, since both publish a full-state write.

**Reviewing whether that fix was the right shape turned out to be the useful part.** gist-web has the same need and solves it differently — `src/managers/queue-manager.ts` fetches from `sseSource.addEventListener('connected', ...)`, *after* the server confirms the connection, not before opening the `EventSource`. Our shape was the divergence.

The fetch now runs from the server's `connected` event — the only transition into `.connected` — via a hook `SseLifecycleManager` registers on `SseConnectionManager`. This orders the two by construction instead of reconciling them afterwards, so it needs no versioning tokens, no merge action, and no reducer changes. It also stops fetching when a connection never establishes, and collapses three trigger sites into one.

Considered and rejected: versioning the full-state writes (several times the size, and depends on allocating tokens at request rather than publish time — easy to get wrong later); awaiting the fetch before connecting (opposite of web, delays the connection, a hung fetch stalls it).

**Scope note:** this also removes the *pre-existing* pre-fetch on the foreground path (`SseLifecycleManager`, present on `main`). Once connection confirmation drives the fetch, keeping it would double-fetch — and it carried the same race. Android had no equivalent.

## 2. Inbox view model ownership (Shahroz16)

`NotificationInboxView` and `NotificationInboxBell` built their model with `ObservedObject(wrappedValue: VisualInboxModel())`. `@ObservedObject` does not own its value, so a parent update could hand the view a brand-new model after the original had already started its lifecycle — losing load state, dedupe guards, and in-flight work.

Both are `@available(iOS 13.0, *)` against an iOS 13 module floor, so `@StateObject` is not an option (only `NotificationInboxOverlay` can use it — it is iOS 16). Each public view now owns the model with `@State` and renders an internal `InboxListView` / `InboxBellView` that takes it as `@ObservedObject`. `VisualInboxModel.init` has no side effects — work begins in `start()` — so the instances SwiftUI discards are inert.

**Public API is unchanged**: same type names, same public initializers, and no existing api-docs baseline moved.

## 3. Missing api-docs baseline

`CioMessagingInbox` was added to `generate-api-docs.sh` without committing the generated baseline, so `check-api-breaking-changes` fails on `feat/overlay-inbox` with `+ CioMessagingInbox.api`. Committed here.

Worth flagging: the generated baseline contains only `class CioMessagingInbox` — the generator does not pick up the public SwiftUI views. So adding the module to the script does not actually give the compatibility job visibility into the new public view surface, which was the point of that request. Probably needs its own look.

## Tests

`SseLifecycleManagerTest`: the two tests asserting a fetch on foreground now assert the connection opens without fetching, then confirm the backfill fires once the hook runs. The hook is captured at `start()` because several tests call `resetMock()`, which clears the mock's recorded arguments.

469 tests, 0 failures; swiftlint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches real-time message/inbox sync and user-switch backfill; a residual race between in-flight HTTP backfill and SSE full-state writes is documented but not fixed in this PR.
> 
> **Overview**
> **SSE inbox backfill** now runs after the server sends its `connected` event (via `setOnConnectionConfirmed` on `SseConnectionManager`), aligned with gist-web, instead of alongside `startConnection()` or on foreground. That removes the race where a fire-and-forget HTTP snapshot could overwrite a newer SSE `inbox_messages` update. Foreground and SSE-enable paths no longer prefetch; `Gist` still calls `fetchUserQueue` when `userId` changes while SSE is already up (user swap with no new `connected`).
> 
> **Visual inbox SwiftUI** public `NotificationInboxBell` and `NotificationInboxView` own `VisualInboxModel` with `@State` (iOS 13–safe) and delegate to internal `InboxBellView` / `InboxListView`; the overlay composes those internals with a shared model. Public API surface is unchanged.
> 
> Adds **`CioMessagingInbox.api`** api-docs baseline and tests for connection-confirmed hook firing once (not on transport open only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9ee6af6a72874521f40785681a970866eec1d91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->