### PR TITLE
ci: pin APN-UIKit SDK package reference when building published version

### DIFF
--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -110,6 +110,24 @@ jobs:
              ".package(name: \"customerio-ios\", url: \"https://github.com/customerio/customerio-ios.git\", .upToNextMajor(from: \"${TAG}\"))" \
              "Apps/Common/Package.swift"
 
+          # 3) SwiftPM reference to the SDK repo root inside `Apps/APN-UIKit`
+          # The LiveActivityExtension target links `LiveActivities_Attributes` / `LiveActivities_Templates`
+          # straight from the SDK, so the project holds its own local reference to `../../` on top of the
+          # one in `Apps/Common/Package.swift` above. Leaving it local while Common points at the remote
+          # makes SwiftPM see two packages with the identity `customerio-ios` and refuse to resolve:
+          #   Conflicting identity for customerio-ios: dependency 'github.com/customerio/customerio-ios'
+          #   and dependency '/path/to/checkout' both point to the same package identity 'customerio-ios'.
+          # So pin this reference to the same published version. The reference keeps its UUID, which is
+          # what `packageReferences` and the target's product dependencies key off of.
+          PBXPROJ="Apps/APN-UIKit/APN UIKit.xcodeproj/project.pbxproj"
+          # Keep the human-readable comments (block header + `packageReferences` entry) in sync.
+          sd 'XCLocalSwiftPackageReference "\.\./\.\./"' 'XCRemoteSwiftPackageReference "customerio-ios"' "$PBXPROJ"
+          # Swap the reference body itself. Matching `isa` together with the `../../` path leaves the
+          # sibling `../Common` local reference alone, which has to stay local.
+          sd 'isa = XCLocalSwiftPackageReference;\n(\s*)relativePath = "\.\./\.\./";' \
+             "isa = XCRemoteSwiftPackageReference;\n\${1}repositoryURL = \"https://github.com/customerio/customerio-ios.git\";\n\${1}requirement = {\n\${1}\tkind = upToNextMajorVersion;\n\${1}\tminimumVersion = \"${TAG}\";\n\${1}};" \
+             "$PBXPROJ"
+
           echo "Finished updating references. Now we have pinned SDK version $TAG."
 
       - name: Set Default Firebase Distribution Groups


### PR DESCRIPTION
Fixes the `Conflicting identity for customerio-ios` SwiftPM failure when sample apps are built against a published tag, by pinning the APN-UIKit project's local SDK package reference alongside the existing `Apps/Common/Package.swift` rewrite.

Verified locally by simulating the pinned build against `4.7.0`: packages resolve (`Customer.io @ 4.7.0` remote + `SampleAppsCommon @ local`) and the APN-UIKit scheme builds with `LiveActivityExtensionExtension.appex` embedded.

Failing run: https://github.com/customerio/customerio-ios/actions/runs/30540872760/job/90865088010

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only scripted edits to sample-app package references; no runtime SDK or app logic changes.
> 
> **Overview**
> When sample apps are built against the **latest published SDK tag**, the reusable workflow already rewrites CocoaPods paths and `Apps/Common/Package.swift` to the remote `customerio-ios` package. **APN-UIKit** still had a second **local** SwiftPM reference to `../../` for Live Activity products, which caused SwiftPM to fail with a **conflicting `customerio-ios` package identity**.
> 
> This change adds a third rewrite step that updates `Apps/APN-UIKit/APN UIKit.xcodeproj/project.pbxproj`: it converts only the `../../` reference (not `../Common`) from `XCLocalSwiftPackageReference` to `XCRemoteSwiftPackageReference` pinned to the same tag, keeping the existing reference UUID so target dependencies keep resolving.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d7067c505017043a6e5e1c970c121a31401de73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->