### PR TITLE
fix(geofence): correct region registration, eviction and baseline handling

### DIFF
--- a/Sources/LocationGeofence/Coordinator/GeofenceDistanceFilter.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceDistanceFilter.swift
@@ -5,15 +5,25 @@ import Foundation
 /// to cap business-geofence registrations at the OS-allowed count (iOS allows 20 total
 /// monitored regions; one slot is reserved for the movement-trigger geofence).
 struct GeofenceDistanceFilter: Sendable {
+    /// Ranks and caps by distance to each region's *boundary* (`edgeDistanceTo`), so a region the
+    /// device is inside ranks first among the candidates and survives both the limit and the
+    /// distance cap.
+    ///
+    /// Only among the candidates: the backend applies its own limit first, ordered by distance to
+    /// each region's center, so in a dense workspace a large region containing the device can be
+    /// cut before it ever reaches this sort. Aligning that server-side ordering with boundary
+    /// distance is a separate change.
+    ///
     /// Ties broken by ascending `id` for deterministic ordering. Distances are rounded to whole
     /// meters before comparison: `CLLocation.distance` can return sub-meter-varying values for
     /// identical inputs, which would otherwise defeat the id tiebreak and make the order of
-    /// equidistant regions nondeterministic. Regions farther than `maxDistance` are excluded
-    /// (`GeofenceConstants.noMonitoringDistanceCap` for no cap). Returns empty when `limit <= 0`.
+    /// equidistant regions nondeterministic. Regions whose boundary is farther than `maxDistance`
+    /// are excluded (`GeofenceConstants.noMonitoringDistanceCap` for no cap). Returns empty when
+    /// `limit <= 0`.
     func nearest(_ regions: [Geofence], to location: LocationData, limit: Int, maxDistance: Double) -> [Geofence] {
         guard limit > 0, !regions.isEmpty else { return [] }
         return regions
-            .map { ($0, $0.distanceTo(location).rounded()) }
+            .map { ($0, $0.edgeDistanceTo(location).rounded()) }
             .filter { $0.1 <= maxDistance }
             .sorted { lhs, rhs in
                 if lhs.1 != rhs.1 { return lhs.1 < rhs.1 }

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+OsRegistration.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+OsRegistration.swift
@@ -19,43 +19,12 @@ extension GeofenceSyncCoordinatorImpl {
         }
     }
 
-    /// True when re-registering would be a no-op: same ids as recorded, all owned by this process
-    /// and still held by the OS. Re-adding re-seeds each region's assumed state from the live fix,
-    /// absorbing any crossing the OS hasn't delivered yet — once per trigger radius at driving
-    /// speed. Any doubt falls through to the wholesale path, which re-establishes ownership, heals
-    /// dropped regions, and tears down under the kill switch (a geofence-free area leaves the
-    /// trigger owned with no business ids, so the ids alone would otherwise match).
-    @MainActor
-    func canSkipReregistration(
-        nearestIds: Set<String>,
-        previouslyRegisteredIds: Set<String>,
-        registerMovementTrigger: Bool
-    ) -> Bool {
-        guard registerMovementTrigger, nearestIds == previouslyRegisteredIds else { return false }
-        let expected = nearestIds.union([GeofenceConstants.movementTriggerIdentifier])
-        return expected.isSubset(of: monitor.monitoredRegionIdentifiers)
-            && expected.isSubset(of: monitor.osMonitoredRegionIdentifiers)
-    }
-
-    /// Moves only the trigger. Explicit stop-then-start, which both monitors serialize. Nothing is
-    /// lost by re-seeding this one region: it is being re-centered precisely because the device
-    /// left the old circle.
-    @MainActor
-    func recenterMovementTrigger(at location: LocationData, radius: Double) {
-        monitor.stopMonitoring(identifier: GeofenceConstants.movementTriggerIdentifier)
-        monitor.startMonitoring(
-            identifier: GeofenceConstants.movementTriggerIdentifier,
-            center: location,
-            radius: radius,
-            transitionTypes: [.exit]
-        )
-    }
-
-    /// Stops all monitored regions, then starts the new business set + movement trigger. Returns the
-    /// OS-accepted identifiers (a region the monitor dropped for blocked permission / invalid
-    /// coordinates is absent) plus the radius cap, so `emitInitialEnters` won't fire an unbalanced
-    /// synthetic enter or one for a device outside the actually-monitored (clamped) circle.
-    /// `@MainActor`-isolated so a same-actor caller (e.g. `applyCachedRegistration`)
+    /// Reconciles the OS-monitored set to the new business set + movement trigger, leaving regions
+    /// that carry over registered untouched — see `setMonitoredRegions` for why re-adding them loses
+    /// transitions. Returns the OS-accepted identifiers (a region the monitor dropped for blocked
+    /// permission / invalid coordinates is absent) plus the radius cap, so `emitInitialEnters` won't
+    /// fire an unbalanced synthetic enter or one for a device outside the actually-monitored
+    /// (clamped) circle. `@MainActor`-isolated so a same-actor caller (e.g. `applyCachedRegistration`)
     /// can register without yielding — see the protocol doc for why that matters.
     @MainActor
     @discardableResult
@@ -65,30 +34,39 @@ extension GeofenceSyncCoordinatorImpl {
         movementTriggerRadius: Double,
         registerMovementTrigger: Bool
     ) -> GeofenceOsRegistration {
-        monitor.stopMonitoringAll()
-        // Register the movement trigger FIRST so it isn't starved when business regions fill the
+        var desired: [GeofenceRegionRequest] = []
+        // Order the movement trigger FIRST so it isn't starved when business regions fill the
         // shared 20-region OS budget (e.g. a host app that also monitors regions): losing it freezes
         // the set, since exiting the trigger is what re-ranks toward now-closer geofences. Kept even
         // when the nearby set is empty (distance cap or an empty fetch) so the device keeps re-fetching
         // as it moves back toward geofences; skipped only when kill-switched (`maxBusinessGeofences == 0`).
         if registerMovementTrigger {
-            monitor.startMonitoring(
+            desired.append(GeofenceRegionRequest(
                 identifier: GeofenceConstants.movementTriggerIdentifier,
                 center: movementTriggerLocation,
                 radius: movementTriggerRadius,
                 transitionTypes: [.exit]
-            )
+            ))
         }
-        for region in businessRegions {
-            monitor.startMonitoring(
+        desired.append(contentsOf: businessRegions.map { region in
+            GeofenceRegionRequest(
                 identifier: region.id,
                 center: LocationData(latitude: region.latitude, longitude: region.longitude),
                 radius: region.radius,
                 transitionTypes: region.transitionTypes
             )
-        }
+        })
+        let diff = monitor.setMonitoredRegions(desired)
+        // Count against what the OS actually holds, not `desired`: a region dropped for blocked
+        // permission or invalid coordinates is in neither, and would otherwise read as unchanged.
+        let registeredIds = monitor.monitoredRegionIdentifiers
+        logger.geofenceRegistrationDiff(
+            added: diff.added.count,
+            removed: diff.removed.count,
+            unchanged: registeredIds.count - diff.added.count
+        )
         return GeofenceOsRegistration(
-            registeredIds: monitor.monitoredRegionIdentifiers,
+            registeredIds: registeredIds,
             maxMonitoringRadius: monitor.maximumMonitoringRadius
         )
     }

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
@@ -41,9 +41,6 @@ extension GeofenceSyncCoordinatorImpl {
         // Read before `recordRegistration` overwrites it — the diff decides which registrations are new.
         let previouslyRegisteredIds = await storage.getRegisteredBusinessIds()
         let nearestIds = Set(nearest.map(\.id))
-        if await appliedUnchangedRemoteSync(regions: regions, nearestIds: nearestIds, parsedConfig: parsedConfig, effectiveConfig: effectiveConfig, anchor: anchor) {
-            return .success(())
-        }
         let osRegistration = await MainActor.run {
             registerWithOsSync(
                 businessRegions: nearest,
@@ -89,17 +86,6 @@ extension GeofenceSyncCoordinatorImpl {
         // Read before `recordRegistration` overwrites it — the diff decides which registrations are new.
         let previouslyRegisteredIds = await storage.getRegisteredBusinessIds()
         let nearestIds = Set(nearest.map(\.id))
-        // Adjacent trigger EXITs usually re-rank onto the same nearest set — leave the OS
-        // registrations alone (see `canSkipReregistration`; geometry can't differ on matching
-        // ids here, ranking re-reads the same cache) and walk only the trigger + anchor.
-        if await canSkipReregistration(
-            nearestIds: nearestIds,
-            previouslyRegisteredIds: previouslyRegisteredIds,
-            registerMovementTrigger: registerMovementTrigger
-        ) {
-            await applyUnchangedRegistration(anchor: anchor, nearestIds: nearestIds, triggerRadius: config.localRefreshTriggerRadius)
-            return .success(())
-        }
         let osRegistration = await MainActor.run {
             registerWithOsSync(
                 businessRegions: nearest,
@@ -118,45 +104,6 @@ extension GeofenceSyncCoordinatorImpl {
         )
         logger.geofenceSyncCompleted(registeredCount: nearest.count, movementTriggerRegistered: registerMovementTrigger)
         return .success(())
-    }
-
-    /// Order-insensitive: server ordering isn't contractual, and `lastUpdated` in `Equatable`
-    /// makes any server-side edit force the wholesale path that applies it.
-    func regionsUnchanged(_ fetched: [Geofence], _ cached: [Geofence]) -> Bool {
-        fetched.sorted { $0.id < $1.id } == cached.sorted { $0.id < $1.id }
-    }
-
-    /// The unchanged-set fast path's shared effects: re-center the trigger and walk the
-    /// ranking-staleness anchor forward, leaving business regions untouched.
-    func applyUnchangedRegistration(anchor: LocationData, nearestIds: Set<String>, triggerRadius: Double) async {
-        await recenterMovementTrigger(at: anchor, radius: triggerRadius)
-        await storage.recordRegistration(center: anchor, businessIds: nearestIds)
-        logger.geofenceRerankUnchanged(keptCount: nearestIds.count)
-    }
-
-    /// Remote fast path: identical payload + unchanged registration (see `canSkipReregistration`)
-    /// ⇒ apply config, advance the refetch anchor, walk the trigger, and return true.
-    /// False = register wholesale.
-    func appliedUnchangedRemoteSync(
-        regions: [Geofence],
-        nearestIds: Set<String>,
-        parsedConfig: GeofenceConfig?,
-        effectiveConfig: GeofenceConfig,
-        anchor: LocationData
-    ) async -> Bool {
-        guard regionsUnchanged(regions, await storage.getCachedGeofences()),
-              await canSkipReregistration(
-                  nearestIds: nearestIds,
-                  previouslyRegisteredIds: storage.getRegisteredBusinessIds(),
-                  registerMovementTrigger: effectiveConfig.maxBusinessGeofences > 0
-              )
-        else { return false }
-        if let parsedConfig {
-            await storage.setCachedConfig(parsedConfig)
-        }
-        await storage.recordSync(timestamp: dateUtil.now, location: anchor)
-        await applyUnchangedRegistration(anchor: anchor, nearestIds: nearestIds, triggerRadius: effectiveConfig.localRefreshTriggerRadius)
-        return true
     }
 
     /// A sign-out/switch can land anywhere inside a gated operation, and the `reset()` it triggers

--- a/Sources/LocationGeofence/GeofenceBootstrap.swift
+++ b/Sources/LocationGeofence/GeofenceBootstrap.swift
@@ -54,6 +54,8 @@ enum GeofenceBootstrap {
         let expectedOwnedRegions = (cachedConfig ?? .fallback).maxBusinessGeofences > 0
             ? lastRegisteredBusinessIds.union([GeofenceConstants.movementTriggerIdentifier])
             : []
+        // Adopt-time seed for the CLMonitor path's geometry bookkeeping (empty on classic).
+        let monitorRecords = await di.geofenceStorage.getMonitorRegionRecords()
 
         // Phase 2: synchronous on the main actor. No `await` between handler-bind and
         // `adoptExistingRegions` / `startMonitoring`, so `ownedRegionIdentifiers` is populated
@@ -88,7 +90,7 @@ enum GeofenceBootstrap {
             // reset's queued removes). The next identify-driven refresh registers instead.
             di.logger.geofenceSyncSkipped(reason: "identified user changed during bootstrap")
         } else if !expectedOwnedRegions.isEmpty, expectedOwnedRegions.isSubset(of: monitor.osMonitoredRegionIdentifiers) {
-            monitor.adoptExistingRegions(matching: expectedOwnedRegions)
+            monitor.adoptExistingRegions(matching: expectedOwnedRegions, records: monitorRecords)
         } else {
             // First launch after install, the OS dropped our regions (e.g. permission revoked then
             // re-granted, which clears `monitoredRegions`), or a partial drop. Register fresh from cache.

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -110,8 +110,8 @@ extension Logger {
         info("Sync completed: registered \(registeredCount) business geofences\(trigger)", geofenceTag)
     }
 
-    func geofenceRerankUnchanged(keptCount: Int) {
-        debug("Re-rank: nearest set unchanged, kept \(keptCount) business geofences monitored; movement trigger re-centered", geofenceTag)
+    func geofenceRegistrationDiff(added: Int, removed: Int, unchanged: Int) {
+        debug("OS registration diff: +\(added) / -\(removed); \(unchanged) left registered untouched", geofenceTag)
     }
 
     func geofenceMovementTrigger(tier: HandleMovementTier) {

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -37,6 +37,16 @@ extension Logger {
         )
     }
 
+    // Logged at error level deliberately: `info`/`debug` are not persisted to the log store for
+    // third-party subsystems, so a field report would not carry them.
+    func geofenceMonitorStoppedMonitoringRegion(_ identifier: String) {
+        error(
+            "CoreLocation stopped monitoring region \(identifier); its transitions are not delivered until the next sync re-registers it",
+            geofenceTag,
+            nil
+        )
+    }
+
     func geofencePermissionUnavailable(currentStatus: CLAuthorizationStatus) {
         info(
             "Geofence registration skipped: location permission not granted (current status: \(currentStatus.rawValue)). The host app controls when and which permission to request.",

--- a/Sources/LocationGeofence/Model/Geofence+Distance.swift
+++ b/Sources/LocationGeofence/Model/Geofence+Distance.swift
@@ -14,4 +14,18 @@ extension Geofence {
     func distanceTo(_ location: LocationData) -> CLLocationDistance {
         distanceTo(latitude: location.latitude, longitude: location.longitude)
     }
+
+    /// Distance in meters from this geofence's *boundary* to the given location, `0` when the
+    /// location is inside.
+    ///
+    /// Monitoring relevance is proximity to the boundary, not to the center: ranking on center
+    /// distance evicts a large region the device currently occupies as soon as
+    /// `maxBusinessGeofences` regions have nearer centers, and an unmonitored region can never
+    /// report its exit.
+    ///
+    /// Not a containment test — this is `0` for every point inside. Use `distanceTo` against
+    /// `radius` to ask whether the device is inside a region.
+    func edgeDistanceTo(_ location: LocationData) -> CLLocationDistance {
+        max(0, distanceTo(location) - radius)
+    }
 }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Rearm.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Rearm.swift
@@ -10,10 +10,19 @@ extension CLMonitorGeofenceMonitor {
     /// fresh add re-arms it. Event-silent when nothing changed: `assuming:` seeds the stored
     /// baseline, so CLMonitor emits only transitions that happened while unmonitored — genuine
     /// catch-up, which the baseline comparison then delivers.
-    func rearmConditions(_ identifiers: Set<String>) {
+    ///
+    /// `records` comes from the caller (`adoptExistingRegions`), which has already seeded the
+    /// geometry bookkeeping from it synchronously — noting it again at drain time would clobber
+    /// a newer circle a sync staged while this operation was still queued.
+    ///
+    /// Each successful add is recorded in `knownConditionIdentifiers` and the mirror persisted, the
+    /// same bookkeeping `startMonitoring` does. Without it the mirror under-reports a condition this
+    /// re-add revived, and the next process seeds ownership from that mirror — so a cold-wake event
+    /// for the revived condition would be dropped by the ownership gate.
+    func rearmConditions(_ identifiers: Set<String>, records: [String: MonitorRegionRecord]) {
         enqueueMonitorOperation { [weak self] monitor in
             guard let self else { return }
-            let records = await self.storage.getMonitorRegionRecords()
+            var revived = false
             for identifier in identifiers {
                 // A record without geometry can't be rebuilt; the next sync re-registers it.
                 guard let record = records[identifier],
@@ -25,7 +34,14 @@ extension CLMonitorGeofenceMonitor {
                     radius: radius
                 )
                 await monitor.add(condition, identifier: identifier, assuming: record.lastState == .enter ? .satisfied : .unsatisfied)
+                // Recorded per identifier rather than in one pass at the end: an `.unmonitored` for
+                // one of these can land between two iterations, and it must be able to take the
+                // identifier back out.
+                self.knownConditionIdentifiers.insert(identifier)
+                revived = true
             }
+            guard revived else { return }
+            self.persistConditionMirror()
         }
     }
 }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
@@ -1,0 +1,207 @@
+import CioInternalCommon
+import CoreLocation
+import Foundation
+
+/// Region registration for the CLMonitor path, split out to keep the monitor's event and lifecycle
+/// plumbing readable. Members are `internal` (not `private`) only because they live in a separate
+/// file from their state; they remain monitor implementation detail.
+@available(iOS 17.0, *)
+extension CLMonitorGeofenceMonitor {
+    func adoptExistingRegions(matching identifiers: Set<String>, records: [String: MonitorRegionRecord]) {
+        let adopted = identifiers.intersection(knownConditionIdentifiers)
+        guard !adopted.isEmpty else { return }
+        ownedRegionIdentifiers.formUnion(adopted)
+        // Seed the geometry map synchronously, before the queued re-arm drains: a sync landing in
+        // that window would otherwise read every adopted region as changed (no recorded circle)
+        // and remove + re-add them all — absorbing any crossing the OS has detected but not yet
+        // delivered. Seeded from the same records the re-arm imposes at the OS, so the diff
+        // compares against what the OS will hold once it drains. A record without geometry stays
+        // unseeded and the next sync re-registers it, matching `rearmConditions`.
+        for identifier in adopted {
+            guard let record = records[identifier], let center = record.center, let radius = record.radius else { continue }
+            noteRegisteredCondition(
+                identifier: identifier,
+                center: center,
+                radius: radius,
+                transitionTypes: record.transitionTypes
+            )
+        }
+        rearmConditions(adopted, records: records)
+        logger.geofenceRegionsAdopted(count: adopted.count)
+    }
+
+    func startMonitoring(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) {
+        reportPermissionTier()
+        // A rejected registration still clears the identifier at the OS. Re-registration releases
+        // ownership before calling in, so without this a reshaped region that is refused would leave
+        // its previous circle live and holding one of the 20 OS slots — with nothing owning it, no
+        // later pass repairs it while the region stays in the desired set.
+        guard CoreLocationGeofenceMonitor.permissionTier(for: authManager.authorizationStatus) != .blocked else {
+            enqueueConditionRemoval(identifier)
+            return
+        }
+
+        let coordinate = CLLocationCoordinate2D(latitude: center.latitude, longitude: center.longitude)
+        guard CLLocationCoordinate2DIsValid(coordinate) else {
+            logger.geofenceInvalidCoordinatesForRegion(identifier)
+            enqueueConditionRemoval(identifier)
+            return
+        }
+
+        // Populate the ownership filter synchronously so a fast-arriving event isn't dropped.
+        ownedRegionIdentifiers.insert(identifier)
+
+        // Parity with the classic monitor's clamp; `maximumRegionMonitoringDistance` is a deprecated
+        // but harmless read with no CLMonitor equivalent — both paths register identical geometry.
+        let clampedRadius = min(radius, authManager.maximumRegionMonitoringDistance)
+
+        // The device's ACTUAL state seeds both CLMonitor's `assuming:` hint and the stored baseline
+        // (see `recordMonitorRegistration`: registration stays silent, the first real crossing
+        // delivers). No fix → geometric expectation: trigger is device-centered (inside),
+        // business geofences outside.
+        noteRegisteredCondition(
+            identifier: identifier,
+            center: LocationData(latitude: coordinate.latitude, longitude: coordinate.longitude),
+            radius: clampedRadius,
+            transitionTypes: transitionTypes
+        )
+
+        let isMovementTrigger = identifier == GeofenceConstants.movementTriggerIdentifier
+        let isInside = isDeviceInside(center: coordinate, radius: clampedRadius) ?? isMovementTrigger
+        let initialTransition: GeofenceTransition = isInside ? .enter : .exit
+        let assumedState: CLMonitor.Event.State = isInside ? .satisfied : .unsatisfied
+
+        enqueueMonitorOperation { [weak self] monitor in
+            guard let self else { return }
+            // Persist before the OS add: storage keys off recorded geometry to preserve the baseline
+            // on an unchanged re-register and reseed on a new/changed circle. The decision lives in
+            // storage because this runs after stop-all, when CLMonitor's own record is already gone.
+            await self.storage.recordMonitorRegistration(
+                identifier: identifier,
+                transitionTypes: transitionTypes,
+                initialState: initialTransition,
+                center: LocationData(latitude: coordinate.latitude, longitude: coordinate.longitude),
+                radius: clampedRadius
+            )
+            // CLMonitor SILENTLY IGNORES an add over a live identifier, keeping the original circle
+            // and reporting no error, so the identifier is cleared first. Keyed on the OS rather
+            // than on this process's bookkeeping, which can be missing an identifier the OS still
+            // holds. Removing one the OS does not hold is a no-op.
+            await monitor.remove(identifier)
+            let condition = CLMonitor.CircularGeographicCondition(center: coordinate, radius: clampedRadius)
+            await monitor.add(condition, identifier: identifier, assuming: assumedState)
+            self.knownConditionIdentifiers.insert(identifier)
+            self.persistConditionMirror()
+        }
+    }
+
+    func stopMonitoring(identifier: String) {
+        guard ownedRegionIdentifiers.contains(identifier) else { return }
+        releaseOwnership(identifier)
+        enqueueConditionRemoval(identifier)
+    }
+
+    /// Drops this process's claim on a condition without touching the OS.
+    private func releaseOwnership(_ identifier: String) {
+        ownedRegionIdentifiers.remove(identifier)
+        registeredConditions.removeValue(forKey: identifier)
+    }
+
+    /// Drops the condition at the OS.
+    ///
+    /// The storage record intentionally survives removal: a remove + re-register cycle relies on
+    /// the persisted baseline to suppress CLMonitor's re-evaluation of an unchanged state.
+    private func enqueueConditionRemoval(_ identifier: String) {
+        enqueueMonitorOperation { [weak self] monitor in
+            guard let self else { return }
+            await monitor.remove(identifier)
+            self.knownConditionIdentifiers.remove(identifier)
+            self.persistConditionMirror()
+        }
+    }
+
+    func stopMonitoringAll() {
+        ownedRegionIdentifiers.removeAll()
+        registeredConditions.removeAll()
+        // Clear against CLMonitor's LIVE identifiers, not the owned/mirror snapshot: an empty owned
+        // set or a lossy mirror must not leave a stale SDK condition holding an OS slot.
+        enqueueMonitorOperation { [weak self] monitor in
+            guard let self else { return }
+            for identifier in await monitor.identifiers {
+                await monitor.remove(identifier)
+            }
+            self.knownConditionIdentifiers.removeAll()
+            self.persistConditionMirror()
+        }
+    }
+
+    @discardableResult
+    func setMonitoredRegions(_ regions: [GeofenceRegionRequest]) -> GeofenceRegionDiff {
+        let desiredIdentifiers = Set(regions.map(\.identifier))
+        var removed: Set<String> = []
+        for identifier in ownedRegionIdentifiers.subtracting(desiredIdentifiers) {
+            stopMonitoring(identifier: identifier)
+            removed.insert(identifier)
+        }
+        // `stopMonitoring` above only reaches conditions this process knows it owns. Sweep the rest
+        // against CLMonitor's LIVE identifiers, the job `stopMonitoringAll` used to do wholesale, so
+        // a lossy mirror can't strand an SDK condition holding an OS slot.
+        enqueueMonitorOperation { [weak self] monitor in
+            guard let self else { return }
+            for identifier in await monitor.identifiers where !desiredIdentifiers.contains(identifier) {
+                await monitor.remove(identifier)
+                self.knownConditionIdentifiers.remove(identifier)
+            }
+            self.persistConditionMirror()
+        }
+        var added: Set<String> = []
+        for region in regions where !isRegisteredUnchanged(region) {
+            // Release ownership first so a region `startMonitoring` rejects (blocked permission,
+            // invalid coordinates) stops counting as registered instead of keeping the claim it
+            // held before the change. `startMonitoring` re-takes it in the same turn on success,
+            // and clears the identifier at the OS from inside its queued add.
+            releaseOwnership(region.identifier)
+            startMonitoring(
+                identifier: region.identifier,
+                center: region.center,
+                radius: region.radius,
+                transitionTypes: region.transitionTypes
+            )
+            // Blocked permission / invalid coordinates make `startMonitoring` a no-op; the caller's
+            // initial-enter decision must not count a region the OS never took.
+            if ownedRegionIdentifiers.contains(region.identifier) { added.insert(region.identifier) }
+        }
+        return GeofenceRegionDiff(added: added, removed: removed)
+    }
+
+    /// True when this monitor owns the condition and registered it with the same circle, so
+    /// re-adding would only risk absorbing an undelivered crossing.
+    ///
+    /// Ownership plus the recorded circle is sufficient: every path that records geometry also
+    /// queues the matching OS add on the FIFO, and every path that invalidates the OS side clears
+    /// ownership or the record synchronously. `knownConditionIdentifiers` must NOT be consulted —
+    /// it is only updated when queued operations drain, so requiring it re-registers any region
+    /// whose add is still in flight — staged either by a sync that landed before an earlier one's
+    /// operations drained or by the launch re-arm. Each is an absorbing remove + add for a circle
+    /// the OS already holds or is about to.
+    private func isRegisteredUnchanged(_ region: GeofenceRegionRequest) -> Bool {
+        guard ownedRegionIdentifiers.contains(region.identifier),
+              let existing = registeredConditions[region.identifier]
+        else { return false }
+        return region.matchesRegistered(
+            center: existing.center,
+            radius: existing.radius,
+            transitionTypes: existing.transitionTypes,
+            clampedTo: authManager.maximumRegionMonitoringDistance
+        )
+    }
+
+    /// Records the circle a condition now holds.
+    private func noteRegisteredCondition(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) {
+        registeredConditions[identifier] = RegisteredCondition(
+            center: center,
+            radius: radius,
+            transitionTypes: transitionTypes
+        )
+    }
+}

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
@@ -76,12 +76,16 @@ extension CLMonitorGeofenceMonitor {
             // Persist before the OS add: storage keys off recorded geometry to preserve the baseline
             // on an unchanged re-register and reseed on a new/changed circle. The decision lives in
             // storage because this runs after stop-all, when CLMonitor's own record is already gone.
+            // Consumed here rather than at staging time: an add already queued when `.unmonitored`
+            // arrived still drains after it, so it is the one that must reseed.
+            let forceReseed = self.conditionsNeedingBaselineReseed.remove(identifier) != nil
             await self.storage.recordMonitorRegistration(
                 identifier: identifier,
                 transitionTypes: transitionTypes,
                 initialState: initialTransition,
                 center: LocationData(latitude: coordinate.latitude, longitude: coordinate.longitude),
-                radius: clampedRadius
+                radius: clampedRadius,
+                forceReseed: forceReseed
             )
             // CLMonitor SILENTLY IGNORES an add over a live identifier, keeping the original circle
             // and reporting no error, so the identifier is cleared first. Keyed on the OS rather
@@ -123,6 +127,8 @@ extension CLMonitorGeofenceMonitor {
     func stopMonitoringAll() {
         ownedRegionIdentifiers.removeAll()
         registeredConditions.removeAll()
+        // Teardown clears the stored records too (sign-out), so nothing is left to reseed.
+        conditionsNeedingBaselineReseed.removeAll()
         // Clear against CLMonitor's LIVE identifiers, not the owned/mirror snapshot: an empty owned
         // set or a lossy mirror must not leave a stale SDK condition holding an OS slot.
         enqueueMonitorOperation { [weak self] monitor in

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -221,13 +221,19 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
         case .unknown:
             return
         case .unmonitored:
-            // CLMonitor gave up on the condition (e.g. condition budget exceeded). As with classic
-            // monitoringDidFail: drop ownership and the mirror entry so nothing claims a condition
-            // the OS no longer holds; the next sync re-registers a fresh set. The stored baseline
+            // CLMonitor gave up on the condition (e.g. condition budget exceeded). Drop the mirror
+            // entry and the recorded circle so the next sync re-registers it. The stored baseline
             // goes too — the region stays in the desired set, so nothing else prunes it, and the
             // device can cross while it is unmonitored.
+            //
+            // Ownership is deliberately KEPT. It only gates which events this process accepts, and
+            // the OS sends events solely for conditions it monitors, so keeping it can't admit a
+            // spurious one. Dropping it strands the region instead: an add already queued here
+            // revives the condition without restoring ownership, and a condition the OS gave up on
+            // stays listed and revives on its own once budget frees (measured). Worst case is the
+            // movement trigger — its events are what drive the next sync, so dropping its ownership
+            // removes the only thing that would restore it before the process restarts.
             logger.geofenceMonitorStoppedMonitoringRegion(identifier)
-            ownedRegionIdentifiers.remove(identifier)
             knownConditionIdentifiers.remove(identifier)
             registeredConditions.removeValue(forKey: identifier)
             // Whichever registration comes next must reseed the baseline rather than preserve it.

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -32,23 +32,42 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
     /// after construction — without the mirror that read is empty on every cold launch.
     private static let conditionMirrorKey = "io.customer.sdk.geofence.clmonitor.conditionIdentifiers"
 
-    private let logger: Logger
+    /// Internal for the `+Registration` extension.
+    let logger: Logger
     /// Persists the per-condition dedup baseline + delivery filter (see `MonitorRegionRecord`).
     /// Internal (not private) so the `+Rearm` extension can read it; immutable injected dependency.
     let storage: GeofenceStorage
     private let userDefaults: UserDefaults
     /// Only for auth status/changes + current-location reads; region monitoring is on `CLMonitor`.
-    private let authManager: CLLocationManager
+    /// Internal for the `+Registration` extension.
+    let authManager: CLLocationManager
     private var onTransition: GeofenceTransitionHandler?
     private var onAuthorizationChanged: GeofenceAuthorizationChangedHandler?
     private var onReconciled: GeofenceReconciledHandler?
     private var lastLoggedPermissionTier: CoreLocationGeofenceMonitor.PermissionTier?
 
     /// In-memory ownership filter, mirrors `ownedRegionIdentifiers` in the classic monitor.
-    private var ownedRegionIdentifiers: Set<String> = []
+    /// The three below are internal for the `+Registration` extension.
+    var ownedRegionIdentifiers: Set<String> = []
     /// Synchronous view of the monitor's condition identifiers: seeded from the mirror at init,
     /// reconciled against `CLMonitor.identifiers` by the pipeline's first operation, then maintained.
-    private var knownConditionIdentifiers: Set<String> = []
+    var knownConditionIdentifiers: Set<String> = []
+    /// Geometry each condition was added with, post-clamp. `CLMonitor` exposes no way to read a
+    /// condition back, so this is the only record `setMonitoredRegions` can diff against.
+    ///
+    /// Deliberately NOT seeded from the mirror at init (which has no geometry anyway). A condition
+    /// inherited from a previous process may be a reboot zombie — still listed, no longer monitored
+    /// (see `rearmConditions`) — and only re-adding revives it. Leaving it absent here makes the
+    /// first pass re-register it; when the bootstrap adopts instead, `adoptExistingRegions` seeds it
+    /// from the persisted records the re-arm then imposes at the OS.
+    var registeredConditions: [String: RegisteredCondition] = [:]
+
+    /// The circle a condition was added with.
+    struct RegisteredCondition: Equatable {
+        let center: LocationData
+        let radius: Double
+        let transitionTypes: Set<GeofenceTransition>
+    }
 
     /// Memoized `CLMonitor` creation so every caller shares one instance — creating a second
     /// monitor with the same name throws "Monitor named ... is already in use".
@@ -127,6 +146,9 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
         let drifted = persisted != knownConditionIdentifiers
         knownConditionIdentifiers = persisted
         ownedRegionIdentifiers.formUnion(persisted)
+        // `registeredConditions` is deliberately not filtered against `persisted`. It starts empty
+        // each process, so its only entries are ones staged while CLMonitor was still loading,
+        // whose adds are queued behind this operation — exactly the identifiers `persisted` lacks.
         persistConditionMirror()
         if drifted { onReconciled?() }
     }
@@ -198,10 +220,22 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
         case .unmonitored:
             // CLMonitor gave up on the condition (e.g. condition budget exceeded). As with classic
             // monitoringDidFail: drop ownership and the mirror entry so nothing claims a condition
-            // the OS no longer holds; the next sync re-registers a fresh set.
+            // the OS no longer holds; the next sync re-registers a fresh set. The stored baseline
+            // goes too — the region stays in the desired set, so nothing else prunes it, and the
+            // device can cross while it is unmonitored.
             ownedRegionIdentifiers.remove(identifier)
             knownConditionIdentifiers.remove(identifier)
+            registeredConditions.removeValue(forKey: identifier)
             persistConditionMirror()
+            // On the pipeline, and skipped if a registration has re-added the identifier since the
+            // line above cleared it: that add wrote a baseline from the device's real position, which
+            // must not then be deleted. Keyed on this monitor's own record of completed adds rather
+            // than on `CLMonitor.identifiers`, because whether a condition the OS gave up on stays
+            // listed is unmeasured — reading it could make this clear permanently inert.
+            enqueueMonitorOperation { [weak self] _ in
+                guard let self, !self.knownConditionIdentifiers.contains(identifier) else { return }
+                await self.storage.clearMonitorRegionRecord(identifier: identifier)
+            }
             return
         @unknown default:
             return
@@ -227,14 +261,6 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
         knownConditionIdentifiers
     }
 
-    func adoptExistingRegions(matching identifiers: Set<String>) {
-        let adopted = identifiers.intersection(knownConditionIdentifiers)
-        guard !adopted.isEmpty else { return }
-        ownedRegionIdentifiers.formUnion(adopted)
-        rearmConditions(adopted)
-        logger.geofenceRegionsAdopted(count: adopted.count)
-    }
-
     func setOnTransition(_ handler: GeofenceTransitionHandler?) {
         onTransition = handler
         drainPendingEventsIfReady()
@@ -246,77 +272,6 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
 
     func setOnReconciled(_ handler: GeofenceReconciledHandler?) {
         onReconciled = handler
-    }
-
-    func startMonitoring(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) {
-        reportPermissionTier()
-        guard CoreLocationGeofenceMonitor.permissionTier(for: authManager.authorizationStatus) != .blocked else { return }
-
-        let coordinate = CLLocationCoordinate2D(latitude: center.latitude, longitude: center.longitude)
-        guard CLLocationCoordinate2DIsValid(coordinate) else {
-            logger.geofenceInvalidCoordinatesForRegion(identifier)
-            return
-        }
-
-        // Populate the ownership filter synchronously so a fast-arriving event isn't dropped.
-        ownedRegionIdentifiers.insert(identifier)
-
-        // Parity with the classic monitor's clamp; `maximumRegionMonitoringDistance` is a deprecated
-        // but harmless read with no CLMonitor equivalent — both paths register identical geometry.
-        let clampedRadius = min(radius, authManager.maximumRegionMonitoringDistance)
-
-        // The device's ACTUAL state seeds both CLMonitor's `assuming:` hint and the stored baseline
-        // (see `recordMonitorRegistration`: registration stays silent, the first real crossing
-        // delivers). No fix → geometric expectation: trigger is device-centered (inside),
-        // business geofences outside.
-        let isMovementTrigger = identifier == GeofenceConstants.movementTriggerIdentifier
-        let isInside = isDeviceInside(center: coordinate, radius: clampedRadius) ?? isMovementTrigger
-        let initialTransition: GeofenceTransition = isInside ? .enter : .exit
-        let assumedState: CLMonitor.Event.State = isInside ? .satisfied : .unsatisfied
-
-        enqueueMonitorOperation { [weak self] monitor in
-            guard let self else { return }
-            // Persist before the OS add: storage keys off recorded geometry to preserve the baseline
-            // on an unchanged re-register and reseed on a new/changed circle. The decision lives in
-            // storage because this runs after stop-all, when CLMonitor's own record is already gone.
-            await self.storage.recordMonitorRegistration(
-                identifier: identifier,
-                transitionTypes: transitionTypes,
-                initialState: initialTransition,
-                center: LocationData(latitude: coordinate.latitude, longitude: coordinate.longitude),
-                radius: clampedRadius
-            )
-            let condition = CLMonitor.CircularGeographicCondition(center: coordinate, radius: clampedRadius)
-            await monitor.add(condition, identifier: identifier, assuming: assumedState)
-            self.knownConditionIdentifiers.insert(identifier)
-            self.persistConditionMirror()
-        }
-    }
-
-    func stopMonitoring(identifier: String) {
-        guard ownedRegionIdentifiers.remove(identifier) != nil else { return }
-        // The storage record intentionally survives removal: a stop-all + re-register cycle relies
-        // on the persisted baseline to suppress CLMonitor's re-evaluation of an unchanged state.
-        enqueueMonitorOperation { [weak self] monitor in
-            guard let self else { return }
-            await monitor.remove(identifier)
-            self.knownConditionIdentifiers.remove(identifier)
-            self.persistConditionMirror()
-        }
-    }
-
-    func stopMonitoringAll() {
-        ownedRegionIdentifiers.removeAll()
-        // Clear against CLMonitor's LIVE identifiers, not the owned/mirror snapshot: an empty owned
-        // set or a lossy mirror must not leave a stale SDK condition holding an OS slot.
-        enqueueMonitorOperation { [weak self] monitor in
-            guard let self else { return }
-            for identifier in await monitor.identifiers {
-                await monitor.remove(identifier)
-            }
-            self.knownConditionIdentifiers.removeAll()
-            self.persistConditionMirror()
-        }
     }
 
     func reportPermissionTier() {
@@ -364,7 +319,7 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
 
     // MARK: - Private
 
-    private func persistConditionMirror() {
+    func persistConditionMirror() {
         userDefaults.set(knownConditionIdentifiers.sorted(), forKey: Self.conditionMirrorKey)
     }
 
@@ -379,7 +334,7 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
 
     /// Whether the device is inside the circle per the last known location; `nil` without a usable
     /// fix. No accuracy padding: a wrong guess costs one corrective event, absorbed by the baseline.
-    private func isDeviceInside(center: CLLocationCoordinate2D, radius: CLLocationDistance) -> Bool? {
+    func isDeviceInside(center: CLLocationCoordinate2D, radius: CLLocationDistance) -> Bool? {
         guard let location = authManager.location,
               CLLocationCoordinate2DIsValid(location.coordinate)
         else {

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -61,6 +61,9 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
     /// first pass re-register it; when the bootstrap adopts instead, `adoptExistingRegions` seeds it
     /// from the persisted records the re-arm then imposes at the OS.
     var registeredConditions: [String: RegisteredCondition] = [:]
+    /// Conditions the OS stopped monitoring since their last registration. The next registration
+    /// reseeds their stored baseline instead of preserving it — see `recordMonitorRegistration`.
+    var conditionsNeedingBaselineReseed: Set<String> = []
 
     /// The circle a condition was added with.
     struct RegisteredCondition: Equatable {
@@ -223,15 +226,21 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
             // the OS no longer holds; the next sync re-registers a fresh set. The stored baseline
             // goes too — the region stays in the desired set, so nothing else prunes it, and the
             // device can cross while it is unmonitored.
+            logger.geofenceMonitorStoppedMonitoringRegion(identifier)
             ownedRegionIdentifiers.remove(identifier)
             knownConditionIdentifiers.remove(identifier)
             registeredConditions.removeValue(forKey: identifier)
+            // Whichever registration comes next must reseed the baseline rather than preserve it.
+            // The clear below only covers the case where none comes: a re-registration with the same
+            // circle preserves the stored state by design, and after the OS gave up that state is no
+            // longer known to match reality.
+            conditionsNeedingBaselineReseed.insert(identifier)
             persistConditionMirror()
             // On the pipeline, and skipped if a registration has re-added the identifier since the
-            // line above cleared it: that add wrote a baseline from the device's real position, which
-            // must not then be deleted. Keyed on this monitor's own record of completed adds rather
-            // than on `CLMonitor.identifiers`, because whether a condition the OS gave up on stays
-            // listed is unmeasured — reading it could make this clear permanently inert.
+            // line above cleared it — deleting a baseline that add just wrote would cost the next
+            // crossing. Keyed on this monitor's own record of completed adds rather than on
+            // `CLMonitor.identifiers`: a condition the OS gave up on stays listed there (measured),
+            // so reading that would make this clear permanently inert.
             enqueueMonitorOperation { [weak self] _ in
                 guard let self, !self.knownConditionIdentifiers.contains(identifier) else { return }
                 await self.storage.clearMonitorRegionRecord(identifier: identifier)

--- a/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
@@ -60,7 +60,7 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
         Set(manager.monitoredRegions.map(\.identifier))
     }
 
-    func adoptExistingRegions(matching identifiers: Set<String>) {
+    func adoptExistingRegions(matching identifiers: Set<String>, records _: [String: MonitorRegionRecord]) {
         let adopted = identifiers.intersection(osMonitoredRegionIdentifiers)
         guard !adopted.isEmpty else { return }
         ownedRegionIdentifiers.formUnion(adopted)
@@ -110,6 +110,51 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
                 manager.stopMonitoring(for: region)
             }
         }
+    }
+
+    @discardableResult
+    func setMonitoredRegions(_ regions: [GeofenceRegionRequest]) -> GeofenceRegionDiff {
+        let desiredIdentifiers = Set(regions.map(\.identifier))
+        var removed: Set<String> = []
+        for identifier in ownedRegionIdentifiers.subtracting(desiredIdentifiers) {
+            stopMonitoring(identifier: identifier)
+            removed.insert(identifier)
+        }
+        var added: Set<String> = []
+        for region in regions where !isRegisteredUnchanged(region) {
+            // Explicit stop before start (no-op when unowned): `startMonitoring(for:)` replaces by
+            // identifier, but the pair keeps the OS-side sequence identical on both monitors.
+            stopMonitoring(identifier: region.identifier)
+            startMonitoring(
+                identifier: region.identifier,
+                center: region.center,
+                radius: region.radius,
+                transitionTypes: region.transitionTypes
+            )
+            // Blocked permission / invalid coordinates make `startMonitoring` a no-op; the caller's
+            // initial-enter decision must not count a region the OS never took.
+            if ownedRegionIdentifiers.contains(region.identifier) { added.insert(region.identifier) }
+        }
+        return GeofenceRegionDiff(added: added, removed: removed)
+    }
+
+    /// True when this monitor owns the region and the OS holds an identical circle, so re-registering
+    /// would only risk absorbing an undelivered crossing. Geometry comes from the live
+    /// `CLCircularRegion` rather than our own bookkeeping, so a region the OS reshaped or dropped
+    /// re-registers rather than being trusted.
+    private func isRegisteredUnchanged(_ region: GeofenceRegionRequest) -> Bool {
+        guard ownedRegionIdentifiers.contains(region.identifier),
+              let existing = manager.monitoredRegions.first(where: { $0.identifier == region.identifier }) as? CLCircularRegion
+        else { return false }
+        var registeredTypes: Set<GeofenceTransition> = []
+        if existing.notifyOnEntry { registeredTypes.insert(.enter) }
+        if existing.notifyOnExit { registeredTypes.insert(.exit) }
+        return region.matchesRegistered(
+            center: LocationData(latitude: existing.center.latitude, longitude: existing.center.longitude),
+            radius: existing.radius,
+            transitionTypes: registeredTypes,
+            clampedTo: manager.maximumRegionMonitoringDistance
+        )
     }
 
     // MARK: - CLLocationManagerDelegate

--- a/Sources/LocationGeofence/Monitor/GeofenceRegionMonitoring.swift
+++ b/Sources/LocationGeofence/Monitor/GeofenceRegionMonitoring.swift
@@ -19,6 +19,43 @@ typealias GeofenceAuthorizationChangedHandler = @MainActor () -> Void
 /// Invoked on the main actor.
 typealias GeofenceReconciledHandler = @MainActor () -> Void
 
+/// A circular region the caller wants monitored, as handed to `setMonitoredRegions`.
+struct GeofenceRegionRequest: Equatable, Sendable {
+    let identifier: String
+    let center: LocationData
+    let radius: Double
+    let transitionTypes: Set<GeofenceTransition>
+}
+
+extension GeofenceRegionRequest {
+    /// Latitude/longitude slack, ~1cm. Absorbs float round-tripping through CoreLocation and JSON.
+    private static let coordinateTolerance = 1e-7
+    /// Radius slack in meters.
+    private static let radiusTolerance = 0.5
+
+    /// Whether an already-registered circle matches this request closely enough to leave alone.
+    /// Compares against the radius the OS would actually hold, so a fence larger than the cap
+    /// doesn't read as "changed" on every pass and churn forever.
+    func matchesRegistered(
+        center: LocationData,
+        radius: Double,
+        transitionTypes: Set<GeofenceTransition>,
+        clampedTo maximumRadius: Double
+    ) -> Bool {
+        abs(center.latitude - self.center.latitude) < Self.coordinateTolerance
+            && abs(center.longitude - self.center.longitude) < Self.coordinateTolerance
+            && abs(radius - min(self.radius, maximumRadius)) < Self.radiusTolerance
+            && transitionTypes == self.transitionTypes
+    }
+}
+
+/// What `setMonitoredRegions` changed. Everything in the desired set that isn't listed here was
+/// already registered with the same circle and was left untouched — the point of the call.
+struct GeofenceRegionDiff: Equatable, Sendable {
+    let added: Set<String>
+    let removed: Set<String>
+}
+
 /// Abstracts CLLocationManager's region monitoring.
 ///
 /// The monitor owns a CLLocationManager and handles the delegate callbacks for region events.
@@ -55,6 +92,16 @@ protocol GeofenceRegionMonitoring: AnyObject, Sendable {
     /// Stops monitoring the region with the given identifier.
     func stopMonitoring(identifier: String)
 
+    /// Reconciles the monitored set to exactly `regions`: stops what is no longer wanted, starts
+    /// what is new or whose circle changed, and leaves everything else registered as-is.
+    ///
+    /// Leaving unchanged regions untouched is part of the contract, not an optimization: stopping
+    /// and re-adding a region discards any boundary crossing the OS has detected but not yet
+    /// delivered, and neither monitor replays it. Implementations must not re-register a region
+    /// whose circle is unchanged.
+    @discardableResult
+    func setMonitoredRegions(_ regions: [GeofenceRegionRequest]) -> GeofenceRegionDiff
+
     /// Stops monitoring all regions managed by this monitor.
     func stopMonitoringAll()
 
@@ -74,10 +121,14 @@ protocol GeofenceRegionMonitoring: AnyObject, Sendable {
 
     /// Re-claims the OS-persisted regions whose identifiers are in `identifiers` as owned by this
     /// monitor, restoring transition recognition on a fresh process where the OS kept monitoring
-    /// but the in-memory ownership set was lost. Adoption must not emit events for unchanged
-    /// regions; the OS-side mechanism is implementation-specific (the classic monitor adopts in
-    /// place, the CLMonitor path re-arms each condition — see `rearmConditions`).
-    func adoptExistingRegions(matching identifiers: Set<String>)
+    /// but the in-memory ownership set was lost. `records` is the persisted per-condition
+    /// bookkeeping (`GeofenceStorage.getMonitorRegionRecords`); the CLMonitor path seeds its
+    /// geometry map from it synchronously, so a sync arriving before the queued re-arm drains
+    /// reads adopted regions as unchanged instead of re-registering them all. Adoption must not
+    /// emit events for unchanged regions; the OS-side mechanism is implementation-specific (the
+    /// classic monitor adopts in place and ignores `records`, the CLMonitor path re-arms each
+    /// condition — see `rearmConditions`).
+    func adoptExistingRegions(matching identifiers: Set<String>, records: [String: MonitorRegionRecord])
 
     /// Logs the current authorization tier (background delivery / foreground only / blocked),
     /// deduped so it emits only when the tier changes since the last report.

--- a/Sources/LocationGeofence/Storage/GeofenceStorage.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage.swift
@@ -106,18 +106,24 @@ actor GeofenceStorage {
     /// changed circle. The unchanged-vs-changed decision is keyed on the persisted `center`/`radius`
     /// (which survive stop-all) rather than CLMonitor's live record (which stop-all removes before the
     /// re-add, so it can never report "unchanged").
+    ///
+    /// `forceReseed` overrides that preservation. The caller sets it when the OS stopped monitoring
+    /// the condition since the last registration: the device can cross while unmonitored, so the
+    /// persisted state is no longer known to match reality and keeping it would suppress the next
+    /// genuine crossing.
     func recordMonitorRegistration(
         identifier: String,
         transitionTypes: Set<GeofenceTransition>,
         initialState: GeofenceTransition,
         center: LocationData,
-        radius: Double
+        radius: Double,
+        forceReseed: Bool = false
     ) {
         var state = loadFromDisk() ?? GeofenceState()
         var records = state.monitorRegionRecords ?? [:]
         let existing = records[identifier]
         let unchangedGeometry = existing?.center == center && existing?.radius == radius
-        let lastState = unchangedGeometry ? (existing?.lastState ?? initialState) : initialState
+        let lastState = unchangedGeometry && !forceReseed ? (existing?.lastState ?? initialState) : initialState
         records[identifier] = MonitorRegionRecord(
             lastState: lastState,
             transitionTypes: transitionTypes,

--- a/Sources/LocationGeofence/Storage/GeofenceStorage.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage.swift
@@ -158,6 +158,16 @@ actor GeofenceStorage {
         loadFromDisk()?.monitorRegionRecords ?? [:]
     }
 
+    /// Drops the baseline for a condition the OS stopped monitoring, so the next registration
+    /// reseeds from the device's real position rather than carrying a state it may have left while
+    /// unmonitored — an unchanged-geometry re-register would preserve that stale value.
+    func clearMonitorRegionRecord(identifier: String) {
+        var state = loadFromDisk() ?? GeofenceState()
+        guard var records = state.monitorRegionRecords, records.removeValue(forKey: identifier) != nil else { return }
+        state.monitorRegionRecords = records
+        saveToDisk(state)
+    }
+
     /// Clears the cooldown map, last-sync record, registration set, and monitor baselines but
     /// preserves the cached geofences and config. Called on sign-out: the workspace cache is shared
     /// across users, while cooldowns belong to the signed-out user and the last-sync anchor would

--- a/Sources/LocationGeofence/Storage/GeofenceStorage.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage.swift
@@ -247,6 +247,18 @@ actor GeofenceStorage {
         var state = loadFromDisk() ?? GeofenceState()
         state.movementTriggerCenter = center
         state.monitoredGeofenceIds = businessIds
+        // Drop per-condition baselines for regions this registration no longer covers. A record
+        // survives `stopMonitoring` on purpose, so an unchanged re-register keeps its baseline and
+        // CLMonitor's re-evaluation stays silent — but a region *evicted* from the set is a
+        // different case. It goes unmonitored, so no EXIT ever balances a `.enter` baseline, and a
+        // later re-registration with the same circle keeps that stale value instead of the state
+        // the device is actually in. The next genuine arrival then reads as no change and is
+        // dropped. Retaining exactly the registered set bounds the records the same way
+        // `monitoredGeofenceIds` is bounded, and clears anything a previous version stranded.
+        if let records = state.monitorRegionRecords {
+            let retained = businessIds.union([GeofenceConstants.movementTriggerIdentifier])
+            state.monitorRegionRecords = records.filter { retained.contains($0.key) }
+        }
         saveToDisk(state)
     }
 

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceDistanceFilterTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceDistanceFilterTests.swift
@@ -8,12 +8,12 @@ struct GeofenceDistanceFilterTests {
     private let filter = GeofenceDistanceFilter()
     private let origin = LocationData(latitude: 0, longitude: 0)
 
-    private func makeRegion(id: String, latitude: Double, longitude: Double) -> Geofence {
+    private func makeRegion(id: String, latitude: Double, longitude: Double, radius: Double = 100) -> Geofence {
         Geofence(
             id: id,
             latitude: latitude,
             longitude: longitude,
-            radius: 100,
+            radius: radius,
             name: id,
             transitionTypes: [.enter, .exit],
             lastUpdated: Date(timeIntervalSince1970: 0)
@@ -92,5 +92,65 @@ struct GeofenceDistanceFilterTests {
         // The no-cap sentinel includes every region regardless of distance.
         let result = filter.nearest(regions, to: origin, limit: 5, maxDistance: GeofenceConstants.noMonitoringDistanceCap)
         #expect(result.map(\.id) == ["near", "far"])
+    }
+
+    // MARK: - Ranking by boundary rather than center
+
+    @Test
+    func nearest_givenDeviceInsideLargeRegion_expectItRanksFirst() {
+        // Device sits inside `big` (center ~2.2 km away, radius 5 km) and outside `small`
+        // (center 1 km away). Ranking on center distance would put `small` first.
+        let regions = [
+            makeRegion(id: "small", latitude: 0.009, longitude: 0, radius: 100),
+            makeRegion(id: "big", latitude: 0.02, longitude: 0, radius: 5000)
+        ]
+        let result = filter.nearest(regions, to: origin, limit: 2, maxDistance: GeofenceConstants.noMonitoringDistanceCap)
+        #expect(result.map(\.id) == ["big", "small"])
+    }
+
+    @Test
+    func nearest_givenLimitFilledByNearerCenters_expectContainingRegionStillMonitored() {
+        // Regression: a region the device occupies must never be evicted by regions with nearer
+        // centers. Evicting it stops monitoring and its exit can then never be reported.
+        var regions = (0 ..< 19).map {
+            makeRegion(id: "decoy\(String(format: "%02d", $0))", latitude: 0.001, longitude: 0, radius: 50)
+        }
+        regions.append(makeRegion(id: "containing", latitude: 0.018, longitude: 0, radius: 2000))
+        let result = filter.nearest(regions, to: origin, limit: 19, maxDistance: GeofenceConstants.noMonitoringDistanceCap)
+        #expect(result.count == 19)
+        #expect(result.first?.id == "containing")
+    }
+
+    @Test
+    func nearest_givenContainingRegionCenterBeyondMaxDistance_expectStillIncluded() {
+        // The distance cap is also boundary-based: a region whose center is outside the cap but
+        // whose area contains the device must survive filtering.
+        let regions = [makeRegion(id: "containing", latitude: 0.05, longitude: 0, radius: 8000)]
+        let result = filter.nearest(regions, to: origin, limit: 5, maxDistance: 1000)
+        #expect(result.map(\.id) == ["containing"])
+    }
+
+    @Test
+    func nearest_givenRegionsFullyOutside_expectOrderedByBoundaryDistance() {
+        // `wide` has the farther center but the nearer boundary, so it ranks first.
+        let regions = [
+            makeRegion(id: "tight", latitude: 0.02, longitude: 0, radius: 100), // edge ~2.1 km
+            makeRegion(id: "wide", latitude: 0.03, longitude: 0, radius: 2000) // edge ~1.3 km
+        ]
+        let result = filter.nearest(regions, to: origin, limit: 2, maxDistance: GeofenceConstants.noMonitoringDistanceCap)
+        #expect(result.map(\.id) == ["wide", "tight"])
+    }
+
+    @Test
+    func nearest_givenMultipleContainingRegions_expectAllRankAheadOfOutsideOnes() {
+        // Every containing region has boundary distance 0, so they tie and break by id, but all
+        // must precede any region the device is outside of.
+        let regions = [
+            makeRegion(id: "outside", latitude: 0.005, longitude: 0, radius: 100),
+            makeRegion(id: "inside-b", latitude: 0.01, longitude: 0, radius: 3000),
+            makeRegion(id: "inside-a", latitude: 0.02, longitude: 0, radius: 5000)
+        ]
+        let result = filter.nearest(regions, to: origin, limit: 3, maxDistance: GeofenceConstants.noMonitoringDistanceCap)
+        #expect(result.map(\.id) == ["inside-a", "inside-b", "outside"])
     }
 }

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -522,7 +522,7 @@ struct GeofenceSyncCoordinatorTests {
     }
 
     @Test
-    func refresh_givenSuccess_expectRegistrationOrderStopAllThenTriggerThenBusiness() async {
+    func refresh_givenSuccess_expectMovementTriggerRegisteredBeforeBusinessRegions() async {
         let storage = makeStorage()
         let api = GeofenceApiServiceMock()
         let region = makeRegion(id: "g1", latitude: 1.0, longitude: 2.0)
@@ -533,10 +533,9 @@ struct GeofenceSyncCoordinatorTests {
         let setup = makeCoordinator(api: api, storage: storage)
         _ = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
 
-        // Verify operations arrived in `stopAll → start movement → start business` order — the
-        // trigger goes first so it isn't starved when business regions fill the shared OS budget.
+        // The trigger goes first so it isn't starved when business regions fill the shared OS budget.
+        // Nothing was registered before, so nothing is stopped.
         #expect(setup.monitor.operationLog == [
-            .stopAll,
             .start(identifier: GeofenceConstants.movementTriggerIdentifier),
             .start(identifier: "g1")
         ])
@@ -1233,9 +1232,9 @@ struct GeofenceSyncCoordinatorTests {
 
     // MARK: unchanged-set fast path (crossing absorption)
 
-    /// Shared arrangement for the fast-path tests: an initial remote refresh registers `regions`
-    /// (wholesale, stopAll #1), so the monitor owns them and the OS holds them — the steady state
-    /// every subsequent re-rank runs against.
+    /// Shared arrangement for the registration-diff tests: an initial remote refresh registers
+    /// `regions`, so the monitor owns them and the OS holds them — the steady state every
+    /// subsequent re-rank runs against.
     private func makeRegisteredSetup(
         regions: [Geofence],
         config: GeofenceConfig,
@@ -1250,7 +1249,7 @@ struct GeofenceSyncCoordinatorTests {
         return setup
     }
 
-    private var fastPathConfig: GeofenceConfig {
+    private var diffConfig: GeofenceConfig {
         GeofenceConfig(
             localRefreshTriggerRadius: 1000,
             remoteFetchRefreshTriggerRadius: 5000,
@@ -1268,14 +1267,14 @@ struct GeofenceSyncCoordinatorTests {
         // business regions must be left alone — only the trigger re-centers and the ranking anchor walks.
         let region = makeRegion(id: "g1", latitude: 0.5, longitude: 0.5)
         let storage = makeStorage()
-        let setup = await makeRegisteredSetup(regions: [region], config: fastPathConfig, storage: storage)
+        let setup = await makeRegisteredSetup(regions: [region], config: diffConfig, storage: storage)
 
         // ~111 m: within the refetch radius → local re-rank, same nearest set.
         let newLocation = LocationData(latitude: 0, longitude: 0.001)
         let result = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude)
 
         #expect(result.isSuccess)
-        #expect(setup.monitor.stopAllCallCount == 1) // the initial registration only
+        #expect(setup.monitor.stopAllCallCount == 0)
         #expect(setup.monitor.startedRegions.filter { $0.identifier == "g1" }.count == 1) // never re-added
         #expect(setup.monitor.stoppedIdentifiers == [GeofenceConstants.movementTriggerIdentifier])
         let triggerStarts = setup.monitor.startedRegions.filter { $0.identifier == GeofenceConstants.movementTriggerIdentifier }
@@ -1285,13 +1284,12 @@ struct GeofenceSyncCoordinatorTests {
     }
 
     @Test
-    func handleMovement_givenEmptyAreaThenKillSwitch_expectTeardownNotTriggerRecenter() async {
-        // The one state where the ids match but skipping would be wrong: a geofence-free area leaves
-        // the trigger armed with no business regions, so a later kill-switched config re-ranks onto
-        // the same (empty) set while the trigger is still owned. Skipping there would re-center a
-        // trigger the kill switch is supposed to remove.
+    func handleMovement_givenEmptyAreaThenKillSwitch_expectTriggerStopped() async {
+        // A geofence-free area leaves the trigger armed with no business regions, so a later
+        // kill-switched config re-ranks onto the same (empty) business set. The desired set is empty
+        // too, so the diff must stop the trigger rather than re-center it.
         let storage = makeStorage()
-        let setup = await makeRegisteredSetup(regions: [], config: fastPathConfig, storage: storage)
+        let setup = await makeRegisteredSetup(regions: [], config: diffConfig, storage: storage)
         #expect(setup.monitor.monitoredRegionIdentifiers == [GeofenceConstants.movementTriggerIdentifier])
 
         await storage.setCachedConfig(GeofenceConfig(
@@ -1306,14 +1304,14 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
 
         #expect(result.isSuccess)
-        #expect(setup.monitor.stopAllCallCount == 2) // wholesale teardown ran, not the fast path
+        #expect(setup.monitor.stoppedIdentifiers == [GeofenceConstants.movementTriggerIdentifier])
         #expect(setup.monitor.monitoredRegionIdentifiers.isEmpty)
     }
 
     @Test
-    func handleMovement_givenRerankChangesNearestSet_expectFullReregistration() async {
-        // Membership actually changed (budget of 1, a closer fence took the slot) — the wholesale
-        // path must run so the OS set matches the new ranking.
+    func handleMovement_givenRerankChangesNearestSet_expectOnlyDepartingRegionStopped() async {
+        // Membership actually changed (budget of 1, a closer fence took the slot) — the departing
+        // region is stopped and the arriving one started, so the OS set matches the new ranking.
         let config = GeofenceConfig(
             localRefreshTriggerRadius: 1000,
             remoteFetchRefreshTriggerRadius: 5000,
@@ -1330,33 +1328,172 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.02)
 
         #expect(result.isSuccess)
-        #expect(setup.monitor.stopAllCallCount == 2)
+        #expect(setup.monitor.stopAllCallCount == 0)
         #expect(setup.monitor.startedRegions.contains { $0.identifier == "near-end" })
+        #expect(setup.monitor.stoppedIdentifiers.contains("near-start"))
+        #expect(setup.monitor.monitoredRegionIdentifiers == ["near-end", GeofenceConstants.movementTriggerIdentifier])
     }
 
     @Test
-    func handleMovement_givenUnchangedSetButOsDroppedRegion_expectFullReregistration() async {
-        // The set compare alone would skip, but the OS silently dropped a region (monitoring
-        // failure). Wholesale re-registration is what heals that — the fast path must step aside.
+    func handleMovement_givenSetChanges_expectCarryOverRegionLeftRegistered() async {
+        // A re-rank that changes membership must leave regions present in both sets completely
+        // untouched: stopping and re-adding one discards any crossing the OS has detected but not
+        // yet delivered, and neither monitor replays it.
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 5000,
+            remoteFetchRefreshExpiry: 3600,
+            duplicateEventsExpiry: 3600,
+            maxBusinessGeofences: 2,
+            maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
+        )
+        let carry = makeRegion(id: "carry", latitude: 0, longitude: 0.001)
+        let leaves = makeRegion(id: "leaves", latitude: 0, longitude: -0.002)
+        let joins = makeRegion(id: "joins", latitude: 0, longitude: 0.021)
+        let setup = await makeRegisteredSetup(regions: [carry, leaves, joins], config: config, storage: makeStorage())
+        #expect(setup.monitor.monitoredRegionIdentifiers == ["carry", "leaves", GeofenceConstants.movementTriggerIdentifier])
+
+        // ~2.2 km east: local re-rank. `joins` takes the slot `leaves` gives up; `carry` stays.
+        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.02)
+
+        #expect(result.isSuccess)
+        #expect(setup.monitor.monitoredRegionIdentifiers == ["carry", "joins", GeofenceConstants.movementTriggerIdentifier])
+        #expect(!setup.monitor.stoppedIdentifiers.contains("carry"))
+        #expect(setup.monitor.startedRegions.filter { $0.identifier == "carry" }.count == 1)
+        #expect(setup.monitor.stoppedIdentifiers.contains("leaves"))
+        #expect(setup.monitor.startedRegions.contains { $0.identifier == "joins" })
+    }
+
+    @Test
+    func handleMovement_givenRadiusAboveOsCap_expectNoReRegistrationChurn() async {
+        // The OS clamps every radius to `maximumMonitoringRadius`. The unchanged check must compare
+        // against that clamped radius, or an over-cap region reads as changed on every pass and
+        // re-registers forever.
+        let monitor = MockGeofenceRegionMonitor()
+        monitor.maximumMonitoringRadius = 500
+        let storage = makeStorage()
+        let api = GeofenceApiServiceMock()
+        let region = makeRegion(id: "wide", latitude: 0, longitude: 0.001, radius: 2000)
+        api.fetchNearbyGeofencesClosure = { _, _, completion in
+            completion(.success(makeApiResponse(regions: [region], config: diffConfig)))
+        }
+        let setup = makeCoordinator(api: api, storage: storage, monitor: monitor)
+        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+
+        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
+
+        #expect(result.isSuccess)
+        #expect(!setup.monitor.stoppedIdentifiers.contains("wide"))
+        #expect(setup.monitor.startedRegions.filter { $0.identifier == "wide" }.count == 1)
+    }
+
+    @Test
+    func handleMovement_givenUnchangedSetButOsDroppedRegion_expectRegionReRegistered() async {
+        // The identifier is still owned in-process but the OS silently dropped it (monitoring
+        // failure). The diff must not trust ownership alone — re-registering is what heals it.
         let region = makeRegion(id: "g1", latitude: 0.5, longitude: 0.5)
-        let setup = await makeRegisteredSetup(regions: [region], config: fastPathConfig, storage: makeStorage())
+        let setup = await makeRegisteredSetup(regions: [region], config: diffConfig, storage: makeStorage())
         setup.monitor.osMonitoredRegions.remove("g1")
 
         let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
 
         #expect(result.isSuccess)
-        #expect(setup.monitor.stopAllCallCount == 2)
+        #expect(setup.monitor.stopAllCallCount == 0)
         #expect(setup.monitor.startedRegions.filter { $0.identifier == "g1" }.count == 2)
     }
 
     @Test
-    func refresh_givenFreshProcessWithMatchingStorage_expectFullReregistration() async {
-        // Fresh process: storage says the same set is registered and the OS still holds it, but this
-        // process owns nothing yet (bootstrap hasn't adopted). Skipping would leave OS events with no
-        // owner — the wholesale path must run to re-establish in-process ownership.
+    func refresh_givenOsHoldsUnownedRegionNoLongerNearest_expectSweptFromOs() async {
+        // A condition the OS still holds from a previous launch that this process never adopted and
+        // the server no longer returns. Ownership-based teardown can't see it, so only the sweep
+        // against live OS state removes it — otherwise it keeps one of the 20 slots indefinitely.
         let storage = makeStorage()
         let dateUtil = DateUtilStub()
-        await storage.setCachedConfig(fastPathConfig)
+        await storage.setCachedConfig(diffConfig)
+        await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-100), location: LocationData(latitude: 0, longitude: 0))
+        await storage.setCachedGeofences([makeRegion(id: "g1", latitude: 0.001, longitude: 0, radius: 500)])
+        let setup = makeCoordinator(storage: storage, dateUtil: dateUtil)
+        setup.monitor.seedOsHeldRegion(
+            identifier: "stranded",
+            center: LocationData(latitude: 5, longitude: 5),
+            radius: 300,
+            transitionTypes: [.enter, .exit]
+        )
+
+        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+
+        #expect(!setup.monitor.osMonitoredRegions.contains("stranded"))
+        #expect(setup.monitor.osMonitoredRegions.contains("g1"))
+    }
+
+    @Test
+    func refresh_givenAdoptedRegionsWithPersistedGeometry_expectUnchangedRegionLeftUntouched() async {
+        // Cold launch on the CLMonitor path: the OS still holds last session's condition and the
+        // persisted record carries its geometry, which adoption seeds synchronously. A sync landing
+        // before the queued re-arm drains must read the unchanged region as unchanged — re-adding
+        // it would absorb a crossing the OS has detected but not yet delivered.
+        let storage = makeStorage()
+        let dateUtil = DateUtilStub()
+        await storage.setCachedConfig(diffConfig)
+        await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-100), location: LocationData(latitude: 0, longitude: 0))
+        await storage.setCachedGeofences([makeRegion(id: "g1", latitude: 0.001, longitude: 0, radius: 500)])
+        let setup = makeCoordinator(storage: storage, dateUtil: dateUtil)
+        setup.monitor.osMonitoredRegions = ["g1"]
+        setup.monitor.adoptExistingRegions(
+            matching: ["g1"],
+            records: [
+                "g1": MonitorRegionRecord(
+                    lastState: .enter,
+                    transitionTypes: [.enter, .exit],
+                    center: LocationData(latitude: 0.001, longitude: 0),
+                    radius: 500
+                )
+            ]
+        )
+
+        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+
+        #expect(!setup.monitor.stoppedIdentifiers.contains("g1"))
+        #expect(setup.monitor.startedRegions.filter { $0.identifier == "g1" }.isEmpty)
+        #expect(setup.monitor.monitoredRegionIdentifiers.contains("g1"))
+    }
+
+    @Test
+    func refresh_givenFreshProcessAndReshapedRegionOsStillHolds_expectOsGeometryUpdated() async {
+        // Fresh process owning nothing, OS still holding `g1` from the previous launch on its old
+        // circle, and the server has since reshaped it. CLMonitor silently ignores an add over a
+        // live identifier, so without an explicit removal the OS keeps the old circle while this
+        // process records the new one — every later pass then reads "unchanged" and never repairs
+        // it. The stale circle would outlive the process indefinitely.
+        let storage = makeStorage()
+        let dateUtil = DateUtilStub()
+        await storage.setCachedConfig(diffConfig)
+        await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-100), location: LocationData(latitude: 0, longitude: 0))
+        await storage.recordRegistration(center: LocationData(latitude: 0, longitude: 0), businessIds: ["g1"])
+        await storage.setCachedGeofences([makeRegion(id: "g1", latitude: 0.5, longitude: 0.5, radius: 750)])
+        let setup = makeCoordinator(storage: storage, dateUtil: dateUtil)
+        setup.monitor.osMonitoredRegions = [GeofenceConstants.movementTriggerIdentifier]
+        setup.monitor.seedOsHeldRegion(
+            identifier: "g1",
+            center: LocationData(latitude: 0.5, longitude: 0.5),
+            radius: 100, // the OLD circle
+            transitionTypes: [.enter, .exit]
+        )
+
+        let result = await setup.coordinator.refresh(latitude: 0.02, longitude: 0)
+
+        #expect(result.isSuccess)
+        #expect(setup.monitor.osGeometry(for: "g1")?.radius == 750)
+    }
+
+    @Test
+    func refresh_givenFreshProcessWithMatchingStorage_expectRegionsRegistered() async {
+        // Fresh process: storage says the same set is registered and the OS still holds it, but this
+        // process owns nothing yet (bootstrap hasn't adopted). Skipping would leave OS events with no
+        // owner — everything must be registered to re-establish in-process ownership.
+        let storage = makeStorage()
+        let dateUtil = DateUtilStub()
+        await storage.setCachedConfig(diffConfig)
         await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-100), location: LocationData(latitude: 0, longitude: 0))
         await storage.recordRegistration(center: LocationData(latitude: 0, longitude: 0), businessIds: ["g1"])
         await storage.setCachedGeofences([makeRegion(id: "g1", latitude: 0.5, longitude: 0.5)])
@@ -1367,8 +1504,9 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.refresh(latitude: 0.02, longitude: 0)
 
         #expect(result.isSuccess)
-        #expect(setup.monitor.stopAllCallCount == 1)
+        #expect(setup.monitor.stopAllCallCount == 0)
         #expect(setup.monitor.startedRegions.contains { $0.identifier == "g1" })
+        #expect(setup.monitor.monitoredRegionIdentifiers == ["g1", GeofenceConstants.movementTriggerIdentifier])
     }
 
     @Test
@@ -1378,7 +1516,7 @@ struct GeofenceSyncCoordinatorTests {
         // walk forward so the next refetch threshold measures from here.
         let region = makeRegion(id: "g1", latitude: 0.5, longitude: 0.5)
         let storage = makeStorage()
-        let setup = await makeRegisteredSetup(regions: [region], config: fastPathConfig, storage: storage)
+        let setup = await makeRegisteredSetup(regions: [region], config: diffConfig, storage: storage)
 
         // ~5.5 km from the fetch anchor → remote tier.
         let newLocation = LocationData(latitude: 0, longitude: 0.05)
@@ -1386,7 +1524,7 @@ struct GeofenceSyncCoordinatorTests {
 
         #expect(result.isSuccess)
         #expect(setup.api.fetchNearbyGeofencesCallsCount == 2)
-        #expect(setup.monitor.stopAllCallCount == 1)
+        #expect(setup.monitor.stopAllCallCount == 0)
         #expect(setup.monitor.startedRegions.filter { $0.identifier == "g1" }.count == 1)
         let triggerStarts = setup.monitor.startedRegions.filter { $0.identifier == GeofenceConstants.movementTriggerIdentifier }
         #expect(triggerStarts.last?.center == newLocation)
@@ -1395,12 +1533,12 @@ struct GeofenceSyncCoordinatorTests {
     }
 
     @Test
-    func handleMovement_givenRemoteRefreshChangesGeometry_expectFullReregistration() async {
-        // Same ids, but the server edited the fence (radius change bumps `lastUpdated`/geometry) —
-        // wholesale re-registration is what applies the new circle to the OS.
+    func handleMovement_givenRemoteRefreshChangesGeometry_expectRegionReRegistered() async {
+        // Same id, but the server edited the fence (radius change) — the geometry compare must catch
+        // it and re-register, or the OS keeps monitoring the old circle forever.
         let original = makeRegion(id: "g1", latitude: 0.5, longitude: 0.5, radius: 100)
         let resized = makeRegion(id: "g1", latitude: 0.5, longitude: 0.5, radius: 250)
-        let config = fastPathConfig
+        let config = diffConfig
         let api = GeofenceApiServiceMock()
         var responses = [[original], [resized]]
         api.fetchNearbyGeofencesClosure = { _, _, completion in
@@ -1412,7 +1550,7 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.05)
 
         #expect(result.isSuccess)
-        #expect(setup.monitor.stopAllCallCount == 2)
+        #expect(setup.monitor.stoppedIdentifiers.contains("g1"))
         #expect(setup.monitor.startedRegions.last { $0.identifier == "g1" }?.radius == 250)
     }
 
@@ -1420,14 +1558,14 @@ struct GeofenceSyncCoordinatorTests {
     func handleMovement_givenEmptyAreaLoop_expectTriggerWalksWithoutChurn() async {
         // The geofence-free corridor: empty response, empty cache, trigger armed. Every 5 km refetch
         // comes back empty again — the trigger must keep walking forward without a stop-all cycle.
-        let setup = await makeRegisteredSetup(regions: [], config: fastPathConfig, storage: makeStorage())
+        let setup = await makeRegisteredSetup(regions: [], config: diffConfig, storage: makeStorage())
 
         let newLocation = LocationData(latitude: 0, longitude: 0.05)
         let result = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude)
 
         #expect(result.isSuccess)
         #expect(setup.api.fetchNearbyGeofencesCallsCount == 2)
-        #expect(setup.monitor.stopAllCallCount == 1)
+        #expect(setup.monitor.stopAllCallCount == 0)
         let triggerStarts = setup.monitor.startedRegions.filter { $0.identifier == GeofenceConstants.movementTriggerIdentifier }
         #expect(triggerStarts.count == 2)
         #expect(triggerStarts.last?.center == newLocation)
@@ -1727,6 +1865,34 @@ struct GeofenceSyncCoordinatorTests {
     }
 
     @Test
+    func handleMovement_givenRegisteredRegionReshapedThenRejected_expectNoLongerReportedRegistered() async {
+        // A region already registered gets reshaped, and the monitor now rejects it (permission
+        // revoked, or the backend moved it to invalid coordinates). The stale claim must go with
+        // the failed re-registration — otherwise it keeps counting toward the registered set and
+        // `emitInitialEnters` can fire an enter for a region the OS is not monitoring.
+        let storage = makeStorage()
+        let dateUtil = DateUtilStub()
+        await storage.setCachedConfig(diffConfig)
+        await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-100), location: LocationData(latitude: 0, longitude: 0))
+        await storage.setCachedGeofences([makeRegion(id: "g1", latitude: 0.001, longitude: 0, radius: 500)])
+        let setup = makeCoordinator(storage: storage, dateUtil: dateUtil)
+
+        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+        #expect(setup.monitor.monitoredRegionIdentifiers.contains("g1"))
+
+        // Same id, different circle, and the monitor now refuses it.
+        await storage.setCachedGeofences([makeRegion(id: "g1", latitude: 0.001, longitude: 0, radius: 900)])
+        setup.monitor.rejectedIdentifiers = ["g1"]
+        _ = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
+
+        #expect(!setup.monitor.monitoredRegionIdentifiers.contains("g1"))
+        // And the circle it held before the refused reshape is gone from the OS, not left occupying
+        // one of the 20 slots with nothing owning it and no later pass repairing it.
+        #expect(!setup.monitor.osMonitoredRegions.contains("g1"))
+        #expect(setup.monitor.osGeometry(for: "g1") == nil)
+    }
+
+    @Test
     func refresh_givenDeviceInsideConfiguredRadiusButOutsideOsCap_expectNoInitialEnter() async {
         // The fence's configured radius exceeds the OS cap, so the monitor registers a smaller clamped
         // circle. The device is inside the configured radius but outside the clamped one, so the inside
@@ -1799,9 +1965,10 @@ struct GeofenceSyncCoordinatorTests {
         let result = await setup.coordinator.refresh(latitude: 0, longitude: 0)
 
         #expect(result.isSuccess)
-        // Cleanup ran: monitoring stopped again (register + cleanup = 2), user-scoped state cleared,
-        // and no initial enters for the signed-out user.
-        #expect(setup.monitor.stopAllCallCount == 2)
+        // Cleanup ran: monitoring torn down wholesale, user-scoped state cleared, and no initial
+        // enters for the signed-out user.
+        #expect(setup.monitor.stopAllCallCount == 1)
+        #expect(setup.monitor.monitoredRegionIdentifiers.isEmpty)
         #expect(await backing.getRegisteredBusinessIds().isEmpty)
         #expect(await backing.getLastSync() == nil)
         #expect(setup.emitter.calls.wrappedValue.isEmpty)

--- a/Tests/LocationGeofence/Geofence/GeofenceBootstrapTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceBootstrapTests.swift
@@ -255,6 +255,51 @@ struct GeofenceBootstrapTests {
     }
 
     @Test
+    func wireMonitor_givenAdoptPath_expectPersistedMonitorRecordsHandedToAdopt() async {
+        // The CLMonitor path seeds its geometry bookkeeping from these records synchronously at
+        // adopt, so a sync landing before the queued re-arm drains reads carried-over regions as
+        // unchanged instead of re-registering them all.
+        let di = DIGraphShared.shared
+        let storage = GeofenceStorage(
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        await storage.setCachedGeofences([
+            Geofence(
+                id: "g1",
+                latitude: 1,
+                longitude: 2,
+                radius: 100,
+                name: "g1",
+                transitionTypes: [.enter],
+                lastUpdated: Date(timeIntervalSince1970: 0)
+            )
+        ])
+        await storage.recordRegistration(center: LocationData(latitude: 10, longitude: 20), businessIds: ["g1"])
+        await storage.recordMonitorRegistration(
+            identifier: "g1",
+            transitionTypes: [.enter],
+            initialState: .exit,
+            center: LocationData(latitude: 1, longitude: 2),
+            radius: 100
+        )
+        di.override(value: storage, forType: GeofenceStorage.self)
+        let monitor = MockGeofenceRegionMonitor()
+        monitor.osMonitoredRegions = ["g1", GeofenceConstants.movementTriggerIdentifier]
+        di.override(value: monitor as GeofenceRegionMonitoring, forType: GeofenceRegionMonitoring.self)
+        let coordinator = GeofenceSyncCoordinatorMock()
+        di.override(value: coordinator as GeofenceSyncCoordinator, forType: GeofenceSyncCoordinator.self)
+        defer { di.reset() }
+
+        await GeofenceBootstrap.wireMonitor(di: di)
+
+        #expect(monitor.adoptExistingRegionsCallsCount == 1)
+        let record = monitor.adoptedRecords["g1"]
+        #expect(record?.center == LocationData(latitude: 1, longitude: 2))
+        #expect(record?.radius == 100)
+        #expect(record?.lastState == .exit)
+    }
+
+    @Test
     func wireMonitor_givenOsAlsoMonitorsHostAppRegions_expectOnlyOwnRegionsAdopted() async {
         // CLLocationManager.monitoredRegions is app-wide. Adoption must claim only the SDK's own
         // regions (cached geofences + movement trigger), never the host app's.

--- a/Tests/LocationGeofence/Geofence/Monitor/GeofenceRegionRequestTests.swift
+++ b/Tests/LocationGeofence/Geofence/Monitor/GeofenceRegionRequestTests.swift
@@ -1,0 +1,141 @@
+@testable import CioInternalCommon
+@testable import CioLocationGeofence
+import Foundation
+import Testing
+
+/// `matchesRegistered` decides whether `setMonitoredRegions` leaves a region alone. A false positive
+/// keeps a stale circle registered; a false negative re-registers every pass and discards crossings
+/// the OS has detected but not yet delivered. Both monitors and the mock share this comparison, so
+/// it is tested here rather than through any one of them.
+@Suite("GeofenceRegionRequest.matchesRegistered")
+struct GeofenceRegionRequestTests {
+    private static let uncapped = Double.greatestFiniteMagnitude
+
+    private func makeRequest(
+        latitude: Double = 10,
+        longitude: Double = 20,
+        radius: Double = 100,
+        transitionTypes: Set<GeofenceTransition> = [.enter, .exit]
+    ) -> GeofenceRegionRequest {
+        GeofenceRegionRequest(
+            identifier: "region",
+            center: LocationData(latitude: latitude, longitude: longitude),
+            radius: radius,
+            transitionTypes: transitionTypes
+        )
+    }
+
+    @Test
+    func matchesRegistered_givenIdenticalCircle_expectMatch() {
+        let request = makeRequest()
+        #expect(request.matchesRegistered(
+            center: LocationData(latitude: 10, longitude: 20),
+            radius: 100,
+            transitionTypes: [.enter, .exit],
+            clampedTo: Self.uncapped
+        ))
+    }
+
+    @Test
+    func matchesRegistered_givenCoordinateDriftWithinTolerance_expectMatch() {
+        // Coordinates round-trip through CoreLocation and JSON; sub-centimetre drift is not a move.
+        let request = makeRequest()
+        #expect(request.matchesRegistered(
+            center: LocationData(latitude: 10 + 5e-8, longitude: 20 - 5e-8),
+            radius: 100,
+            transitionTypes: [.enter, .exit],
+            clampedTo: Self.uncapped
+        ))
+    }
+
+    @Test
+    func matchesRegistered_givenMovedCenter_expectNoMatch() {
+        let request = makeRequest()
+        #expect(!request.matchesRegistered(
+            center: LocationData(latitude: 10.001, longitude: 20),
+            radius: 100,
+            transitionTypes: [.enter, .exit],
+            clampedTo: Self.uncapped
+        ))
+    }
+
+    @Test
+    func matchesRegistered_givenRadiusDriftWithinTolerance_expectMatch() {
+        let request = makeRequest()
+        #expect(request.matchesRegistered(
+            center: LocationData(latitude: 10, longitude: 20),
+            radius: 100.2,
+            transitionTypes: [.enter, .exit],
+            clampedTo: Self.uncapped
+        ))
+    }
+
+    @Test
+    func matchesRegistered_givenResizedRadius_expectNoMatch() {
+        let request = makeRequest(radius: 100)
+        #expect(!request.matchesRegistered(
+            center: LocationData(latitude: 10, longitude: 20),
+            radius: 250,
+            transitionTypes: [.enter, .exit],
+            clampedTo: Self.uncapped
+        ))
+    }
+
+    @Test
+    func matchesRegistered_givenRadiusAboveCapAndRegisteredAtCap_expectMatch() {
+        // The OS clamps on registration. Comparing the requested radius against the clamped one it
+        // holds would mark every over-cap region changed on every pass and re-register it forever.
+        let request = makeRequest(radius: 5000)
+        #expect(request.matchesRegistered(
+            center: LocationData(latitude: 10, longitude: 20),
+            radius: 1000,
+            transitionTypes: [.enter, .exit],
+            clampedTo: 1000
+        ))
+    }
+
+    @Test
+    func matchesRegistered_givenRadiusAboveCapButRegisteredBelowCap_expectNoMatch() {
+        // Registered narrower than the cap allows: the OS is holding a circle we did not ask for.
+        let request = makeRequest(radius: 5000)
+        #expect(!request.matchesRegistered(
+            center: LocationData(latitude: 10, longitude: 20),
+            radius: 400,
+            transitionTypes: [.enter, .exit],
+            clampedTo: 1000
+        ))
+    }
+
+    @Test
+    func matchesRegistered_givenRadiusBelowCap_expectCapIgnored() {
+        let request = makeRequest(radius: 100)
+        #expect(request.matchesRegistered(
+            center: LocationData(latitude: 10, longitude: 20),
+            radius: 100,
+            transitionTypes: [.enter, .exit],
+            clampedTo: 1000
+        ))
+    }
+
+    @Test
+    func matchesRegistered_givenNarrowedTransitionTypes_expectNoMatch() {
+        let request = makeRequest(transitionTypes: [.enter, .exit])
+        #expect(!request.matchesRegistered(
+            center: LocationData(latitude: 10, longitude: 20),
+            radius: 100,
+            transitionTypes: [.enter],
+            clampedTo: Self.uncapped
+        ))
+    }
+
+    @Test
+    func matchesRegistered_givenDifferentSingleTransitionType_expectNoMatch() {
+        let request = makeRequest(transitionTypes: [.exit])
+        #expect(!request.matchesRegistered(
+            center: LocationData(latitude: 10, longitude: 20),
+            radius: 100,
+            transitionTypes: [.enter],
+            clampedTo: Self.uncapped
+        ))
+    }
+}

--- a/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
@@ -646,6 +646,37 @@ struct GeofenceStorageTests {
     }
 
     @Test
+    func clearMonitorRegionRecord_givenOsStoppedMonitoring_expectNextArrivalDelivered() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let center = LocationData(latitude: 10, longitude: 20)
+        await storage.recordMonitorRegistration(identifier: "geo_1", transitionTypes: [.enter, .exit], initialState: .exit, center: center, radius: 100)
+        #expect(await storage.recordMonitorEvent(.enter, forIdentifier: "geo_1") == .deliver)
+        // CLMonitor reports .unmonitored. The region is still in the desired set, so the registration
+        // prune keeps its record; without this clear, the device can leave while unmonitored and the
+        // unchanged-geometry re-register carries the stale .enter, dropping the next real arrival.
+        await storage.clearMonitorRegionRecord(identifier: "geo_1")
+        await storage.recordMonitorRegistration(identifier: "geo_1", transitionTypes: [.enter, .exit], initialState: .exit, center: center, radius: 100)
+        #expect(await storage.recordMonitorEvent(.enter, forIdentifier: "geo_1") == .deliver)
+    }
+
+    @Test
+    func clearMonitorRegionRecord_givenOtherRegions_expectOnlyTargetDropped() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let center = LocationData(latitude: 10, longitude: 20)
+        await storage.recordMonitorRegistration(identifier: "geo_1", transitionTypes: [.enter], initialState: .exit, center: center, radius: 100)
+        await storage.recordMonitorRegistration(identifier: "geo_2", transitionTypes: [.enter], initialState: .exit, center: center, radius: 100)
+        await storage.clearMonitorRegionRecord(identifier: "geo_1")
+        #expect(await storage.getMonitorRegionRecords().keys.sorted() == ["geo_2"])
+        // Clearing an identifier with no record must not disturb what is stored.
+        await storage.clearMonitorRegionRecord(identifier: "absent")
+        #expect(await storage.getMonitorRegionRecords().keys.sorted() == ["geo_2"])
+    }
+
+    @Test
     func recordMonitorEvent_givenUnregisteredTransitionType_expectRecordedNotDelivered() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }

--- a/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
@@ -662,6 +662,35 @@ struct GeofenceStorageTests {
     }
 
     @Test
+    func recordMonitorRegistration_givenForceReseedOnUnchangedGeometry_expectBaselineReset() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let center = LocationData(latitude: 10, longitude: 20)
+        await storage.recordMonitorRegistration(identifier: "geo_1", transitionTypes: [.enter, .exit], initialState: .exit, center: center, radius: 100)
+        #expect(await storage.recordMonitorEvent(.enter, forIdentifier: "geo_1") == .deliver)
+        // The OS gave up on the condition and a registration with the SAME circle drained before the
+        // deferred record clear could run. Preserving `.enter` here would suppress the next arrival,
+        // because the device can have left while the region was unmonitored.
+        await storage.recordMonitorRegistration(identifier: "geo_1", transitionTypes: [.enter, .exit], initialState: .exit, center: center, radius: 100, forceReseed: true)
+        #expect(await storage.recordMonitorEvent(.enter, forIdentifier: "geo_1") == .deliver)
+    }
+
+    @Test
+    func recordMonitorRegistration_givenUnchangedGeometryWithoutForceReseed_expectBaselinePreserved() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let center = LocationData(latitude: 10, longitude: 20)
+        await storage.recordMonitorRegistration(identifier: "geo_1", transitionTypes: [.enter, .exit], initialState: .exit, center: center, radius: 100)
+        #expect(await storage.recordMonitorEvent(.enter, forIdentifier: "geo_1") == .deliver)
+        // Ordinary re-registration still preserves the baseline, so CLMonitor re-evaluating the same
+        // state is not delivered twice.
+        await storage.recordMonitorRegistration(identifier: "geo_1", transitionTypes: [.enter, .exit], initialState: .exit, center: center, radius: 100)
+        #expect(await storage.recordMonitorEvent(.enter, forIdentifier: "geo_1") == .suppressedNoChange)
+    }
+
+    @Test
     func clearMonitorRegionRecord_givenOtherRegions_expectOnlyTargetDropped() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }

--- a/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
@@ -700,4 +700,78 @@ struct GeofenceStorageTests {
         #expect(records["geo_1"]?.radius == 100)
         #expect(records["geo_1"]?.lastState == .enter)
     }
+
+    // MARK: - Monitor baseline pruning
+
+    @Test
+    func recordRegistration_givenEvictedRegion_expectItsBaselineDropped() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let centre = LocationData(latitude: 10, longitude: 20)
+        await storage.recordMonitorRegistration(identifier: "evicted", transitionTypes: [.enter, .exit], initialState: .enter, center: centre, radius: 500)
+        await storage.recordMonitorRegistration(identifier: "kept", transitionTypes: [.enter, .exit], initialState: .exit, center: centre, radius: 500)
+
+        await storage.recordRegistration(center: centre, businessIds: ["kept"])
+
+        let records = await storage.getMonitorRegionRecords()
+        #expect(records["evicted"] == nil)
+        #expect(records["kept"] != nil)
+    }
+
+    @Test
+    func recordRegistration_givenMovementTrigger_expectItsBaselineRetained() async {
+        // The trigger is never in `businessIds` but is always registered; pruning it would discard
+        // the baseline that makes its EXIT deliverable.
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let centre = LocationData(latitude: 10, longitude: 20)
+        await storage.recordMonitorRegistration(identifier: GeofenceConstants.movementTriggerIdentifier, transitionTypes: [.exit], initialState: .enter, center: centre, radius: 1000)
+
+        await storage.recordRegistration(center: centre, businessIds: ["g1"])
+
+        #expect(await storage.getMonitorRegionRecords()[GeofenceConstants.movementTriggerIdentifier] != nil)
+    }
+
+    @Test
+    func revisit_givenRegionEvictedWhileInside_expectGenuineEnterStillDelivered() async {
+        // The regression. A region evicted while the device is inside keeps a `.enter` baseline that
+        // no EXIT ever balances, because it is no longer monitored. Re-registering the same circle
+        // later preserves that baseline, so the arrival on a genuine revisit reads as no change and
+        // is dropped. Pruning on eviction is what keeps the revisit deliverable.
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let centre = LocationData(latitude: 10, longitude: 20)
+        let radius: Double = 500
+
+        await storage.recordMonitorRegistration(identifier: "F", transitionTypes: [.enter, .exit], initialState: .exit, center: centre, radius: radius)
+        #expect(await storage.recordMonitorEvent(.enter, forIdentifier: "F") == .deliver)
+
+        // Evicted while still inside — F is absent from the new registration snapshot.
+        await storage.recordRegistration(center: centre, businessIds: [])
+
+        // Much later: re-registered with an identical circle, device now outside.
+        await storage.recordMonitorRegistration(identifier: "F", transitionTypes: [.enter, .exit], initialState: .exit, center: centre, radius: radius)
+
+        #expect(await storage.recordMonitorEvent(.enter, forIdentifier: "F") == .deliver)
+    }
+
+    @Test
+    func recordRegistration_givenRetainedRegion_expectBaselinePreserved() async {
+        // Pruning must not touch a region that is still registered: its baseline is what keeps an
+        // unchanged re-register silent instead of re-delivering the state the device is already in.
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let centre = LocationData(latitude: 10, longitude: 20)
+        await storage.recordMonitorRegistration(identifier: "g1", transitionTypes: [.enter, .exit], initialState: .exit, center: centre, radius: 500)
+        #expect(await storage.recordMonitorEvent(.enter, forIdentifier: "g1") == .deliver)
+
+        await storage.recordRegistration(center: centre, businessIds: ["g1"])
+        await storage.recordMonitorRegistration(identifier: "g1", transitionTypes: [.enter, .exit], initialState: .exit, center: centre, radius: 500)
+
+        #expect(await storage.recordMonitorEvent(.enter, forIdentifier: "g1") == .suppressedNoChange)
+    }
 }

--- a/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
+++ b/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
@@ -30,6 +30,9 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
     private(set) var stopAllCallCount = 0
     private(set) var operationLog: [MockMonitorOperation] = []
     private var activeIdentifiers: Set<String> = []
+    /// What each owned region is currently registered with — the mock's stand-in for the classic
+    /// monitor's live `CLCircularRegion` and CLMonitor's geometry mirror.
+    private var registeredGeometry: [String: MonitoredRegionRecord] = [:]
 
     /// Seedable OS-persisted set — tests set this to model regions the OS still monitors on a
     /// fresh process (where `activeIdentifiers`, the in-memory ownership filter, starts empty).
@@ -40,6 +43,7 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
     var rejectedIdentifiers: Set<String> = []
     private(set) var adoptExistingRegionsCallsCount = 0
     private(set) var adoptedIdentifiers: Set<String> = []
+    private(set) var adoptedRecords: [String: MonitorRegionRecord] = [:]
     private(set) var reportPermissionTierCallsCount = 0
 
     var monitoredRegionIdentifiers: Set<String> {
@@ -54,11 +58,44 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
         osMonitoredRegions
     }
 
-    func adoptExistingRegions(matching identifiers: Set<String>) {
+    func adoptExistingRegions(matching identifiers: Set<String>, records: [String: MonitorRegionRecord]) {
         adoptExistingRegionsCallsCount += 1
+        adoptedRecords = records
         let adopted = identifiers.intersection(osMonitoredRegions)
         adoptedIdentifiers.formUnion(adopted)
         activeIdentifiers.formUnion(adopted)
+        // Mirror the CLMonitor path: adoption seeds the geometry bookkeeping from the persisted
+        // records (stored post-clamp, used as-is), which the re-arm then imposes at the OS — so a
+        // sync right after adopt reads an unchanged region as unchanged instead of re-adding it.
+        for identifier in adopted {
+            guard let record = records[identifier],
+                  let center = record.center, let radius = record.radius
+            else { continue }
+            registeredGeometry[identifier] = MonitoredRegionRecord(
+                identifier: identifier,
+                center: center,
+                radius: radius,
+                transitionTypes: record.transitionTypes
+            )
+        }
+    }
+
+    /// Models a condition the OS already holds that this process has NOT adopted — the state a
+    /// fresh launch is in before the bootstrap runs, and the one where an ignored add would leave
+    /// the OS on a stale circle.
+    func seedOsHeldRegion(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) {
+        registeredGeometry[identifier] = MonitoredRegionRecord(
+            identifier: identifier,
+            center: center,
+            radius: min(radius, maximumMonitoringRadius),
+            transitionTypes: transitionTypes
+        )
+        osMonitoredRegions.insert(identifier)
+    }
+
+    /// The circle the OS is holding, as opposed to what the caller last asked for.
+    func osGeometry(for identifier: String) -> MonitoredRegionRecord? {
+        registeredGeometry[identifier]
     }
 
     func reportPermissionTier() {
@@ -81,14 +118,38 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
     }
 
     func startMonitoring(identifier: String, center: LocationData, radius: Double, transitionTypes: Set<GeofenceTransition>) {
-        // Mirror the real monitor's early return: a rejected id is neither recorded nor owned.
-        guard !rejectedIdentifiers.contains(identifier) else { return }
+        // Mirror the real monitors: a rejected id is neither recorded nor owned, and any circle the
+        // OS was already holding for it is cleared rather than left live.
+        guard !rejectedIdentifiers.contains(identifier) else {
+            if osMonitoredRegions.remove(identifier) != nil {
+                registeredGeometry.removeValue(forKey: identifier)
+                stoppedIdentifiers.append(identifier)
+                operationLog.append(.stop(identifier: identifier))
+            }
+            return
+        }
+        // `startedRegions` keeps what the caller asked for; `registeredGeometry` keeps what the OS
+        // would hold, which is what the unchanged check compares against.
         startedRegions.append(MonitoredRegionRecord(
             identifier: identifier,
             center: center,
             radius: radius,
             transitionTypes: transitionTypes
         ))
+        // Models the real CLMonitor path: an add over an identifier the OS already holds is silently
+        // ignored and the original circle survives (verified on-device), so the monitor clears the
+        // identifier at the OS first. Modelled as the same remove-then-add pair. The classic monitor
+        // replaces by identifier, so a caller correct against this mock is correct against both.
+        if osMonitoredRegions.remove(identifier) != nil {
+            stoppedIdentifiers.append(identifier)
+            operationLog.append(.stop(identifier: identifier))
+        }
+        registeredGeometry[identifier] = MonitoredRegionRecord(
+            identifier: identifier,
+            center: center,
+            radius: min(radius, maximumMonitoringRadius),
+            transitionTypes: transitionTypes
+        )
         activeIdentifiers.insert(identifier)
         // Mirror the real monitors: a successful add is reflected in the OS-persisted set too
         // (classic's `monitoredRegions`, CLMonitor's condition mirror).
@@ -97,8 +158,11 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
     }
 
     func stopMonitoring(identifier: String) {
+        // Mirror both real monitors: stopping a region this process doesn't own is a no-op that
+        // never reaches the OS.
+        guard activeIdentifiers.remove(identifier) != nil else { return }
         stoppedIdentifiers.append(identifier)
-        activeIdentifiers.remove(identifier)
+        registeredGeometry.removeValue(forKey: identifier)
         osMonitoredRegions.remove(identifier)
         operationLog.append(.stop(identifier: identifier))
     }
@@ -109,7 +173,61 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
         // the OS still holds that this process never adopted survives the call.
         osMonitoredRegions.subtract(activeIdentifiers)
         activeIdentifiers.removeAll()
+        registeredGeometry.removeAll()
         operationLog.append(.stopAll)
+    }
+
+    /// Mirrors both real monitors: stop what left the set, skip what is registered with the same
+    /// circle, start the rest.
+    @discardableResult
+    func setMonitoredRegions(_ regions: [GeofenceRegionRequest]) -> GeofenceRegionDiff {
+        let desiredIdentifiers = Set(regions.map(\.identifier))
+        var removed: Set<String> = []
+        for identifier in activeIdentifiers.subtracting(desiredIdentifiers) {
+            stopMonitoring(identifier: identifier)
+            removed.insert(identifier)
+        }
+        // Mirror the CLMonitor path's sweep against live OS state, so a lossy mirror can't strand a
+        // condition on an OS slot. The classic monitor can't sweep — `CLLocationManager` shares
+        // `monitoredRegions` app-wide, so it would tear down the host app's regions.
+        for identifier in osMonitoredRegions.subtracting(desiredIdentifiers) {
+            osMonitoredRegions.remove(identifier)
+            registeredGeometry.removeValue(forKey: identifier)
+            stoppedIdentifiers.append(identifier)
+            operationLog.append(.stop(identifier: identifier))
+        }
+        var added: Set<String> = []
+        for region in regions where !isRegisteredUnchanged(region) {
+            // Mirror the real monitors: the previous claim is released before the re-registration,
+            // so one the monitor rejects stops counting as registered. Ownership only — what the OS
+            // holds (`osMonitoredRegions` / `registeredGeometry`) changes when the OS is told to.
+            activeIdentifiers.remove(region.identifier)
+            startMonitoring(
+                identifier: region.identifier,
+                center: region.center,
+                radius: region.radius,
+                transitionTypes: region.transitionTypes
+            )
+            if activeIdentifiers.contains(region.identifier) { added.insert(region.identifier) }
+        }
+        return GeofenceRegionDiff(added: added, removed: removed)
+    }
+
+    private func isRegisteredUnchanged(_ region: GeofenceRegionRequest) -> Bool {
+        // Owned AND still held by the OS. The OS-side check models the classic monitor's live
+        // `monitoredRegions` read; the CLMonitor path instead trusts its staged record, whose add
+        // is queued FIFO — in this synchronous mock staged and drained coincide, so one check
+        // matches both.
+        guard activeIdentifiers.contains(region.identifier),
+              osMonitoredRegions.contains(region.identifier),
+              let existing = registeredGeometry[region.identifier]
+        else { return false }
+        return region.matchesRegistered(
+            center: existing.center,
+            radius: existing.radius,
+            transitionTypes: existing.transitionTypes,
+            clampedTo: maximumMonitoringRadius
+        )
     }
 
     func simulateTransition(identifier: String, transition: GeofenceTransition, location: LocationData?) {


### PR DESCRIPTION
> [!IMPORTANT]
> **Squash-merge this PR.** Everything on this branch is `chore`, so a merge commit would put no releasable message on `main` and cut no release at all. Squashing makes this PR's title the single commit message semantic-release reads — which is why it is a `fix(...)`, and why the title needs a deliberate read before merging: it becomes the version bump *and* the changelog entry for the whole patch.

### What this is

A release branch collecting post-4.7.0 fixes so one release is cut for all of them, rather than one per merge.

| PR | What | Reviewed |
|---|---|---|
| #1190 | Region registration reconciles by diff instead of tearing the whole set down and rebuilding it on every sync | Approved, 3 review rounds + Bugbot |
| #1191 | Nearest-set selection ranks by boundary distance instead of centre; monitor baselines pruned to the registered set | Approved, 2 review rounds + Bugbot |
| #1193 | The dedup baseline is reseeded after the OS stops monitoring a region, instead of preserving a value recorded before it gave up | Approved, Bugbot |

**Read those three for the reasoning, the trade-offs and the review history.** This description deliberately doesn't restate them.

`main` has also been merged into this branch, so CI tests what will actually ship.

### Reviewing this PR

Almost all of this has been reviewed on the PR it came from, and that discussion lives there rather than here. **Two things have not**, and they are what is worth your attention:

#### 1. A direct commit — ownership is no longer dropped when the OS stops monitoring a region

One line removed from the `.unmonitored` handler, plus the comment explaining why. It did not go through its own PR.

`.unmonitored` used to drop the region from `ownedRegionIdentifiers`, mirroring the classic monitor's `monitoringDidFailFor`. That is correct for classic region monitoring, where a failed region genuinely leaves `monitoredRegions`. It is not correct for `CLMonitor`: measured on iOS 26.5, a condition the OS gives up on **stays listed in `CLMonitor.identifiers` and revives on its own once budget frees**. Ownership gates which events this process accepts, so dropping it strands the region — the OS resumes delivering and the SDK discards everything.

The worst case is the movement trigger, which is re-registered on every sync cycle and so is the most exposed region of all. Its events are what drive the next sync, so losing its ownership removes the only thing that would restore it before the process restarts.

Keeping ownership cannot admit a spurious event: the OS emits only for conditions it is actually monitoring. The one behaviour change is that a repeated `.unmonitored` for the same identifier is now processed rather than dropped by the ownership gate, which can log the error more than once per region. Guarding that with a `knownConditionIdentifiers` check was considered and rejected — in the exact interleaving #1193 fixes, the queued add has not drained yet, so the guard would skip the baseline reseed.

#### 2. The combination of #1190 and #1191

Both touch `GeofenceStorage.swift`, in different places. Their interaction is the only thing this PR adds that neither sub-PR could show on its own:

- #1191's `recordRegistration` prunes `monitorRegionRecords` to the registered set; #1190's `.unmonitored` handler clears a single record via `clearMonitorRegionRecord`. Both run on the storage actor, so they serialise; neither can observe the other mid-write.
- Every caller of `recordRegistration` passes the set it just registered, so the prune never drops a record for a region that is still monitored.

### Validation of the combined branch

- Full suite green on the merged result. SwiftLint `--strict` clean, API baseline regenerates with no diff — no public API changes.
- **On-device drive on the shipping content (2026-08-05, ~2 hours).** 8 registration cycles, every one `+N / -0` — no region removed at any point. 13 transitions correctly paired across 5 regions. Four remote-refresh cycles and three local re-ranks observed directly. A terminated app was relaunched **in the background** by a boundary crossing and delivered it, with adoption re-arming 10 conditions 87 ms after process start. 49 minutes parked inside a region produced zero duplicate enters.
- Earlier drives, including a paired A/B against three unmodified control apps, are described in #1190.

The direct commit above is not covered by that drive: `.unmonitored` cannot be triggered on a device, and `CLMonitor` cannot be constructed in a test bundle, so the monitor adapter has no unit coverage either. It rests on an exhaustive state-space model of the registration logic — which drives the defect's invariant violations to zero under both possible OS semantics, with no regression on any other invariant — plus a review of every consumer of the ownership set.

### Adding to this release

Target this branch, squash-merge, and title it `chore(...)` like the two above — individual titles don't reach `main`, so they can't affect the version. Two things to remember before this PR merges:

- If anything landing here is a **feature**, retitle this PR to `feat(...)` or a minor ships as a patch.
- Widen this PR's title if the contents stop being geofence-only.
- If `main` moves during the window, merge it into this branch so CI tests what will actually ship.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core geofence registration, ranking, and event-dedup baselines on both Core Location paths; missed or duplicate transitions directly affect customer messaging.
> 
> **Overview**
> Replaces **stop-all + rebuild** geofence sync with **`setMonitoredRegions`**, which only stops/starts regions whose membership or circle changed so undelivered OS crossings are not absorbed on every refresh or re-rank. The coordinator drops the unchanged-set fast paths (`canSkipReregistration`, remote identical-payload shortcuts, trigger-only re-center) in favor of this diff path on both classic and CLMonitor backends.
> 
> **Nearest selection** now ranks and distance-filters on **boundary distance** (`edgeDistanceTo`) instead of center distance, so a large region the device is inside is not evicted when the OS slot budget fills.
> 
> **CLMonitor** gains geometry bookkeeping for diffs, bootstrap **adopt** seeds from persisted `MonitorRegionRecord`s, and **`.unmonitored`** keeps in-process ownership while clearing mirror/geometry and forcing baseline reseed (`forceReseed` / `clearMonitorRegionRecord`). **Storage** prunes monitor baselines to the registered business set plus movement trigger on each `recordRegistration`.
> 
> Logging shifts from rerank-unchanged to registration diff counts; errors are logged when CoreLocation stops monitoring a region.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e486a5802eaddcc510d803c7087073b919f29659. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

