### PR TITLE
chore(geofence): reconcile OS regions by diff instead of wholesale re-registration

### DIFF
--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+OsRegistration.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+OsRegistration.swift
@@ -19,43 +19,12 @@ extension GeofenceSyncCoordinatorImpl {
         }
     }
 
-    /// True when re-registering would be a no-op: same ids as recorded, all owned by this process
-    /// and still held by the OS. Re-adding re-seeds each region's assumed state from the live fix,
-    /// absorbing any crossing the OS hasn't delivered yet — once per trigger radius at driving
-    /// speed. Any doubt falls through to the wholesale path, which re-establishes ownership, heals
-    /// dropped regions, and tears down under the kill switch (a geofence-free area leaves the
-    /// trigger owned with no business ids, so the ids alone would otherwise match).
-    @MainActor
-    func canSkipReregistration(
-        nearestIds: Set<String>,
-        previouslyRegisteredIds: Set<String>,
-        registerMovementTrigger: Bool
-    ) -> Bool {
-        guard registerMovementTrigger, nearestIds == previouslyRegisteredIds else { return false }
-        let expected = nearestIds.union([GeofenceConstants.movementTriggerIdentifier])
-        return expected.isSubset(of: monitor.monitoredRegionIdentifiers)
-            && expected.isSubset(of: monitor.osMonitoredRegionIdentifiers)
-    }
-
-    /// Moves only the trigger. Explicit stop-then-start, which both monitors serialize. Nothing is
-    /// lost by re-seeding this one region: it is being re-centered precisely because the device
-    /// left the old circle.
-    @MainActor
-    func recenterMovementTrigger(at location: LocationData, radius: Double) {
-        monitor.stopMonitoring(identifier: GeofenceConstants.movementTriggerIdentifier)
-        monitor.startMonitoring(
-            identifier: GeofenceConstants.movementTriggerIdentifier,
-            center: location,
-            radius: radius,
-            transitionTypes: [.exit]
-        )
-    }
-
-    /// Stops all monitored regions, then starts the new business set + movement trigger. Returns the
-    /// OS-accepted identifiers (a region the monitor dropped for blocked permission / invalid
-    /// coordinates is absent) plus the radius cap, so `emitInitialEnters` won't fire an unbalanced
-    /// synthetic enter or one for a device outside the actually-monitored (clamped) circle.
-    /// `@MainActor`-isolated so a same-actor caller (e.g. `applyCachedRegistration`)
+    /// Reconciles the OS-monitored set to the new business set + movement trigger, leaving regions
+    /// that carry over registered untouched — see `setMonitoredRegions` for why re-adding them loses
+    /// transitions. Returns the OS-accepted identifiers (a region the monitor dropped for blocked
+    /// permission / invalid coordinates is absent) plus the radius cap, so `emitInitialEnters` won't
+    /// fire an unbalanced synthetic enter or one for a device outside the actually-monitored
+    /// (clamped) circle. `@MainActor`-isolated so a same-actor caller (e.g. `applyCachedRegistration`)
     /// can register without yielding — see the protocol doc for why that matters.
     @MainActor
     @discardableResult
