### PR TITLE
ci: cover every podspec in the release workflow and override script

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -362,6 +362,7 @@ jobs:
             CustomerIOMessagingPushFCM
             CustomerIOMessagingInApp
             CustomerIOLocation
+            CustomerIOLocationGeofence
             CustomerIOLiveActivitiesAttributes
             CustomerIOLiveActivities
             CustomerIOLiveActivitiesTemplates

--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -88,19 +88,28 @@ jobs:
           echo "Switching local references to published version: $TAG"
 
           # 1) CocoaPods Podfile in `Apps/CocoaPods-FCM/Podfile`
-          # Example lines to replace:
+          # Example line to replace:
           #   pod 'CustomerIODataPipelines', :path => ...
           #   =>  pod 'CustomerIODataPipelines', '1.2.3'
-          sd "pod 'CustomerIODataPipelines', :path =>.*" "pod 'CustomerIODataPipelines', '$TAG'" "Apps/CocoaPods-FCM/Podfile"
-          sd "pod 'CustomerIOMessagingPushAPN', :path =>.*" "pod 'CustomerIOMessagingPushAPN', '$TAG'" "Apps/CocoaPods-FCM/Podfile"
-          sd "pod 'CustomerIOMessagingInApp', :path =>.*" "pod 'CustomerIOMessagingInApp', '$TAG'" "Apps/CocoaPods-FCM/Podfile"
-          sd "pod 'CustomerIOLocation', :path =>.*" "pod 'CustomerIOLocation', '$TAG'" "Apps/CocoaPods-FCM/Podfile"
-          sd "pod 'CustomerIOLocationGeofence', :path =>.*" "pod 'CustomerIOLocationGeofence', '$TAG'" "Apps/CocoaPods-FCM/Podfile"
-          sd "pod 'CustomerIOLiveActivities', :path =>.*" "pod 'CustomerIOLiveActivities', '$TAG'" "Apps/CocoaPods-FCM/Podfile"
-          sd "pod 'CustomerIOLiveActivitiesAttributes', :path =>.*" "pod 'CustomerIOLiveActivitiesAttributes', '$TAG'" "Apps/CocoaPods-FCM/Podfile"
-          # Declared in both the app and the widget extension targets; sd rewrites every occurrence.
-          sd "pod 'CustomerIOLiveActivitiesTemplates', :path =>.*" "pod 'CustomerIOLiveActivitiesTemplates', '$TAG'" "Apps/CocoaPods-FCM/Podfile"
-          # If you have other modules: repeat
+          #
+          # The pod list is derived FROM the Podfile rather than hardcoded here. A hardcoded
+          # list silently drifts: a pod left off it keeps building from local source, so the
+          # post-release smoke test never installs its published pod and cannot catch a broken
+          # one. Deriving the list means adding a module to the Podfile is enough.
+          PODFILE="Apps/CocoaPods-FCM/Podfile"
+          cio_pods=$(grep -oE "pod '(CustomerIO[A-Za-z]*)', :path" "$PODFILE" | sed -E "s/pod '([^']*)', :path/\1/" | sort -u)
+          if [[ -z "$cio_pods" ]]; then
+            echo "::error::Found no Customer.io pods on a local path in $PODFILE. Has its format changed?"
+            exit 1
+          fi
+          echo "Pinning these pods to $TAG:"
+          echo "$cio_pods" | sed 's/^/  /'
+          for pod in $cio_pods; do
+            # Anchored on `', :path` so e.g. CustomerIOMessagingPush does not also rewrite
+            # CustomerIOMessagingPushAPN. Pods declared in more than one target (the Live
+            # Activities widget shares two) are rewritten in every occurrence by sd.
+            sd "pod '$pod', :path =>.*" "pod '$pod', '$TAG'" "$PODFILE"
+          done
 
           # 2) SwiftPM package in `Apps/Common/Package.swift`
           # Original: .package(path: "../../")

