### PR TITLE
ci: wait for CustomerIOLocationGeofence to reach the CocoaPods CDN

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -373,6 +373,7 @@ jobs:
             CustomerIOMessagingInApp
             CustomerIOMessagingInbox
             CustomerIOLocation
+            CustomerIOLocationGeofence
             CustomerIOLiveActivitiesAttributes
             CustomerIOLiveActivities
             CustomerIOLiveActivitiesTemplates


### PR DESCRIPTION
`deploy-cocoapods` pushes 14 podspecs; `wait-for-cocoapods` polled 13. `CustomerIOLocationGeofence` was never waited on, so sample-app builds could start before the CDN served it.

Part of MBL-2244 groundwork, but independent of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to a deployment wait list; no runtime SDK or application behavior changes.
> 
> **Overview**
> Fixes a mismatch in the iOS SDK deploy workflow: **`deploy-cocoapods` already publishes `CustomerIOLocationGeofence`**, but **`wait-for-cocoapods` did not poll the CDN for that pod**.
> 
> The wait step’s pod list now includes **`CustomerIOLocationGeofence`**, so sample-app builds that depend on `wait-for-cocoapods` are less likely to start before the new version is visible on the CocoaPods CDN.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bb39d3bfabf195c73bb6d9b7f1eec06c7e76d3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->