### PR TITLE
chore: preserve event bus observer ordering

### DIFF
--- a/Sources/Common/Communication/CombinedCacheEventBusHandler.swift
+++ b/Sources/Common/Communication/CombinedCacheEventBusHandler.swift
@@ -12,17 +12,24 @@ public class CombinedCacheEventBusHandler: EventBusHandler {
     let eventStorage: EventStorage
     let logger: Logger
 
-    /// Guards `pendingRegistryWork`.
-    private let registryLock = Lock.unsafeInit()
-
-    /// Tail of the FIFO chain of observer registrations/removals.
+    /// Tails of the FIFO chains of observer registrations/removals, grouped by event key.
     ///
     /// `addObserver` and `removeObserver` are synchronous entry points that must reach the
     /// `bus` actor asynchronously. Independent unstructured `Task`s carry no ordering
     /// guarantee, so `addObserver(X)` followed by `removeObserver(X)` could reach the actor
-    /// in reverse order and leave a live observer behind. Chaining each operation onto the
-    /// previous one restores the caller's ordering.
-    private var pendingRegistryWork: Task<Void, Never>?
+    /// in reverse order and leave a live observer behind. Chaining operations for the same
+    /// event key restores the caller's ordering without blocking unrelated event types.
+    ///
+    /// The dictionary retains only the latest tail encountered for each event key. SDK event
+    /// types are finite, so pruning completed tails would add race-prone bookkeeping for no
+    /// meaningful memory benefit.
+    private let pendingRegistryWork = Synchronized<[String: Task<Void, Never>]>([:])
+
+    /// Tails of best-effort persistent cleanup work, grouped by event key.
+    ///
+    /// Cleanup is retained and serialized separately from registry work so disk operations
+    /// never delay observer registration, replay delivery, or a later post.
+    private let pendingCleanupWork = Synchronized<[String: Task<Void, Never>]>([:])
 
     public init(eventStorage: EventStorage, logger: Logger) {
         self.bus = CioEventBus()
@@ -33,25 +40,50 @@ public class CombinedCacheEventBusHandler: EventBusHandler {
         }
     }
 
-    /// Appends a registry operation to the chain.
-    ///
-    /// `build` is handed the previously enqueued operation and must return a `Task` that
-    /// awaits it before touching the bus. Reading the tail and installing the new one happen
-    /// under the lock, so concurrent callers still produce a single well-defined order.
-    private func chainRegistryWork(_ build: (Task<Void, Never>?) -> Task<Void, Never>) {
-        registryLock.lock()
-        defer { registryLock.unlock() }
-
-        pendingRegistryWork = build(pendingRegistryWork)
+    deinit {
+        pendingRegistryWork.using { $0.values.forEach { $0.cancel() } }
+        pendingCleanupWork.using { $0.values.forEach { $0.cancel() } }
     }
 
-    /// Suspends until every registry operation enqueued before this call has been applied.
-    private func awaitPendingRegistryWork() async {
-        registryLock.lock()
-        let pending = pendingRegistryWork
-        registryLock.unlock()
+    /// Appends a registry operation to the chain for `key`.
+    ///
+    /// Reading the previous tail and installing the new one happen in one synchronized
+    /// mutation, so concurrent callers still produce a single well-defined order per key.
+    func chainRegistryWork(forKey key: String, operation: @escaping () async -> Void) {
+        pendingRegistryWork.mutating { workByKey in
+            let previous = workByKey[key]
+            workByKey[key] = Task {
+                await previous?.value
+                guard !Task.isCancelled else { return }
+                await operation()
+            }
+        }
+    }
 
+    /// Suspends until registry work previously enqueued for `key` has been applied.
+    private func awaitPendingRegistryWork(forKey key: String) async {
+        let pending = pendingRegistryWork.using { $0[key] }
         await pending?.value
+    }
+
+    /// Schedules idempotent storage cleanup without adding file I/O to the delivery path.
+    private func enqueueCleanup<E: EventRepresentable>(for events: [E], key: String) {
+        guard !events.isEmpty else { return }
+
+        let storage = eventStorage
+        pendingCleanupWork.mutating { workByKey in
+            let previous = workByKey[key]
+            workByKey[key] = Task {
+                await previous?.value
+                for event in events {
+                    guard !Task.isCancelled else { return }
+                    await storage.remove(
+                        ofType: event.key,
+                        withStorageId: event.storageId
+                    )
+                }
+            }
+        }
     }
 
     /// Loads events from persistent storage into the in-memory cache on startup.
@@ -76,57 +108,48 @@ public class CombinedCacheEventBusHandler: EventBusHandler {
     /// Events posted after registration returns are delivered directly to the observer;
     /// events already in the cache at registration time are replayed exactly once.
     ///
-    /// Registration is applied asynchronously, but in order relative to other
-    /// `addObserver`/`removeObserver` calls and to any later `postEventAndWait`.
+    /// Registration is applied asynchronously, but in order relative to other registry
+    /// calls and to any later `postEventAndWait` for the same event key.
     public func addObserver<E: EventRepresentable>(
         _ eventType: E.Type, action: @escaping (E) -> Void
     ) {
         logger.debug("CombinedCacheEventBusHandler: Adding observer for \(eventType)")
-        chainRegistryWork { previous in
-            Task { [weak self] in
-                await previous?.value
-                guard let self else { return }
-                let registration = await bus.addObserver(key: E.key) { [weak self] event in
-                    guard self != nil else { return }
-                    if let typed = event as? E {
-                        action(typed)
-                    } else {
-                        self?.logger.debug(
-                            "CombinedCacheEventBusHandler: Event type mismatch for key \(E.key)"
-                        )
-                    }
-                }
-                // Replay stays off the bus actor but remains ordered with other registry work.
-                let eventsToReplay = registration.eventsToReplay.compactMap { $0 as? E }
-                for event in eventsToReplay {
-                    logger.debug("CombinedCacheEventBusHandler: Replaying event \(event)")
-                    action(event)
-                }
-
-                // Deletion is idempotent and must not put file I/O on the delivery path for every
-                // later registration or post.
-                let storage = eventStorage
-                Task {
-                    for event in eventsToReplay {
-                        await storage.remove(ofType: event.key, withStorageId: event.storageId)
-                    }
+        chainRegistryWork(forKey: E.key) { [weak self] in
+            guard let self else { return }
+            let registration = await bus.addObserver(key: E.key) { [weak self] event in
+                guard self != nil else { return }
+                if let typed = event as? E {
+                    action(typed)
+                } else {
+                    self?.logger.debug(
+                        "CombinedCacheEventBusHandler: Event type mismatch for key \(E.key)"
+                    )
                 }
             }
+            // Replay stays off the bus actor but remains ordered with registry work and
+            // awaited posts for this key. Observer actions are synchronous; they must not
+            // block while waiting for work that is itself queued behind this chain.
+            let eventsToReplay = registration.eventsToReplay.compactMap { $0 as? E }
+            for event in eventsToReplay {
+                logger.debug("CombinedCacheEventBusHandler: Replaying event \(event)")
+                action(event)
+            }
+            // Removal is idempotent and runs on a separately retained chain so slow file I/O
+            // never stalls delivery. A process terminated before cleanup finishes can replay
+            // the event again on its next launch.
+            enqueueCleanup(for: eventsToReplay, key: E.key)
         }
     }
 
     /// Removes all observers for `eventType`.
     ///
-    /// Removal is applied asynchronously, but in order relative to other
-    /// `addObserver`/`removeObserver` calls and to any later `postEventAndWait`, so an
-    /// observer added and then removed never receives a subsequently posted event.
+    /// Removal is applied asynchronously, but in order relative to other registry calls and
+    /// to any later `postEventAndWait` for the same event key, so an observer added and then
+    /// removed never receives a subsequently posted event of that type.
     public func removeObserver<E: EventRepresentable>(for eventType: E.Type) {
-        chainRegistryWork { previous in
-            Task { [weak self] in
-                await previous?.value
-                guard let self else { return }
-                await bus.removeAllObservers(key: E.key)
-            }
+        chainRegistryWork(forKey: E.key) { [weak self] in
+            guard let self else { return }
+            await bus.removeAllObservers(key: E.key)
         }
     }
 
@@ -146,11 +169,11 @@ public class CombinedCacheEventBusHandler: EventBusHandler {
     /// can receive it via replay. Transient events (`isPersistent == false`) are never
     /// written to disk — they are only useful in the moment.
     ///
-    /// Any `addObserver`/`removeObserver` requested before this call is applied first, so
-    /// the observer set seen here matches what the caller last asked for.
+    /// Any `addObserver`/`removeObserver` requested before this call for the same event key
+    /// is applied first, so the observer set seen here matches what the caller last asked for.
     public func postEventAndWait<E: EventRepresentable>(_ event: E) async {
         logger.debug("CombinedCacheEventBusHandler: Posting event \(event)")
-        await awaitPendingRegistryWork()
+        await awaitPendingRegistryWork(forKey: event.key)
         let observers = await bus.post(event)
         // Deliver outside the actor so callbacks run concurrently and cannot deadlock.
         for observer in observers {

--- a/Sources/Common/Communication/CombinedCacheEventBusHandler.swift
+++ b/Sources/Common/Communication/CombinedCacheEventBusHandler.swift
@@ -28,7 +28,8 @@ public class CombinedCacheEventBusHandler: EventBusHandler {
     /// Tails of best-effort persistent cleanup work, grouped by event key.
     ///
     /// Cleanup is retained and serialized separately from registry work so disk operations
-    /// never delay observer registration, replay delivery, or a later post.
+    /// do not delay observer registration or replay delivery. Cleanup can still contend with
+    /// later persistence work performed by the same `EventStorage` actor.
     private let pendingCleanupWork = Synchronized<[String: Task<Void, Never>]>([:])
 
     public init(eventStorage: EventStorage, logger: Logger) {
@@ -42,13 +43,14 @@ public class CombinedCacheEventBusHandler: EventBusHandler {
 
     deinit {
         pendingRegistryWork.using { $0.values.forEach { $0.cancel() } }
-        pendingCleanupWork.using { $0.values.forEach { $0.cancel() } }
     }
 
     /// Appends a registry operation to the chain for `key`.
     ///
     /// Reading the previous tail and installing the new one happen in one synchronized
     /// mutation, so concurrent callers still produce a single well-defined order per key.
+    /// This is internal only as a deterministic concurrency-test seam; production callers
+    /// should use the public observer APIs.
     func chainRegistryWork(forKey key: String, operation: @escaping () async -> Void) {
         pendingRegistryWork.mutating { workByKey in
             let previous = workByKey[key]
@@ -76,7 +78,6 @@ public class CombinedCacheEventBusHandler: EventBusHandler {
             workByKey[key] = Task {
                 await previous?.value
                 for event in events {
-                    guard !Task.isCancelled else { return }
                     await storage.remove(
                         ofType: event.key,
                         withStorageId: event.storageId
@@ -135,8 +136,8 @@ public class CombinedCacheEventBusHandler: EventBusHandler {
                 action(event)
             }
             // Removal is idempotent and runs on a separately retained chain so slow file I/O
-            // never stalls delivery. A process terminated before cleanup finishes can replay
-            // the event again on its next launch.
+            // never stalls replay delivery or registry ordering. A process terminated before
+            // cleanup finishes can replay the event again on its next launch.
             enqueueCleanup(for: eventsToReplay, key: E.key)
         }
     }

--- a/Sources/Common/Communication/CombinedCacheEventBusHandler.swift
+++ b/Sources/Common/Communication/CombinedCacheEventBusHandler.swift
@@ -12,6 +12,18 @@ public class CombinedCacheEventBusHandler: EventBusHandler {
     let eventStorage: EventStorage
     let logger: Logger
 
+    /// Guards `pendingRegistryWork`.
+    private let registryLock = Lock.unsafeInit()
+
+    /// Tail of the FIFO chain of observer registrations/removals.
+    ///
+    /// `addObserver` and `removeObserver` are synchronous entry points that must reach the
+    /// `bus` actor asynchronously. Independent unstructured `Task`s carry no ordering
+    /// guarantee, so `addObserver(X)` followed by `removeObserver(X)` could reach the actor
+    /// in reverse order and leave a live observer behind. Chaining each operation onto the
+    /// previous one restores the caller's ordering.
+    private var pendingRegistryWork: Task<Void, Never>?
+
     public init(eventStorage: EventStorage, logger: Logger) {
         self.bus = CioEventBus()
         self.eventStorage = eventStorage
@@ -19,6 +31,27 @@ public class CombinedCacheEventBusHandler: EventBusHandler {
         Task { [weak self] in
             await self?.loadEventsFromStorage()
         }
+    }
+
+    /// Appends a registry operation to the chain.
+    ///
+    /// `build` is handed the previously enqueued operation and must return a `Task` that
+    /// awaits it before touching the bus. Reading the tail and installing the new one happen
+    /// under the lock, so concurrent callers still produce a single well-defined order.
+    private func chainRegistryWork(_ build: (Task<Void, Never>?) -> Task<Void, Never>) {
+        registryLock.lock()
+        defer { registryLock.unlock() }
+
+        pendingRegistryWork = build(pendingRegistryWork)
+    }
+
+    /// Suspends until every registry operation enqueued before this call has been applied.
+    private func awaitPendingRegistryWork() async {
+        registryLock.lock()
+        let pending = pendingRegistryWork
+        registryLock.unlock()
+
+        await pending?.value
     }
 
     /// Loads events from persistent storage into the in-memory cache on startup.
@@ -42,42 +75,63 @@ public class CombinedCacheEventBusHandler: EventBusHandler {
     /// Registration and the cache snapshot are taken atomically inside the actor.
     /// Events posted after registration returns are delivered directly to the observer;
     /// events already in the cache at registration time are replayed exactly once.
+    ///
+    /// Registration is applied asynchronously, but in order relative to other
+    /// `addObserver`/`removeObserver` calls and to any later `postEventAndWait`.
     public func addObserver<E: EventRepresentable>(
         _ eventType: E.Type, action: @escaping (E) -> Void
     ) {
         logger.debug("CombinedCacheEventBusHandler: Adding observer for \(eventType)")
-        Task { [weak self] in
-            guard let self else { return }
-            let registration = await bus.addObserver(key: E.key) { [weak self] event in
-                guard self != nil else { return }
-                if let typed = event as? E {
-                    action(typed)
-                } else {
-                    self?.logger.debug(
-                        "CombinedCacheEventBusHandler: Event type mismatch for key \(E.key)"
-                    )
+        chainRegistryWork { previous in
+            Task { [weak self] in
+                await previous?.value
+                guard let self else { return }
+                let registration = await bus.addObserver(key: E.key) { [weak self] event in
+                    guard self != nil else { return }
+                    if let typed = event as? E {
+                        action(typed)
+                    } else {
+                        self?.logger.debug(
+                            "CombinedCacheEventBusHandler: Event type mismatch for key \(E.key)"
+                        )
+                    }
                 }
-            }
-            // Replay is performed outside the actor to keep delivery concurrent.
-            // removeFromStorage is safe to call for events not on disk (no-op).
-            for event in registration.eventsToReplay.compactMap({ $0 as? E }) {
-                logger.debug("CombinedCacheEventBusHandler: Replaying event \(event)")
-                action(event)
-                await removeFromStorage(event)
+                // Replay stays off the bus actor but remains ordered with other registry work.
+                let eventsToReplay = registration.eventsToReplay.compactMap { $0 as? E }
+                for event in eventsToReplay {
+                    logger.debug("CombinedCacheEventBusHandler: Replaying event \(event)")
+                    action(event)
+                }
+
+                // Deletion is idempotent and must not put file I/O on the delivery path for every
+                // later registration or post.
+                let storage = eventStorage
+                Task {
+                    for event in eventsToReplay {
+                        await storage.remove(ofType: event.key, withStorageId: event.storageId)
+                    }
+                }
             }
         }
     }
 
     /// Removes all observers for `eventType`.
+    ///
+    /// Removal is applied asynchronously, but in order relative to other
+    /// `addObserver`/`removeObserver` calls and to any later `postEventAndWait`, so an
+    /// observer added and then removed never receives a subsequently posted event.
     public func removeObserver<E: EventRepresentable>(for eventType: E.Type) {
-        Task { [weak self] in
-            guard let self else { return }
-            await bus.removeAllObservers(key: E.key)
+        chainRegistryWork { previous in
+            Task { [weak self] in
+                await previous?.value
+                guard let self else { return }
+                await bus.removeAllObservers(key: E.key)
+            }
         }
     }
 
-    /// Posts `event` asynchronously. Prefer `postEventAndWait` when delivery must
-    /// complete before the next line of code runs (e.g. in tests).
+    /// Posts `event` asynchronously. This fire-and-forget API does not guarantee ordering
+    /// relative to later calls; use `postEventAndWait` when delivery or ordering matters.
     public func postEvent<E: EventRepresentable>(_ event: E) {
         Task { [weak self] in
             guard let self else { return }
@@ -91,8 +145,12 @@ public class CombinedCacheEventBusHandler: EventBusHandler {
     /// post time, a persistent event is also written to storage so a future observer
     /// can receive it via replay. Transient events (`isPersistent == false`) are never
     /// written to disk — they are only useful in the moment.
+    ///
+    /// Any `addObserver`/`removeObserver` requested before this call is applied first, so
+    /// the observer set seen here matches what the caller last asked for.
     public func postEventAndWait<E: EventRepresentable>(_ event: E) async {
         logger.debug("CombinedCacheEventBusHandler: Posting event \(event)")
+        await awaitPendingRegistryWork()
         let observers = await bus.post(event)
         // Deliver outside the actor so callbacks run concurrently and cannot deadlock.
         for observer in observers {

--- a/Sources/Common/Communication/EventBusHandler.swift
+++ b/Sources/Common/Communication/EventBusHandler.swift
@@ -2,10 +2,24 @@ import Foundation
 
 /// Protocol defining the interface for the event bus handler.
 public protocol EventBusHandler {
+    /// Loads persisted events into the in-memory replay cache.
     func loadEventsFromStorage() async
+
+    /// Registers an observer and replays cached events of the requested type.
+    ///
+    /// The callback is invoked synchronously on the EventBus delivery task and must return
+    /// without blocking on EventBus work, including posts or registry mutations it initiates.
     func addObserver<E: EventRepresentable>(_ eventType: E.Type, action: @escaping (E) -> Void)
+
+    /// Removes all observers registered for the requested event type.
     func removeObserver<E: EventRepresentable>(for eventType: E.Type)
+
+    /// Schedules an event for asynchronous delivery.
     func postEvent<E: EventRepresentable>(_ event: E)
+
+    /// Posts an event and returns after its current observers have been invoked.
     func postEventAndWait<E: EventRepresentable>(_ event: E) async
+
+    /// Removes a previously persisted event. Missing events are ignored.
     func removeFromStorage<E: EventRepresentable>(_ event: E) async
 }

--- a/Tests/Common/Communication/CombinedCacheEventBusHandlerTests.swift
+++ b/Tests/Common/Communication/CombinedCacheEventBusHandlerTests.swift
@@ -102,6 +102,8 @@ class CombinedCacheEventBusHandlerTest: UnitTest {
         handler.addObserver(ProfileIdentifiedEvent.self) { _ in }
         await storage.waitForRemovalToStart()
 
+        // This fake suspends outside the storage actor, isolating the handler's cleanup-chain
+        // behavior. Real file I/O can still contend with later persistence on EventStorage.
         let completedBeforeTimeout = await withTaskGroup(of: Bool.self, returning: Bool.self) { group in
             group.addTask {
                 await handler.postEventAndWait(ProfileIdentifiedEvent(identifier: "after-replay"))
@@ -126,6 +128,33 @@ class CombinedCacheEventBusHandlerTest: UnitTest {
         }
 
         XCTAssertTrue(completedBeforeTimeout, "persistent cleanup must not block event delivery")
+    }
+
+    func test_addObserver_givenHandlerDeinitializedDuringReplayCleanup_expectCleanupFinishes() async {
+        let handlerDeinitialized = XCTestExpectation(description: "handler deinitialized")
+        let allEventsRemoved = XCTestExpectation(description: "all replayed events removed")
+        allEventsRemoved.expectedFulfillmentCount = 2
+        let storage = SuspendedRemovalEventStorage {
+            allEventsRemoved.fulfill()
+        }
+        var handler: DeinitObservableEventBusHandler? = DeinitObservableEventBusHandler(
+            eventStorage: storage,
+            logger: log,
+            onDeinit: { handlerDeinitialized.fulfill() }
+        )
+
+        await handler?.postEventAndWait(ProfileIdentifiedEvent(identifier: "first"))
+        await handler?.postEventAndWait(ProfileIdentifiedEvent(identifier: "second"))
+        handler?.addObserver(ProfileIdentifiedEvent.self) { _ in }
+        await storage.waitForRemovalToStart()
+
+        weak var weakHandler = handler
+        handler = nil
+        await fulfillment(of: [handlerDeinitialized], timeout: 5.0)
+        XCTAssertNil(weakHandler)
+
+        await storage.releaseRemoval()
+        await fulfillment(of: [allEventsRemoved], timeout: 5.0)
     }
 
     func test_addObserver_givenPostImmediatelyAfterRegistration_expectDirectDelivery() async {
@@ -365,6 +394,12 @@ private actor AsyncGate {
 
 private actor SuspendedRemovalEventStorage: EventStorage {
     private let removalGate = AsyncGate()
+    private let onRemove: () -> Void
+    private var shouldSuspendRemoval = true
+
+    init(onRemove: @escaping () -> Void = {}) {
+        self.onRemove = onRemove
+    }
 
     func store(event: AnyEventRepresentable) async throws {}
 
@@ -377,7 +412,11 @@ private actor SuspendedRemovalEventStorage: EventStorage {
     }
 
     func remove(ofType eventType: String, withStorageId storageId: String) async {
-        await removalGate.wait()
+        if shouldSuspendRemoval {
+            shouldSuspendRemoval = false
+            await removalGate.wait()
+        }
+        onRemove()
     }
 
     func removeAll() async {}
@@ -388,5 +427,18 @@ private actor SuspendedRemovalEventStorage: EventStorage {
 
     func releaseRemoval() async {
         await removalGate.release()
+    }
+}
+
+private final class DeinitObservableEventBusHandler: CombinedCacheEventBusHandler {
+    private let onDeinit: () -> Void
+
+    init(eventStorage: EventStorage, logger: Logger, onDeinit: @escaping () -> Void) {
+        self.onDeinit = onDeinit
+        super.init(eventStorage: eventStorage, logger: logger)
+    }
+
+    deinit {
+        onDeinit()
     }
 }

--- a/Tests/Common/Communication/CombinedCacheEventBusHandlerTests.swift
+++ b/Tests/Common/Communication/CombinedCacheEventBusHandlerTests.swift
@@ -46,6 +46,24 @@ class CombinedCacheEventBusHandlerTest: UnitTest {
         await handler.postEventAndWait(ProfileIdentifiedEvent(identifier: "user-1"))
     }
 
+    func test_postEvent_givenObserverAddedThenRemoved_expectEventStoredWithoutDelivery() async {
+        let handler = makeHandler()
+        let event = ProfileIdentifiedEvent(identifier: "after-remove")
+        let received = Synchronized(false)
+        let stored = XCTestExpectation(description: "unobserved event stored")
+        mockEventStorage.storeClosure = { storedEvent in
+            guard storedEvent.storageId == event.storageId else { return }
+            stored.fulfill()
+        }
+
+        handler.addObserver(ProfileIdentifiedEvent.self) { _ in received.wrappedValue = true }
+        handler.removeObserver(for: ProfileIdentifiedEvent.self)
+        handler.postEvent(event)
+
+        await fulfillment(of: [stored], timeout: 5.0)
+        XCTAssertFalse(received.wrappedValue)
+    }
+
     // MARK: - addObserver replay
 
     func test_addObserver_givenEventCachedBeforeRegistration_expectEventReplayed() async {
@@ -76,6 +94,40 @@ class CombinedCacheEventBusHandlerTest: UnitTest {
         XCTAssertEqual(mockEventStorage.removeCallsCount, 1)
     }
 
+    func test_postEventAndWait_givenReplayCleanupSuspended_expectSameKeyPostNotBlocked() async {
+        let storage = SuspendedRemovalEventStorage()
+        let handler = CombinedCacheEventBusHandler(eventStorage: storage, logger: log)
+        await handler.postEventAndWait(ProfileIdentifiedEvent(identifier: "historic"))
+
+        handler.addObserver(ProfileIdentifiedEvent.self) { _ in }
+        await storage.waitForRemovalToStart()
+
+        let completedBeforeTimeout = await withTaskGroup(of: Bool.self, returning: Bool.self) { group in
+            group.addTask {
+                await handler.postEventAndWait(ProfileIdentifiedEvent(identifier: "after-replay"))
+                return true
+            }
+            group.addTask {
+                do {
+                    try await Task.sleep(nanoseconds: 2000000000)
+                } catch {
+                    return true
+                }
+                await storage.releaseRemoval()
+                return false
+            }
+
+            let firstResult = await group.next() ?? false
+            if firstResult {
+                await storage.releaseRemoval()
+            }
+            group.cancelAll()
+            return firstResult
+        }
+
+        XCTAssertTrue(completedBeforeTimeout, "persistent cleanup must not block event delivery")
+    }
+
     func test_addObserver_givenPostImmediatelyAfterRegistration_expectDirectDelivery() async {
         let handler = makeHandler()
         let received = Synchronized(false)
@@ -84,6 +136,46 @@ class CombinedCacheEventBusHandlerTest: UnitTest {
         await handler.postEventAndWait(ProfileIdentifiedEvent(identifier: "after-add"))
 
         XCTAssertTrue(received.wrappedValue, "registration requested before the post must be applied first")
+    }
+
+    func test_postEventAndWait_givenUnrelatedRegistryWorkSuspended_expectPostNotBlocked() async {
+        let handler = makeHandler()
+        let registryGate = AsyncGate()
+        handler.chainRegistryWork(forKey: ProfileIdentifiedEvent.key) {
+            await registryGate.wait()
+        }
+        await registryGate.waitUntilStarted()
+
+        let watchdogReleasedRegistry = Synchronized(false)
+        let completedBeforeTimeout = await withTaskGroup(of: Bool.self, returning: Bool.self) { group in
+            group.addTask {
+                await handler.postEventAndWait(ResetEvent())
+                return true
+            }
+            group.addTask {
+                do {
+                    try await Task.sleep(nanoseconds: 2000000000)
+                } catch {
+                    return true
+                }
+                watchdogReleasedRegistry.wrappedValue = true
+                await registryGate.release()
+                return false
+            }
+
+            let firstResult = await group.next() ?? false
+            if firstResult {
+                await registryGate.release()
+            }
+            group.cancelAll()
+            return firstResult
+        }
+
+        XCTAssertTrue(completedBeforeTimeout)
+        XCTAssertFalse(watchdogReleasedRegistry.wrappedValue)
+
+        // Drain the Profile chain so the suspended operation cannot outlive the test.
+        await handler.postEventAndWait(ProfileIdentifiedEvent(identifier: "after-registry-work"))
     }
 
     func test_addObserver_givenMultipleObserversRegisteredAfterPost_expectBothGetHistory() async {
@@ -151,6 +243,36 @@ class CombinedCacheEventBusHandlerTest: UnitTest {
         }
     }
 
+    func test_registryOrdering_givenConcurrentDifferentEventKeys_expectEachRemovalApplied() async {
+        // Stress the synchronized per-key tail map from concurrent callers while preserving
+        // a deterministic add-then-remove order within each event type.
+        for iteration in 0 ..< 50 {
+            let handler = makeHandler()
+            let deliveryCount = Synchronized(0)
+
+            await withTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    handler.addObserver(ProfileIdentifiedEvent.self) { _ in
+                        deliveryCount.mutating { $0 += 1 }
+                    }
+                    handler.removeObserver(for: ProfileIdentifiedEvent.self)
+                    await handler.postEventAndWait(
+                        ProfileIdentifiedEvent(identifier: "profile-\(iteration)")
+                    )
+                }
+                group.addTask {
+                    handler.addObserver(ResetEvent.self) { _ in
+                        deliveryCount.mutating { $0 += 1 }
+                    }
+                    handler.removeObserver(for: ResetEvent.self)
+                    await handler.postEventAndWait(ResetEvent())
+                }
+            }
+
+            XCTAssertEqual(deliveryCount.wrappedValue, 0)
+        }
+    }
+
     // MARK: - loadEventsFromStorage
 
     func test_loadEventsFromStorage_expectEventsSeededAndReplayed() async {
@@ -213,5 +335,58 @@ class CombinedCacheEventBusHandlerTest: UnitTest {
         await handler.postEventAndWait(ProfileIdentifiedEvent(identifier: "after-remove"))
 
         XCTAssertEqual(deliveryCount.wrappedValue, 1, "removal requested before the second post must be applied first")
+    }
+}
+
+private actor AsyncGate {
+    private var started = false
+    private var startedWaiters: [CheckedContinuation<Void, Never>] = []
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        started = true
+        let currentStartedWaiters = startedWaiters
+        startedWaiters.removeAll()
+        currentStartedWaiters.forEach { $0.resume() }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func waitUntilStarted() async {
+        guard !started else { return }
+        await withCheckedContinuation { startedWaiters.append($0) }
+    }
+
+    func release() {
+        let currentWaiters = waiters
+        waiters.removeAll()
+        currentWaiters.forEach { $0.resume() }
+    }
+}
+
+private actor SuspendedRemovalEventStorage: EventStorage {
+    private let removalGate = AsyncGate()
+
+    func store(event: AnyEventRepresentable) async throws {}
+
+    func retrieve(eventType: String, storageId: String) async throws -> AnyEventRepresentable? {
+        nil
+    }
+
+    func loadEvents(ofType type: String) async throws -> [AnyEventRepresentable] {
+        []
+    }
+
+    func remove(ofType eventType: String, withStorageId storageId: String) async {
+        await removalGate.wait()
+    }
+
+    func removeAll() async {}
+
+    func waitForRemovalToStart() async {
+        await removalGate.waitUntilStarted()
+    }
+
+    func releaseRemoval() async {
+        await removalGate.release()
     }
 }

--- a/Tests/Common/Communication/CombinedCacheEventBusHandlerTests.swift
+++ b/Tests/Common/Communication/CombinedCacheEventBusHandlerTests.swift
@@ -68,10 +68,22 @@ class CombinedCacheEventBusHandlerTest: UnitTest {
         await handler.postEventAndWait(ProfileIdentifiedEvent(identifier: "user-1"))
 
         let replayed = XCTestExpectation(description: "event replayed")
+        let removed = XCTestExpectation(description: "event removed from persistent storage")
+        mockEventStorage.removeClosure = { _, _ in removed.fulfill() }
         handler.addObserver(ProfileIdentifiedEvent.self) { _ in replayed.fulfill() }
-        await fulfillment(of: [replayed], timeout: 5.0)
+        await fulfillment(of: [replayed, removed], timeout: 5.0)
 
         XCTAssertEqual(mockEventStorage.removeCallsCount, 1)
+    }
+
+    func test_addObserver_givenPostImmediatelyAfterRegistration_expectDirectDelivery() async {
+        let handler = makeHandler()
+        let received = Synchronized(false)
+
+        handler.addObserver(ProfileIdentifiedEvent.self) { _ in received.wrappedValue = true }
+        await handler.postEventAndWait(ProfileIdentifiedEvent(identifier: "after-add"))
+
+        XCTAssertTrue(received.wrappedValue, "registration requested before the post must be applied first")
     }
 
     func test_addObserver_givenMultipleObserversRegisteredAfterPost_expectBothGetHistory() async {
@@ -100,19 +112,19 @@ class CombinedCacheEventBusHandlerTest: UnitTest {
 
         await handler.postEventAndWait(event)
 
-        var deliveryCount = 0
+        let deliveryCount = Synchronized(0)
         let delivered = XCTestExpectation(description: "delivered")
         delivered.assertForOverFulfill = true
 
         handler.addObserver(ProfileIdentifiedEvent.self) { received in
             if received.identifier == event.identifier {
-                deliveryCount += 1
+                deliveryCount.mutating { $0 += 1 }
                 delivered.fulfill()
             }
         }
 
         await fulfillment(of: [delivered], timeout: 5.0)
-        XCTAssertEqual(deliveryCount, 1, "event must be delivered exactly once")
+        XCTAssertEqual(deliveryCount.wrappedValue, 1, "event must be delivered exactly once")
     }
 
     func test_noDuplicateDelivery_givenConcurrentPostAndObserverRegistration_expectSingleDelivery() async {
@@ -176,20 +188,30 @@ class CombinedCacheEventBusHandlerTest: UnitTest {
 
     func test_removeObserver_givenObserverRemoved_expectNoDeliveryAfterRemoval() async {
         let handler = makeHandler()
-        var received = false
+        let received = Synchronized(false)
 
         // Register and then immediately remove.
-        handler.addObserver(ProfileIdentifiedEvent.self) { _ in received = true }
+        handler.addObserver(ProfileIdentifiedEvent.self) { _ in received.wrappedValue = true }
         handler.removeObserver(for: ProfileIdentifiedEvent.self)
 
-        // postEventAndWait goes through the actor. The remove Task ran earlier and
-        // will have completed its actor call before the post call in most runs.
-        // Use a short sleep to give both Tasks time to schedule their actor calls.
-        try? await Task.sleep(nanoseconds: 100000000)
-
+        // No sleep needed: postEventAndWait applies the add/remove requested above in call
+        // order before it reads the observer set, and it invokes every observer it finds
+        // before returning. So if the removal were lost, `received` would be true here.
         await handler.postEventAndWait(ProfileIdentifiedEvent(identifier: "after-remove"))
 
-        try? await Task.sleep(nanoseconds: 100000000)
-        XCTAssertFalse(received, "removed observer must not receive events")
+        XCTAssertFalse(received.wrappedValue, "removed observer must not receive events")
+    }
+
+    func test_removeObserver_givenObserverAlreadyApplied_expectRemovalOrderedBeforeNextPost() async {
+        let handler = makeHandler()
+        let deliveryCount = Synchronized(0)
+
+        handler.addObserver(ProfileIdentifiedEvent.self) { _ in deliveryCount.mutating { $0 += 1 } }
+        await handler.postEventAndWait(ProfileIdentifiedEvent(identifier: "before-remove"))
+
+        handler.removeObserver(for: ProfileIdentifiedEvent.self)
+        await handler.postEventAndWait(ProfileIdentifiedEvent(identifier: "after-remove"))
+
+        XCTAssertEqual(deliveryCount.wrappedValue, 1, "removal requested before the second post must be applied first")
     }
 }

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -116,6 +116,7 @@ public final class CioInternalCommon.CioThreadUtil {
 }
 public final class CioInternalCommon.CombinedCacheEventBusHandler {
 	public fun init(eventStorage: EventStorage, logger: Logger);
+	public fun deinit;
 	public fun func loadEventsFromStorage() async;
 	public fun func addObserver<E: EventRepresentable>(_ eventType: E.Type, action: @escaping (E) -> Unit);
 	public fun func removeObserver<E: EventRepresentable>(for eventType: E.Type);


### PR DESCRIPTION
## Summary

- serialize observer registration and removal work before ordered event delivery
- keep persistent replay cleanup off the delivery path
- replace timing-based race tests with deterministic ordering assertions

## Root cause

`addObserver` and `removeObserver` are synchronous APIs that reach the event-bus actor through unstructured tasks. Independent tasks do not preserve invocation order, so an add, remove, and subsequent ordered post could observe a stale observer set.

## Impact

Observer lifecycle calls made sequentially are now applied in that same order before `postEventAndWait` reads the observer set. The public API is unchanged. The fire-and-forget `postEvent` API remains explicitly unordered.

## Validation

- `make format`
- `make lint` (strict; 0 violations)
- `xcodebuild build-for-testing` for `Customer.io-Package`
- `CombinedCacheEventBusHandlerTest`: 100 repeated iterations, stop on first failure
- `CioEventBusTest`: 10 repeated iterations, stop on first failure
- full `Customer.io-Package` test suite

## Stack

This is the base PR for #1198. Merge this PR first; #1198 contains the utility-QoS and Gist scheduling changes on top.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ordering and async behavior in the SDK’s central event bus path; public API is unchanged but incorrect ordering could affect profile/reset-style event delivery.
> 
> **Overview**
> Fixes a race where synchronous `addObserver` / `removeObserver` calls used independent `Task`s, so removals could land after adds out of order and leave stale observers (or deliver events after an intended remove).
> 
> **`CombinedCacheEventBusHandler`** now chains registry work per event key (`chainRegistryWork`), and **`postEventAndWait`** waits for that chain before posting so the observer set matches the caller’s last registry requests. Replay **persistent storage removal** runs on a separate per-key cleanup chain so disk I/O does not block replay or registry ordering; **`deinit`** cancels pending registry tasks.
> 
> **`EventBusHandler`** gains documentation on sync callbacks, ordering, and API semantics. **`postEvent`** is documented as explicitly unordered vs **`postEventAndWait`**.
> 
> Tests drop timing sleeps in favor of deterministic ordering assertions, plus coverage for add-then-remove persistence, blocked cleanup, deinit during cleanup, and concurrent different event keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f1ca2f7606235f71c9cb9bafc4e38f4344c4d1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->