### PR TITLE
chore: warm up CocoaPods spec repo before publishing

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -216,6 +216,14 @@ jobs:
         # Pinned so a new cocoapods release cannot break deployments. Bump deliberately.
         run: gem install cocoapods -v 1.16.2
 
+      - name: Warm up CocoaPods spec repo
+        run: |
+          if [[ -d "$HOME/.cocoapods/repos/cocoapods" ]]; then
+            pod repo update cocoapods
+          else
+            pod repo add cocoapods https://github.com/CocoaPods/Specs.git
+          fi
+
       - name: Push all podspecs to CocoaPods
         run: |
           # Podspecs are grouped into tiers by their dependencies on each other.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only workflow change with no SDK or runtime impact; slightly longer deploy job if a full spec clone is needed on a fresh runner.
> 
> **Overview**
> Adds a **Warm up CocoaPods spec repo** step to the `deploy-cocoapods` job in `deploy-sdk.yml`, running after CocoaPods is installed and before **Push all podspecs to CocoaPods**.
> 
> If `~/.cocoapods/repos/cocoapods` already exists, the step runs `pod repo update cocoapods`; otherwise it runs `pod repo add cocoapods` against the official Specs git URL. That preloads or refreshes the local spec index so later `pod trunk push` / lint work is less likely to hit cold-cache or missing-repo failures on CI runners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b4cff86ca5899fbf700b713218686de21415957. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->