### PR TITLE
chore(geofence): select nearest regions by boundary distance and prune stale baselines

### DIFF
--- a/Sources/LocationGeofence/Coordinator/GeofenceDistanceFilter.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceDistanceFilter.swift
@@ -6,7 +6,13 @@ import Foundation
 /// monitored regions; one slot is reserved for the movement-trigger geofence).
 struct GeofenceDistanceFilter: Sendable {
     /// Ranks and caps by distance to each region's *boundary* (`edgeDistanceTo`), so a region the
-    /// device is inside always ranks first and survives both the limit and the distance cap.
+    /// device is inside ranks first among the candidates and survives both the limit and the
+    /// distance cap.
+    ///
+    /// Only among the candidates: the backend applies its own limit first, ordered by distance to
+    /// each region's center, so in a dense workspace a large region containing the device can be
+    /// cut before it ever reaches this sort. Aligning that server-side ordering with boundary
+    /// distance is a separate change.
     ///
     /// Ties broken by ascending `id` for deterministic ordering. Distances are rounded to whole
     /// meters before comparison: `CLLocation.distance` can return sub-meter-varying values for

--- a/Sources/LocationGeofence/Coordinator/GeofenceDistanceFilter.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceDistanceFilter.swift
@@ -5,15 +5,19 @@ import Foundation
 /// to cap business-geofence registrations at the OS-allowed count (iOS allows 20 total
 /// monitored regions; one slot is reserved for the movement-trigger geofence).
 struct GeofenceDistanceFilter: Sendable {
+    /// Ranks and caps by distance to each region's *boundary* (`edgeDistanceTo`), so a region the
+    /// device is inside always ranks first and survives both the limit and the distance cap.
+    ///
     /// Ties broken by ascending `id` for deterministic ordering. Distances are rounded to whole
     /// meters before comparison: `CLLocation.distance` can return sub-meter-varying values for
     /// identical inputs, which would otherwise defeat the id tiebreak and make the order of
-    /// equidistant regions nondeterministic. Regions farther than `maxDistance` are excluded
-    /// (`GeofenceConstants.noMonitoringDistanceCap` for no cap). Returns empty when `limit <= 0`.
+    /// equidistant regions nondeterministic. Regions whose boundary is farther than `maxDistance`
+    /// are excluded (`GeofenceConstants.noMonitoringDistanceCap` for no cap). Returns empty when
+    /// `limit <= 0`.
     func nearest(_ regions: [Geofence], to location: LocationData, limit: Int, maxDistance: Double) -> [Geofence] {
         guard limit > 0, !regions.isEmpty else { return [] }
         return regions
-            .map { ($0, $0.distanceTo(location).rounded()) }
+            .map { ($0, $0.edgeDistanceTo(location).rounded()) }
             .filter { $0.1 <= maxDistance }
             .sorted { lhs, rhs in
                 if lhs.1 != rhs.1 { return lhs.1 < rhs.1 }

--- a/Sources/LocationGeofence/Model/Geofence+Distance.swift
+++ b/Sources/LocationGeofence/Model/Geofence+Distance.swift
@@ -14,4 +14,18 @@ extension Geofence {
     func distanceTo(_ location: LocationData) -> CLLocationDistance {
         distanceTo(latitude: location.latitude, longitude: location.longitude)
     }
+
+    /// Distance in meters from this geofence's *boundary* to the given location, `0` when the
+    /// location is inside.
+    ///
+    /// Monitoring relevance is proximity to the boundary, not to the center: ranking on center
+    /// distance evicts a large region the device currently occupies as soon as
+    /// `maxBusinessGeofences` regions have nearer centers, and an unmonitored region can never
+    /// report its exit.
+    ///
+    /// Not a containment test — this is `0` for every point inside. Use `distanceTo` against
+    /// `radius` to ask whether the device is inside a region.
+    func edgeDistanceTo(_ location: LocationData) -> CLLocationDistance {
+        max(0, distanceTo(location) - radius)
+    }
 }

--- a/Sources/LocationGeofence/Storage/GeofenceStorage.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage.swift
@@ -247,6 +247,18 @@ actor GeofenceStorage {
         var state = loadFromDisk() ?? GeofenceState()
         state.movementTriggerCenter = center
         state.monitoredGeofenceIds = businessIds
+        // Drop per-condition baselines for regions this registration no longer covers. A record
+        // survives `stopMonitoring` on purpose, so an unchanged re-register keeps its baseline and
+        // CLMonitor's re-evaluation stays silent — but a region *evicted* from the set is a
+        // different case. It goes unmonitored, so no EXIT ever balances a `.enter` baseline, and a
+        // later re-registration with the same circle keeps that stale value instead of the state
+        // the device is actually in. The next genuine arrival then reads as no change and is
+        // dropped. Retaining exactly the registered set bounds the records the same way
+        // `monitoredGeofenceIds` is bounded, and clears anything a previous version stranded.
+        if let records = state.monitorRegionRecords {
+            let retained = businessIds.union([GeofenceConstants.movementTriggerIdentifier])
+            state.monitorRegionRecords = records.filter { retained.contains($0.key) }
+        }
         saveToDisk(state)
     }
 

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceDistanceFilterTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceDistanceFilterTests.swift
@@ -8,12 +8,12 @@ struct GeofenceDistanceFilterTests {
     private let filter = GeofenceDistanceFilter()
     private let origin = LocationData(latitude: 0, longitude: 0)
 
-    private func makeRegion(id: String, latitude: Double, longitude: Double) -> Geofence {
+    private func makeRegion(id: String, latitude: Double, longitude: Double, radius: Double = 100) -> Geofence {
         Geofence(
             id: id,
             latitude: latitude,
             longitude: longitude,
-            radius: 100,
+            radius: radius,
             name: id,
             transitionTypes: [.enter, .exit],
             lastUpdated: Date(timeIntervalSince1970: 0)
@@ -92,5 +92,65 @@ struct GeofenceDistanceFilterTests {
         // The no-cap sentinel includes every region regardless of distance.
         let result = filter.nearest(regions, to: origin, limit: 5, maxDistance: GeofenceConstants.noMonitoringDistanceCap)
         #expect(result.map(\.id) == ["near", "far"])
+    }
+
+    // MARK: - Ranking by boundary rather than center
+
+    @Test
+    func nearest_givenDeviceInsideLargeRegion_expectItRanksFirst() {
+        // Device sits inside `big` (center ~2.2 km away, radius 5 km) and outside `small`
+        // (center 1 km away). Ranking on center distance would put `small` first.
+        let regions = [
+            makeRegion(id: "small", latitude: 0.009, longitude: 0, radius: 100),
+            makeRegion(id: "big", latitude: 0.02, longitude: 0, radius: 5000)
+        ]
+        let result = filter.nearest(regions, to: origin, limit: 2, maxDistance: GeofenceConstants.noMonitoringDistanceCap)
+        #expect(result.map(\.id) == ["big", "small"])
+    }
+
+    @Test
+    func nearest_givenLimitFilledByNearerCenters_expectContainingRegionStillMonitored() {
+        // Regression: a region the device occupies must never be evicted by regions with nearer
+        // centers. Evicting it stops monitoring and its exit can then never be reported.
+        var regions = (0 ..< 19).map {
+            makeRegion(id: "decoy\(String(format: "%02d", $0))", latitude: 0.001, longitude: 0, radius: 50)
+        }
+        regions.append(makeRegion(id: "containing", latitude: 0.018, longitude: 0, radius: 2000))
+        let result = filter.nearest(regions, to: origin, limit: 19, maxDistance: GeofenceConstants.noMonitoringDistanceCap)
+        #expect(result.count == 19)
+        #expect(result.first?.id == "containing")
+    }
+
+    @Test
+    func nearest_givenContainingRegionCenterBeyondMaxDistance_expectStillIncluded() {
+        // The distance cap is also boundary-based: a region whose center is outside the cap but
+        // whose area contains the device must survive filtering.
+        let regions = [makeRegion(id: "containing", latitude: 0.05, longitude: 0, radius: 8000)]
+        let result = filter.nearest(regions, to: origin, limit: 5, maxDistance: 1000)
+        #expect(result.map(\.id) == ["containing"])
+    }
+
+    @Test
+    func nearest_givenRegionsFullyOutside_expectOrderedByBoundaryDistance() {
+        // `wide` has the farther center but the nearer boundary, so it ranks first.
+        let regions = [
+            makeRegion(id: "tight", latitude: 0.02, longitude: 0, radius: 100), // edge ~2.1 km
+            makeRegion(id: "wide", latitude: 0.03, longitude: 0, radius: 2000) // edge ~1.3 km
+        ]
+        let result = filter.nearest(regions, to: origin, limit: 2, maxDistance: GeofenceConstants.noMonitoringDistanceCap)
+        #expect(result.map(\.id) == ["wide", "tight"])
+    }
+
+    @Test
+    func nearest_givenMultipleContainingRegions_expectAllRankAheadOfOutsideOnes() {
+        // Every containing region has boundary distance 0, so they tie and break by id, but all
+        // must precede any region the device is outside of.
+        let regions = [
+            makeRegion(id: "outside", latitude: 0.005, longitude: 0, radius: 100),
+            makeRegion(id: "inside-b", latitude: 0.01, longitude: 0, radius: 3000),
+            makeRegion(id: "inside-a", latitude: 0.02, longitude: 0, radius: 5000)
+        ]
+        let result = filter.nearest(regions, to: origin, limit: 3, maxDistance: GeofenceConstants.noMonitoringDistanceCap)
+        #expect(result.map(\.id) == ["inside-a", "inside-b", "outside"])
     }
 }

--- a/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
@@ -700,4 +700,78 @@ struct GeofenceStorageTests {
         #expect(records["geo_1"]?.radius == 100)
         #expect(records["geo_1"]?.lastState == .enter)
     }
+
+    // MARK: - Monitor baseline pruning
+
+    @Test
+    func recordRegistration_givenEvictedRegion_expectItsBaselineDropped() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let centre = LocationData(latitude: 10, longitude: 20)
+        await storage.recordMonitorRegistration(identifier: "evicted", transitionTypes: [.enter, .exit], initialState: .enter, center: centre, radius: 500)
+        await storage.recordMonitorRegistration(identifier: "kept", transitionTypes: [.enter, .exit], initialState: .exit, center: centre, radius: 500)
+
+        await storage.recordRegistration(center: centre, businessIds: ["kept"])
+
+        let records = await storage.getMonitorRegionRecords()
+        #expect(records["evicted"] == nil)
+        #expect(records["kept"] != nil)
+    }
+
+    @Test
+    func recordRegistration_givenMovementTrigger_expectItsBaselineRetained() async {
+        // The trigger is never in `businessIds` but is always registered; pruning it would discard
+        // the baseline that makes its EXIT deliverable.
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let centre = LocationData(latitude: 10, longitude: 20)
+        await storage.recordMonitorRegistration(identifier: GeofenceConstants.movementTriggerIdentifier, transitionTypes: [.exit], initialState: .enter, center: centre, radius: 1000)
+
+        await storage.recordRegistration(center: centre, businessIds: ["g1"])
+
+        #expect(await storage.getMonitorRegionRecords()[GeofenceConstants.movementTriggerIdentifier] != nil)
+    }
+
+    @Test
+    func revisit_givenRegionEvictedWhileInside_expectGenuineEnterStillDelivered() async {
+        // The regression. A region evicted while the device is inside keeps a `.enter` baseline that
+        // no EXIT ever balances, because it is no longer monitored. Re-registering the same circle
+        // later preserves that baseline, so the arrival on a genuine revisit reads as no change and
+        // is dropped. Pruning on eviction is what keeps the revisit deliverable.
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let centre = LocationData(latitude: 10, longitude: 20)
+        let radius: Double = 500
+
+        await storage.recordMonitorRegistration(identifier: "F", transitionTypes: [.enter, .exit], initialState: .exit, center: centre, radius: radius)
+        #expect(await storage.recordMonitorEvent(.enter, forIdentifier: "F") == .deliver)
+
+        // Evicted while still inside — F is absent from the new registration snapshot.
+        await storage.recordRegistration(center: centre, businessIds: [])
+
+        // Much later: re-registered with an identical circle, device now outside.
+        await storage.recordMonitorRegistration(identifier: "F", transitionTypes: [.enter, .exit], initialState: .exit, center: centre, radius: radius)
+
+        #expect(await storage.recordMonitorEvent(.enter, forIdentifier: "F") == .deliver)
+    }
+
+    @Test
+    func recordRegistration_givenRetainedRegion_expectBaselinePreserved() async {
+        // Pruning must not touch a region that is still registered: its baseline is what keeps an
+        // unchanged re-register silent instead of re-delivering the state the device is already in.
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let centre = LocationData(latitude: 10, longitude: 20)
+        await storage.recordMonitorRegistration(identifier: "g1", transitionTypes: [.enter, .exit], initialState: .exit, center: centre, radius: 500)
+        #expect(await storage.recordMonitorEvent(.enter, forIdentifier: "g1") == .deliver)
+
+        await storage.recordRegistration(center: centre, businessIds: ["g1"])
+        await storage.recordMonitorRegistration(identifier: "g1", transitionTypes: [.enter, .exit], initialState: .exit, center: centre, radius: 500)
+
+        #expect(await storage.recordMonitorEvent(.enter, forIdentifier: "g1") == .suppressedNoChange)
+    }
 }


### PR DESCRIPTION
### Summary

Two related correctness improvements in how the nearest region set is chosen and how per-region state is retained. Both surfaced from the same question: what happens to a region the device is *inside* when the set changes.

No urgency — nothing here is tied to a reported failure. Kept separate from the registration fix so that one stays minimal.

### 1. Rank by boundary distance, not centre

Nearest-set selection ranked and capped on distance to each region's centre, ignoring radius. A region the device sits inside therefore ranks at its own radius rather than at zero, so a large region is evicted as soon as `maxBusinessGeofences` regions have nearer centres. An evicted region is unmonitored, so its exit is never reported.

The `maxMonitoringDistance` cutoff had the same shape: a region whose centre fell outside the cap was filtered out even when its area contained the device.

Ranking and filtering now use `edgeDistanceTo`, which clamps to zero inside the region, so an occupied region sorts first and survives both the cap and the limit.

Two things worth knowing:

- When all regions share a radius the ranking order is unchanged — subtracting a constant preserves order. Accounts with mixed radii are the ones affected.
- The distance cap does change: measuring to the boundary widens the effective cutoff by one radius, so regions just outside the old limit now register. The server's own selection is ordered by centre distance, so in a dense workspace a large region containing the device can still be cut before the SDK sees it; aligning that is a backend follow-up.

Demonstrated on a simulator: a 2 km region the device sat inside was dropped once 20 nearer-centred regions appeared, and its exit never arrived.

### 2. Prune monitor baselines to the registered set

A per-region baseline deliberately survives `stopMonitoring`, so an unchanged re-register keeps it and `CLMonitor` re-evaluating the same state is not delivered as a duplicate. That is correct for a region being replaced and incorrect for one being evicted: an evicted region goes unmonitored, so no EXIT ever balances an `.enter` baseline. Re-registering the same circle later preserves that stale value instead of the state the device is actually in, and the next genuine arrival reads as no change.

Cost when it happens is one missed arrival plus an EXIT with no matching ENTER; the EXIT clears the baseline, so it does not persist beyond that.

`recordRegistration` now retains records only for the registered set plus the movement trigger. Regions still in the set keep their baseline, so the duplicate suppression these records exist for is unaffected. This also bounds the records the same way `monitoredGeofenceIds` is already bounded — previously they were only ever added to, or cleared wholesale on sign-out.

**Existing installs**: no migration step. The prune runs on every sync, so the first sync after updating clears anything a previous build stranded. Clearing all records on upgrade was considered and rejected — with no baseline the next crossing is suppressed, which would cost every user one event.

`CLMonitor` path only (iOS 18+); the classic path keeps no baseline.

Ports Android `21914158`, whose commit message names this gap on iOS.

### Why these two together

They share a precondition. Centre-distance ranking is what makes an occupied region get evicted in the first place, which is what strands the baseline. Fixing the ranking removes most of the trigger; pruning handles the rest.

### Validation

- Both changes revert-verified: each new test fails with only its own fix backed out.
- Simulator A/B for the ranking change — the containing region now survives eviction and its exit is reported.
- Storage-level reproduction of the stale baseline before and after the prune.
- Full suite green — 1040 XCTest, 575 Swift Testing, 0 failures. SwiftLint `--strict` clean, no public API changes.

### Merge order

Targets **`release-july-launch-fixes`**, not `main` — the release branch gathers this and #1190 (plus anything else going into the same patch) so one release is cut for all of it rather than one per merge.

Order into the release branch no longer affects what ships. Merging this one first keeps `GeofenceStorage.swift`'s history clean; the two merge cleanly either way, sharing only that file in different places.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core geofence selection and persisted CLMonitor dedup state; behavior shifts for mixed radii and distance caps, but scope is localized with strong test coverage.
> 
> **Overview**
> Fixes two geofence correctness issues: which regions stay monitored when the OS cap bites, and whether **CLMonitor** enter events still fire after a region drops out of the set and comes back.
> 
> **Boundary-based nearest selection** — `GeofenceDistanceFilter` now ranks and applies `maxDistance` using new `Geofence.edgeDistanceTo` (0 inside the circle) instead of center distance. Occupied large regions are no longer evicted in favor of many small nearby centers, and regions whose center is outside the cap but whose area contains the device still qualify.
> 
> **Baseline pruning on registration** — `GeofenceStorage.recordRegistration` filters `monitorRegionRecords` to the current business IDs plus the movement trigger. Evicted regions lose stale `.enter` baselines that could suppress a real enter on re-registration; retained regions keep dedup behavior unchanged.
> 
> Tests cover boundary ranking edge cases and the eviction/revisit regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0949d28311b009498f12f6b9b92f8cb1a29ebd75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


