### PR TITLE
ci: pin test destination to an existing simulator (iPhone 17)

### DIFF
--- a/fastlane/Scanfile
+++ b/fastlane/Scanfile
@@ -3,13 +3,12 @@
 scheme("Customer.io-Package")
 
 # -destination for xcodebuild
-# Device *and* OS are pinned deliberately: an unpinned or nonexistent destination makes
-# fastlane log "couldn't find matching simulator" and quietly fall back to some other
-# simulator, so the OS under test becomes an accident of the runner image. A missing
-# runtime should fail loudly instead.
-# iOS 26.2 is bundled on both macos-15 and macos-26, so this destination is valid before
-# and after the runner migration. See § Installed Simulators in
-# https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md
+# Device and OS are both pinned: when a destination does not resolve, fastlane logs
+# "couldn't find matching simulator" and quietly falls back to another one, making the tested
+# OS an accident of the runner image. iOS 26.2 ships on both macos-15 and macos-26, so this
+# survives the runner migration — but it only resolves because CI selects Xcode 26.x. An
+# older image-default Xcode cannot drive a 26.x runtime, so this destination depends on the
+# xcode-version pin in mobile-ci-tools' ios-test.yml. Change one, check the other.
 devices([
   "iPhone 17 (26.2)"
 ])

--- a/fastlane/Scanfile
+++ b/fastlane/Scanfile
@@ -3,9 +3,15 @@
 scheme("Customer.io-Package")
 
 # -destination for xcodebuild
-# chosen to be a simulator that *all* xcode versions include. Help: https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#installed-simulators
+# Device *and* OS are pinned deliberately: an unpinned or nonexistent destination makes
+# fastlane log "couldn't find matching simulator" and quietly fall back to some other
+# simulator, so the OS under test becomes an accident of the runner image. A missing
+# runtime should fail loudly instead.
+# iOS 26.2 is bundled on both macos-15 and macos-26, so this destination is valid before
+# and after the runner migration. See § Installed Simulators in
+# https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md
 devices([
-  "iPhone 16"
+  "iPhone 17 (26.2)"
 ])
 
 output_types("html,junit")


### PR DESCRIPTION
[MBL-2224: Migrate iOS CI to `macos-26` + Xcode 26.6, and stop downloading simulator runtimes we already have](https://linear.app/customerio/issue/MBL-2224/migrate-ios-ci-to-macos-26-xcode-266-and-stop-downloading-simulator)

---

Our test destination pins a simulator model that does not exist on the runner image we are migrating to. When a destination cannot be resolved, fastlane does not fail — it quietly falls back to whatever simulator it can find, so the OS we actually test against becomes an accident of the image rather than a decision. The sibling FCM repo has been in exactly that state for months, testing on iOS 18.5 while its CI reported a much newer toolchain.

Pins a simulator and OS that genuinely exist, chosen so the destination is valid on both the current and the new image and therefore needs no coordination with the runner change.

Should merge before the shared-workflow runner migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Fastlane simulator selection; no app runtime, auth, or data-path changes.
> 
> **Overview**
> **iOS unit/UI tests** now target a **fixed simulator destination** in `fastlane/Scanfile`: `iPhone 17 (26.2)` replaces the generic `iPhone 16` entry.
> 
> The change is meant to stop **fastlane from quietly picking another simulator** when the named device isn’t available (which would make the tested iOS version depend on the runner image). Comments document that **iOS 26.2** is expected on both current and upcoming macOS runner images, and that this destination only works when CI uses **Xcode 26.x** (coordinated with `mobile-ci-tools` `ios-test.yml`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cfde09fb2a149fd3def58f5cf8c7e8c26a0ffbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->