### PR TITLE
chore(geofence): reseed the monitor baseline after the OS stops monitoring

### DIFF
--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -37,6 +37,16 @@ extension Logger {
         )
     }
 
+    // Logged at error level deliberately: `info`/`debug` are not persisted to the log store for
+    // third-party subsystems, so a field report would not carry them.
+    func geofenceMonitorStoppedMonitoringRegion(_ identifier: String) {
+        error(
+            "CoreLocation stopped monitoring region \(identifier); its transitions are not delivered until the next sync re-registers it",
+            geofenceTag,
+            nil
+        )
+    }
+
     func geofencePermissionUnavailable(currentStatus: CLAuthorizationStatus) {
         info(
             "Geofence registration skipped: location permission not granted (current status: \(currentStatus.rawValue)). The host app controls when and which permission to request.",

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
@@ -76,12 +76,16 @@ extension CLMonitorGeofenceMonitor {
             // Persist before the OS add: storage keys off recorded geometry to preserve the baseline
             // on an unchanged re-register and reseed on a new/changed circle. The decision lives in
             // storage because this runs after stop-all, when CLMonitor's own record is already gone.
+            // Consumed here rather than at staging time: an add already queued when `.unmonitored`
+            // arrived still drains after it, so it is the one that must reseed.
+            let forceReseed = self.conditionsNeedingBaselineReseed.remove(identifier) != nil
             await self.storage.recordMonitorRegistration(
                 identifier: identifier,
                 transitionTypes: transitionTypes,
                 initialState: initialTransition,
                 center: LocationData(latitude: coordinate.latitude, longitude: coordinate.longitude),
-                radius: clampedRadius
+                radius: clampedRadius,
+                forceReseed: forceReseed
             )
             // CLMonitor SILENTLY IGNORES an add over a live identifier, keeping the original circle
             // and reporting no error, so the identifier is cleared first. Keyed on the OS rather
@@ -123,6 +127,8 @@ extension CLMonitorGeofenceMonitor {
     func stopMonitoringAll() {
         ownedRegionIdentifiers.removeAll()
         registeredConditions.removeAll()
+        // Teardown clears the stored records too (sign-out), so nothing is left to reseed.
+        conditionsNeedingBaselineReseed.removeAll()
         // Clear against CLMonitor's LIVE identifiers, not the owned/mirror snapshot: an empty owned
         // set or a lossy mirror must not leave a stale SDK condition holding an OS slot.
         enqueueMonitorOperation { [weak self] monitor in

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -226,6 +226,7 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
             // the OS no longer holds; the next sync re-registers a fresh set. The stored baseline
             // goes too — the region stays in the desired set, so nothing else prunes it, and the
             // device can cross while it is unmonitored.
+            logger.geofenceMonitorStoppedMonitoringRegion(identifier)
             ownedRegionIdentifiers.remove(identifier)
             knownConditionIdentifiers.remove(identifier)
             registeredConditions.removeValue(forKey: identifier)

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -61,6 +61,9 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
     /// first pass re-register it; when the bootstrap adopts instead, `adoptExistingRegions` seeds it
     /// from the persisted records the re-arm then imposes at the OS.
     var registeredConditions: [String: RegisteredCondition] = [:]
+    /// Conditions the OS stopped monitoring since their last registration. The next registration
+    /// reseeds their stored baseline instead of preserving it — see `recordMonitorRegistration`.
+    var conditionsNeedingBaselineReseed: Set<String> = []
 
     /// The circle a condition was added with.
     struct RegisteredCondition: Equatable {
@@ -226,12 +229,17 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
             ownedRegionIdentifiers.remove(identifier)
             knownConditionIdentifiers.remove(identifier)
             registeredConditions.removeValue(forKey: identifier)
+            // Whichever registration comes next must reseed the baseline rather than preserve it.
+            // The clear below only covers the case where none comes: a re-registration with the same
+            // circle preserves the stored state by design, and after the OS gave up that state is no
+            // longer known to match reality.
+            conditionsNeedingBaselineReseed.insert(identifier)
             persistConditionMirror()
             // On the pipeline, and skipped if a registration has re-added the identifier since the
-            // line above cleared it: that add wrote a baseline from the device's real position, which
-            // must not then be deleted. Keyed on this monitor's own record of completed adds rather
-            // than on `CLMonitor.identifiers`, because whether a condition the OS gave up on stays
-            // listed is unmeasured — reading it could make this clear permanently inert.
+            // line above cleared it — deleting a baseline that add just wrote would cost the next
+            // crossing. Keyed on this monitor's own record of completed adds rather than on
+            // `CLMonitor.identifiers`, because whether a condition the OS gave up on stays listed is
+            // unmeasured — reading it could make this clear permanently inert.
             enqueueMonitorOperation { [weak self] _ in
                 guard let self, !self.knownConditionIdentifiers.contains(identifier) else { return }
                 await self.storage.clearMonitorRegionRecord(identifier: identifier)

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -239,8 +239,8 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
             // On the pipeline, and skipped if a registration has re-added the identifier since the
             // line above cleared it — deleting a baseline that add just wrote would cost the next
             // crossing. Keyed on this monitor's own record of completed adds rather than on
-            // `CLMonitor.identifiers`, because whether a condition the OS gave up on stays listed is
-            // unmeasured — reading it could make this clear permanently inert.
+            // `CLMonitor.identifiers`: a condition the OS gave up on stays listed there (measured),
+            // so reading that would make this clear permanently inert.
             enqueueMonitorOperation { [weak self] _ in
                 guard let self, !self.knownConditionIdentifiers.contains(identifier) else { return }
                 await self.storage.clearMonitorRegionRecord(identifier: identifier)

--- a/Sources/LocationGeofence/Storage/GeofenceStorage.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage.swift
@@ -106,18 +106,24 @@ actor GeofenceStorage {
     /// changed circle. The unchanged-vs-changed decision is keyed on the persisted `center`/`radius`
     /// (which survive stop-all) rather than CLMonitor's live record (which stop-all removes before the
     /// re-add, so it can never report "unchanged").
+    ///
+    /// `forceReseed` overrides that preservation. The caller sets it when the OS stopped monitoring
+    /// the condition since the last registration: the device can cross while unmonitored, so the
+    /// persisted state is no longer known to match reality and keeping it would suppress the next
+    /// genuine crossing.
     func recordMonitorRegistration(
         identifier: String,
         transitionTypes: Set<GeofenceTransition>,
         initialState: GeofenceTransition,
         center: LocationData,
-        radius: Double
+        radius: Double,
+        forceReseed: Bool = false
     ) {
         var state = loadFromDisk() ?? GeofenceState()
         var records = state.monitorRegionRecords ?? [:]
         let existing = records[identifier]
         let unchangedGeometry = existing?.center == center && existing?.radius == radius
-        let lastState = unchangedGeometry ? (existing?.lastState ?? initialState) : initialState
+        let lastState = unchangedGeometry && !forceReseed ? (existing?.lastState ?? initialState) : initialState
         records[identifier] = MonitorRegionRecord(
             lastState: lastState,
             transitionTypes: transitionTypes,

--- a/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
@@ -662,6 +662,35 @@ struct GeofenceStorageTests {
     }
 
     @Test
+    func recordMonitorRegistration_givenForceReseedOnUnchangedGeometry_expectBaselineReset() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let center = LocationData(latitude: 10, longitude: 20)
+        await storage.recordMonitorRegistration(identifier: "geo_1", transitionTypes: [.enter, .exit], initialState: .exit, center: center, radius: 100)
+        #expect(await storage.recordMonitorEvent(.enter, forIdentifier: "geo_1") == .deliver)
+        // The OS gave up on the condition and a registration with the SAME circle drained before the
+        // deferred record clear could run. Preserving `.enter` here would suppress the next arrival,
+        // because the device can have left while the region was unmonitored.
+        await storage.recordMonitorRegistration(identifier: "geo_1", transitionTypes: [.enter, .exit], initialState: .exit, center: center, radius: 100, forceReseed: true)
+        #expect(await storage.recordMonitorEvent(.enter, forIdentifier: "geo_1") == .deliver)
+    }
+
+    @Test
+    func recordMonitorRegistration_givenUnchangedGeometryWithoutForceReseed_expectBaselinePreserved() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        let center = LocationData(latitude: 10, longitude: 20)
+        await storage.recordMonitorRegistration(identifier: "geo_1", transitionTypes: [.enter, .exit], initialState: .exit, center: center, radius: 100)
+        #expect(await storage.recordMonitorEvent(.enter, forIdentifier: "geo_1") == .deliver)
+        // Ordinary re-registration still preserves the baseline, so CLMonitor re-evaluating the same
+        // state is not delivered twice.
+        await storage.recordMonitorRegistration(identifier: "geo_1", transitionTypes: [.enter, .exit], initialState: .exit, center: center, radius: 100)
+        #expect(await storage.recordMonitorEvent(.enter, forIdentifier: "geo_1") == .suppressedNoChange)
+    }
+
+    @Test
     func clearMonitorRegionRecord_givenOtherRegions_expectOnlyTargetDropped() async {
         let dir = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }


### PR DESCRIPTION
Fixes the Bugbot finding on #1192 ([stale baseline after unmonitored](https://github.com/customerio/customerio-ios/pull/1192#discussion_r3713889532)). Targets `release-july-launch-fixes` so it ships in the same patch.

### The defect

`.unmonitored` defers clearing the stored baseline and skips that clear when a registration has re-added the identifier since, reasoning that the add wrote a fresh one. That reasoning holds only when the circle changed. `recordMonitorRegistration` **preserves** `lastState` on unchanged geometry — by design, so CLMonitor re-evaluating the same state isn't delivered twice — so a re-registration with the same circle keeps a baseline recorded before the OS gave up.

The device can cross while the region is unmonitored. The next genuine crossing in that direction then reads as no change and is dropped.

Reachable when an add is staged before `.unmonitored` arrives and drains after it:

```
sync stages startMonitoring(g1, same circle)  → op A queued
.unmonitored(g1)                              → in-memory state cleared, clear op B queued
op A drains  → unchanged geometry, stale baseline preserved; known.insert(g1)
op B drains  → known contains g1 → clear skipped
```

Cost is one suppressed crossing, self-correcting on the opposite transition. Not a regression — before the deferred clear existed the baseline was never cleared at all — but the guard's own justification is wrong in this path, so it is worth closing rather than narrowing.

### Why not just tighten the guard

Because a registration staged *after* the event has the same problem. `recordMonitorRegistration` keys its preserve-vs-reseed decision on the **persisted** record, which the `.unmonitored` handler does not touch, so any unchanged-geometry re-registration preserves the stale state regardless of ordering. Making the guard ordering-aware would fix only the interleaving Bugbot happened to describe.

### The change

The monitor marks the identifier when the OS gives up, and the next registration consumes that mark and passes `forceReseed` so storage reseeds instead of preserving. The mark is consumed inside the queued operation rather than at staging time, so an add already queued when `.unmonitored` arrived is the one that reseeds. The deferred clear stays for the case where no registration follows.

### Logging

`.unmonitored` was not logged anywhere, so a field report cannot tell us whether the OS ever gives up on a condition — the exact trigger for the baseline being stale. Added one log at the point the handler runs.

At `error` level on purpose: `info` and `debug` are not persisted to the log store for third-party subsystems, so they do not survive into a collected archive. This is the same reason the two validation drives came back with no SDK logs. The condition is rare and genuinely degrades delivery until the next sync re-registers, which fits the level.

### Validation

- 309 LocationGeofence tests pass (re-run after the logging commit).
- The new storage test is **revert-verified**: with `&& !forceReseed` removed it fails on the expectation that the next arrival is delivered, i.e. it fails for the right reason.
- A second test pins the behaviour this must not break — an ordinary re-registration still preserves the baseline, so duplicate suppression is unaffected.
- The monitor-side wiring is not unit-coverable: `CLMonitor` cannot be instantiated from a test bundle. Same caveat as the rest of that adapter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches geofence transition deduplication and CLMonitor lifecycle; wrong reseed logic could duplicate or drop events, but scope is narrow and storage behavior is unit-tested.
> 
> **Overview**
> Fixes a case where **CLMonitor** reports `.unmonitored` and a later re-registration uses the **same circle**: unchanged-geometry registration used to **preserve** the persisted enter/exit baseline, so a crossing that happened while the OS was not monitoring could be **suppressed** as a duplicate.
> 
> The monitor now tracks identifiers that need a **baseline reseed** when `.unmonitored` fires. The **next** queued registration consumes that flag and passes **`forceReseed`** into `recordMonitorRegistration`, which resets `lastState` instead of preserving it. The mark is cleared on **`stopMonitoringAll`** (sign-out teardown).
> 
> Adds **error-level** logging when CoreLocation stops monitoring a region so field archives can surface the condition (info/debug are not persisted for third-party subsystems).
> 
> Storage tests cover **`forceReseed`** on unchanged geometry and confirm normal re-registration still suppresses duplicate CLMonitor re-evaluations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eaefd6ad2e0f965d889c6d9ce5564ab2ac7fc55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