@@ -65,30 +34,39 @@ extension GeofenceSyncCoordinatorImpl {
         movementTriggerRadius: Double,
         registerMovementTrigger: Bool
     ) -> GeofenceOsRegistration {
-        monitor.stopMonitoringAll()
-        // Register the movement trigger FIRST so it isn't starved when business regions fill the
+        var desired: [GeofenceRegionRequest] = []
+        // Order the movement trigger FIRST so it isn't starved when business regions fill the
         // shared 20-region OS budget (e.g. a host app that also monitors regions): losing it freezes
         // the set, since exiting the trigger is what re-ranks toward now-closer geofences. Kept even
         // when the nearby set is empty (distance cap or an empty fetch) so the device keeps re-fetching
         // as it moves back toward geofences; skipped only when kill-switched (`maxBusinessGeofences == 0`).
         if registerMovementTrigger {
-            monitor.startMonitoring(
+            desired.append(GeofenceRegionRequest(
                 identifier: GeofenceConstants.movementTriggerIdentifier,
                 center: movementTriggerLocation,
                 radius: movementTriggerRadius,
                 transitionTypes: [.exit]
-            )
+            ))
         }
-        for region in businessRegions {
-            monitor.startMonitoring(
+        desired.append(contentsOf: businessRegions.map { region in
+            GeofenceRegionRequest(
                 identifier: region.id,
                 center: LocationData(latitude: region.latitude, longitude: region.longitude),
                 radius: region.radius,
                 transitionTypes: region.transitionTypes
             )
-        }
+        })
+        let diff = monitor.setMonitoredRegions(desired)
+        // Count against what the OS actually holds, not `desired`: a region dropped for blocked
+        // permission or invalid coordinates is in neither, and would otherwise read as unchanged.
+        let registeredIds = monitor.monitoredRegionIdentifiers
+        logger.geofenceRegistrationDiff(
+            added: diff.added.count,
+            removed: diff.removed.count,
+            unchanged: registeredIds.count - diff.added.count
+        )
         return GeofenceOsRegistration(
-            registeredIds: monitor.monitoredRegionIdentifiers,
+            registeredIds: registeredIds,
             maxMonitoringRadius: monitor.maximumMonitoringRadius
         )
     }

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
@@ -41,9 +41,6 @@ extension GeofenceSyncCoordinatorImpl {
         // Read before `recordRegistration` overwrites it — the diff decides which registrations are new.
         let previouslyRegisteredIds = await storage.getRegisteredBusinessIds()
         let nearestIds = Set(nearest.map(\.id))
-        if await appliedUnchangedRemoteSync(regions: regions, nearestIds: nearestIds, parsedConfig: parsedConfig, effectiveConfig: effectiveConfig, anchor: anchor) {
-            return .success(())
-        }
         let osRegistration = await MainActor.run {
             registerWithOsSync(
                 businessRegions: nearest,
@@ -89,17 +86,6 @@ extension GeofenceSyncCoordinatorImpl {
         // Read before `recordRegistration` overwrites it — the diff decides which registrations are new.
         let previouslyRegisteredIds = await storage.getRegisteredBusinessIds()
         let nearestIds = Set(nearest.map(\.id))
-        // Adjacent trigger EXITs usually re-rank onto the same nearest set — leave the OS
-        // registrations alone (see `canSkipReregistration`; geometry can't differ on matching
-        // ids here, ranking re-reads the same cache) and walk only the trigger + anchor.
-        if await canSkipReregistration(
-            nearestIds: nearestIds,
-            previouslyRegisteredIds: previouslyRegisteredIds,
-            registerMovementTrigger: registerMovementTrigger
-        ) {
-            await applyUnchangedRegistration(anchor: anchor, nearestIds: nearestIds, triggerRadius: config.localRefreshTriggerRadius)
-            return .success(())
-        }
         let osRegistration = await MainActor.run {
             registerWithOsSync(
                 businessRegions: nearest,
@@ -118,45 +104,6 @@ extension GeofenceSyncCoordinatorImpl {
         )
         logger.geofenceSyncCompleted(registeredCount: nearest.count, movementTriggerRegistered: registerMovementTrigger)
         return .success(())
-    }
-
-    /// Order-insensitive: server ordering isn't contractual, and `lastUpdated` in `Equatable`
-    /// makes any server-side edit force the wholesale path that applies it.
-    func regionsUnchanged(_ fetched: [Geofence], _ cached: [Geofence]) -> Bool {
-        fetched.sorted { $0.id < $1.id } == cached.sorted { $0.id < $1.id }
-    }
-
-    /// The unchanged-set fast path's shared effects: re-center the trigger and walk the
-    /// ranking-staleness anchor forward, leaving business regions untouched.
-    func applyUnchangedRegistration(anchor: LocationData, nearestIds: Set<String>, triggerRadius: Double) async {
-        await recenterMovementTrigger(at: anchor, radius: triggerRadius)
-        await storage.recordRegistration(center: anchor, businessIds: nearestIds)
-        logger.geofenceRerankUnchanged(keptCount: nearestIds.count)
-    }
-
-    /// Remote fast path: identical payload + unchanged registration (see `canSkipReregistration`)
-    /// ⇒ apply config, advance the refetch anchor, walk the trigger, and return true.
-    /// False = register wholesale.
-    func appliedUnchangedRemoteSync(
-        regions: [Geofence],
-        nearestIds: Set<String>,
-        parsedConfig: GeofenceConfig?,
-        effectiveConfig: GeofenceConfig,
-        anchor: LocationData
-    ) async -> Bool {
-        guard regionsUnchanged(regions, await storage.getCachedGeofences()),
-              await canSkipReregistration(
-                  nearestIds: nearestIds,
-                  previouslyRegisteredIds: storage.getRegisteredBusinessIds(),
-                  registerMovementTrigger: effectiveConfig.maxBusinessGeofences > 0
-              )
-        else { return false }
-        if let parsedConfig {
-            await storage.setCachedConfig(parsedConfig)
-        }
-        await storage.recordSync(timestamp: dateUtil.now, location: anchor)
-        await applyUnchangedRegistration(anchor: anchor, nearestIds: nearestIds, triggerRadius: effectiveConfig.localRefreshTriggerRadius)
-        return true
     }
 
     /// A sign-out/switch can land anywhere inside a gated operation, and the `reset()` it triggers

--- a/Sources/LocationGeofence/GeofenceBootstrap.swift
+++ b/Sources/LocationGeofence/GeofenceBootstrap.swift
@@ -54,6 +54,8 @@ enum GeofenceBootstrap {
         let expectedOwnedRegions = (cachedConfig ?? .fallback).maxBusinessGeofences > 0
             ? lastRegisteredBusinessIds.union([GeofenceConstants.movementTriggerIdentifier])
             : []
+        // Adopt-time seed for the CLMonitor path's geometry bookkeeping (empty on classic).
+        let monitorRecords = await di.geofenceStorage.getMonitorRegionRecords()
 
         // Phase 2: synchronous on the main actor. No `await` between handler-bind and
         // `adoptExistingRegions` / `startMonitoring`, so `ownedRegionIdentifiers` is populated
@@ -88,7 +90,7 @@ enum GeofenceBootstrap {
             // reset's queued removes). The next identify-driven refresh registers instead.
             di.logger.geofenceSyncSkipped(reason: "identified user changed during bootstrap")
         } else if !expectedOwnedRegions.isEmpty, expectedOwnedRegions.isSubset(of: monitor.osMonitoredRegionIdentifiers) {
-            monitor.adoptExistingRegions(matching: expectedOwnedRegions)
+            monitor.adoptExistingRegions(matching: expectedOwnedRegions, records: monitorRecords)
         } else {
             // First launch after install, the OS dropped our regions (e.g. permission revoked then
             // re-granted, which clears `monitoredRegions`), or a partial drop. Register fresh from cache.

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -110,8 +110,8 @@ extension Logger {
         info("Sync completed: registered \(registeredCount) business geofences\(trigger)", geofenceTag)
     }
 
-    func geofenceRerankUnchanged(keptCount: Int) {
-        debug("Re-rank: nearest set unchanged, kept \(keptCount) business geofences monitored; movement trigger re-centered", geofenceTag)
+    func geofenceRegistrationDiff(added: Int, removed: Int, unchanged: Int) {
+        debug("OS registration diff: +\(added) / -\(removed); \(unchanged) left registered untouched", geofenceTag)
     }
 
     func geofenceMovementTrigger(tier: HandleMovementTier) {

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Rearm.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Rearm.swift
@@ -10,10 +10,12 @@ extension CLMonitorGeofenceMonitor {
     /// fresh add re-arms it. Event-silent when nothing changed: `assuming:` seeds the stored
     /// baseline, so CLMonitor emits only transitions that happened while unmonitored — genuine
     /// catch-up, which the baseline comparison then delivers.
-    func rearmConditions(_ identifiers: Set<String>) {
-        enqueueMonitorOperation { [weak self] monitor in
-            guard let self else { return }
-            let records = await self.storage.getMonitorRegionRecords()
+    ///
+    /// `records` comes from the caller (`adoptExistingRegions`), which has already seeded the
+    /// geometry bookkeeping from it synchronously — noting it again at drain time would clobber
+    /// a newer circle a sync staged while this operation was still queued.
+    func rearmConditions(_ identifiers: Set<String>, records: [String: MonitorRegionRecord]) {
+        enqueueMonitorOperation { monitor in
             for identifier in identifiers {
                 // A record without geometry can't be rebuilt; the next sync re-registers it.
                 guard let record = records[identifier],
@@ -25,14 +27,6 @@ extension CLMonitorGeofenceMonitor {
                     radius: radius
                 )
                 await monitor.add(condition, identifier: identifier, assuming: record.lastState == .enter ? .satisfied : .unsatisfied)
-                // This process now knows what the condition holds, so `setMonitoredRegions` can
-                // leave it alone instead of re-adding it on the next sync.
-                self.noteRegisteredCondition(
-                    identifier: identifier,
-                    center: center,
-                    radius: radius,
-                    transitionTypes: record.transitionTypes
-                )
             }
         }
     }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Rearm.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Rearm.swift
@@ -14,8 +14,15 @@ extension CLMonitorGeofenceMonitor {
     /// `records` comes from the caller (`adoptExistingRegions`), which has already seeded the
     /// geometry bookkeeping from it synchronously — noting it again at drain time would clobber
     /// a newer circle a sync staged while this operation was still queued.
+    ///
+    /// Each successful add is recorded in `knownConditionIdentifiers` and the mirror persisted, the
+    /// same bookkeeping `startMonitoring` does. Without it the mirror under-reports a condition this
+    /// re-add revived, and the next process seeds ownership from that mirror — so a cold-wake event
+    /// for the revived condition would be dropped by the ownership gate.
     func rearmConditions(_ identifiers: Set<String>, records: [String: MonitorRegionRecord]) {
-        enqueueMonitorOperation { monitor in
+        enqueueMonitorOperation { [weak self] monitor in
+            guard let self else { return }
+            var revived = false
             for identifier in identifiers {
                 // A record without geometry can't be rebuilt; the next sync re-registers it.
                 guard let record = records[identifier],
@@ -27,7 +34,14 @@ extension CLMonitorGeofenceMonitor {
                     radius: radius
                 )
                 await monitor.add(condition, identifier: identifier, assuming: record.lastState == .enter ? .satisfied : .unsatisfied)
+                // Recorded per identifier rather than in one pass at the end: an `.unmonitored` for
+                // one of these can land between two iterations, and it must be able to take the
+                // identifier back out.
+                self.knownConditionIdentifiers.insert(identifier)
+                revived = true
             }
+            guard revived else { return }
+            self.persistConditionMirror()
         }
     }
 }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Rearm.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Rearm.swift
@@ -25,6 +25,14 @@ extension CLMonitorGeofenceMonitor {
                     radius: radius
                 )
                 await monitor.add(condition, identifier: identifier, assuming: record.lastState == .enter ? .satisfied : .unsatisfied)
+                // This process now knows what the condition holds, so `setMonitoredRegions` can
+                // leave it alone instead of re-adding it on the next sync.
+                self.noteRegisteredCondition(
+                    identifier: identifier,
+                    center: center,
+                    radius: radius,
+                    transitionTypes: record.transitionTypes
+                )
             }
         }
     }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
@@ -176,9 +176,16 @@ extension CLMonitorGeofenceMonitor {
 
     /// True when this monitor owns the condition and registered it with the same circle, so
     /// re-adding would only risk absorbing an undelivered crossing.
+    ///
+    /// Ownership plus the recorded circle is sufficient: every path that records geometry also
+    /// queues the matching OS add on the FIFO, and every path that invalidates the OS side clears
+    /// ownership or the record synchronously. `knownConditionIdentifiers` must NOT be consulted —
+    /// it is only updated when queued operations drain, so requiring it re-registers regions whose
+    /// add is still in flight (a sync landing before an earlier one's ops drained) and regions
+    /// revived by `rearmConditions` (which never inserts into it) — each an absorbing remove + add
+    /// for a circle the OS already holds or is about to.
     private func isRegisteredUnchanged(_ region: GeofenceRegionRequest) -> Bool {
         guard ownedRegionIdentifiers.contains(region.identifier),
-              knownConditionIdentifiers.contains(region.identifier),
               let existing = registeredConditions[region.identifier]
         else { return false }
         return region.matchesRegistered(

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
@@ -1,0 +1,174 @@
+import CioInternalCommon
+import CoreLocation
+import Foundation
+
+/// Region registration for the CLMonitor path, split out to keep the monitor's event and lifecycle
+/// plumbing readable. Members are `internal` (not `private`) only because they live in a separate
+/// file from their state; they remain monitor implementation detail.
+@available(iOS 17.0, *)
+extension CLMonitorGeofenceMonitor {
+    func adoptExistingRegions(matching identifiers: Set<String>) {
+        let adopted = identifiers.intersection(knownConditionIdentifiers)
+        guard !adopted.isEmpty else { return }
+        ownedRegionIdentifiers.formUnion(adopted)
+        rearmConditions(adopted)
+        logger.geofenceRegionsAdopted(count: adopted.count)
+    }
+
+    func startMonitoring(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) {
+        reportPermissionTier()
+        guard CoreLocationGeofenceMonitor.permissionTier(for: authManager.authorizationStatus) != .blocked else { return }
+
+        let coordinate = CLLocationCoordinate2D(latitude: center.latitude, longitude: center.longitude)
+        guard CLLocationCoordinate2DIsValid(coordinate) else {
+            logger.geofenceInvalidCoordinatesForRegion(identifier)
+            return
+        }
+
+        // Populate the ownership filter synchronously so a fast-arriving event isn't dropped.
+        ownedRegionIdentifiers.insert(identifier)
+
+        // Parity with the classic monitor's clamp; `maximumRegionMonitoringDistance` is a deprecated
+        // but harmless read with no CLMonitor equivalent — both paths register identical geometry.
+        let clampedRadius = min(radius, authManager.maximumRegionMonitoringDistance)
+
+        // The device's ACTUAL state seeds both CLMonitor's `assuming:` hint and the stored baseline
+        // (see `recordMonitorRegistration`: registration stays silent, the first real crossing
+        // delivers). No fix → geometric expectation: trigger is device-centered (inside),
+        // business geofences outside.
+        noteRegisteredCondition(
+            identifier: identifier,
+            center: LocationData(latitude: coordinate.latitude, longitude: coordinate.longitude),
+            radius: clampedRadius,
+            transitionTypes: transitionTypes
+        )
+
+        let isMovementTrigger = identifier == GeofenceConstants.movementTriggerIdentifier
+        let isInside = isDeviceInside(center: coordinate, radius: clampedRadius) ?? isMovementTrigger
+        let initialTransition: GeofenceTransition = isInside ? .enter : .exit
+        let assumedState: CLMonitor.Event.State = isInside ? .satisfied : .unsatisfied
+
+        enqueueMonitorOperation { [weak self] monitor in
+            guard let self else { return }
+            // Persist before the OS add: storage keys off recorded geometry to preserve the baseline
+            // on an unchanged re-register and reseed on a new/changed circle. The decision lives in
+            // storage because this runs after stop-all, when CLMonitor's own record is already gone.
+            await self.storage.recordMonitorRegistration(
+                identifier: identifier,
+                transitionTypes: transitionTypes,
+                initialState: initialTransition,
+                center: LocationData(latitude: coordinate.latitude, longitude: coordinate.longitude),
+                radius: clampedRadius
+            )
+            let condition = CLMonitor.CircularGeographicCondition(center: coordinate, radius: clampedRadius)
+            await monitor.add(condition, identifier: identifier, assuming: assumedState)
+            self.knownConditionIdentifiers.insert(identifier)
+            self.persistConditionMirror()
+        }
+    }
+
+    func stopMonitoring(identifier: String) {
+        guard ownedRegionIdentifiers.remove(identifier) != nil else { return }
+        registeredConditions.removeValue(forKey: identifier)
+        enqueueConditionRemoval(identifier)
+    }
+
+    /// Drops the condition at the OS. Split from `stopMonitoring` because re-registration must be
+    /// able to clear a condition this process has not adopted — see `setMonitoredRegions`.
+    ///
+    /// The storage record intentionally survives removal: a remove + re-register cycle relies on
+    /// the persisted baseline to suppress CLMonitor's re-evaluation of an unchanged state.
+    private func enqueueConditionRemoval(_ identifier: String) {
+        enqueueMonitorOperation { [weak self] monitor in
+            guard let self else { return }
+            await monitor.remove(identifier)
+            self.knownConditionIdentifiers.remove(identifier)
+            self.persistConditionMirror()
+        }
+    }
+
+    func stopMonitoringAll() {
+        ownedRegionIdentifiers.removeAll()
+        registeredConditions.removeAll()
+        // Clear against CLMonitor's LIVE identifiers, not the owned/mirror snapshot: an empty owned
+        // set or a lossy mirror must not leave a stale SDK condition holding an OS slot.
+        enqueueMonitorOperation { [weak self] monitor in
+            guard let self else { return }
+            for identifier in await monitor.identifiers {
+                await monitor.remove(identifier)
+            }
+            self.knownConditionIdentifiers.removeAll()
+            self.persistConditionMirror()
+        }
+    }
+
+    @discardableResult
+    func setMonitoredRegions(_ regions: [GeofenceRegionRequest]) -> GeofenceRegionDiff {
+        let desiredIdentifiers = Set(regions.map(\.identifier))
+        var removed: Set<String> = []
+        for identifier in ownedRegionIdentifiers.subtracting(desiredIdentifiers) {
+            stopMonitoring(identifier: identifier)
+            removed.insert(identifier)
+        }
+        // `stopMonitoring` above only reaches conditions this process knows it owns. Sweep the rest
+        // against CLMonitor's LIVE identifiers, the job `stopMonitoringAll` used to do wholesale, so
+        // a lossy mirror can't strand an SDK condition holding an OS slot.
+        enqueueMonitorOperation { [weak self] monitor in
+            guard let self else { return }
+            for identifier in await monitor.identifiers where !desiredIdentifiers.contains(identifier) {
+                await monitor.remove(identifier)
+                self.knownConditionIdentifiers.remove(identifier)
+            }
+            self.persistConditionMirror()
+        }
+        var added: Set<String> = []
+        for region in regions where !isRegisteredUnchanged(region) {
+            // CLMonitor SILENTLY IGNORES an add over a live identifier — it keeps the original
+            // circle and reports no error — so a reshaped region must be removed first; the
+            // pipeline is FIFO, so the remove lands before the add. `stopMonitoring` only reaches
+            // regions this process owns, and a condition the OS holds that adoption missed would
+            // otherwise keep its old circle forever: the add is dropped, but the new geometry is
+            // still recorded here, so every later pass reads "unchanged" and never repairs it.
+            if ownedRegionIdentifiers.contains(region.identifier) {
+                stopMonitoring(identifier: region.identifier)
+            } else if knownConditionIdentifiers.contains(region.identifier) {
+                enqueueConditionRemoval(region.identifier)
+            }
+            startMonitoring(
+                identifier: region.identifier,
+                center: region.center,
+                radius: region.radius,
+                transitionTypes: region.transitionTypes
+            )
+            // Blocked permission / invalid coordinates make `startMonitoring` a no-op; the caller's
+            // initial-enter decision must not count a region the OS never took.
+            if ownedRegionIdentifiers.contains(region.identifier) { added.insert(region.identifier) }
+        }
+        return GeofenceRegionDiff(added: added, removed: removed)
+    }
+
+    /// True when this monitor owns the condition and registered it with the same circle, so
+    /// re-adding would only risk absorbing an undelivered crossing.
+    private func isRegisteredUnchanged(_ region: GeofenceRegionRequest) -> Bool {
+        guard ownedRegionIdentifiers.contains(region.identifier),
+              knownConditionIdentifiers.contains(region.identifier),
+              let existing = registeredConditions[region.identifier]
+        else { return false }
+        return region.matchesRegistered(
+            center: existing.center,
+            radius: existing.radius,
+            transitionTypes: existing.transitionTypes,
+            clampedTo: authManager.maximumRegionMonitoringDistance
+        )
+    }
+
+    /// Records the circle a condition now holds. Internal for the `+Rearm` extension, which re-adds
+    /// conditions from persisted records.
+    func noteRegisteredCondition(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) {
+        registeredConditions[identifier] = RegisteredCondition(
+            center: center,
+            radius: radius,
+            transitionTypes: transitionTypes
+        )
+    }
+}

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
@@ -17,11 +17,19 @@ extension CLMonitorGeofenceMonitor {
 
     func startMonitoring(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) {
         reportPermissionTier()
-        guard CoreLocationGeofenceMonitor.permissionTier(for: authManager.authorizationStatus) != .blocked else { return }
+        // A rejected registration still clears the identifier at the OS. Re-registration releases
+        // ownership before calling in, so without this a reshaped region that is refused would leave
+        // its previous circle live and holding one of the 20 OS slots — with nothing owning it, no
+        // later pass repairs it while the region stays in the desired set.
+        guard CoreLocationGeofenceMonitor.permissionTier(for: authManager.authorizationStatus) != .blocked else {
+            enqueueConditionRemoval(identifier)
+            return
+        }
 
         let coordinate = CLLocationCoordinate2D(latitude: center.latitude, longitude: center.longitude)
         guard CLLocationCoordinate2DIsValid(coordinate) else {
             logger.geofenceInvalidCoordinatesForRegion(identifier)
+            enqueueConditionRemoval(identifier)
             return
         }
 
@@ -60,6 +68,11 @@ extension CLMonitorGeofenceMonitor {
                 center: LocationData(latitude: coordinate.latitude, longitude: coordinate.longitude),
                 radius: clampedRadius
             )
+            // CLMonitor SILENTLY IGNORES an add over a live identifier, keeping the original circle
+            // and reporting no error, so the identifier is cleared first. Keyed on the OS rather
+            // than on this process's bookkeeping, which can be missing an identifier the OS still
+            // holds. Removing one the OS does not hold is a no-op.
+            await monitor.remove(identifier)
             let condition = CLMonitor.CircularGeographicCondition(center: coordinate, radius: clampedRadius)
             await monitor.add(condition, identifier: identifier, assuming: assumedState)
             self.knownConditionIdentifiers.insert(identifier)
@@ -68,13 +81,18 @@ extension CLMonitorGeofenceMonitor {
     }
 
     func stopMonitoring(identifier: String) {
-        guard ownedRegionIdentifiers.remove(identifier) != nil else { return }
-        registeredConditions.removeValue(forKey: identifier)
+        guard ownedRegionIdentifiers.contains(identifier) else { return }
+        releaseOwnership(identifier)
         enqueueConditionRemoval(identifier)
     }
 
-    /// Drops the condition at the OS. Split from `stopMonitoring` because re-registration must be
-    /// able to clear a condition this process has not adopted — see `setMonitoredRegions`.
+    /// Drops this process's claim on a condition without touching the OS.
+    private func releaseOwnership(_ identifier: String) {
+        ownedRegionIdentifiers.remove(identifier)
+        registeredConditions.removeValue(forKey: identifier)
+    }
+
+    /// Drops the condition at the OS.
     ///
     /// The storage record intentionally survives removal: a remove + re-register cycle relies on
     /// the persisted baseline to suppress CLMonitor's re-evaluation of an unchanged state.
@@ -123,17 +141,11 @@ extension CLMonitorGeofenceMonitor {
         }
         var added: Set<String> = []
         for region in regions where !isRegisteredUnchanged(region) {
-            // CLMonitor SILENTLY IGNORES an add over a live identifier — it keeps the original
-            // circle and reports no error — so a reshaped region must be removed first; the
-            // pipeline is FIFO, so the remove lands before the add. `stopMonitoring` only reaches
-            // regions this process owns, and a condition the OS holds that adoption missed would
-            // otherwise keep its old circle forever: the add is dropped, but the new geometry is
-            // still recorded here, so every later pass reads "unchanged" and never repairs it.
-            if ownedRegionIdentifiers.contains(region.identifier) {
-                stopMonitoring(identifier: region.identifier)
-            } else if knownConditionIdentifiers.contains(region.identifier) {
-                enqueueConditionRemoval(region.identifier)
-            }
+            // Release ownership first so a region `startMonitoring` rejects (blocked permission,
+            // invalid coordinates) stops counting as registered instead of keeping the claim it
+            // held before the change. `startMonitoring` re-takes it in the same turn on success,
+            // and clears the identifier at the OS from inside its queued add.
+            releaseOwnership(region.identifier)
             startMonitoring(
                 identifier: region.identifier,
                 center: region.center,

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
@@ -7,11 +7,26 @@ import Foundation
 /// file from their state; they remain monitor implementation detail.
 @available(iOS 17.0, *)
 extension CLMonitorGeofenceMonitor {
-    func adoptExistingRegions(matching identifiers: Set<String>) {
+    func adoptExistingRegions(matching identifiers: Set<String>, records: [String: MonitorRegionRecord]) {
         let adopted = identifiers.intersection(knownConditionIdentifiers)
         guard !adopted.isEmpty else { return }
         ownedRegionIdentifiers.formUnion(adopted)
-        rearmConditions(adopted)
+        // Seed the geometry map synchronously, before the queued re-arm drains: a sync landing in
+        // that window would otherwise read every adopted region as changed (no recorded circle)
+        // and remove + re-add them all — absorbing any crossing the OS has detected but not yet
+        // delivered. Seeded from the same records the re-arm imposes at the OS, so the diff
+        // compares against what the OS will hold once it drains. A record without geometry stays
+        // unseeded and the next sync re-registers it, matching `rearmConditions`.
+        for identifier in adopted {
+            guard let record = records[identifier], let center = record.center, let radius = record.radius else { continue }
+            noteRegisteredCondition(
+                identifier: identifier,
+                center: center,
+                radius: radius,
+                transitionTypes: record.transitionTypes
+            )
+        }
+        rearmConditions(adopted, records: records)
         logger.geofenceRegionsAdopted(count: adopted.count)
     }
 
@@ -174,9 +189,8 @@ extension CLMonitorGeofenceMonitor {
         )
     }
 
-    /// Records the circle a condition now holds. Internal for the `+Rearm` extension, which re-adds
-    /// conditions from persisted records.
-    func noteRegisteredCondition(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) {
+    /// Records the circle a condition now holds.
+    private func noteRegisteredCondition(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) {
         registeredConditions[identifier] = RegisteredCondition(
             center: center,
             radius: radius,

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
@@ -180,10 +180,10 @@ extension CLMonitorGeofenceMonitor {
     /// Ownership plus the recorded circle is sufficient: every path that records geometry also
     /// queues the matching OS add on the FIFO, and every path that invalidates the OS side clears
     /// ownership or the record synchronously. `knownConditionIdentifiers` must NOT be consulted —
-    /// it is only updated when queued operations drain, so requiring it re-registers regions whose
-    /// add is still in flight (a sync landing before an earlier one's ops drained) and regions
-    /// revived by `rearmConditions` (which never inserts into it) — each an absorbing remove + add
-    /// for a circle the OS already holds or is about to.
+    /// it is only updated when queued operations drain, so requiring it re-registers any region
+    /// whose add is still in flight — staged either by a sync that landed before an earlier one's
+    /// operations drained or by the launch re-arm. Each is an absorbing remove + add for a circle
+    /// the OS already holds or is about to.
     private func isRegisteredUnchanged(_ region: GeofenceRegionRequest) -> Bool {
         guard ownedRegionIdentifiers.contains(region.identifier),
               let existing = registeredConditions[region.identifier]

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -55,10 +55,11 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
     /// Geometry each condition was added with, post-clamp. `CLMonitor` exposes no way to read a
     /// condition back, so this is the only record `setMonitoredRegions` can diff against.
     ///
-    /// Deliberately NOT seeded from the mirror at init. A condition inherited from a previous
-    /// process may be a reboot zombie — still listed, no longer monitored (see `rearmConditions`) —
-    /// and only re-adding revives it. Leaving it absent here makes the first pass re-register it;
-    /// `rearmConditions` fills it in when the bootstrap adopts instead.
+    /// Deliberately NOT seeded from the mirror at init (which has no geometry anyway). A condition
+    /// inherited from a previous process may be a reboot zombie — still listed, no longer monitored
+    /// (see `rearmConditions`) — and only re-adding revives it. Leaving it absent here makes the
+    /// first pass re-register it; when the bootstrap adopts instead, `adoptExistingRegions` seeds it
+    /// from the persisted records the re-arm then imposes at the OS.
     var registeredConditions: [String: RegisteredCondition] = [:]
 
     /// The circle a condition was added with.

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -145,7 +145,9 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
         let drifted = persisted != knownConditionIdentifiers
         knownConditionIdentifiers = persisted
         ownedRegionIdentifiers.formUnion(persisted)
-        registeredConditions = registeredConditions.filter { persisted.contains($0.key) }
+        // `registeredConditions` is deliberately not filtered against `persisted`. It starts empty
+        // each process, so its only entries are ones staged while CLMonitor was still loading,
+        // whose adds are queued behind this operation — exactly the identifiers `persisted` lacks.
         persistConditionMirror()
         if drifted { onReconciled?() }
     }
@@ -217,11 +219,22 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
         case .unmonitored:
             // CLMonitor gave up on the condition (e.g. condition budget exceeded). As with classic
             // monitoringDidFail: drop ownership and the mirror entry so nothing claims a condition
-            // the OS no longer holds; the next sync re-registers a fresh set.
+            // the OS no longer holds; the next sync re-registers a fresh set. The stored baseline
+            // goes too — the region stays in the desired set, so nothing else prunes it, and the
+            // device can cross while it is unmonitored.
             ownedRegionIdentifiers.remove(identifier)
             knownConditionIdentifiers.remove(identifier)
             registeredConditions.removeValue(forKey: identifier)
             persistConditionMirror()
+            // On the pipeline, and skipped if a registration has re-added the identifier since the
+            // line above cleared it: that add wrote a baseline from the device's real position, which
+            // must not then be deleted. Keyed on this monitor's own record of completed adds rather
+            // than on `CLMonitor.identifiers`, because whether a condition the OS gave up on stays
+            // listed is unmeasured — reading it could make this clear permanently inert.
+            enqueueMonitorOperation { [weak self] _ in
+                guard let self, !self.knownConditionIdentifiers.contains(identifier) else { return }
+                await self.storage.clearMonitorRegionRecord(identifier: identifier)
+            }
             return
         @unknown default:
             return

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -32,23 +32,41 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
     /// after construction — without the mirror that read is empty on every cold launch.
     private static let conditionMirrorKey = "io.customer.sdk.geofence.clmonitor.conditionIdentifiers"
 
-    private let logger: Logger
+    /// Internal for the `+Registration` extension.
+    let logger: Logger
     /// Persists the per-condition dedup baseline + delivery filter (see `MonitorRegionRecord`).
     /// Internal (not private) so the `+Rearm` extension can read it; immutable injected dependency.
     let storage: GeofenceStorage
     private let userDefaults: UserDefaults
     /// Only for auth status/changes + current-location reads; region monitoring is on `CLMonitor`.
-    private let authManager: CLLocationManager
+    /// Internal for the `+Registration` extension.
+    let authManager: CLLocationManager
     private var onTransition: GeofenceTransitionHandler?
     private var onAuthorizationChanged: GeofenceAuthorizationChangedHandler?
     private var onReconciled: GeofenceReconciledHandler?
     private var lastLoggedPermissionTier: CoreLocationGeofenceMonitor.PermissionTier?
 
     /// In-memory ownership filter, mirrors `ownedRegionIdentifiers` in the classic monitor.
-    private var ownedRegionIdentifiers: Set<String> = []
+    /// The three below are internal for the `+Registration` extension.
+    var ownedRegionIdentifiers: Set<String> = []
     /// Synchronous view of the monitor's condition identifiers: seeded from the mirror at init,
     /// reconciled against `CLMonitor.identifiers` by the pipeline's first operation, then maintained.
-    private var knownConditionIdentifiers: Set<String> = []
+    var knownConditionIdentifiers: Set<String> = []
+    /// Geometry each condition was added with, post-clamp. `CLMonitor` exposes no way to read a
+    /// condition back, so this is the only record `setMonitoredRegions` can diff against.
+    ///
+    /// Deliberately NOT seeded from the mirror at init. A condition inherited from a previous
+    /// process may be a reboot zombie — still listed, no longer monitored (see `rearmConditions`) —
+    /// and only re-adding revives it. Leaving it absent here makes the first pass re-register it;
+    /// `rearmConditions` fills it in when the bootstrap adopts instead.
+    var registeredConditions: [String: RegisteredCondition] = [:]
+
+    /// The circle a condition was added with.
+    struct RegisteredCondition: Equatable {
+        let center: LocationData
+        let radius: Double
+        let transitionTypes: Set<GeofenceTransition>
+    }
 
     /// Memoized `CLMonitor` creation so every caller shares one instance — creating a second
     /// monitor with the same name throws "Monitor named ... is already in use".
@@ -127,6 +145,7 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
         let drifted = persisted != knownConditionIdentifiers
         knownConditionIdentifiers = persisted
         ownedRegionIdentifiers.formUnion(persisted)
+        registeredConditions = registeredConditions.filter { persisted.contains($0.key) }
         persistConditionMirror()
         if drifted { onReconciled?() }
     }
@@ -201,6 +220,7 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
             // the OS no longer holds; the next sync re-registers a fresh set.
             ownedRegionIdentifiers.remove(identifier)
             knownConditionIdentifiers.remove(identifier)
+            registeredConditions.removeValue(forKey: identifier)
             persistConditionMirror()
             return
         @unknown default:
@@ -227,14 +247,6 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
         knownConditionIdentifiers
     }
 
-    func adoptExistingRegions(matching identifiers: Set<String>) {
-        let adopted = identifiers.intersection(knownConditionIdentifiers)
-        guard !adopted.isEmpty else { return }
-        ownedRegionIdentifiers.formUnion(adopted)
-        rearmConditions(adopted)
-        logger.geofenceRegionsAdopted(count: adopted.count)
-    }
-
     func setOnTransition(_ handler: GeofenceTransitionHandler?) {
         onTransition = handler
         drainPendingEventsIfReady()
@@ -246,77 +258,6 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
 
     func setOnReconciled(_ handler: GeofenceReconciledHandler?) {
         onReconciled = handler
-    }
-
-    func startMonitoring(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) {
-        reportPermissionTier()
-        guard CoreLocationGeofenceMonitor.permissionTier(for: authManager.authorizationStatus) != .blocked else { return }
-
-        let coordinate = CLLocationCoordinate2D(latitude: center.latitude, longitude: center.longitude)
-        guard CLLocationCoordinate2DIsValid(coordinate) else {
-            logger.geofenceInvalidCoordinatesForRegion(identifier)
-            return
-        }
-
-        // Populate the ownership filter synchronously so a fast-arriving event isn't dropped.
-        ownedRegionIdentifiers.insert(identifier)
-
-        // Parity with the classic monitor's clamp; `maximumRegionMonitoringDistance` is a deprecated
-        // but harmless read with no CLMonitor equivalent — both paths register identical geometry.
-        let clampedRadius = min(radius, authManager.maximumRegionMonitoringDistance)
-
-        // The device's ACTUAL state seeds both CLMonitor's `assuming:` hint and the stored baseline
-        // (see `recordMonitorRegistration`: registration stays silent, the first real crossing
-        // delivers). No fix → geometric expectation: trigger is device-centered (inside),
-        // business geofences outside.
-        let isMovementTrigger = identifier == GeofenceConstants.movementTriggerIdentifier
-        let isInside = isDeviceInside(center: coordinate, radius: clampedRadius) ?? isMovementTrigger
-        let initialTransition: GeofenceTransition = isInside ? .enter : .exit
-        let assumedState: CLMonitor.Event.State = isInside ? .satisfied : .unsatisfied
-
-        enqueueMonitorOperation { [weak self] monitor in
-            guard let self else { return }
-            // Persist before the OS add: storage keys off recorded geometry to preserve the baseline
-            // on an unchanged re-register and reseed on a new/changed circle. The decision lives in
-            // storage because this runs after stop-all, when CLMonitor's own record is already gone.
-            await self.storage.recordMonitorRegistration(
-                identifier: identifier,
-                transitionTypes: transitionTypes,
-                initialState: initialTransition,
-                center: LocationData(latitude: coordinate.latitude, longitude: coordinate.longitude),
-                radius: clampedRadius
-            )
-            let condition = CLMonitor.CircularGeographicCondition(center: coordinate, radius: clampedRadius)
-            await monitor.add(condition, identifier: identifier, assuming: assumedState)
-            self.knownConditionIdentifiers.insert(identifier)
-            self.persistConditionMirror()
-        }
-    }
-
-    func stopMonitoring(identifier: String) {
-        guard ownedRegionIdentifiers.remove(identifier) != nil else { return }
-        // The storage record intentionally survives removal: a stop-all + re-register cycle relies
-        // on the persisted baseline to suppress CLMonitor's re-evaluation of an unchanged state.
-        enqueueMonitorOperation { [weak self] monitor in
-            guard let self else { return }
-            await monitor.remove(identifier)
-            self.knownConditionIdentifiers.remove(identifier)
-            self.persistConditionMirror()
-        }
-    }
-
-    func stopMonitoringAll() {
-        ownedRegionIdentifiers.removeAll()
-        // Clear against CLMonitor's LIVE identifiers, not the owned/mirror snapshot: an empty owned
-        // set or a lossy mirror must not leave a stale SDK condition holding an OS slot.
-        enqueueMonitorOperation { [weak self] monitor in
-            guard let self else { return }
-            for identifier in await monitor.identifiers {
-                await monitor.remove(identifier)
-            }
-            self.knownConditionIdentifiers.removeAll()
-            self.persistConditionMirror()
-        }
     }
 
     func reportPermissionTier() {
@@ -364,7 +305,7 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
 
     // MARK: - Private
 
-    private func persistConditionMirror() {
+    func persistConditionMirror() {
         userDefaults.set(knownConditionIdentifiers.sorted(), forKey: Self.conditionMirrorKey)
     }
 
@@ -379,7 +320,7 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
 
     /// Whether the device is inside the circle per the last known location; `nil` without a usable
     /// fix. No accuracy padding: a wrong guess costs one corrective event, absorbed by the baseline.
-    private func isDeviceInside(center: CLLocationCoordinate2D, radius: CLLocationDistance) -> Bool? {
+    func isDeviceInside(center: CLLocationCoordinate2D, radius: CLLocationDistance) -> Bool? {
         guard let location = authManager.location,
               CLLocationCoordinate2DIsValid(location.coordinate)
         else {

--- a/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
@@ -112,6 +112,51 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
         }
     }
 
+    @discardableResult
+    func setMonitoredRegions(_ regions: [GeofenceRegionRequest]) -> GeofenceRegionDiff {
+        let desiredIdentifiers = Set(regions.map(\.identifier))
+        var removed: Set<String> = []
+        for identifier in ownedRegionIdentifiers.subtracting(desiredIdentifiers) {
+            stopMonitoring(identifier: identifier)
+            removed.insert(identifier)
+        }
+        var added: Set<String> = []
+        for region in regions where !isRegisteredUnchanged(region) {
+            // Explicit stop before start (no-op when unowned): `startMonitoring(for:)` replaces by
+            // identifier, but the pair keeps the OS-side sequence identical on both monitors.
+            stopMonitoring(identifier: region.identifier)
+            startMonitoring(
+                identifier: region.identifier,
+                center: region.center,
+                radius: region.radius,
+                transitionTypes: region.transitionTypes
+            )
+            // Blocked permission / invalid coordinates make `startMonitoring` a no-op; the caller's
+            // initial-enter decision must not count a region the OS never took.
+            if ownedRegionIdentifiers.contains(region.identifier) { added.insert(region.identifier) }
+        }
+        return GeofenceRegionDiff(added: added, removed: removed)
+    }
+
+    /// True when this monitor owns the region and the OS holds an identical circle, so re-registering
+    /// would only risk absorbing an undelivered crossing. Geometry comes from the live
+    /// `CLCircularRegion` rather than our own bookkeeping, so a region the OS reshaped or dropped
+    /// re-registers rather than being trusted.
+    private func isRegisteredUnchanged(_ region: GeofenceRegionRequest) -> Bool {
+        guard ownedRegionIdentifiers.contains(region.identifier),
+              let existing = manager.monitoredRegions.first(where: { $0.identifier == region.identifier }) as? CLCircularRegion
+        else { return false }
+        var registeredTypes: Set<GeofenceTransition> = []
+        if existing.notifyOnEntry { registeredTypes.insert(.enter) }
+        if existing.notifyOnExit { registeredTypes.insert(.exit) }
+        return region.matchesRegistered(
+            center: LocationData(latitude: existing.center.latitude, longitude: existing.center.longitude),
+            radius: existing.radius,
+            transitionTypes: registeredTypes,
+            clampedTo: manager.maximumRegionMonitoringDistance
+        )
+    }
+
     // MARK: - CLLocationManagerDelegate
 
     func locationManager(_ manager: CLLocationManager, didEnterRegion region: CLRegion) {

--- a/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
@@ -60,7 +60,7 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
         Set(manager.monitoredRegions.map(\.identifier))
     }
 
-    func adoptExistingRegions(matching identifiers: Set<String>) {
+    func adoptExistingRegions(matching identifiers: Set<String>, records _: [String: MonitorRegionRecord]) {
         let adopted = identifiers.intersection(osMonitoredRegionIdentifiers)
         guard !adopted.isEmpty else { return }
         ownedRegionIdentifiers.formUnion(adopted)

--- a/Sources/LocationGeofence/Monitor/GeofenceRegionMonitoring.swift
+++ b/Sources/LocationGeofence/Monitor/GeofenceRegionMonitoring.swift
@@ -121,10 +121,14 @@ protocol GeofenceRegionMonitoring: AnyObject, Sendable {
 
     /// Re-claims the OS-persisted regions whose identifiers are in `identifiers` as owned by this
     /// monitor, restoring transition recognition on a fresh process where the OS kept monitoring
-    /// but the in-memory ownership set was lost. Adoption must not emit events for unchanged
-    /// regions; the OS-side mechanism is implementation-specific (the classic monitor adopts in
-    /// place, the CLMonitor path re-arms each condition — see `rearmConditions`).
-    func adoptExistingRegions(matching identifiers: Set<String>)
+    /// but the in-memory ownership set was lost. `records` is the persisted per-condition
+    /// bookkeeping (`GeofenceStorage.getMonitorRegionRecords`); the CLMonitor path seeds its
+    /// geometry map from it synchronously, so a sync arriving before the queued re-arm drains
+    /// reads adopted regions as unchanged instead of re-registering them all. Adoption must not
+    /// emit events for unchanged regions; the OS-side mechanism is implementation-specific (the
+    /// classic monitor adopts in place and ignores `records`, the CLMonitor path re-arms each
+    /// condition — see `rearmConditions`).
+    func adoptExistingRegions(matching identifiers: Set<String>, records: [String: MonitorRegionRecord])
 
     /// Logs the current authorization tier (background delivery / foreground only / blocked),
     /// deduped so it emits only when the tier changes since the last report.

--- a/Sources/LocationGeofence/Monitor/GeofenceRegionMonitoring.swift
+++ b/Sources/LocationGeofence/Monitor/GeofenceRegionMonitoring.swift
@@ -19,6 +19,43 @@ typealias GeofenceAuthorizationChangedHandler = @MainActor () -> Void
 /// Invoked on the main actor.
 typealias GeofenceReconciledHandler = @MainActor () -> Void
 
+/// A circular region the caller wants monitored, as handed to `setMonitoredRegions`.
+struct GeofenceRegionRequest: Equatable, Sendable {
+    let identifier: String
+    let center: LocationData
+    let radius: Double
+    let transitionTypes: Set<GeofenceTransition>
+}
+
+extension GeofenceRegionRequest {
+    /// Latitude/longitude slack, ~1cm. Absorbs float round-tripping through CoreLocation and JSON.
+    private static let coordinateTolerance = 1e-7
+    /// Radius slack in meters.
+    private static let radiusTolerance = 0.5
+
+    /// Whether an already-registered circle matches this request closely enough to leave alone.
+    /// Compares against the radius the OS would actually hold, so a fence larger than the cap
+    /// doesn't read as "changed" on every pass and churn forever.
+    func matchesRegistered(
+        center: LocationData,
+        radius: Double,
+        transitionTypes: Set<GeofenceTransition>,
+        clampedTo maximumRadius: Double
+    ) -> Bool {
+        abs(center.latitude - self.center.latitude) < Self.coordinateTolerance
+            && abs(center.longitude - self.center.longitude) < Self.coordinateTolerance
+            && abs(radius - min(self.radius, maximumRadius)) < Self.radiusTolerance
+            && transitionTypes == self.transitionTypes
+    }
+}
+
+/// What `setMonitoredRegions` changed. Everything in the desired set that isn't listed here was
+/// already registered with the same circle and was left untouched — the point of the call.
+struct GeofenceRegionDiff: Equatable, Sendable {
+    let added: Set<String>
+    let removed: Set<String>
+}
+
 /// Abstracts CLLocationManager's region monitoring.
 ///
 /// The monitor owns a CLLocationManager and handles the delegate callbacks for region events.
@@ -54,6 +91,16 @@ protocol GeofenceRegionMonitoring: AnyObject, Sendable {
 
     /// Stops monitoring the region with the given identifier.
     func stopMonitoring(identifier: String)
+
+    /// Reconciles the monitored set to exactly `regions`: stops what is no longer wanted, starts
+    /// what is new or whose circle changed, and leaves everything else registered as-is.
+    ///
+    /// Leaving unchanged regions untouched is part of the contract, not an optimization: stopping
+    /// and re-adding a region discards any boundary crossing the OS has detected but not yet
+    /// delivered, and neither monitor replays it. Implementations must not re-register a region
+    /// whose circle is unchanged.
+    @discardableResult
+    func setMonitoredRegions(_ regions: [GeofenceRegionRequest]) -> GeofenceRegionDiff
 
     /// Stops monitoring all regions managed by this monitor.
     func stopMonitoringAll()

--- a/Sources/LocationGeofence/Storage/GeofenceStorage.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage.swift
@@ -158,6 +158,16 @@ actor GeofenceStorage {
         loadFromDisk()?.monitorRegionRecords ?? [:]
     }
 
+    /// Drops the baseline for a condition the OS stopped monitoring, so the next registration
+    /// reseeds from the device's real position rather than carrying a state it may have left while
+    /// unmonitored — an unchanged-geometry re-register would preserve that stale value.
+    func clearMonitorRegionRecord(identifier: String) {
+        var state = loadFromDisk() ?? GeofenceState()
+        guard var records = state.monitorRegionRecords, records.removeValue(forKey: identifier) != nil else { return }
+        state.monitorRegionRecords = records
+        saveToDisk(state)
+    }
+
     /// Clears the cooldown map, last-sync record, registration set, and monitor baselines but
     /// preserves the cached geofences and config. Called on sign-out: the workspace cache is shared
     /// across users, while cooldowns belong to the signed-out user and the last-sync anchor would

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -522,7 +522,7 @@ struct GeofenceSyncCoordinatorTests {
     }
 
     @Test
-    func refresh_givenSuccess_expectRegistrationOrderStopAllThenTriggerThenBusiness() async {
+    func refresh_givenSuccess_expectMovementTriggerRegisteredBeforeBusinessRegions() async {
         let storage = makeStorage()
         let api = GeofenceApiServiceMock()
         let region = makeRegion(id: "g1", latitude: 1.0, longitude: 2.0)
@@ -533,10 +533,9 @@ struct GeofenceSyncCoordinatorTests {
         let setup = makeCoordinator(api: api, storage: storage)
         _ = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
 
-        // Verify operations arrived in `stopAll → start movement → start business` order — the
-        // trigger goes first so it isn't starved when business regions fill the shared OS budget.
+        // The trigger goes first so it isn't starved when business regions fill the shared OS budget.
+        // Nothing was registered before, so nothing is stopped.
         #expect(setup.monitor.operationLog == [
-            .stopAll,
             .start(identifier: GeofenceConstants.movementTriggerIdentifier),
             .start(identifier: "g1")
         ])
@@ -1233,9 +1232,9 @@ struct GeofenceSyncCoordinatorTests {
 
     // MARK: unchanged-set fast path (crossing absorption)
 
-    /// Shared arrangement for the fast-path tests: an initial remote refresh registers `regions`
-    /// (wholesale, stopAll #1), so the monitor owns them and the OS holds them — the steady state
-    /// every subsequent re-rank runs against.
+    /// Shared arrangement for the registration-diff tests: an initial remote refresh registers
+    /// `regions`, so the monitor owns them and the OS holds them — the steady state every
+    /// subsequent re-rank runs against.
     private func makeRegisteredSetup(
         regions: [Geofence],
         config: GeofenceConfig,
@@ -1250,7 +1249,7 @@ struct GeofenceSyncCoordinatorTests {
         return setup
     }
 
-    private var fastPathConfig: GeofenceConfig {
+    private var diffConfig: GeofenceConfig {
         GeofenceConfig(
             localRefreshTriggerRadius: 1000,
             remoteFetchRefreshTriggerRadius: 5000,
@@ -1268,14 +1267,14 @@ struct GeofenceSyncCoordinatorTests {
         // business regions must be left alone — only the trigger re-centers and the ranking anchor walks.
         let region = makeRegion(id: "g1", latitude: 0.5, longitude: 0.5)
         let storage = makeStorage()
-        let setup = await makeRegisteredSetup(regions: [region], config: fastPathConfig, storage: storage)
+        let setup = await makeRegisteredSetup(regions: [region], config: diffConfig, storage: storage)
 
         // ~111 m: within the refetch radius → local re-rank, same nearest set.
         let newLocation = LocationData(latitude: 0, longitude: 0.001)
         let result = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude)
 
         #expect(result.isSuccess)
-        #expect(setup.monitor.stopAllCallCount == 1) // the initial registration only
+        #expect(setup.monitor.stopAllCallCount == 0)
         #expect(setup.monitor.startedRegions.filter { $0.identifier == "g1" }.count == 1) // never re-added
         #expect(setup.monitor.stoppedIdentifiers == [GeofenceConstants.movementTriggerIdentifier])
         let triggerStarts = setup.monitor.startedRegions.filter { $0.identifier == GeofenceConstants.movementTriggerIdentifier }
@@ -1285,13 +1284,12 @@ struct GeofenceSyncCoordinatorTests {
     }
 
     @Test
-    func handleMovement_givenEmptyAreaThenKillSwitch_expectTeardownNotTriggerRecenter() async {
-        // The one state where the ids match but skipping would be wrong: a geofence-free area leaves
-        // the trigger armed with no business regions, so a later kill-switched config re-ranks onto
-        // the same (empty) set while the trigger is still owned. Skipping there would re-center a
-        // trigger the kill switch is supposed to remove.
+    func handleMovement_givenEmptyAreaThenKillSwitch_expectTriggerStopped() async {
+        // A geofence-free area leaves the trigger armed with no business regions, so a later
+        // kill-switched config re-ranks onto the same (empty) business set. The desired set is empty
+        // too, so the diff must stop the trigger rather than re-center it.
         let storage = makeStorage()
-        let setup = await makeRegisteredSetup(regions: [], config: fastPathConfig, storage: storage)
+        let setup = await makeRegisteredSetup(regions: [], config: diffConfig, storage: storage)
         #expect(setup.monitor.monitoredRegionIdentifiers == [GeofenceConstants.movementTriggerIdentifier])
 
         await storage.setCachedConfig(GeofenceConfig(
@@ -1306,14 +1304,14 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
 
         #expect(result.isSuccess)
-        #expect(setup.monitor.stopAllCallCount == 2) // wholesale teardown ran, not the fast path
+        #expect(setup.monitor.stoppedIdentifiers == [GeofenceConstants.movementTriggerIdentifier])
         #expect(setup.monitor.monitoredRegionIdentifiers.isEmpty)
     }
 
     @Test
-    func handleMovement_givenRerankChangesNearestSet_expectFullReregistration() async {
-        // Membership actually changed (budget of 1, a closer fence took the slot) — the wholesale
-        // path must run so the OS set matches the new ranking.
+    func handleMovement_givenRerankChangesNearestSet_expectOnlyDepartingRegionStopped() async {
+        // Membership actually changed (budget of 1, a closer fence took the slot) — the departing
+        // region is stopped and the arriving one started, so the OS set matches the new ranking.
         let config = GeofenceConfig(
             localRefreshTriggerRadius: 1000,
             remoteFetchRefreshTriggerRadius: 5000,
@@ -1330,33 +1328,116 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.02)
 
         #expect(result.isSuccess)
-        #expect(setup.monitor.stopAllCallCount == 2)
+        #expect(setup.monitor.stopAllCallCount == 0)
         #expect(setup.monitor.startedRegions.contains { $0.identifier == "near-end" })
+        #expect(setup.monitor.stoppedIdentifiers.contains("near-start"))
+        #expect(setup.monitor.monitoredRegionIdentifiers == ["near-end", GeofenceConstants.movementTriggerIdentifier])
     }
 
     @Test
-    func handleMovement_givenUnchangedSetButOsDroppedRegion_expectFullReregistration() async {
-        // The set compare alone would skip, but the OS silently dropped a region (monitoring
-        // failure). Wholesale re-registration is what heals that — the fast path must step aside.
+    func handleMovement_givenSetChanges_expectCarryOverRegionLeftRegistered() async {
+        // A re-rank that changes membership must leave regions present in both sets completely
+        // untouched: stopping and re-adding one discards any crossing the OS has detected but not
+        // yet delivered, and neither monitor replays it.
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 5000,
+            remoteFetchRefreshExpiry: 3600,
+            duplicateEventsExpiry: 3600,
+            maxBusinessGeofences: 2,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
+        )
+        let carry = makeRegion(id: "carry", latitude: 0, longitude: 0.001)
+        let leaves = makeRegion(id: "leaves", latitude: 0, longitude: -0.002)
+        let joins = makeRegion(id: "joins", latitude: 0, longitude: 0.021)
+        let setup = await makeRegisteredSetup(regions: [carry, leaves, joins], config: config, storage: makeStorage())
+        #expect(setup.monitor.monitoredRegionIdentifiers == ["carry", "leaves", GeofenceConstants.movementTriggerIdentifier])
+
+        // ~2.2 km east: local re-rank. `joins` takes the slot `leaves` gives up; `carry` stays.
+        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.02)
+
+        #expect(result.isSuccess)
+        #expect(setup.monitor.monitoredRegionIdentifiers == ["carry", "joins", GeofenceConstants.movementTriggerIdentifier])
+        #expect(!setup.monitor.stoppedIdentifiers.contains("carry"))
+        #expect(setup.monitor.startedRegions.filter { $0.identifier == "carry" }.count == 1)
+        #expect(setup.monitor.stoppedIdentifiers.contains("leaves"))
+        #expect(setup.monitor.startedRegions.contains { $0.identifier == "joins" })
+    }
+
+    @Test
+    func handleMovement_givenRadiusAboveOsCap_expectNoReRegistrationChurn() async {
+        // The OS clamps every radius to `maximumMonitoringRadius`. The unchanged check must compare
+        // against that clamped radius, or an over-cap region reads as changed on every pass and
+        // re-registers forever.
+        let monitor = MockGeofenceRegionMonitor()
+        monitor.maximumMonitoringRadius = 500
+        let storage = makeStorage()
+        let api = GeofenceApiServiceMock()
+        let region = makeRegion(id: "wide", latitude: 0, longitude: 0.001, radius: 2000)
+        api.fetchNearbyGeofencesClosure = { _, _, completion in
+            completion(.success(makeApiResponse(regions: [region], config: diffConfig)))
+        }
+        let setup = makeCoordinator(api: api, storage: storage, monitor: monitor)
+        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+
+        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
+
+        #expect(result.isSuccess)
+        #expect(!setup.monitor.stoppedIdentifiers.contains("wide"))
+        #expect(setup.monitor.startedRegions.filter { $0.identifier == "wide" }.count == 1)
+    }
+
+    @Test
+    func handleMovement_givenUnchangedSetButOsDroppedRegion_expectRegionReRegistered() async {
+        // The identifier is still owned in-process but the OS silently dropped it (monitoring
+        // failure). The diff must not trust ownership alone — re-registering is what heals it.
         let region = makeRegion(id: "g1", latitude: 0.5, longitude: 0.5)
-        let setup = await makeRegisteredSetup(regions: [region], config: fastPathConfig, storage: makeStorage())
+        let setup = await makeRegisteredSetup(regions: [region], config: diffConfig, storage: makeStorage())
         setup.monitor.osMonitoredRegions.remove("g1")
 
         let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
 
         #expect(result.isSuccess)
-        #expect(setup.monitor.stopAllCallCount == 2)
+        #expect(setup.monitor.stopAllCallCount == 0)
         #expect(setup.monitor.startedRegions.filter { $0.identifier == "g1" }.count == 2)
     }
 
     @Test
-    func refresh_givenFreshProcessWithMatchingStorage_expectFullReregistration() async {
-        // Fresh process: storage says the same set is registered and the OS still holds it, but this
-        // process owns nothing yet (bootstrap hasn't adopted). Skipping would leave OS events with no
-        // owner — the wholesale path must run to re-establish in-process ownership.
+    func refresh_givenFreshProcessAndReshapedRegionOsStillHolds_expectOsGeometryUpdated() async {
+        // Fresh process owning nothing, OS still holding `g1` from the previous launch on its old
+        // circle, and the server has since reshaped it. CLMonitor silently ignores an add over a
+        // live identifier, so without an explicit removal the OS keeps the old circle while this
+        // process records the new one — every later pass then reads "unchanged" and never repairs
+        // it. The stale circle would outlive the process indefinitely.
         let storage = makeStorage()
         let dateUtil = DateUtilStub()
-        await storage.setCachedConfig(fastPathConfig)
+        await storage.setCachedConfig(diffConfig)
+        await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-100), location: LocationData(latitude: 0, longitude: 0))
+        await storage.recordRegistration(center: LocationData(latitude: 0, longitude: 0), businessIds: ["g1"])
+        await storage.setCachedGeofences([makeRegion(id: "g1", latitude: 0.5, longitude: 0.5, radius: 750)])
+        let setup = makeCoordinator(storage: storage, dateUtil: dateUtil)
+        setup.monitor.osMonitoredRegions = [GeofenceConstants.movementTriggerIdentifier]
+        setup.monitor.seedOsHeldRegion(
+            identifier: "g1",
+            center: LocationData(latitude: 0.5, longitude: 0.5),
+            radius: 100, // the OLD circle
+            transitionTypes: [.enter, .exit]
+        )
+
+        let result = await setup.coordinator.refresh(latitude: 0.02, longitude: 0)
+
+        #expect(result.isSuccess)
+        #expect(setup.monitor.osGeometry(for: "g1")?.radius == 750)
+    }
+
+    @Test
+    func refresh_givenFreshProcessWithMatchingStorage_expectRegionsRegistered() async {
+        // Fresh process: storage says the same set is registered and the OS still holds it, but this
+        // process owns nothing yet (bootstrap hasn't adopted). Skipping would leave OS events with no
+        // owner — everything must be registered to re-establish in-process ownership.
+        let storage = makeStorage()
+        let dateUtil = DateUtilStub()
+        await storage.setCachedConfig(diffConfig)
         await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-100), location: LocationData(latitude: 0, longitude: 0))
         await storage.recordRegistration(center: LocationData(latitude: 0, longitude: 0), businessIds: ["g1"])
         await storage.setCachedGeofences([makeRegion(id: "g1", latitude: 0.5, longitude: 0.5)])
@@ -1367,8 +1448,9 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.refresh(latitude: 0.02, longitude: 0)
 
         #expect(result.isSuccess)
-        #expect(setup.monitor.stopAllCallCount == 1)
+        #expect(setup.monitor.stopAllCallCount == 0)
         #expect(setup.monitor.startedRegions.contains { $0.identifier == "g1" })
+        #expect(setup.monitor.monitoredRegionIdentifiers == ["g1", GeofenceConstants.movementTriggerIdentifier])
     }
 
     @Test
@@ -1378,7 +1460,7 @@ struct GeofenceSyncCoordinatorTests {
         // walk forward so the next refetch threshold measures from here.
         let region = makeRegion(id: "g1", latitude: 0.5, longitude: 0.5)
         let storage = makeStorage()
-        let setup = await makeRegisteredSetup(regions: [region], config: fastPathConfig, storage: storage)
+        let setup = await makeRegisteredSetup(regions: [region], config: diffConfig, storage: storage)
 
         // ~5.5 km from the fetch anchor → remote tier.
         let newLocation = LocationData(latitude: 0, longitude: 0.05)
@@ -1386,7 +1468,7 @@ struct GeofenceSyncCoordinatorTests {
 
         #expect(result.isSuccess)
         #expect(setup.api.fetchNearbyGeofencesCallsCount == 2)
-        #expect(setup.monitor.stopAllCallCount == 1)
+        #expect(setup.monitor.stopAllCallCount == 0)
         #expect(setup.monitor.startedRegions.filter { $0.identifier == "g1" }.count == 1)
         let triggerStarts = setup.monitor.startedRegions.filter { $0.identifier == GeofenceConstants.movementTriggerIdentifier }
         #expect(triggerStarts.last?.center == newLocation)
@@ -1395,12 +1477,12 @@ struct GeofenceSyncCoordinatorTests {
     }
 
     @Test
-    func handleMovement_givenRemoteRefreshChangesGeometry_expectFullReregistration() async {
-        // Same ids, but the server edited the fence (radius change bumps `lastUpdated`/geometry) —
-        // wholesale re-registration is what applies the new circle to the OS.
+    func handleMovement_givenRemoteRefreshChangesGeometry_expectRegionReRegistered() async {
+        // Same id, but the server edited the fence (radius change) — the geometry compare must catch
+        // it and re-register, or the OS keeps monitoring the old circle forever.
         let original = makeRegion(id: "g1", latitude: 0.5, longitude: 0.5, radius: 100)
         let resized = makeRegion(id: "g1", latitude: 0.5, longitude: 0.5, radius: 250)
-        let config = fastPathConfig
+        let config = diffConfig
         let api = GeofenceApiServiceMock()
         var responses = [[original], [resized]]
         api.fetchNearbyGeofencesClosure = { _, _, completion in
@@ -1412,7 +1494,7 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.05)
 
         #expect(result.isSuccess)
-        #expect(setup.monitor.stopAllCallCount == 2)
+        #expect(setup.monitor.stoppedIdentifiers.contains("g1"))
         #expect(setup.monitor.startedRegions.last { $0.identifier == "g1" }?.radius == 250)
     }
 
@@ -1420,14 +1502,14 @@ struct GeofenceSyncCoordinatorTests {
     func handleMovement_givenEmptyAreaLoop_expectTriggerWalksWithoutChurn() async {
         // The geofence-free corridor: empty response, empty cache, trigger armed. Every 5 km refetch
         // comes back empty again — the trigger must keep walking forward without a stop-all cycle.
-        let setup = await makeRegisteredSetup(regions: [], config: fastPathConfig, storage: makeStorage())
+        let setup = await makeRegisteredSetup(regions: [], config: diffConfig, storage: makeStorage())
 
         let newLocation = LocationData(latitude: 0, longitude: 0.05)
         let result = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude)
 
         #expect(result.isSuccess)
         #expect(setup.api.fetchNearbyGeofencesCallsCount == 2)
-        #expect(setup.monitor.stopAllCallCount == 1)
+        #expect(setup.monitor.stopAllCallCount == 0)
         let triggerStarts = setup.monitor.startedRegions.filter { $0.identifier == GeofenceConstants.movementTriggerIdentifier }
         #expect(triggerStarts.count == 2)
         #expect(triggerStarts.last?.center == newLocation)
@@ -1799,9 +1881,10 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.refresh(latitude: 0, longitude: 0)
 
         #expect(result.isSuccess)
-        // Cleanup ran: monitoring stopped again (register + cleanup = 2), user-scoped state cleared,
-        // and no initial enters for the signed-out user.
-        #expect(setup.monitor.stopAllCallCount == 2)
+        // Cleanup ran: monitoring torn down wholesale, user-scoped state cleared, and no initial
+        // enters for the signed-out user.
+        #expect(setup.monitor.stopAllCallCount == 1)
+        #expect(setup.monitor.monitoredRegionIdentifiers.isEmpty)
         #expect(await backing.getRegisteredBusinessIds().isEmpty)
         #expect(await backing.getLastSync() == nil)
         #expect(setup.emitter.calls.wrappedValue.isEmpty)

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -1403,6 +1403,30 @@ struct GeofenceSyncCoordinatorTests {
     }
 
     @Test
+    func refresh_givenOsHoldsUnownedRegionNoLongerNearest_expectSweptFromOs() async {
+        // A condition the OS still holds from a previous launch that this process never adopted and
+        // the server no longer returns. Ownership-based teardown can't see it, so only the sweep
+        // against live OS state removes it — otherwise it keeps one of the 20 slots indefinitely.
+        let storage = makeStorage()
+        let dateUtil = DateUtilStub()
+        await storage.setCachedConfig(diffConfig)
+        await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-100), location: LocationData(latitude: 0, longitude: 0))
+        await storage.setCachedGeofences([makeRegion(id: "g1", latitude: 0.001, longitude: 0, radius: 500)])
+        let setup = makeCoordinator(storage: storage, dateUtil: dateUtil)
+        setup.monitor.seedOsHeldRegion(
+            identifier: "stranded",
+            center: LocationData(latitude: 5, longitude: 5),
+            radius: 300,
+            transitionTypes: [.enter, .exit]
+        )
+
+        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+
+        #expect(!setup.monitor.osMonitoredRegions.contains("stranded"))
+        #expect(setup.monitor.osMonitoredRegions.contains("g1"))
+    }
+
+    @Test
     func refresh_givenFreshProcessAndReshapedRegionOsStillHolds_expectOsGeometryUpdated() async {
         // Fresh process owning nothing, OS still holding `g1` from the previous launch on its old
         // circle, and the server has since reshaped it. CLMonitor silently ignores an add over a
@@ -1806,6 +1830,34 @@ struct GeofenceSyncCoordinatorTests {
         // this is non-vacuous.
         await awaitEmits(setup.emitter, count: 0)
         #expect(setup.emitter.calls.wrappedValue.isEmpty)
+    }
+
+    @Test
+    func handleMovement_givenRegisteredRegionReshapedThenRejected_expectNoLongerReportedRegistered() async {
+        // A region already registered gets reshaped, and the monitor now rejects it (permission
+        // revoked, or the backend moved it to invalid coordinates). The stale claim must go with
+        // the failed re-registration — otherwise it keeps counting toward the registered set and
+        // `emitInitialEnters` can fire an enter for a region the OS is not monitoring.
+        let storage = makeStorage()
+        let dateUtil = DateUtilStub()
+        await storage.setCachedConfig(diffConfig)
+        await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-100), location: LocationData(latitude: 0, longitude: 0))
+        await storage.setCachedGeofences([makeRegion(id: "g1", latitude: 0.001, longitude: 0, radius: 500)])
+        let setup = makeCoordinator(storage: storage, dateUtil: dateUtil)
+
+        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+        #expect(setup.monitor.monitoredRegionIdentifiers.contains("g1"))
+
+        // Same id, different circle, and the monitor now refuses it.
+        await storage.setCachedGeofences([makeRegion(id: "g1", latitude: 0.001, longitude: 0, radius: 900)])
+        setup.monitor.rejectedIdentifiers = ["g1"]
+        _ = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
+
+        #expect(!setup.monitor.monitoredRegionIdentifiers.contains("g1"))
+        // And the circle it held before the refused reshape is gone from the OS, not left occupying
+        // one of the 20 slots with nothing owning it and no later pass repairing it.
+        #expect(!setup.monitor.osMonitoredRegions.contains("g1"))
+        #expect(setup.monitor.osGeometry(for: "g1") == nil)
     }
 
     @Test

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -1427,6 +1427,38 @@ struct GeofenceSyncCoordinatorTests {
     }
 
     @Test
+    func refresh_givenAdoptedRegionsWithPersistedGeometry_expectUnchangedRegionLeftUntouched() async {
+        // Cold launch on the CLMonitor path: the OS still holds last session's condition and the
+        // persisted record carries its geometry, which adoption seeds synchronously. A sync landing
+        // before the queued re-arm drains must read the unchanged region as unchanged — re-adding
+        // it would absorb a crossing the OS has detected but not yet delivered.
+        let storage = makeStorage()
+        let dateUtil = DateUtilStub()
+        await storage.setCachedConfig(diffConfig)
+        await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-100), location: LocationData(latitude: 0, longitude: 0))
+        await storage.setCachedGeofences([makeRegion(id: "g1", latitude: 0.001, longitude: 0, radius: 500)])
+        let setup = makeCoordinator(storage: storage, dateUtil: dateUtil)
+        setup.monitor.osMonitoredRegions = ["g1"]
+        setup.monitor.adoptExistingRegions(
+            matching: ["g1"],
+            records: [
+                "g1": MonitorRegionRecord(
+                    lastState: .enter,
+                    transitionTypes: [.enter, .exit],
+                    center: LocationData(latitude: 0.001, longitude: 0),
+                    radius: 500
+                )
+            ]
+        )
+
+        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+
+        #expect(!setup.monitor.stoppedIdentifiers.contains("g1"))
+        #expect(setup.monitor.startedRegions.filter { $0.identifier == "g1" }.isEmpty)
+        #expect(setup.monitor.monitoredRegionIdentifiers.contains("g1"))
+    }
+
+    @Test
     func refresh_givenFreshProcessAndReshapedRegionOsStillHolds_expectOsGeometryUpdated() async {
         // Fresh process owning nothing, OS still holding `g1` from the previous launch on its old
         // circle, and the server has since reshaped it. CLMonitor silently ignores an add over a

--- a/Tests/LocationGeofence/Geofence/GeofenceBootstrapTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceBootstrapTests.swift
@@ -255,6 +255,51 @@ struct GeofenceBootstrapTests {
     }
 
     @Test
+    func wireMonitor_givenAdoptPath_expectPersistedMonitorRecordsHandedToAdopt() async {
+        // The CLMonitor path seeds its geometry bookkeeping from these records synchronously at
+        // adopt, so a sync landing before the queued re-arm drains reads carried-over regions as
+        // unchanged instead of re-registering them all.
+        let di = DIGraphShared.shared
+        let storage = GeofenceStorage(
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        await storage.setCachedGeofences([
+            Geofence(
+                id: "g1",
+                latitude: 1,
+                longitude: 2,
+                radius: 100,
+                name: "g1",
+                transitionTypes: [.enter],
+                lastUpdated: Date(timeIntervalSince1970: 0)
+            )
+        ])
+        await storage.recordRegistration(center: LocationData(latitude: 10, longitude: 20), businessIds: ["g1"])
+        await storage.recordMonitorRegistration(
+            identifier: "g1",
+            transitionTypes: [.enter],
+            initialState: .exit,
+            center: LocationData(latitude: 1, longitude: 2),
+            radius: 100
+        )
+        di.override(value: storage, forType: GeofenceStorage.self)
+        let monitor = MockGeofenceRegionMonitor()
+        monitor.osMonitoredRegions = ["g1", GeofenceConstants.movementTriggerIdentifier]
+        di.override(value: monitor as GeofenceRegionMonitoring, forType: GeofenceRegionMonitoring.self)
+        let coordinator = GeofenceSyncCoordinatorMock()
+        di.override(value: coordinator as GeofenceSyncCoordinator, forType: GeofenceSyncCoordinator.self)
+        defer { di.reset() }
+
+        await GeofenceBootstrap.wireMonitor(di: di)
+
+        #expect(monitor.adoptExistingRegionsCallsCount == 1)
+        let record = monitor.adoptedRecords["g1"]
+        #expect(record?.center == LocationData(latitude: 1, longitude: 2))
+        #expect(record?.radius == 100)
+        #expect(record?.lastState == .exit)
+    }
+
+    @Test
     func wireMonitor_givenOsAlsoMonitorsHostAppRegions_expectOnlyOwnRegionsAdopted() async {
         // CLLocationManager.monitoredRegions is app-wide. Adoption must claim only the SDK's own
         // regions (cached geofences + movement trigger), never the host app's.

--- a/Tests/LocationGeofence/Geofence/Monitor/GeofenceRegionRequestTests.swift
+++ b/Tests/LocationGeofence/Geofence/Monitor/GeofenceRegionRequestTests.swift
@@ -1,0 +1,141 @@
+@testable import CioInternalCommon
+@testable import CioLocationGeofence
+import Foundation
+import Testing
+
+/// `matchesRegistered` decides whether `setMonitoredRegions` leaves a region alone. A false positive
+/// keeps a stale circle registered; a false negative re-registers every pass and discards crossings
+/// the OS has detected but not yet delivered. Both monitors and the mock share this comparison, so
+/// it is tested here rather than through any one of them.
+@Suite("GeofenceRegionRequest.matchesRegistered")
+struct GeofenceRegionRequestTests {
+    private static let uncapped = Double.greatestFiniteMagnitude
+
+    private func makeRequest(
+        latitude: Double = 10,
+        longitude: Double = 20,
+        radius: Double = 100,
+        transitionTypes: Set<GeofenceTransition> = [.enter, .exit]
+    ) -> GeofenceRegionRequest {
+        GeofenceRegionRequest(
+            identifier: "region",
+            center: LocationData(latitude: latitude, longitude: longitude),
+            radius: radius,
+            transitionTypes: transitionTypes
+        )
+    }
+
+    @Test
+    func matchesRegistered_givenIdenticalCircle_expectMatch() {
+        let request = makeRequest()
+        #expect(request.matchesRegistered(
+            center: LocationData(latitude: 10, longitude: 20),
+            radius: 100,
+            transitionTypes: [.enter, .exit],
+            clampedTo: Self.uncapped
+        ))
+    }
+
+    @Test
+    func matchesRegistered_givenCoordinateDriftWithinTolerance_expectMatch() {
+        // Coordinates round-trip through CoreLocation and JSON; sub-centimetre drift is not a move.
+        let request = makeRequest()
+        #expect(request.matchesRegistered(
+            center: LocationData(latitude: 10 + 5e-8, longitude: 20 - 5e-8),
+            radius: 100,
+            transitionTypes: [.enter, .exit],
+            clampedTo: Self.uncapped
+        ))
+    }
+
+    @Test
+    func matchesRegistered_givenMovedCenter_expectNoMatch() {
+        let request = makeRequest()
+        #expect(!request.matchesRegistered(
+            center: LocationData(latitude: 10.001, longitude: 20),
+            radius: 100,
+            transitionTypes: [.enter, .exit],
+            clampedTo: Self.uncapped
+        ))
+    }
+
+    @Test
+    func matchesRegistered_givenRadiusDriftWithinTolerance_expectMatch() {
+        let request = makeRequest()
+        #expect(request.matchesRegistered(
+            center: LocationData(latitude: 10, longitude: 20),
+            radius: 100.2,
+            transitionTypes: [.enter, .exit],
+            clampedTo: Self.uncapped
+        ))
+    }
+
+    @Test
+    func matchesRegistered_givenResizedRadius_expectNoMatch() {
+        let request = makeRequest(radius: 100)
+        #expect(!request.matchesRegistered(
+            center: LocationData(latitude: 10, longitude: 20),
+            radius: 250,
+            transitionTypes: [.enter, .exit],
+            clampedTo: Self.uncapped
+        ))
+    }
+
+    @Test
+    func matchesRegistered_givenRadiusAboveCapAndRegisteredAtCap_expectMatch() {
+        // The OS clamps on registration. Comparing the requested radius against the clamped one it
+        // holds would mark every over-cap region changed on every pass and re-register it forever.
+        let request = makeRequest(radius: 5000)
+        #expect(request.matchesRegistered(
+            center: LocationData(latitude: 10, longitude: 20),
+            radius: 1000,
+            transitionTypes: [.enter, .exit],
+            clampedTo: 1000
+        ))
+    }
+
+    @Test
+    func matchesRegistered_givenRadiusAboveCapButRegisteredBelowCap_expectNoMatch() {
+        // Registered narrower than the cap allows: the OS is holding a circle we did not ask for.
+        let request = makeRequest(radius: 5000)
+        #expect(!request.matchesRegistered(
+            center: LocationData(latitude: 10, longitude: 20),
+            radius: 400,
+            transitionTypes: [.enter, .exit],
+            clampedTo: 1000
+        ))
+    }
+
+    @Test
+    func matchesRegistered_givenRadiusBelowCap_expectCapIgnored() {
+        let request = makeRequest(radius: 100)
+        #expect(request.matchesRegistered(
+            center: LocationData(latitude: 10, longitude: 20),
+            radius: 100,
+            transitionTypes: [.enter, .exit],
+            clampedTo: 1000
+        ))
+    }
+
+    @Test
+    func matchesRegistered_givenNarrowedTransitionTypes_expectNoMatch() {
+        let request = makeRequest(transitionTypes: [.enter, .exit])
+        #expect(!request.matchesRegistered(
+            center: LocationData(latitude: 10, longitude: 20),
+            radius: 100,
+            transitionTypes: [.enter],
+            clampedTo: Self.uncapped
+        ))
+    }
+
+    @Test
+    func matchesRegistered_givenDifferentSingleTransitionType_expectNoMatch() {
+        let request = makeRequest(transitionTypes: [.exit])
+        #expect(!request.matchesRegistered(
+            center: LocationData(latitude: 10, longitude: 20),
+            radius: 100,
+            transitionTypes: [.enter],
+            clampedTo: Self.uncapped
+        ))
+    }
+}

--- a/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
@@ -646,6 +646,37 @@ struct GeofenceStorageTests {
     }
 
     @Test
+    func clearMonitorRegionRecord_givenOsStoppedMonitoring_expectNextArrivalDelivered() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let center = LocationData(latitude: 10, longitude: 20)
+        await storage.recordMonitorRegistration(identifier: "geo_1", transitionTypes: [.enter, .exit], initialState: .exit, center: center, radius: 100)
+        #expect(await storage.recordMonitorEvent(.enter, forIdentifier: "geo_1") == .deliver)
+        // CLMonitor reports .unmonitored. The region is still in the desired set, so the registration
+        // prune keeps its record; without this clear, the device can leave while unmonitored and the
+        // unchanged-geometry re-register carries the stale .enter, dropping the next real arrival.
+        await storage.clearMonitorRegionRecord(identifier: "geo_1")
+        await storage.recordMonitorRegistration(identifier: "geo_1", transitionTypes: [.enter, .exit], initialState: .exit, center: center, radius: 100)
+        #expect(await storage.recordMonitorEvent(.enter, forIdentifier: "geo_1") == .deliver)
+    }
+
+    @Test
+    func clearMonitorRegionRecord_givenOtherRegions_expectOnlyTargetDropped() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let center = LocationData(latitude: 10, longitude: 20)
+        await storage.recordMonitorRegistration(identifier: "geo_1", transitionTypes: [.enter], initialState: .exit, center: center, radius: 100)
+        await storage.recordMonitorRegistration(identifier: "geo_2", transitionTypes: [.enter], initialState: .exit, center: center, radius: 100)
+        await storage.clearMonitorRegionRecord(identifier: "geo_1")
+        #expect(await storage.getMonitorRegionRecords().keys.sorted() == ["geo_2"])
+        // Clearing an identifier with no record must not disturb what is stored.
+        await storage.clearMonitorRegionRecord(identifier: "absent")
+        #expect(await storage.getMonitorRegionRecords().keys.sorted() == ["geo_2"])
+    }
+
+    @Test
     func recordMonitorEvent_givenUnregisteredTransitionType_expectRecordedNotDelivered() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }

--- a/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
+++ b/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
@@ -102,8 +102,16 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
     }
 
     func startMonitoring(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) {
-        // Mirror the real monitor's early return: a rejected id is neither recorded nor owned.
-        guard !rejectedIdentifiers.contains(identifier) else { return }
+        // Mirror the real monitors: a rejected id is neither recorded nor owned, and any circle the
+        // OS was already holding for it is cleared rather than left live.
+        guard !rejectedIdentifiers.contains(identifier) else {
+            if osMonitoredRegions.remove(identifier) != nil {
+                registeredGeometry.removeValue(forKey: identifier)
+                stoppedIdentifiers.append(identifier)
+                operationLog.append(.stop(identifier: identifier))
+            }
+            return
+        }
         // `startedRegions` keeps what the caller asked for; `registeredGeometry` keeps what the OS
         // would hold, which is what the unchanged check compares against.
         startedRegions.append(MonitoredRegionRecord(
@@ -112,18 +120,20 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
             radius: radius,
             transitionTypes: transitionTypes
         ))
-        // Models CLMonitor, the stricter of the two real monitors: an add over an identifier the OS
-        // already holds is silently ignored and the original circle survives (verified on-device).
-        // The classic monitor replaces instead, so a caller correct against this mock is correct
-        // against both.
-        if !osMonitoredRegions.contains(identifier) {
-            registeredGeometry[identifier] = MonitoredRegionRecord(
-                identifier: identifier,
-                center: center,
-                radius: min(radius, maximumMonitoringRadius),
-                transitionTypes: transitionTypes
-            )
+        // Models the real CLMonitor path: an add over an identifier the OS already holds is silently
+        // ignored and the original circle survives (verified on-device), so the monitor clears the
+        // identifier at the OS first. Modelled as the same remove-then-add pair. The classic monitor
+        // replaces by identifier, so a caller correct against this mock is correct against both.
+        if osMonitoredRegions.remove(identifier) != nil {
+            stoppedIdentifiers.append(identifier)
+            operationLog.append(.stop(identifier: identifier))
         }
+        registeredGeometry[identifier] = MonitoredRegionRecord(
+            identifier: identifier,
+            center: center,
+            radius: min(radius, maximumMonitoringRadius),
+            transitionTypes: transitionTypes
+        )
         activeIdentifiers.insert(identifier)
         // Mirror the real monitors: a successful add is reflected in the OS-persisted set too
         // (classic's `monitoredRegions`, CLMonitor's condition mirror).
@@ -161,18 +171,21 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
             stopMonitoring(identifier: identifier)
             removed.insert(identifier)
         }
+        // Mirror the CLMonitor path's sweep against live OS state, so a lossy mirror can't strand a
+        // condition on an OS slot. The classic monitor can't sweep — `CLLocationManager` shares
+        // `monitoredRegions` app-wide, so it would tear down the host app's regions.
+        for identifier in osMonitoredRegions.subtracting(desiredIdentifiers) {
+            osMonitoredRegions.remove(identifier)
+            registeredGeometry.removeValue(forKey: identifier)
+            stoppedIdentifiers.append(identifier)
+            operationLog.append(.stop(identifier: identifier))
+        }
         var added: Set<String> = []
         for region in regions where !isRegisteredUnchanged(region) {
-            // Same split as the real CLMonitor path: an unowned condition the OS still holds must
-            // be removed explicitly, or the add is ignored and the old circle survives.
-            if activeIdentifiers.contains(region.identifier) {
-                stopMonitoring(identifier: region.identifier)
-            } else if osMonitoredRegions.contains(region.identifier) {
-                osMonitoredRegions.remove(region.identifier)
-                registeredGeometry.removeValue(forKey: region.identifier)
-                stoppedIdentifiers.append(region.identifier)
-                operationLog.append(.stop(identifier: region.identifier))
-            }
+            // Mirror the real monitors: the previous claim is released before the re-registration,
+            // so one the monitor rejects stops counting as registered. Ownership only — what the OS
+            // holds (`osMonitoredRegions` / `registeredGeometry`) changes when the OS is told to.
+            activeIdentifiers.remove(region.identifier)
             startMonitoring(
                 identifier: region.identifier,
                 center: region.center,

--- a/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
+++ b/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
@@ -30,6 +30,9 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
     private(set) var stopAllCallCount = 0
     private(set) var operationLog: [MockMonitorOperation] = []
     private var activeIdentifiers: Set<String> = []
+    /// What each owned region is currently registered with — the mock's stand-in for the classic
+    /// monitor's live `CLCircularRegion` and CLMonitor's geometry mirror.
+    private var registeredGeometry: [String: MonitoredRegionRecord] = [:]
 
     /// Seedable OS-persisted set — tests set this to model regions the OS still monitors on a
     /// fresh process (where `activeIdentifiers`, the in-memory ownership filter, starts empty).
@@ -61,6 +64,24 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
         activeIdentifiers.formUnion(adopted)
     }
 
+    /// Models a condition the OS already holds that this process has NOT adopted — the state a
+    /// fresh launch is in before the bootstrap runs, and the one where an ignored add would leave
+    /// the OS on a stale circle.
+    func seedOsHeldRegion(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) {
+        registeredGeometry[identifier] = MonitoredRegionRecord(
+            identifier: identifier,
+            center: center,
+            radius: min(radius, maximumMonitoringRadius),
+            transitionTypes: transitionTypes
+        )
+        osMonitoredRegions.insert(identifier)
+    }
+
+    /// The circle the OS is holding, as opposed to what the caller last asked for.
+    func osGeometry(for identifier: String) -> MonitoredRegionRecord? {
+        registeredGeometry[identifier]
+    }
+
     func reportPermissionTier() {
         reportPermissionTierCallsCount += 1
     }
@@ -83,12 +104,26 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
     func startMonitoring(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) {
         // Mirror the real monitor's early return: a rejected id is neither recorded nor owned.
         guard !rejectedIdentifiers.contains(identifier) else { return }
+        // `startedRegions` keeps what the caller asked for; `registeredGeometry` keeps what the OS
+        // would hold, which is what the unchanged check compares against.
         startedRegions.append(MonitoredRegionRecord(
             identifier: identifier,
             center: center,
             radius: radius,
             transitionTypes: transitionTypes
         ))
+        // Models CLMonitor, the stricter of the two real monitors: an add over an identifier the OS
+        // already holds is silently ignored and the original circle survives (verified on-device).
+        // The classic monitor replaces instead, so a caller correct against this mock is correct
+        // against both.
+        if !osMonitoredRegions.contains(identifier) {
+            registeredGeometry[identifier] = MonitoredRegionRecord(
+                identifier: identifier,
+                center: center,
+                radius: min(radius, maximumMonitoringRadius),
+                transitionTypes: transitionTypes
+            )
+        }
         activeIdentifiers.insert(identifier)
         // Mirror the real monitors: a successful add is reflected in the OS-persisted set too
         // (classic's `monitoredRegions`, CLMonitor's condition mirror).
@@ -97,8 +132,11 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
     }
 
     func stopMonitoring(identifier: String) {
+        // Mirror both real monitors: stopping a region this process doesn't own is a no-op that
+        // never reaches the OS.
+        guard activeIdentifiers.remove(identifier) != nil else { return }
         stoppedIdentifiers.append(identifier)
-        activeIdentifiers.remove(identifier)
+        registeredGeometry.removeValue(forKey: identifier)
         osMonitoredRegions.remove(identifier)
         operationLog.append(.stop(identifier: identifier))
     }
@@ -109,7 +147,56 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
         // the OS still holds that this process never adopted survives the call.
         osMonitoredRegions.subtract(activeIdentifiers)
         activeIdentifiers.removeAll()
+        registeredGeometry.removeAll()
         operationLog.append(.stopAll)
+    }
+
+    /// Mirrors both real monitors: stop what left the set, skip what is registered with the same
+    /// circle, start the rest.
+    @discardableResult
+    func setMonitoredRegions(_ regions: [GeofenceRegionRequest]) -> GeofenceRegionDiff {
+        let desiredIdentifiers = Set(regions.map(\.identifier))
+        var removed: Set<String> = []
+        for identifier in activeIdentifiers.subtracting(desiredIdentifiers) {
+            stopMonitoring(identifier: identifier)
+            removed.insert(identifier)
+        }
+        var added: Set<String> = []
+        for region in regions where !isRegisteredUnchanged(region) {
+            // Same split as the real CLMonitor path: an unowned condition the OS still holds must
+            // be removed explicitly, or the add is ignored and the old circle survives.
+            if activeIdentifiers.contains(region.identifier) {
+                stopMonitoring(identifier: region.identifier)
+            } else if osMonitoredRegions.contains(region.identifier) {
+                osMonitoredRegions.remove(region.identifier)
+                registeredGeometry.removeValue(forKey: region.identifier)
+                stoppedIdentifiers.append(region.identifier)
+                operationLog.append(.stop(identifier: region.identifier))
+            }
+            startMonitoring(
+                identifier: region.identifier,
+                center: region.center,
+                radius: region.radius,
+                transitionTypes: region.transitionTypes
+            )
+            if activeIdentifiers.contains(region.identifier) { added.insert(region.identifier) }
+        }
+        return GeofenceRegionDiff(added: added, removed: removed)
+    }
+
+    private func isRegisteredUnchanged(_ region: GeofenceRegionRequest) -> Bool {
+        // Owned AND still held by the OS: both real monitors check the OS side too, so a region the
+        // OS dropped re-registers instead of being trusted.
+        guard activeIdentifiers.contains(region.identifier),
+              osMonitoredRegions.contains(region.identifier),
+              let existing = registeredGeometry[region.identifier]
+        else { return false }
+        return region.matchesRegistered(
+            center: existing.center,
+            radius: existing.radius,
+            transitionTypes: existing.transitionTypes,
+            clampedTo: maximumMonitoringRadius
+        )
     }
 
     func simulateTransition(identifier: String, transition: GeofenceTransition, location: LocationData?) {

--- a/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
+++ b/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
@@ -43,6 +43,7 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
     var rejectedIdentifiers: Set<String> = []
     private(set) var adoptExistingRegionsCallsCount = 0
     private(set) var adoptedIdentifiers: Set<String> = []
+    private(set) var adoptedRecords: [String: MonitorRegionRecord] = [:]
     private(set) var reportPermissionTierCallsCount = 0
 
     var monitoredRegionIdentifiers: Set<String> {
@@ -57,11 +58,26 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
         osMonitoredRegions
     }
 
-    func adoptExistingRegions(matching identifiers: Set<String>) {
+    func adoptExistingRegions(matching identifiers: Set<String>, records: [String: MonitorRegionRecord]) {
         adoptExistingRegionsCallsCount += 1
+        adoptedRecords = records
         let adopted = identifiers.intersection(osMonitoredRegions)
         adoptedIdentifiers.formUnion(adopted)
         activeIdentifiers.formUnion(adopted)
+        // Mirror the CLMonitor path: adoption seeds the geometry bookkeeping from the persisted
+        // records (stored post-clamp, used as-is), which the re-arm then imposes at the OS — so a
+        // sync right after adopt reads an unchanged region as unchanged instead of re-adding it.
+        for identifier in adopted {
+            guard let record = records[identifier],
+                  let center = record.center, let radius = record.radius
+            else { continue }
+            registeredGeometry[identifier] = MonitoredRegionRecord(
+                identifier: identifier,
+                center: center,
+                radius: radius,
+                transitionTypes: record.transitionTypes
+            )
+        }
     }
 
     /// Models a condition the OS already holds that this process has NOT adopted — the state a

--- a/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
+++ b/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
@@ -214,8 +214,10 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
     }
 
     private func isRegisteredUnchanged(_ region: GeofenceRegionRequest) -> Bool {
-        // Owned AND still held by the OS: both real monitors check the OS side too, so a region the
-        // OS dropped re-registers instead of being trusted.
+        // Owned AND still held by the OS. The OS-side check models the classic monitor's live
+        // `monitoredRegions` read; the CLMonitor path instead trusts its staged record, whose add
+        // is queued FIFO — in this synchronous mock staged and drained coincide, so one check
+        // matches both.
         guard activeIdentifiers.contains(region.identifier),
               osMonitoredRegions.contains(region.identifier),
               let existing = registeredGeometry[region.identifier]


### PR DESCRIPTION
### Summary

Region registration rebuilt the entire monitored set on every sync: stop everything, then re-add the new set. This replaces that with a diff — stop what left the set, start what is new or reshaped, leave carry-over regions registered as they are. An unchanged set now issues no OS calls at all.

This came out of continued real-world drive testing after 4.7.0, on routes long enough to exercise many sync cycles in the background. It brings iOS in line with how Android already registers regions.

### Why

Two behaviours trace back to the same root: the stop and the add are separate operations on an async pipeline, and nothing persists the intended set between them.

**Interrupted re-registration.** If the app is suspended part-way through the sequence, the OS is left holding fewer regions than intended. The movement trigger is re-registered in that same sequence, so the SDK cannot schedule its own wake to correct it; the set is restored on the next app run. On-device measurement: 3 of 17 re-registration cycles applied the removes without the adds.

**Transition loss on set change.** A boundary crossing the OS had detected but not yet delivered was discarded by the teardown. Since carry-over regions are no longer torn down, this window closes too.

Neither is reachable while the app is in the foreground, and neither leaves persistent state behind — the next sync reconciles.

### The change

`GeofenceRegionMonitoring` gains `setMonitoredRegions(_:)`, which takes the desired set and returns what it changed. The diff lives in the monitors rather than the coordinator so each compares against the geometry it actually registered, after the OS radius clamp — otherwise a region larger than the cap reads as "changed" on every pass and churns forever.

A reshaped region is removed before being re-added. On the `CLMonitor` path (iOS 18+) that ordering is required: `add` over an identifier that is already live keeps the original condition and reports no error, verified with a probe. The removal is keyed on what the OS holds rather than on what this process has adopted, so a condition adopted at launch is still repaired if its geometry changes.

What counts as unchanged is decided from this process's ownership plus the circle it recorded — deliberately not from the mirror of drained OS operations. That mirror only updates when a queued add finishes, so consulting it re-registers any region whose add is still in flight — staged either by a sync that landed before an earlier one's operations drained, or by the launch re-arm. That is the churn this PR exists to remove. Ownership and the recorded circle are sufficient because every path that records geometry also queues the matching OS add, and every path that invalidates the OS side clears one of the two synchronously.

Removed along the way:

- `canSkipReregistration` and the two unchanged-set fast paths — the degenerate case of the diff.
- `recenterMovementTrigger` — the trigger is now part of the same reconciliation.

The registration log line counts only the regions the monitor actually took, so one dropped for blocked permission or invalid coordinates is not reported as registered.

The launch re-arm, which re-adds adopted conditions at the OS, now records them in the condition mirror the way a normal registration does. It never did, so the mirror under-reported anything it revived; because the next process seeds ownership from that mirror, a cold-wake event for a revived condition was dropped. Until the unchanged check stopped consulting the mirror this was masked — the next sync re-registered those conditions and rewrote the mirror on the way through, which is precisely the churn being removed here.

### Validation

- Paired A/B drive on device, three unmodified control apps against one carrying this change. The three controls each lost their full region set once during the run and stayed empty until reopened; the app with the fix held all 7 regions through 10 sync cycles.
- Cold-wake path exercised on the same drive. On a cold process the registered-geometry map starts empty, so every region reads as new and the diff degenerates to today's behaviour — adds only, no removes.
- Upgrade path (new binary over an existing container) confirmed: regions persisted by the OS are adopted at launch and then reconciled.
- Full suite green at the head commit — 1604 passed, 0 failures, 17 skipped. SwiftLint `--strict` clean, no public API changes.

New unit coverage for the diff itself: `GeofenceRegionRequestTests` (tolerance and clamp behaviour of `matchesRegistered`) plus coordinator cases for add/remove/unchanged, permission-dropped regions, and the reshape-before-re-add ordering.

Two things here resist unit testing: `CLMonitor` cannot be instantiated from a test bundle, and what the ordering guarantees turn on is pipeline-drain latency, which the synchronous mock cannot represent. Those parts were checked with an executable model of the registration functions against a fake `CLMonitor` carrying the measured semantics (`add` over a live identifier silently ignored, `remove` of an absent one a no-op). It enumerates sync / adopt / `.unmonitored` / relaunch sequences with every drain point after each — 2.56M paths — and asserts three invariants: the OS converges on the desired set and geometry, a region registered with unchanged geometry is never re-registered, and the persisted mirror equals what the OS holds. No violations, under both possible `.unmonitored` semantics. The result is only worth as much as the harness, so each superseded version of this code was run back through it and each reproduces the defect it had — that is how the mirror gap above was found rather than reasoned about. Making `CLMonitor` injectable so the adapter is directly testable is worth a separate ticket.

### Reviewing

`CLMonitorGeofenceMonitor+Registration.swift` is the file to read closely — it holds the registered-geometry mirror and the ordering guarantees. `GeofenceRegionMonitoring.swift` states the contract that unchanged regions must not be re-registered, which is the part that must not regress later.

### Merge order

Targets **`release-july-launch-fixes`**, not `main` — the release branch gathers this and #1191 (plus anything else going into the same patch) so one release is cut for all of it rather than one per merge.

Order into the release branch no longer affects what ships, but merging #1191 first keeps `GeofenceStorage.swift`'s history clean. The two merge cleanly either way — they share only that file, in different places.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large change to background geofence OS registration (CLMonitor ordering, adoption geometry, transition preservation); mistakes can drop events or leave stale regions, though coverage and on-device validation are strong.
> 
> **Overview**
> Geofence sync no longer tears down the full OS region set on every refresh. **`registerWithOsSync`** builds a desired list (movement trigger first, then business fences) and calls **`setMonitoredRegions`**, which adds, removes, or skips each region based on whether its circle actually changed.
> 
> **`GeofenceRegionMonitoring`** gains **`GeofenceRegionRequest`**, **`GeofenceRegionDiff`**, and **`matchesRegistered`** (tolerance + OS radius clamp). The contract is explicit: unchanged circles must stay registered so pending boundary crossings are not dropped.
> 
> The coordinator drops **`canSkipReregistration`**, **`recenterMovementTrigger`**, and the remote/local “unchanged set” fast paths—those cases are handled inside the diff. Logging switches from rerank-unchanged to **`geofenceRegistrationDiff`**.
> 
> On **CLMonitor**, registration moves to **`CLMonitorGeofenceMonitor+Registration`**: an in-memory **`registeredConditions`** map drives **`isRegisteredUnchanged`**; adds **`remove` then `add`** because silent overwrites are ignored; **`setMonitoredRegions`** can sweep stray OS identifiers. **Bootstrap** passes persisted **`monitorRecords`** into **`adoptExistingRegions`** so geometry is seeded before the queued re-arm. **Re-arm** updates the condition mirror per revived id; **`.unmonitored`** clears storage via **`clearMonitorRegionRecord`**.
> 
> **Classic `CLLocationManager`** gets the same **`setMonitoredRegions`** diff, comparing against live **`CLCircularRegion`** geometry.
> 
> Tests and the mock monitor were expanded for diff behavior, adoption records, and **`matchesRegistered`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1810fe007ee9eb0b877b996ffc7ac3ee6226ebc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




