### PR TITLE
fix: prioritize SDK background work

### DIFF
--- a/Sources/Common/Util/ThreadUtil.swift
+++ b/Sources/Common/Util/ThreadUtil.swift
@@ -5,7 +5,7 @@ public protocol ThreadUtil {
     /// Schedules deferrable bulk work that should not compete with user-visible operations.
     func runBackground(_ block: @escaping () -> Void)
 
-    /// Schedules non-deferrable, user-visible work, such as network requests needed to populate UI.
+    /// Schedules user-visible work that should run at a higher priority than deferrable bulk work.
     func runUtility(_ block: @escaping () -> Void)
 
     /// Schedules work that must execute on the main thread.

--- a/Sources/Common/Util/ThreadUtil.swift
+++ b/Sources/Common/Util/ThreadUtil.swift
@@ -5,7 +5,7 @@ public protocol ThreadUtil {
     /// Schedules deferrable bulk work that should not compete with user-visible operations.
     func runBackground(_ block: @escaping () -> Void)
 
-    /// Schedules user-visible work that should run at a higher priority than deferrable bulk work.
+    /// Schedules non-interactive work that should run above deferrable background processing.
     func runUtility(_ block: @escaping () -> Void)
 
     /// Schedules work that must execute on the main thread.

--- a/Sources/Common/Util/ThreadUtil.swift
+++ b/Sources/Common/Util/ThreadUtil.swift
@@ -2,8 +2,13 @@ import Foundation
 
 // allows us to more easily have automated tests with threading
 public protocol ThreadUtil {
+    /// Schedules deferrable bulk work that should not compete with user-visible operations.
     func runBackground(_ block: @escaping () -> Void)
+
+    /// Schedules non-deferrable, user-visible work, such as network requests needed to populate UI.
     func runUtility(_ block: @escaping () -> Void)
+
+    /// Schedules work that must execute on the main thread.
     func runMain(_ block: @escaping () -> Void)
 }
 

--- a/Sources/Common/Util/ThreadUtil.swift
+++ b/Sources/Common/Util/ThreadUtil.swift
@@ -15,6 +15,22 @@ public protocol ThreadUtil {
     func runMainActor(_ block: @MainActor @escaping () -> Void)
 }
 
+public extension ThreadUtil {
+    /// Preserves source compatibility for conformers that predate the utility scheduling seam.
+    func runUtility(_ block: @escaping () -> Void) {
+        runBackground(block)
+    }
+
+    /// Preserves source compatibility while honoring the existing `runMain` contract.
+    func runMainActor(_ block: @MainActor @escaping () -> Void) {
+        runMain {
+            MainActor.assumeIsolated {
+                block()
+            }
+        }
+    }
+}
+
 // sourcery: InjectRegisterShared = "ThreadUtil"
 public class CioThreadUtil: ThreadUtil {
     public func runMain(_ block: @escaping () -> Void) {

--- a/Sources/Common/Util/ThreadUtil.swift
+++ b/Sources/Common/Util/ThreadUtil.swift
@@ -11,7 +11,8 @@ public protocol ThreadUtil {
     /// Schedules work that must execute on the main thread.
     func runMain(_ block: @escaping () -> Void)
 
-    /// Schedules work that must execute in main-actor isolation.
+    /// Schedules work asynchronously in main-actor isolation and FIFO order. The ordering lets
+    /// callers combine related main-thread mutations into one operation without interleaving.
     func runMainActor(_ block: @MainActor @escaping () -> Void)
 }
 

--- a/Sources/Common/Util/ThreadUtil.swift
+++ b/Sources/Common/Util/ThreadUtil.swift
@@ -21,20 +21,11 @@ public extension ThreadUtil {
         runBackground(block)
     }
 
-    /// Preserves source compatibility while honoring the existing `runMain` contract.
+    /// Preserves source compatibility with the same asynchronous semantics as the production implementation.
     func runMainActor(_ block: @MainActor @escaping () -> Void) {
-        runMain {
-            if Thread.isMainThread {
-                MainActor.assumeIsolated {
-                    block()
-                }
-            } else {
-                // Be defensive for legacy/test conformers that execute `runMain` inline.
-                DispatchQueue.main.async {
-                    MainActor.assumeIsolated {
-                        block()
-                    }
-                }
+        DispatchQueue.main.async {
+            MainActor.assumeIsolated {
+                block()
             }
         }
     }

--- a/Sources/Common/Util/ThreadUtil.swift
+++ b/Sources/Common/Util/ThreadUtil.swift
@@ -10,12 +10,23 @@ public protocol ThreadUtil {
 
     /// Schedules work that must execute on the main thread.
     func runMain(_ block: @escaping () -> Void)
+
+    /// Schedules work that must execute in main-actor isolation.
+    func runMainActor(_ block: @MainActor @escaping () -> Void)
 }
 
 // sourcery: InjectRegisterShared = "ThreadUtil"
 public class CioThreadUtil: ThreadUtil {
     public func runMain(_ block: @escaping () -> Void) {
         DispatchQueue.main.async(execute: block)
+    }
+
+    public func runMainActor(_ block: @MainActor @escaping () -> Void) {
+        DispatchQueue.main.async {
+            MainActor.assumeIsolated {
+                block()
+            }
+        }
     }
 
     public func runBackground(_ block: @escaping () -> Void) {

--- a/Sources/Common/Util/ThreadUtil.swift
+++ b/Sources/Common/Util/ThreadUtil.swift
@@ -24,8 +24,17 @@ public extension ThreadUtil {
     /// Preserves source compatibility while honoring the existing `runMain` contract.
     func runMainActor(_ block: @MainActor @escaping () -> Void) {
         runMain {
-            MainActor.assumeIsolated {
-                block()
+            if Thread.isMainThread {
+                MainActor.assumeIsolated {
+                    block()
+                }
+            } else {
+                // Be defensive for legacy/test conformers that execute `runMain` inline.
+                DispatchQueue.main.async {
+                    MainActor.assumeIsolated {
+                        block()
+                    }
+                }
             }
         }
     }

--- a/Sources/Common/Util/ThreadUtil.swift
+++ b/Sources/Common/Util/ThreadUtil.swift
@@ -3,6 +3,7 @@ import Foundation
 // allows us to more easily have automated tests with threading
 public protocol ThreadUtil {
     func runBackground(_ block: @escaping () -> Void)
+    func runUtility(_ block: @escaping () -> Void)
     func runMain(_ block: @escaping () -> Void)
 }
 
@@ -14,5 +15,9 @@ public class CioThreadUtil: ThreadUtil {
 
     public func runBackground(_ block: @escaping () -> Void) {
         DispatchQueue.global(qos: .background).async(execute: block)
+    }
+
+    public func runUtility(_ block: @escaping () -> Void) {
+        DispatchQueue.global(qos: .utility).async(execute: block)
     }
 }

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -267,10 +267,8 @@ class Gist: GistProvider {
         }
 
         if !skipMessageFetch {
-            threadUtil.runMain { [weak self] in
-                Task { @MainActor [weak self] in
-                    self?.fetchUserMessages()
-                }
+            Task { @MainActor [weak self] in
+                self?.fetchUserMessages()
             }
         }
     }

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -308,8 +308,10 @@ class Gist: GistProvider {
             return
         }
 
-        threadUtil.runBackground {
-            self.queueManager.fetchUserQueue(state: state) { [weak self] response in
+        threadUtil.runUtility { [weak self] in
+            guard let self else { return }
+
+            queueManager.fetchUserQueue(state: state) { [weak self] response in
                 guard let self else { return }
 
                 switch response {

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -311,6 +311,7 @@ class Gist: GistProvider {
         threadUtil.runUtility { [weak self] in
             guard let self else { return }
 
+            logger.logWithModuleTag("Gist: Starting queue fetch at utility priority", level: .debug)
             queueManager.fetchUserQueue(state: state) { [weak self] response in
                 guard let self else { return }
 

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -76,10 +76,9 @@ class Gist: GistProvider {
         sseEnabledSubscriber = nil
         userIdSubscriber = nil
 
-        // Do not weakly capture `self` from deinit. Capture the timer itself so the queued cleanup
-        // still runs after this instance has finished deallocating.
+        // The timer callback holds Gist weakly, so deinit can run while the timer is scheduled.
+        // Capture the timer itself so queued cleanup does not depend on a deallocating `self`.
         let timer = queueTimer
-        queueTimer = nil
         threadUtil.runMainActor {
             timer?.invalidate()
         }
@@ -182,7 +181,8 @@ class Gist: GistProvider {
     }
 
     private func invalidateTimer() {
-        // Timer state is only read or modified from the main actor.
+        // All live-instance timer mutations are serialized on the main actor. Deinit only captures
+        // the final timer reference so it can schedule cleanup after this instance is released.
         threadUtil.runMainActor { [weak self] in
             guard let self else { return }
 
@@ -260,20 +260,20 @@ class Gist: GistProvider {
 
     private func setupPollingAndFetch(skipMessageFetch: Bool, pollingInterval: Double) {
         logger.logWithModuleTag("Gist: Setting up polling timer - interval: \(pollingInterval)s, skipInitialFetch: \(skipMessageFetch)", level: .info)
-        invalidateTimer()
 
-        // Invalidation above, timer setup, and the optional initial fetch use the same main-actor
-        // scheduler, preserving FIFO ordering while keeping the complete path observable in tests.
+        // Replace the timer in one main-actor operation. Keeping invalidation and creation together
+        // prevents concurrent setup callers from interleaving and leaving an orphaned timer behind.
         threadUtil.runMainActor { [weak self] in
             guard let self else { return }
 
-            queueTimer = Timer.scheduledTimer(
-                timeInterval: pollingInterval,
-                target: self,
-                selector: #selector(fetchUserMessages),
-                userInfo: nil,
-                repeats: true
-            )
+            let timerWasActive = queueTimer != nil
+            logger.logWithModuleTag("Gist: Replacing polling timer (wasActive: \(timerWasActive))", level: .debug)
+            queueTimer?.invalidate()
+            queueTimer = Timer.scheduledTimer(withTimeInterval: pollingInterval, repeats: true) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.fetchUserMessages()
+                }
+            }
             logger.logWithModuleTag("Gist: Polling timer started with interval: \(pollingInterval)s", level: .debug)
 
             if !skipMessageFetch {
@@ -283,9 +283,8 @@ class Gist: GistProvider {
     }
 
     /// Fetches the user messages from the remote service and dispatches actions to the `InAppMessageManager`.
-    /// The method must be marked with `@objc` and public to be used as a selector in the `Timer` scheduled.
-    /// Also, the method must be called on main thread since it checks the application state.
-    @MainActor @objc
+    /// The method runs on the main actor because it checks the application state.
+    @MainActor
     func fetchUserMessages() {
         guard applicationStateProvider.applicationState != .background else {
             logger.logWithModuleTag("Gist: Application in background, skipping queue check", level: .debug)

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -26,6 +26,7 @@ class Gist: GistProvider {
     private let queueManager: QueueManager
     private let threadUtil: ThreadUtil
     private let sseLifecycleManager: SseLifecycleManager
+    private let applicationStateProvider: ApplicationStateProvider
 
     private var pollIntervalSubscriber: InAppMessageStoreSubscriber?
     private var sseEnabledSubscriber: InAppMessageStoreSubscriber?
@@ -38,7 +39,8 @@ class Gist: GistProvider {
         inAppMessageManager: InAppMessageManager,
         queueManager: QueueManager,
         threadUtil: ThreadUtil,
-        sseLifecycleManager: SseLifecycleManager
+        sseLifecycleManager: SseLifecycleManager,
+        applicationStateProvider: ApplicationStateProvider = RealApplicationStateProvider()
     ) {
         self.logger = logger
         self.gistDelegate = gistDelegate
@@ -46,6 +48,7 @@ class Gist: GistProvider {
         self.queueManager = queueManager
         self.threadUtil = threadUtil
         self.sseLifecycleManager = sseLifecycleManager
+        self.applicationStateProvider = applicationStateProvider
 
         subscribeToInAppMessageState()
 
@@ -275,7 +278,7 @@ class Gist: GistProvider {
     /// Also, the method must be called on main thread since it checks the application state.
     @objc
     func fetchUserMessages() {
-        guard UIApplication.shared.applicationState != .background else {
+        guard applicationStateProvider.applicationState != .background else {
             logger.logWithModuleTag("Gist: Application in background, skipping queue check", level: .debug)
             return
         }

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -76,7 +76,13 @@ class Gist: GistProvider {
         sseEnabledSubscriber = nil
         userIdSubscriber = nil
 
-        invalidateTimer()
+        // Do not weakly capture `self` from deinit. Capture the timer itself so the queued cleanup
+        // still runs after this instance has finished deallocating.
+        let timer = queueTimer
+        queueTimer = nil
+        threadUtil.runMainActor {
+            timer?.invalidate()
+        }
     }
 
     private func subscribeToInAppMessageState() {
@@ -317,7 +323,7 @@ class Gist: GistProvider {
         threadUtil.runUtility { [weak self] in
             guard let self else { return }
 
-            logger.logWithModuleTag("Gist: Starting queue fetch at utility priority", level: .debug)
+            logger.logWithModuleTag("Gist: Initiating queue fetch from utility-priority work", level: .debug)
             queueManager.fetchUserQueue(state: state) { [weak self] response in
                 guard let self else { return }
 

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -176,12 +176,14 @@ class Gist: GistProvider {
     }
 
     private func invalidateTimer() {
-        // Timer must be scheduled or modified on main.
-        let timerWasActive = queueTimer != nil
-        logger.logWithModuleTag("Gist: Invalidating polling timer (wasActive: \(timerWasActive))", level: .debug)
-        threadUtil.runMain {
-            self.queueTimer?.invalidate()
-            self.queueTimer = nil
+        // Timer state is only read or modified from the main actor.
+        threadUtil.runMainActor { [weak self] in
+            guard let self else { return }
+
+            let timerWasActive = queueTimer != nil
+            logger.logWithModuleTag("Gist: Invalidating polling timer (wasActive: \(timerWasActive))", level: .debug)
+            queueTimer?.invalidate()
+            queueTimer = nil
         }
     }
 
@@ -254,8 +256,8 @@ class Gist: GistProvider {
         logger.logWithModuleTag("Gist: Setting up polling timer - interval: \(pollingInterval)s, skipInitialFetch: \(skipMessageFetch)", level: .info)
         invalidateTimer()
 
-        // Timer setup and the optional initial fetch share one main-actor hop so their ordering is
-        // deterministic and tests can execute the complete path through the injected scheduler.
+        // Invalidation above, timer setup, and the optional initial fetch use the same main-actor
+        // scheduler, preserving FIFO ordering while keeping the complete path observable in tests.
         threadUtil.runMainActor { [weak self] in
             guard let self else { return }
 

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -40,7 +40,7 @@ class Gist: GistProvider {
         queueManager: QueueManager,
         threadUtil: ThreadUtil,
         sseLifecycleManager: SseLifecycleManager,
-        applicationStateProvider: ApplicationStateProvider = RealApplicationStateProvider()
+        applicationStateProvider: ApplicationStateProvider
     ) {
         self.logger = logger
         self.gistDelegate = gistDelegate
@@ -267,8 +267,10 @@ class Gist: GistProvider {
         }
 
         if !skipMessageFetch {
-            threadUtil.runMain {
-                self.fetchUserMessages()
+            threadUtil.runMain { [weak self] in
+                Task { @MainActor [weak self] in
+                    self?.fetchUserMessages()
+                }
             }
         }
     }
@@ -276,7 +278,7 @@ class Gist: GistProvider {
     /// Fetches the user messages from the remote service and dispatches actions to the `InAppMessageManager`.
     /// The method must be marked with `@objc` and public to be used as a selector in the `Timer` scheduled.
     /// Also, the method must be called on main thread since it checks the application state.
-    @objc
+    @MainActor @objc
     func fetchUserMessages() {
         guard applicationStateProvider.applicationState != .background else {
             logger.logWithModuleTag("Gist: Application in background, skipping queue check", level: .debug)

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -295,6 +295,11 @@ class Gist: GistProvider {
             return
         }
 
+        fetchUserQueueIfPollingActive()
+    }
+
+    /// Keep the store callback nonisolated because the manager invokes it from its own task.
+    private func fetchUserQueueIfPollingActive() {
         inAppMessageManager.fetchState { [weak self] state in
             guard let self else { return }
 

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -1,6 +1,5 @@
 import CioInternalCommon
 import Foundation
-import UIKit
 
 // wrapper around Gist SDK to make it mockable
 protocol GistProvider: AutoMockable {
@@ -269,9 +268,14 @@ class Gist: GistProvider {
             let timerWasActive = queueTimer != nil
             logger.logWithModuleTag("Gist: Replacing polling timer (wasActive: \(timerWasActive))", level: .debug)
             queueTimer?.invalidate()
-            queueTimer = Timer.scheduledTimer(withTimeInterval: pollingInterval, repeats: true) { [weak self] _ in
+            queueTimer = Timer.scheduledTimer(withTimeInterval: pollingInterval, repeats: true) { [weak self] timer in
                 MainActor.assumeIsolated {
-                    self?.fetchUserMessages()
+                    guard let self else {
+                        timer.invalidate()
+                        return
+                    }
+
+                    self.fetchUserMessages()
                 }
             }
             logger.logWithModuleTag("Gist: Polling timer started with interval: \(pollingInterval)s", level: .debug)

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -254,21 +254,22 @@ class Gist: GistProvider {
         logger.logWithModuleTag("Gist: Setting up polling timer - interval: \(pollingInterval)s, skipInitialFetch: \(skipMessageFetch)", level: .info)
         invalidateTimer()
 
-        // Timer must be scheduled on the main thread
-        threadUtil.runMain {
-            self.queueTimer = Timer.scheduledTimer(
+        // Timer setup and the optional initial fetch share one main-actor hop so their ordering is
+        // deterministic and tests can execute the complete path through the injected scheduler.
+        threadUtil.runMainActor { [weak self] in
+            guard let self else { return }
+
+            queueTimer = Timer.scheduledTimer(
                 timeInterval: pollingInterval,
                 target: self,
-                selector: #selector(self.fetchUserMessages),
+                selector: #selector(fetchUserMessages),
                 userInfo: nil,
                 repeats: true
             )
-            self.logger.logWithModuleTag("Gist: Polling timer started with interval: \(pollingInterval)s", level: .debug)
-        }
+            logger.logWithModuleTag("Gist: Polling timer started with interval: \(pollingInterval)s", level: .debug)
 
-        if !skipMessageFetch {
-            Task { @MainActor [weak self] in
-                self?.fetchUserMessages()
+            if !skipMessageFetch {
+                fetchUserMessages()
             }
         }
     }

--- a/Sources/MessagingInApp/Gist/Gist.swift
+++ b/Sources/MessagingInApp/Gist/Gist.swift
@@ -30,7 +30,7 @@ class Gist: GistProvider {
     private var pollIntervalSubscriber: InAppMessageStoreSubscriber?
     private var sseEnabledSubscriber: InAppMessageStoreSubscriber?
     private var userIdSubscriber: InAppMessageStoreSubscriber?
-    private var queueTimer: Timer?
+    private let queueTimer = CioInternalCommon.Synchronized<Timer?>(nil)
 
     init(
         logger: Logger,
@@ -76,10 +76,14 @@ class Gist: GistProvider {
         userIdSubscriber = nil
 
         // The timer callback holds Gist weakly, so deinit can run while the timer is scheduled.
-        // Capture the timer itself so queued cleanup does not depend on a deallocating `self`.
-        let timer = queueTimer
+        // Capture the synchronized storage so cleanup does not depend on a deallocating `self`
+        // or send a non-Sendable Timer across isolation boundaries.
+        let queueTimer = queueTimer
         threadUtil.runMainActor {
-            timer?.invalidate()
+            queueTimer.mutating { timer in
+                timer?.invalidate()
+                timer = nil
+            }
         }
     }
 
@@ -180,15 +184,17 @@ class Gist: GistProvider {
     }
 
     private func invalidateTimer() {
-        // All live-instance timer mutations are serialized on the main actor. Deinit only captures
-        // the final timer reference so it can schedule cleanup after this instance is released.
+        // Timer mutations happen on the main actor, while synchronized storage also makes the
+        // deinit handoff atomic with any pending replacement.
         threadUtil.runMainActor { [weak self] in
             guard let self else { return }
 
-            let timerWasActive = queueTimer != nil
-            logger.logWithModuleTag("Gist: Invalidating polling timer (wasActive: \(timerWasActive))", level: .debug)
-            queueTimer?.invalidate()
-            queueTimer = nil
+            self.queueTimer.mutating { timer in
+                let timerWasActive = timer != nil
+                self.logger.logWithModuleTag("Gist: Invalidating polling timer (wasActive: \(timerWasActive))", level: .debug)
+                timer?.invalidate()
+                timer = nil
+            }
         }
     }
 
@@ -265,17 +271,19 @@ class Gist: GistProvider {
         threadUtil.runMainActor { [weak self] in
             guard let self else { return }
 
-            let timerWasActive = queueTimer != nil
-            logger.logWithModuleTag("Gist: Replacing polling timer (wasActive: \(timerWasActive))", level: .debug)
-            queueTimer?.invalidate()
-            queueTimer = Timer.scheduledTimer(withTimeInterval: pollingInterval, repeats: true) { [weak self] timer in
-                MainActor.assumeIsolated {
-                    guard let self else {
-                        timer.invalidate()
-                        return
-                    }
+            self.queueTimer.mutating { timer in
+                let timerWasActive = timer != nil
+                self.logger.logWithModuleTag("Gist: Replacing polling timer (wasActive: \(timerWasActive))", level: .debug)
+                timer?.invalidate()
+                timer = Timer.scheduledTimer(withTimeInterval: pollingInterval, repeats: true) { [weak self] timer in
+                    MainActor.assumeIsolated {
+                        guard let self else {
+                            timer.invalidate()
+                            return
+                        }
 
-                    self.fetchUserMessages()
+                        self.fetchUserMessages()
+                    }
                 }
             }
             logger.logWithModuleTag("Gist: Polling timer started with interval: \(pollingInterval)s", level: .debug)

--- a/Sources/MessagingInApp/Gist/Utilities/ApplicationStateProvider.swift
+++ b/Sources/MessagingInApp/Gist/Utilities/ApplicationStateProvider.swift
@@ -8,6 +8,7 @@ import UIKit
 protocol ApplicationStateProvider: AutoMockable {
     /// Returns the current application state.
     /// Must be called from the main thread.
+    @MainActor
     var applicationState: UIApplication.State { get }
 }
 
@@ -15,6 +16,7 @@ protocol ApplicationStateProvider: AutoMockable {
 /// Production implementation that wraps UIApplication.shared.
 /// Returns the actual application state from the system.
 struct RealApplicationStateProvider: ApplicationStateProvider {
+    @MainActor
     var applicationState: UIApplication.State {
         UIApplication.shared.applicationState
     }

--- a/Sources/MessagingInApp/Gist/Utilities/ApplicationStateProvider.swift
+++ b/Sources/MessagingInApp/Gist/Utilities/ApplicationStateProvider.swift
@@ -8,7 +8,6 @@ import UIKit
 protocol ApplicationStateProvider: AutoMockable {
     /// Returns the current application state.
     /// Must be called from the main thread.
-    @MainActor
     var applicationState: UIApplication.State { get }
 }
 
@@ -16,7 +15,6 @@ protocol ApplicationStateProvider: AutoMockable {
 /// Production implementation that wraps UIApplication.shared.
 /// Returns the actual application state from the system.
 struct RealApplicationStateProvider: ApplicationStateProvider {
-    @MainActor
     var applicationState: UIApplication.State {
         UIApplication.shared.applicationState
     }

--- a/Sources/MessagingInApp/autogenerated/AutoDependencyInjection.generated.swift
+++ b/Sources/MessagingInApp/autogenerated/AutoDependencyInjection.generated.swift
@@ -171,7 +171,7 @@ extension DIGraphShared {
     }
 
     private func _get_gistProvider() -> GistProvider {
-        Gist(logger: logger, gistDelegate: gistDelegate, inAppMessageManager: inAppMessageManager, queueManager: queueManager, threadUtil: threadUtil, sseLifecycleManager: sseLifecycleManager)
+        Gist(logger: logger, gistDelegate: gistDelegate, inAppMessageManager: inAppMessageManager, queueManager: queueManager, threadUtil: threadUtil, sseLifecycleManager: sseLifecycleManager, applicationStateProvider: applicationStateProvider)
     }
 
     // GistDelegate (singleton)

--- a/Tests/Common/Util/ThreadUtilTest.swift
+++ b/Tests/Common/Util/ThreadUtilTest.swift
@@ -1,0 +1,16 @@
+@testable import CioInternalCommon
+import SharedTests
+import XCTest
+
+class ThreadUtilTest: UnitTest {
+    func test_runMainActor_expectBlockRunsOnMainThread() {
+        let blockExecuted = expectation(description: "main-actor block executed")
+
+        CioThreadUtil().runMainActor {
+            XCTAssertTrue(Thread.isMainThread)
+            blockExecuted.fulfill()
+        }
+
+        wait(for: [blockExecuted], timeout: 1)
+    }
+}

--- a/Tests/Common/Util/ThreadUtilTest.swift
+++ b/Tests/Common/Util/ThreadUtilTest.swift
@@ -2,6 +2,19 @@
 import SharedTests
 import XCTest
 
+private final class LegacyThreadUtil: ThreadUtil {
+    private(set) var runBackgroundCallsCount = 0
+
+    func runBackground(_ block: @escaping () -> Void) {
+        runBackgroundCallsCount += 1
+        block()
+    }
+
+    func runMain(_ block: @escaping () -> Void) {
+        DispatchQueue.main.async(execute: block)
+    }
+}
+
 class ThreadUtilTest: UnitTest {
     func test_runMainActor_expectBlockRunsOnMainThread() {
         let blockExecuted = expectation(description: "main-actor block executed")
@@ -12,5 +25,29 @@ class ThreadUtilTest: UnitTest {
         }
 
         wait(for: [blockExecuted], timeout: 1)
+    }
+
+    func test_runUtility_expectBlockRunsOffMainThread() {
+        let blockExecuted = expectation(description: "utility block executed")
+
+        CioThreadUtil().runUtility {
+            XCTAssertFalse(Thread.isMainThread)
+            blockExecuted.fulfill()
+        }
+
+        wait(for: [blockExecuted], timeout: 1)
+    }
+
+    func test_defaultScheduling_givenLegacyConformer_expectNewSeamsRemainUsable() {
+        let threadUtil = LegacyThreadUtil()
+        let mainActorBlockExecuted = expectation(description: "default main-actor block executed")
+
+        threadUtil.runUtility {}
+        threadUtil.runMainActor {
+            mainActorBlockExecuted.fulfill()
+        }
+
+        wait(for: [mainActorBlockExecuted], timeout: 1)
+        XCTAssertEqual(threadUtil.runBackgroundCallsCount, 1)
     }
 }

--- a/Tests/Common/Util/ThreadUtilTest.swift
+++ b/Tests/Common/Util/ThreadUtilTest.swift
@@ -11,7 +11,7 @@ private final class LegacyThreadUtil: ThreadUtil {
     }
 
     func runMain(_ block: @escaping () -> Void) {
-        DispatchQueue.main.async(execute: block)
+        block()
     }
 }
 
@@ -43,8 +43,11 @@ class ThreadUtilTest: UnitTest {
         let mainActorBlockExecuted = expectation(description: "default main-actor block executed")
 
         threadUtil.runUtility {}
-        threadUtil.runMainActor {
-            mainActorBlockExecuted.fulfill()
+        DispatchQueue.global().async {
+            threadUtil.runMainActor {
+                XCTAssertTrue(Thread.isMainThread)
+                mainActorBlockExecuted.fulfill()
+            }
         }
 
         wait(for: [mainActorBlockExecuted], timeout: 1)

--- a/Tests/MessagingInApp/State/InAppMessageStateTests.swift
+++ b/Tests/MessagingInApp/State/InAppMessageStateTests.swift
@@ -11,6 +11,12 @@ extension InAppMessageManager {
 }
 
 class InAppMessageStateTests: IntegrationTest {
+    private struct FetchHarness {
+        let gist: Gist
+        let threadUtil: ThreadUtilStub
+        let queueNetwork: GistQueueNetworkMock
+    }
+
     var inAppMessageManager: InAppMessageManager!
     private let engineWebMock = EngineWebInstanceMock()
     private var engineWebProvider: EngineWebProvider {
@@ -18,15 +24,18 @@ class InAppMessageStateTests: IntegrationTest {
     }
 
     private let globalEventListener = InAppEventListenerMock()
+    private var applicationStateProviderMock: ApplicationStateProviderMock!
     var gist: Gist!
     var queueManager: QueueManager!
 
     override func setUp() {
         super.setUp()
         engineWebMock.underlyingView = UIView()
+        applicationStateProviderMock = ApplicationStateProviderMock()
+        applicationStateProviderMock.underlyingApplicationState = .active
         MessagingInApp.shared.setEventListener(globalEventListener)
 
-        mockCollection.add(mocks: [engineWebMock, globalEventListener])
+        mockCollection.add(mocks: [engineWebMock, globalEventListener, applicationStateProviderMock])
 
         diGraphShared.override(value: CioThreadUtil(), forType: ThreadUtil.self)
         diGraphShared.override(value: engineWebProvider, forType: EngineWebProvider.self)
@@ -59,7 +68,7 @@ class InAppMessageStateTests: IntegrationTest {
             queueManager: queueManager,
             threadUtil: diGraphShared.threadUtil,
             sseLifecycleManager: diGraphShared.sseLifecycleManager,
-            applicationStateProvider: diGraphShared.applicationStateProvider
+            applicationStateProvider: applicationStateProviderMock
         )
     }
 
@@ -538,10 +547,12 @@ class InAppMessageStateTests: IntegrationTest {
     /// synchronously, so the only fetch that can occur is the one asked for below, and it completes
     /// before the call returns. The controlled 304 response also returns before the shared visual
     /// inbox repository can be reached.
-    func test_fetchUserMessages_givenIdentifiedUser_expectSingleQueueFetchScheduledAtUtilityPriority() async throws {
+    private func makeFetchHarness(
+        applicationState: UIApplication.State
+    ) async -> FetchHarness {
         let state = InAppMessageState(siteId: .random, dataCenter: .random, userId: .random)
         let applicationStateProvider = ApplicationStateProviderMock()
-        applicationStateProvider.underlyingApplicationState = .active
+        applicationStateProvider.underlyingApplicationState = applicationState
 
         let inAppMessageManagerMock = InAppMessageManagerMock()
         // Inert subscriptions: no state replay, so nothing in `init` can schedule a fetch.
@@ -593,14 +604,34 @@ class InAppMessageStateTests: IntegrationTest {
             )
         }
 
+        return FetchHarness(
+            gist: gistUnderTest,
+            threadUtil: threadUtil,
+            queueNetwork: queueNetworkMock
+        )
+    }
+
+    func test_fetchUserMessages_givenIdentifiedUser_expectSingleQueueFetchScheduledAtUtilityPriority() async throws {
+        let harness = await makeFetchHarness(applicationState: .active)
+
         // The production application-state provider requires this selector to run on main.
-        await MainActor.run { gistUnderTest.fetchUserMessages() }
+        await MainActor.run { harness.gist.fetchUserMessages() }
 
         // Both counts are exact. The whole path ran inline on this thread, so anything beyond one
         // utility dispatch or one request would be a second fetch this test never asked for.
-        XCTAssertEqual(threadUtil.runUtilityCallsCount, 1)
-        XCTAssertEqual(threadUtil.runBackgroundCallsCount, 0)
-        XCTAssertEqual(queueNetworkMock.requestCallsCount, 1)
+        XCTAssertEqual(harness.threadUtil.runUtilityCallsCount, 1)
+        XCTAssertEqual(harness.threadUtil.runBackgroundCallsCount, 0)
+        XCTAssertEqual(harness.queueNetwork.requestCallsCount, 1)
+    }
+
+    func test_fetchUserMessages_givenBackgroundApp_expectNoQueueFetchScheduled() async {
+        let harness = await makeFetchHarness(applicationState: .background)
+
+        await MainActor.run { harness.gist.fetchUserMessages() }
+
+        XCTAssertEqual(harness.threadUtil.runUtilityCallsCount, 0)
+        XCTAssertEqual(harness.threadUtil.runBackgroundCallsCount, 0)
+        XCTAssertEqual(harness.queueNetwork.requestCallsCount, 0)
     }
 
     var sampleFetchResponseBody: String {

--- a/Tests/MessagingInApp/State/InAppMessageStateTests.swift
+++ b/Tests/MessagingInApp/State/InAppMessageStateTests.swift
@@ -58,7 +58,8 @@ class InAppMessageStateTests: IntegrationTest {
             inAppMessageManager: inAppMessageManager,
             queueManager: queueManager,
             threadUtil: diGraphShared.threadUtil,
-            sseLifecycleManager: diGraphShared.sseLifecycleManager
+            sseLifecycleManager: diGraphShared.sseLifecycleManager,
+            applicationStateProvider: diGraphShared.applicationStateProvider
         )
     }
 
@@ -524,8 +525,8 @@ class InAppMessageStateTests: IntegrationTest {
 
     // MARK: fetch user messages from backend services
 
-    /// A queue fetch is user-visible work, so it must be scheduled at utility priority instead of
-    /// the lower-priority background queue used for deferrable bulk work.
+    /// A queue fetch should run above deferrable background processing, but does not need the
+    /// interactive priority reserved for UI work.
     ///
     /// Every collaborator capable of replaying state or scheduling observable work on this path is
     /// isolated in this test. Building a `Gist` on the class-wide `InAppMessageStoreManager` is not

--- a/Tests/MessagingInApp/State/InAppMessageStateTests.swift
+++ b/Tests/MessagingInApp/State/InAppMessageStateTests.swift
@@ -548,9 +548,10 @@ class InAppMessageStateTests: IntegrationTest {
     /// before the call returns. The controlled 304 response also returns before the shared visual
     /// inbox repository can be reached.
     private func makeFetchHarness(
-        applicationState: UIApplication.State
+        applicationState: UIApplication.State,
+        pollInterval: TimeInterval = 600
     ) async -> FetchHarness {
-        let state = InAppMessageState(siteId: .random, dataCenter: .random, userId: .random)
+        let state = InAppMessageState(siteId: .random, dataCenter: .random, pollInterval: pollInterval, userId: .random)
         let applicationStateProvider = ApplicationStateProviderMock()
         applicationStateProvider.underlyingApplicationState = applicationState
 
@@ -654,12 +655,32 @@ class InAppMessageStateTests: IntegrationTest {
         }
     }
 
-    func test_fetchUserMessagesFromRemoteQueue_givenActiveTimer_expectGistCanDeallocateAndCleanUp() async {
-        var harness: FetchHarness? = await makeFetchHarness(applicationState: .active)
+    func test_fetchUserMessagesFromRemoteQueue_givenReplacedTimer_expectResetStopsAllPolling() async throws {
+        let harness = await makeFetchHarness(applicationState: .active, pollInterval: 0.05)
+
+        harness.gist.fetchUserMessagesFromRemoteQueue()
+        harness.gist.fetchUserMessagesFromRemoteQueue()
+        await waitUntil(pollInterval: 0.01) {
+            harness.threadUtil.runMainActorExecutionsCount >= 2
+        }
+
+        harness.gist.resetState()
+        await waitUntil(pollInterval: 0.01) {
+            harness.threadUtil.runMainActorExecutionsCount >= 3
+        }
+        let requestsAfterReset = harness.queueNetwork.requestCallsCount
+
+        try await Task.sleep(nanoseconds: 200000000)
+
+        XCTAssertEqual(harness.queueNetwork.requestCallsCount, requestsAfterReset)
+    }
+
+    func test_fetchUserMessagesFromRemoteQueue_givenActiveTimer_expectGistCanDeallocateAndCleanUp() async throws {
+        var harness: FetchHarness? = await makeFetchHarness(applicationState: .active, pollInterval: 0.05)
         var retainedGist = harness?.gist
         let isGistReleased = { [weak retainedGist] in retainedGist == nil }
-        guard let threadUtil = harness?.threadUtil else {
-            XCTFail("Expected the fetch harness to provide a thread utility")
+        guard let threadUtil = harness?.threadUtil, let queueNetwork = harness?.queueNetwork else {
+            XCTFail("Expected the fetch harness to provide its collaborators")
             return
         }
 
@@ -675,6 +696,11 @@ class InAppMessageStateTests: IntegrationTest {
         await waitUntil {
             isGistReleased() && threadUtil.runMainActorExecutionsCount > executionsBeforeDeinit
         }
+        let requestsAfterDeinit = queueNetwork.requestCallsCount
+
+        try await Task.sleep(nanoseconds: 200000000)
+
+        XCTAssertEqual(queueNetwork.requestCallsCount, requestsAfterDeinit)
     }
 
     var sampleFetchResponseBody: String {

--- a/Tests/MessagingInApp/State/InAppMessageStateTests.swift
+++ b/Tests/MessagingInApp/State/InAppMessageStateTests.swift
@@ -524,37 +524,82 @@ class InAppMessageStateTests: IntegrationTest {
 
     // MARK: fetch user messages from backend services
 
-    func test_fetchUserMessages_expectUtilityThread() async {
-        await inAppMessageManager.dispatchAsync(action: .initialize(siteId: .random, dataCenter: .random, environment: .production))
-        await inAppMessageManager.dispatchAsync(action: .setUserIdentifier(user: .random))
-        setupHttpResponse(code: 304, body: Data())
+    /// A queue fetch is user-visible work, so it must be scheduled at utility priority, never at
+    /// background priority where the OS is free to defer it indefinitely.
+    ///
+    /// Every collaborator capable of replaying state or scheduling observable work on this path is
+    /// isolated in this test. Building a `Gist` on the class-wide `InAppMessageStoreManager` is not
+    /// viable here: `init` subscribes to the store, ReSwift replays the current state to a new
+    /// subscriber, and that replay drives a fetch of its own. It arrives on a store task at an
+    /// unpredictable moment, is indistinguishable from the fetch under test, and — because the store
+    /// keeps the subscription alive — can still arrive after this test has finished.
+    /// `InAppMessageManagerMock` gives the Gist no store to subscribe to and hands it state
+    /// synchronously, so the only fetch that can occur is the one asked for below, and it completes
+    /// before the call returns. The controlled 304 response also returns before the shared visual
+    /// inbox repository can be reached.
+    func test_fetchUserMessages_givenIdentifiedUser_expectSingleQueueFetchScheduledAtUtilityPriority() async throws {
+        let applicationState = await MainActor.run { UIApplication.shared.applicationState }
+        try XCTSkipIf(applicationState == .background, "A backgrounded XCTest host bypasses this foreground path.")
+
+        let state = InAppMessageState(siteId: .random, dataCenter: .random, userId: .random)
+
+        let inAppMessageManagerMock = InAppMessageManagerMock()
+        // Inert subscriptions: no state replay, so nothing in `init` can schedule a fetch.
+        inAppMessageManagerMock.subscribeClosure = { _, _ in Task {} }
+        inAppMessageManagerMock.unsubscribeClosure = { _ in Task {} }
+        inAppMessageManagerMock.dispatchClosure = { _, completion in
+            completion?()
+            return Task {}
+        }
+        inAppMessageManagerMock.fetchStateClosure = { completion in
+            completion(state)
+            return Task { state }
+        }
+
+        let queueNetworkMock = GistQueueNetworkMock()
+        // 304 with no cached response is the shortest path through `QueueManager` that still proves a
+        // request was made, and it finishes inline.
+        queueNetworkMock.requestClosure = { _, _, completionHandler in
+            let response = HTTPURLResponse(
+                url: URL(string: "https://test.com")!, statusCode: 304, httpVersion: nil, headerFields: nil
+            )!
+
+            completionHandler(.success((Data(), response)))
+        }
+
+        let queueManagerUnderTest = QueueManager(
+            keyValueStore: InMemorySharedKeyValueStorage(),
+            gistQueueNetwork: queueNetworkMock,
+            inAppMessageManager: inAppMessageManagerMock,
+            anonymousMessageManager: AnonymousMessageManagerMock(),
+            inboxMessageCache: InboxMessageCacheManager(
+                keyValueStore: InMemorySharedKeyValueStorage(),
+                logger: diGraphShared.logger
+            ),
+            visualInboxRepository: diGraphShared.visualInboxRepository,
+            logger: diGraphShared.logger
+        )
 
         let threadUtil = ThreadUtilStub()
-        let sseLifecycleManager = SseLifecycleManagerMock()
-        mockCollection.add(mock: sseLifecycleManager)
         let gistUnderTest = await MainActor.run {
             Gist(
                 logger: diGraphShared.logger,
                 gistDelegate: diGraphShared.gistDelegate,
-                inAppMessageManager: inAppMessageManager,
-                queueManager: queueManager,
+                inAppMessageManager: inAppMessageManagerMock,
+                queueManager: queueManagerUnderTest,
                 threadUtil: threadUtil,
-                sseLifecycleManager: sseLifecycleManager
+                sseLifecycleManager: SseLifecycleManagerMock()
             )
         }
 
-        threadUtil.reset()
-        gistQueueNetworkMock.resetMock()
-        let utilityExpectation = expectation(description: "Queue fetch dispatched at utility priority")
-        threadUtil.runUtilityClosure = { utilityExpectation.fulfill() }
-
+        // `fetchUserMessages` reads `UIApplication.applicationState`, so it must be called on main.
         await MainActor.run { gistUnderTest.fetchUserMessages() }
 
-        await fulfillment(of: [utilityExpectation], timeout: 1)
-        XCTAssertTrue(threadUtil.runUtilityCalled)
-        XCTAssertFalse(threadUtil.runBackgroundCalled)
-        XCTAssertEqual(gistQueueNetworkMock.requestCallsCount, 1)
-        gistUnderTest.resetState()
+        // Both counts are exact. The whole path ran inline on this thread, so anything beyond one
+        // utility dispatch or one request would be a second fetch this test never asked for.
+        XCTAssertEqual(threadUtil.runUtilityCallsCount, 1)
+        XCTAssertEqual(threadUtil.runBackgroundCallsCount, 0)
+        XCTAssertEqual(queueNetworkMock.requestCallsCount, 1)
     }
 
     var sampleFetchResponseBody: String {

--- a/Tests/MessagingInApp/State/InAppMessageStateTests.swift
+++ b/Tests/MessagingInApp/State/InAppMessageStateTests.swift
@@ -524,8 +524,8 @@ class InAppMessageStateTests: IntegrationTest {
 
     // MARK: fetch user messages from backend services
 
-    /// A queue fetch is user-visible work, so it must be scheduled at utility priority, never at
-    /// background priority where the OS is free to defer it indefinitely.
+    /// A queue fetch is user-visible work, so it must be scheduled at utility priority instead of
+    /// the lower-priority background queue used for deferrable bulk work.
     ///
     /// Every collaborator capable of replaying state or scheduling observable work on this path is
     /// isolated in this test. Building a `Gist` on the class-wide `InAppMessageStoreManager` is not
@@ -538,10 +538,9 @@ class InAppMessageStateTests: IntegrationTest {
     /// before the call returns. The controlled 304 response also returns before the shared visual
     /// inbox repository can be reached.
     func test_fetchUserMessages_givenIdentifiedUser_expectSingleQueueFetchScheduledAtUtilityPriority() async throws {
-        let applicationState = await MainActor.run { UIApplication.shared.applicationState }
-        try XCTSkipIf(applicationState == .background, "A backgrounded XCTest host bypasses this foreground path.")
-
         let state = InAppMessageState(siteId: .random, dataCenter: .random, userId: .random)
+        let applicationStateProvider = ApplicationStateProviderMock()
+        applicationStateProvider.underlyingApplicationState = .active
 
         let inAppMessageManagerMock = InAppMessageManagerMock()
         // Inert subscriptions: no state replay, so nothing in `init` can schedule a fetch.
@@ -588,11 +587,12 @@ class InAppMessageStateTests: IntegrationTest {
                 inAppMessageManager: inAppMessageManagerMock,
                 queueManager: queueManagerUnderTest,
                 threadUtil: threadUtil,
-                sseLifecycleManager: SseLifecycleManagerMock()
+                sseLifecycleManager: SseLifecycleManagerMock(),
+                applicationStateProvider: applicationStateProvider
             )
         }
 
-        // `fetchUserMessages` reads `UIApplication.applicationState`, so it must be called on main.
+        // The production application-state provider requires this selector to run on main.
         await MainActor.run { gistUnderTest.fetchUserMessages() }
 
         // Both counts are exact. The whole path ran inline on this thread, so anything beyond one

--- a/Tests/MessagingInApp/State/InAppMessageStateTests.swift
+++ b/Tests/MessagingInApp/State/InAppMessageStateTests.swift
@@ -524,6 +524,33 @@ class InAppMessageStateTests: IntegrationTest {
 
     // MARK: fetch user messages from backend services
 
+    func test_fetchUserMessages_expectUtilityThread() async {
+        await inAppMessageManager.dispatchAsync(action: .initialize(siteId: .random, dataCenter: .random, environment: .production))
+        await inAppMessageManager.dispatchAsync(action: .setUserIdentifier(user: .random))
+        setupHttpResponse(code: 304, body: Data())
+
+        let threadUtil = ThreadUtilStub()
+        let sseLifecycleManager = SseLifecycleManagerMock()
+        mockCollection.add(mock: sseLifecycleManager)
+        let utilityExpectation = expectation(description: "Queue fetch dispatched at utility priority")
+        threadUtil.runUtilityClosure = { utilityExpectation.fulfill() }
+        let gistUnderTest = Gist(
+            logger: diGraphShared.logger,
+            gistDelegate: diGraphShared.gistDelegate,
+            inAppMessageManager: inAppMessageManager,
+            queueManager: queueManager,
+            threadUtil: threadUtil,
+            sseLifecycleManager: sseLifecycleManager
+        )
+
+        await MainActor.run { gistUnderTest.fetchUserMessages() }
+
+        await fulfillment(of: [utilityExpectation], timeout: 1)
+        XCTAssertTrue(threadUtil.runUtilityCalled)
+        XCTAssertFalse(threadUtil.runBackgroundCalled)
+        gistUnderTest.resetState()
+    }
+
     var sampleFetchResponseBody: String {
         readSampleDataFile(subdirectory: "InAppUserQueue", fileName: "fetch_response.json")
     }

--- a/Tests/MessagingInApp/State/InAppMessageStateTests.swift
+++ b/Tests/MessagingInApp/State/InAppMessageStateTests.swift
@@ -532,22 +532,28 @@ class InAppMessageStateTests: IntegrationTest {
         let threadUtil = ThreadUtilStub()
         let sseLifecycleManager = SseLifecycleManagerMock()
         mockCollection.add(mock: sseLifecycleManager)
+        let gistUnderTest = await MainActor.run {
+            Gist(
+                logger: diGraphShared.logger,
+                gistDelegate: diGraphShared.gistDelegate,
+                inAppMessageManager: inAppMessageManager,
+                queueManager: queueManager,
+                threadUtil: threadUtil,
+                sseLifecycleManager: sseLifecycleManager
+            )
+        }
+
+        threadUtil.reset()
+        gistQueueNetworkMock.resetMock()
         let utilityExpectation = expectation(description: "Queue fetch dispatched at utility priority")
         threadUtil.runUtilityClosure = { utilityExpectation.fulfill() }
-        let gistUnderTest = Gist(
-            logger: diGraphShared.logger,
-            gistDelegate: diGraphShared.gistDelegate,
-            inAppMessageManager: inAppMessageManager,
-            queueManager: queueManager,
-            threadUtil: threadUtil,
-            sseLifecycleManager: sseLifecycleManager
-        )
 
         await MainActor.run { gistUnderTest.fetchUserMessages() }
 
         await fulfillment(of: [utilityExpectation], timeout: 1)
         XCTAssertTrue(threadUtil.runUtilityCalled)
         XCTAssertFalse(threadUtil.runBackgroundCalled)
+        XCTAssertEqual(gistQueueNetworkMock.requestCallsCount, 1)
         gistUnderTest.resetState()
     }
 

--- a/Tests/MessagingInApp/State/InAppMessageStateTests.swift
+++ b/Tests/MessagingInApp/State/InAppMessageStateTests.swift
@@ -640,7 +640,7 @@ class InAppMessageStateTests: IntegrationTest {
         harness.gist.fetchUserMessagesFromRemoteQueue()
 
         await waitUntil {
-            harness.threadUtil.runMainActorExecutionsCount >= 2
+            harness.threadUtil.runMainActorExecutionsCount >= 1
         }
 
         XCTAssertEqual(harness.threadUtil.runUtilityCallsCount, 1)
@@ -651,6 +651,27 @@ class InAppMessageStateTests: IntegrationTest {
         harness.gist.resetState()
         await waitUntil {
             harness.threadUtil.runMainActorExecutionsCount > executionsBeforeReset
+        }
+    }
+
+    func test_fetchUserMessagesFromRemoteQueue_givenActiveTimer_expectGistCanDeallocateAndCleanUp() async {
+        var harness: FetchHarness? = await makeFetchHarness(applicationState: .active)
+        weak let weakGist = harness?.gist
+        guard let threadUtil = harness?.threadUtil else {
+            XCTFail("Expected the fetch harness to provide a thread utility")
+            return
+        }
+
+        harness?.gist.fetchUserMessagesFromRemoteQueue()
+        await waitUntil {
+            threadUtil.runMainActorExecutionsCount >= 1
+        }
+
+        let executionsBeforeDeinit = threadUtil.runMainActorExecutionsCount
+        harness = nil
+
+        await waitUntil {
+            weakGist == nil && threadUtil.runMainActorExecutionsCount > executionsBeforeDeinit
         }
     }
 

--- a/Tests/MessagingInApp/State/InAppMessageStateTests.swift
+++ b/Tests/MessagingInApp/State/InAppMessageStateTests.swift
@@ -634,6 +634,19 @@ class InAppMessageStateTests: IntegrationTest {
         XCTAssertEqual(harness.queueNetwork.requestCallsCount, 0)
     }
 
+    func test_fetchUserMessagesFromRemoteQueue_givenActiveApp_expectMainActorSetupAndUtilityFetch() async {
+        let harness = await makeFetchHarness(applicationState: .active)
+
+        harness.gist.fetchUserMessagesFromRemoteQueue()
+
+        XCTAssertEqual(harness.threadUtil.runMainActorCallsCount, 1)
+        XCTAssertEqual(harness.threadUtil.runUtilityCallsCount, 1)
+        XCTAssertEqual(harness.threadUtil.runBackgroundCallsCount, 0)
+        XCTAssertEqual(harness.queueNetwork.requestCallsCount, 1)
+
+        await MainActor.run { harness.gist.resetState() }
+    }
+
     var sampleFetchResponseBody: String {
         readSampleDataFile(subdirectory: "InAppUserQueue", fileName: "fetch_response.json")
     }

--- a/Tests/MessagingInApp/State/InAppMessageStateTests.swift
+++ b/Tests/MessagingInApp/State/InAppMessageStateTests.swift
@@ -639,12 +639,19 @@ class InAppMessageStateTests: IntegrationTest {
 
         harness.gist.fetchUserMessagesFromRemoteQueue()
 
-        XCTAssertEqual(harness.threadUtil.runMainActorCallsCount, 1)
+        await waitUntil {
+            harness.threadUtil.runMainActorExecutionsCount == 2
+        }
+
+        XCTAssertEqual(harness.threadUtil.runMainActorCallsCount, 2)
         XCTAssertEqual(harness.threadUtil.runUtilityCallsCount, 1)
         XCTAssertEqual(harness.threadUtil.runBackgroundCallsCount, 0)
         XCTAssertEqual(harness.queueNetwork.requestCallsCount, 1)
 
-        await MainActor.run { harness.gist.resetState() }
+        harness.gist.resetState()
+        await waitUntil {
+            harness.threadUtil.runMainActorExecutionsCount == 3
+        }
     }
 
     var sampleFetchResponseBody: String {

--- a/Tests/MessagingInApp/State/InAppMessageStateTests.swift
+++ b/Tests/MessagingInApp/State/InAppMessageStateTests.swift
@@ -656,7 +656,8 @@ class InAppMessageStateTests: IntegrationTest {
 
     func test_fetchUserMessagesFromRemoteQueue_givenActiveTimer_expectGistCanDeallocateAndCleanUp() async {
         var harness: FetchHarness? = await makeFetchHarness(applicationState: .active)
-        weak let weakGist = harness?.gist
+        var retainedGist = harness?.gist
+        let isGistReleased = { [weak retainedGist] in retainedGist == nil }
         guard let threadUtil = harness?.threadUtil else {
             XCTFail("Expected the fetch harness to provide a thread utility")
             return
@@ -668,10 +669,11 @@ class InAppMessageStateTests: IntegrationTest {
         }
 
         let executionsBeforeDeinit = threadUtil.runMainActorExecutionsCount
+        retainedGist = nil
         harness = nil
 
         await waitUntil {
-            weakGist == nil && threadUtil.runMainActorExecutionsCount > executionsBeforeDeinit
+            isGistReleased() && threadUtil.runMainActorExecutionsCount > executionsBeforeDeinit
         }
     }
 

--- a/Tests/MessagingInApp/State/InAppMessageStateTests.swift
+++ b/Tests/MessagingInApp/State/InAppMessageStateTests.swift
@@ -640,17 +640,17 @@ class InAppMessageStateTests: IntegrationTest {
         harness.gist.fetchUserMessagesFromRemoteQueue()
 
         await waitUntil {
-            harness.threadUtil.runMainActorExecutionsCount == 2
+            harness.threadUtil.runMainActorExecutionsCount >= 2
         }
 
-        XCTAssertEqual(harness.threadUtil.runMainActorCallsCount, 2)
         XCTAssertEqual(harness.threadUtil.runUtilityCallsCount, 1)
         XCTAssertEqual(harness.threadUtil.runBackgroundCallsCount, 0)
         XCTAssertEqual(harness.queueNetwork.requestCallsCount, 1)
 
+        let executionsBeforeReset = harness.threadUtil.runMainActorExecutionsCount
         harness.gist.resetState()
         await waitUntil {
-            harness.threadUtil.runMainActorExecutionsCount == 3
+            harness.threadUtil.runMainActorExecutionsCount > executionsBeforeReset
         }
     }
 

--- a/Tests/Migration/DataPipelineMigrationAssistantTests.swift
+++ b/Tests/Migration/DataPipelineMigrationAssistantTests.swift
@@ -71,6 +71,8 @@ class DataPipelineMigrationAssistantTests: UnitTest {
 
         XCTAssertNotNil(migrationAssistant.handleQueueBacklog(siteId: testSiteId))
         XCTAssertEqual(backgroundQueueMock.deleteProcessedTaskCallsCount, counter)
+        XCTAssertTrue(threadUtilStub.runBackgroundCalled)
+        XCTAssertFalse(threadUtilStub.runUtilityCalled)
     }
 
     func test_givenBacklog_expectTaskRunButNotProcessedDeleted() {

--- a/Tests/Shared/Stub/ThreadUtilStub.swift
+++ b/Tests/Shared/Stub/ThreadUtilStub.swift
@@ -10,14 +10,17 @@ import Foundation
 /// retaining XCTest state in an escaping closure.
 public class ThreadUtilStub: ThreadUtil {
     private let _runMainCallsCount: Synchronized<Int> = .init(0)
+    private let _runMainActorCallsCount: Synchronized<Int> = .init(0)
     private let _runBackgroundCallsCount: Synchronized<Int> = .init(0)
     private let _runUtilityCallsCount: Synchronized<Int> = .init(0)
 
     public var runMainCallsCount: Int { _runMainCallsCount.wrappedValue }
+    public var runMainActorCallsCount: Int { _runMainActorCallsCount.wrappedValue }
     public var runBackgroundCallsCount: Int { _runBackgroundCallsCount.wrappedValue }
     public var runUtilityCallsCount: Int { _runUtilityCallsCount.wrappedValue }
 
     public var runMainCalled: Bool { runMainCallsCount > 0 }
+    public var runMainActorCalled: Bool { runMainActorCallsCount > 0 }
     public var runBackgroundCalled: Bool { runBackgroundCallsCount > 0 }
     public var runUtilityCalled: Bool { runUtilityCallsCount > 0 }
 
@@ -28,6 +31,22 @@ public class ThreadUtilStub: ThreadUtil {
     public func runMain(_ block: @escaping () -> Void) {
         _runMainCallsCount.mutating { $0 += 1 }
         block()
+    }
+
+    public func runMainActor(_ block: @MainActor @escaping () -> Void) {
+        _runMainActorCallsCount.mutating { $0 += 1 }
+
+        if Thread.isMainThread {
+            MainActor.assumeIsolated {
+                block()
+            }
+        } else {
+            DispatchQueue.main.sync {
+                MainActor.assumeIsolated {
+                    block()
+                }
+            }
+        }
     }
 
     public func runBackground(_ block: @escaping () -> Void) {

--- a/Tests/Shared/Stub/ThreadUtilStub.swift
+++ b/Tests/Shared/Stub/ThreadUtilStub.swift
@@ -1,36 +1,42 @@
 import CioInternalCommon
 import Foundation
 
+/// Runs every scheduled block inline on the calling thread and records how each one was scheduled.
+///
+/// Only counters are exposed on purpose. An injectable "call me back" closure would let a test attach
+/// an `XCTestExpectation` to a stub whose lifetime it does not own, and any late block — from a timer,
+/// a store replay, or a retained subscription — could then fulfil that expectation after the test
+/// finished and crash whichever test happened to be running. Counters let tests inspect calls without
+/// retaining XCTest state in an escaping closure.
 public class ThreadUtilStub: ThreadUtil {
-    public var runMainCalled = false
-    public var runBackgroundCalled = false
-    public var runUtilityCalled = false
-    public var runUtilityClosure: (() -> Void)?
+    private let _runMainCallsCount: Synchronized<Int> = .init(0)
+    private let _runBackgroundCallsCount: Synchronized<Int> = .init(0)
+    private let _runUtilityCallsCount: Synchronized<Int> = .init(0)
+
+    public var runMainCallsCount: Int { _runMainCallsCount.wrappedValue }
+    public var runBackgroundCallsCount: Int { _runBackgroundCallsCount.wrappedValue }
+    public var runUtilityCallsCount: Int { _runUtilityCallsCount.wrappedValue }
+
+    public var runMainCalled: Bool { runMainCallsCount > 0 }
+    public var runBackgroundCalled: Bool { runBackgroundCallsCount > 0 }
+    public var runUtilityCalled: Bool { runUtilityCallsCount > 0 }
 
     public init() {
         // Public initializer
     }
 
     public func runMain(_ block: @escaping () -> Void) {
-        runMainCalled = true
+        _runMainCallsCount.mutating { $0 += 1 }
         block()
     }
 
     public func runBackground(_ block: @escaping () -> Void) {
-        runBackgroundCalled = true
+        _runBackgroundCallsCount.mutating { $0 += 1 }
         block()
     }
 
     public func runUtility(_ block: @escaping () -> Void) {
-        runUtilityCalled = true
-        runUtilityClosure?()
+        _runUtilityCallsCount.mutating { $0 += 1 }
         block()
-    }
-
-    public func reset() {
-        runMainCalled = false
-        runBackgroundCalled = false
-        runUtilityCalled = false
-        runUtilityClosure = nil
     }
 }

--- a/Tests/Shared/Stub/ThreadUtilStub.swift
+++ b/Tests/Shared/Stub/ThreadUtilStub.swift
@@ -1,7 +1,8 @@
 import CioInternalCommon
 import Foundation
 
-/// Runs every scheduled block inline on the calling thread and records how each one was scheduled.
+/// Runs non-actor blocks inline and enqueues main-actor blocks on the main queue, recording how each
+/// block was scheduled and completed.
 ///
 /// Only counters are exposed on purpose. An injectable "call me back" closure would let a test attach
 /// an `XCTestExpectation` to a stub whose lifetime it does not own, and any late block — from a timer,
@@ -11,11 +12,13 @@ import Foundation
 public class ThreadUtilStub: ThreadUtil {
     private let _runMainCallsCount: Synchronized<Int> = .init(0)
     private let _runMainActorCallsCount: Synchronized<Int> = .init(0)
+    private let _runMainActorExecutionsCount: Synchronized<Int> = .init(0)
     private let _runBackgroundCallsCount: Synchronized<Int> = .init(0)
     private let _runUtilityCallsCount: Synchronized<Int> = .init(0)
 
     public var runMainCallsCount: Int { _runMainCallsCount.wrappedValue }
     public var runMainActorCallsCount: Int { _runMainActorCallsCount.wrappedValue }
+    public var runMainActorExecutionsCount: Int { _runMainActorExecutionsCount.wrappedValue }
     public var runBackgroundCallsCount: Int { _runBackgroundCallsCount.wrappedValue }
     public var runUtilityCallsCount: Int { _runUtilityCallsCount.wrappedValue }
 
@@ -36,16 +39,11 @@ public class ThreadUtilStub: ThreadUtil {
     public func runMainActor(_ block: @MainActor @escaping () -> Void) {
         _runMainActorCallsCount.mutating { $0 += 1 }
 
-        if Thread.isMainThread {
+        DispatchQueue.main.async { [self] in
             MainActor.assumeIsolated {
                 block()
             }
-        } else {
-            DispatchQueue.main.sync {
-                MainActor.assumeIsolated {
-                    block()
-                }
-            }
+            _runMainActorExecutionsCount.mutating { $0 += 1 }
         }
     }
 

--- a/Tests/Shared/Stub/ThreadUtilStub.swift
+++ b/Tests/Shared/Stub/ThreadUtilStub.swift
@@ -4,6 +4,8 @@ import Foundation
 public class ThreadUtilStub: ThreadUtil {
     public var runMainCalled = false
     public var runBackgroundCalled = false
+    public var runUtilityCalled = false
+    public var runUtilityClosure: (() -> Void)?
 
     public init() {
         // Public initializer
@@ -19,8 +21,16 @@ public class ThreadUtilStub: ThreadUtil {
         block()
     }
 
+    public func runUtility(_ block: @escaping () -> Void) {
+        runUtilityCalled = true
+        runUtilityClosure?()
+        block()
+    }
+
     public func reset() {
         runMainCalled = false
         runBackgroundCalled = false
+        runUtilityCalled = false
+        runUtilityClosure = nil
     }
 }

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -113,6 +113,7 @@ public final class CioInternalCommon.CioSharedDataStore {
 public final class CioInternalCommon.CioThreadUtil {
 	public fun func runMain(_ block: @escaping () -> Unit);
 	public fun func runBackground(_ block: @escaping () -> Unit);
+	public fun func runUtility(_ block: @escaping () -> Unit);
 }
 public final class CioInternalCommon.CombinedCacheEventBusHandler {
 	public fun init(eventStorage: EventStorage, logger: Logger);
@@ -602,6 +603,7 @@ public final class CioInternalCommon.TaskDetail {
 }
 public interface CioInternalCommon.ThreadUtil {
 	public fun func runBackground(_ block: @escaping () -> Unit);
+	public fun func runUtility(_ block: @escaping () -> Unit);
 	public fun func runMain(_ block: @escaping () -> Unit);
 }
 public final class CioInternalCommon.TrackDeliveryEventRequestBody {

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -112,6 +112,7 @@ public final class CioInternalCommon.CioSharedDataStore {
 }
 public final class CioInternalCommon.CioThreadUtil {
 	public fun func runMain(_ block: @escaping () -> Unit);
+	public fun func runMainActor(_ block: @MainActor @escaping () -> Unit);
 	public fun func runBackground(_ block: @escaping () -> Unit);
 	public fun func runUtility(_ block: @escaping () -> Unit);
 }
@@ -605,6 +606,7 @@ public interface CioInternalCommon.ThreadUtil {
 	public fun func runBackground(_ block: @escaping () -> Unit);
 	public fun func runUtility(_ block: @escaping () -> Unit);
 	public fun func runMain(_ block: @escaping () -> Unit);
+	public fun func runMainActor(_ block: @MainActor @escaping () -> Unit);
 }
 public final class CioInternalCommon.TrackDeliveryEventRequestBody {
 	public final val payload: DeliveryPayload;


### PR DESCRIPTION
## Summary

- add a utility-QoS scheduler to `ThreadUtil`
- use utility QoS only for Gist queue requests that feed customer-visible in-app and inbox startup content
- keep migration work on background QoS
- weak-capture Gist during the asynchronous request
- update the generated internal API baseline for the intentional `runUtility` addition

## Root cause

Hosted message-inbox run 31045137765 restored the profile and logged that Gist polling was scheduled, while the exact backend delivery existed, but no queue network request began before the UI timed out. Live SDK diagnostics isolated the missing boundary to the `.background` QoS dispatch on the constrained hosted macOS runner.

The first patch raised the shared background scheduler globally. Claude Opus blocked that because migration also uses the shared method. The final patch instead adds a scoped `.utility` path used only by Gist; `runBackground` remains `.background` and migration coverage asserts that separation.

## Stack

- Base: #1200 — event-bus observer ordering
- This PR: utility-QoS and Gist scheduling only

Merge #1200 first. This PR is based directly on that branch and its six-file diff does not include the event-bus implementation or tests.

## Validation

- feature diff is byte-for-byte equivalent to the pre-split #1198 feature diff
- `make format`
- `make lint` (strict; 0 violations)
- `xcodebuild build-for-testing` for `Customer.io-Package`
- `InAppMessageStateTests`: 50 repeated iterations, stop on first failure
- `InAppMessageStateTests`, `GistDelegateImplTests`, and `DataPipelineMigrationAssistantTests`: 5 repeated iterations, stop on first failure
- full `Customer.io-Package` test suite
- repository API baseline generated with the official script; API checker previously passed
- local full message-inbox E2E previously passed in 2m16s
  - startup queue HTTP 200
  - backend/SSE delivery
  - real `MAESTRO VISUAL INBOX` content
  - opened/read, click, deletion, and empty state
- pre-split hosted smoke passed: https://github.com/customerio/customerio-ios/actions/runs/31054106101
- pre-split hosted message inbox passed in 16m41s: https://github.com/customerio/customerio-ios/actions/runs/31055851224
  - Maestro flow 3m29s, one test, zero failures
  - queue HTTP 200 and complete visual/action evidence in uploaded artifacts

Fresh hosted checks for the stacked head are running.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes threading QoS and main-actor timer lifecycle for in-app queue polling—a customer-visible startup path—but scope is limited to Gist scheduling with strong regression tests.
> 
> **Overview**
> Addresses hosted inbox startup timeouts where Gist queue HTTP never started because work was scheduled at **background** QoS on a constrained runner.
> 
> **`ThreadUtil`** gains **`runUtility`** (`.utility` QoS) and **`runMainActor`** (FIFO main-actor async), with protocol-extension defaults so older conformers keep working. **`CioThreadUtil`** implements both; migration backlog handling stays on **`runBackground`**.
> 
> **`Gist`** routes remote queue fetches through **`runUtility`** instead of **`runBackground`**, injects **`ApplicationStateProvider`** for foreground/background checks (replacing direct **`UIApplication`** use), and refactors polling timers: **`Synchronized<Timer?>`**, invalidate/create in a single **`runMainActor`** block, block-based timers with **`@MainActor`** **`fetchUserMessages`**, and safe timer teardown on deinit.
> 
> Tests add **`ThreadUtilTest`**, richer **`ThreadUtilStub`** counters, isolated fetch harnesses in **`InAppMessageStateTests`**, and migration assertions that backlog still uses background only. Internal API baseline updated for the new **`ThreadUtil`** surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56e28bcc6004654147f39442b3ae0e130309ac44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->