--- a/scripts/cocoapods_override_sdk.rb
+++ b/scripts/cocoapods_override_sdk.rb
@@ -57,8 +57,16 @@ def get_all_cio_pods(is_app_extension, push_service)
   pods_for_all_targets = [
     'CustomerIOCommon',
     'CustomerIODataPipelines',
+    # A dependency of CustomerIODataPipelines. It has to be overridden too: leaving it out
+    # resolves it from the trunk while everything around it comes from local/branch source,
+    # which is the mixed install this helper exists to avoid.
+    'CustomerIOTrackingMigration',
     'CustomerIOLocation',
-    'CustomerIOMessagingPush'
+    'CustomerIOMessagingPush',
+    # Live Activities attributes + templates. Both are App Extension compatible by design —
+    # a widget extension is what renders them.
+    'CustomerIOLiveActivitiesAttributes',
+    'CustomerIOLiveActivitiesTemplates'
   ]
 
   if push_service == "apn" 
@@ -78,6 +86,9 @@ def get_all_cio_pods(is_app_extension, push_service)
     pods_for_all_targets.push('CustomerIOMessagingInApp')
     # Geofencing is a host-app feature (region monitoring + launch-time background delivery), not usable in an App Extension.
     pods_for_all_targets.push('CustomerIOLocationGeofence')
+    # The app-side Live Activities module (starts/updates activities, handles widget-URL taps).
+    # Host app only; the widget extension renders from the Attributes + Templates pods above.
+    pods_for_all_targets.push('CustomerIOLiveActivities')
   end
 
   return pods_for_all_targets


### PR DESCRIPTION
Audited every place our podspecs are enumerated against the 13 `*.podspec` files on `main`. Three lists had drifted; all three are fixed here. No SDK source changes.

## What was wrong

**1. CocoaPods CDN-propagation wait — `deploy-sdk.yml`**

Listed 12 of 13 pods, omitting `CustomerIOLocationGeofence`. The release proceeds to build sample apps once the wait finishes, and the smoke test *does* install that pod, so `pod install` could run before it was servable from the CDN.

**2. Sample-app Podfile rewrite — `reusable_build_sample_apps.yml`**

Pinned 8 of the 12 pods the Podfile installs from a local path. `CustomerIOCommon`, `CustomerIOMessagingPush`, `CustomerIOMessagingPushFCM` and `CustomerIOTrackingMigration` kept building from local source, so the post-release smoke test never installed their published pods and could not have caught a broken one.

Rather than adding four more lines to a list that had already drifted twice (the old `# If you have other modules: repeat` comment invited exactly this), the list is now **derived from the Podfile**. Adding a module to the Podfile is now sufficient, and the step fails loudly if it extracts nothing.

**3. Local-override helper — `scripts/cocoapods_override_sdk.rb`**

Omitted `CustomerIOTrackingMigration` and the three Live Activities pods, so those resolved from the trunk while everything around them came from local/branch source — the mixed install this helper exists to prevent. `CustomerIOTrackingMigration` is the notable one: all three wrapper sample apps (React Native, Flutter, Expo) patch it in by hand today, which is the symptom.

Attributes + Templates go in the all-targets list (App Extension compatible — a widget extension is what renders them); the app-side `CustomerIOLiveActivities` goes in the host-app-only branch alongside `MessagingInApp` and `LocationGeofence`.

## Verification

- Ran the new derived rewrite loop **under bash** against a scratch copy of the Podfile: all 12 pods pinned, none left on `:path`, non-Customer.io pods untouched, and the pod declared in two targets rewritten in both. The `', :path` anchor keeps `CustomerIOMessagingPush` from also rewriting `...PushAPN`/`...PushFCM`.
- `ruby -c` on the override script; both workflows parse as YAML. Exercised `get_all_cio_pods` across all four `push_service` × `is_app_extension` combinations — together they now cover all 12 non-umbrella podspecs.
- Checked the push `tiers=(…)` list separately: all 13 present, and every declared sibling dependency pushes in an earlier tier. Left unchanged.
- Confirmed `update-version-cocoapods.sh` globs `./*.podspec`, and that the `CustomerIO` umbrella exposes a subspec for all 12 public siblings (only `CustomerIOCommon` is unexposed, correctly — it arrives transitively). Both already complete.

## Notes for review

- The derived loop relies on bash word-splitting an unquoted `$cio_pods`; the step declares `shell: bash`. Worth a look, since it would silently iterate once under zsh.
- Adding pods to `cocoapods_override_sdk.rb` changes what the three wrapper sample apps install on their next `pod install`, because they load this file from `main` at install time. The two they hand-patch today become redundant but harmless.
- All three gaps predate the inbox work, which is why this targets `main` directly rather than riding along on a feature branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)