### PR TITLE
chore: preserve async location and event replay ordering

### DIFF
--- a/.github/workflows/maestro-e2e.yml
+++ b/.github/workflows/maestro-e2e.yml
@@ -144,6 +144,7 @@ jobs:
           MAESTRO_APP_API_KEY: ${{ secrets.MOBILE_E2E_APP_API_KEY }}
           INBOX_TRANSACTIONAL_MESSAGE_ID: ${{ vars.MOBILE_E2E_INBOX_TRANSACTIONAL_MESSAGE_ID }}
           LIVE_ACTIVITY_APP_IDENTIFIER: ${{ secrets.MOBILE_E2E_LIVE_ACTIVITY_APP_IDENTIFIER }}
+          MAESTRO_DRIVER_STARTUP_TIMEOUT: "300000"
         run: |
           ./.e2e-harness/e2e run \
             --platform ios \

--- a/Sources/Common/Communication/CombinedCacheEventBusHandler.swift
+++ b/Sources/Common/Communication/CombinedCacheEventBusHandler.swift
@@ -18,7 +18,8 @@ public class CombinedCacheEventBusHandler: EventBusHandler {
     /// `bus` actor asynchronously. Independent unstructured `Task`s carry no ordering
     /// guarantee, so `addObserver(X)` followed by `removeObserver(X)` could reach the actor
     /// in reverse order and leave a live observer behind. Chaining operations for the same
-    /// event key restores the caller's ordering without blocking unrelated event types.
+    /// event key restores the caller's ordering without chaining unrelated event types together.
+    /// Startup loads still share one `EventStorage` actor, so their disk reads are serialized.
     ///
     /// The dictionary retains only the latest tail encountered for each event key. SDK event
     /// types are finite, so pruning completed tails would add race-prone bookkeeping for no
@@ -36,8 +37,11 @@ public class CombinedCacheEventBusHandler: EventBusHandler {
         self.bus = CioEventBus()
         self.eventStorage = eventStorage
         self.logger = logger
-        Task { [weak self] in
-            await self?.loadEventsFromStorage()
+
+        // Seed each event cache on the same per-key chain used by observer registration.
+        // This makes startup ordering deterministic without blocking unrelated event types.
+        for eventType in EventTypesRegistry.allEventTypes() {
+            enqueueStoredEventsLoad(for: eventType)
         }
     }
 
@@ -51,14 +55,17 @@ public class CombinedCacheEventBusHandler: EventBusHandler {
     /// mutation, so concurrent callers still produce a single well-defined order per key.
     /// This is internal only as a deterministic concurrency-test seam; production callers
     /// should use the public observer APIs.
-    func chainRegistryWork(forKey key: String, operation: @escaping () async -> Void) {
+    @discardableResult
+    func chainRegistryWork(forKey key: String, operation: @escaping () async -> Void) -> Task<Void, Never> {
         pendingRegistryWork.mutating { workByKey in
             let previous = workByKey[key]
-            workByKey[key] = Task {
+            let next = Task {
                 await previous?.value
                 guard !Task.isCancelled else { return }
                 await operation()
             }
+            workByKey[key] = next
+            return next
         }
     }
 
@@ -89,7 +96,20 @@ public class CombinedCacheEventBusHandler: EventBusHandler {
 
     /// Loads events from persistent storage into the in-memory cache on startup.
     public func loadEventsFromStorage() async {
-        for eventType in EventTypesRegistry.allEventTypes() {
+        let loadTasks = EventTypesRegistry.allEventTypes().map { eventType in
+            enqueueStoredEventsLoad(for: eventType)
+        }
+        for loadTask in loadTasks {
+            await loadTask.value
+        }
+    }
+
+    @discardableResult
+    private func enqueueStoredEventsLoad(
+        for eventType: any EventRepresentable.Type
+    ) -> Task<Void, Never> {
+        chainRegistryWork(forKey: eventType.key) { [weak self] in
+            guard let self else { return }
             do {
                 let events: [AnyEventRepresentable] = try await eventStorage.loadEvents(
                     ofType: eventType.key

--- a/Sources/Location/LocationServices.swift
+++ b/Sources/Location/LocationServices.swift
@@ -97,6 +97,14 @@ actor LocationServicesImplementation: LocationServices {
     private let locationSyncCoordinator: LocationSyncCoordinator
     private let lifecycleNotifying: AppLifecycleNotifying
     private let applicationStateProvider: ApplicationStateProvider
+    /// Serializes calls from the synchronous `setLastKnownLocation` API so locations are
+    /// processed in the same order the host app supplies them.
+    private nonisolated let pendingSetLastKnownLocationWork = Synchronized<Task<Void, Never>?>(nil)
+    /// Retains the latest fire-and-forget request entry task so tests can join it without sleeps.
+    /// Overlap tests observe the earlier request in flight before joining this latest entry.
+    private nonisolated let pendingLocationRequestEntryWork = Synchronized<Task<Void, Never>?>(nil)
+    /// Retains the latest fire-and-forget stop task so tests can join it without sleeps.
+    private nonisolated let pendingStopLocationWork = Synchronized<Task<Void, Never>?>(nil)
     private var currentTask: Task<Void, Never>?
     /// Set when a tracked request arrives while another request is in flight, so the tracked
     /// intent survives the single-request gate (the lifecycle's tracked request and geofence's
@@ -147,17 +155,38 @@ actor LocationServicesImplementation: LocationServices {
     }
 
     nonisolated func setLastKnownLocation(_ location: CLLocation) {
-        Task { await self.setLastKnownLocationImpl(location) }
+        pendingSetLastKnownLocationWork.mutating { pendingWork in
+            let previousWork = pendingWork
+            pendingWork = Task { [weak self] in
+                await previousWork?.value
+                await self?.setLastKnownLocationImpl(location)
+            }
+        }
+    }
+
+    /// Waits for location work that was enqueued before this method was called.
+    /// Internal synchronization seam used by tests for the synchronous public API.
+    nonisolated func waitForPendingSetLastKnownLocation() async {
+        let pendingWork = pendingSetLastKnownLocationWork.using { $0 }
+        await pendingWork?.value
     }
 
     nonisolated func requestLocationUpdate() {
-        Task { await self.startRequestIfNeeded(track: true, respectMode: true) }
+        let requestEntryWork = Task { [weak self] in
+            guard let self else { return }
+            await self.startRequestIfNeeded(track: true, respectMode: true)
+        }
+        pendingLocationRequestEntryWork.wrappedValue = requestEntryWork
     }
 
     nonisolated func requestLocationUpdateSilently() {
         // Internal consumers (geofencing) need a fix regardless of the tracking mode, and it must
         // not emit a track event or be cached.
-        Task { await self.startRequestIfNeeded(track: false, respectMode: false) }
+        let requestEntryWork = Task { [weak self] in
+            guard let self else { return }
+            await self.startRequestIfNeeded(track: false, respectMode: false)
+        }
+        pendingLocationRequestEntryWork.wrappedValue = requestEntryWork
     }
 
     nonisolated func getLastKnownLocation() async -> LocationData? {
@@ -166,7 +195,37 @@ actor LocationServicesImplementation: LocationServices {
 
     /// Cancels any in-flight location request. No-op if nothing in progress. Called automatically when the app enters background; not exposed on the public LocationServices protocol.
     nonisolated func stopLocationUpdates() {
-        Task { await self.stopLocationUpdatesImpl() }
+        let stopWork = Task { [weak self] in
+            guard let self else { return }
+            await self.stopLocationUpdatesImpl()
+        }
+        pendingStopLocationWork.wrappedValue = stopWork
+    }
+
+    /// Waits until the latest request has entered the actor and applied its request intent.
+    /// This joins the latest assigned entry only. Overlap tests must first observe any earlier
+    /// request in flight before releasing a held request.
+    nonisolated func waitForPendingLocationRequestEntry() async {
+        let requestEntryWork = pendingLocationRequestEntryWork.using { $0 }
+        await requestEntryWork?.value
+    }
+
+    /// Waits for the latest request entry and any location acquisition it started or joined.
+    /// Internal synchronization seam used by tests for the synchronous public API.
+    nonisolated func waitForPendingLocationRequest() async {
+        await waitForPendingLocationRequestEntry()
+        await waitForCurrentLocationRequest()
+    }
+
+    /// Waits for the latest stop request to finish cancelling the provider.
+    /// Internal synchronization seam used by tests for the synchronous public API.
+    nonisolated func waitForPendingStopLocationUpdates() async {
+        let stopWork = pendingStopLocationWork.using { $0 }
+        await stopWork?.value
+    }
+
+    private func waitForCurrentLocationRequest() async {
+        await currentTask?.value
     }
 
     private func stopLocationUpdatesImpl() async {

--- a/Tests/Common/Communication/CombinedCacheEventBusHandlerTests.swift
+++ b/Tests/Common/Communication/CombinedCacheEventBusHandlerTests.swift
@@ -304,18 +304,42 @@ class CombinedCacheEventBusHandlerTest: UnitTest {
 
     // MARK: - loadEventsFromStorage
 
-    func test_loadEventsFromStorage_expectEventsSeededAndReplayed() async {
+    func test_initialization_expectEventsSeededBeforeObserverRegistration() async {
         let event = ProfileIdentifiedEvent(identifier: "persisted")
         mockEventStorage.loadEventsClosure = { key in
             key == ProfileIdentifiedEvent.key ? [event] : []
         }
 
         let handler = makeHandler()
-        // Explicitly await loading so the cache is populated before the observer registers.
-        // This avoids a race with the background Task launched in init.
+        let replayed = XCTestExpectation(description: "persisted event replayed to new observer")
+        replayed.assertForOverFulfill = true
+        // Registration requested immediately after initialization must run after the
+        // persisted cache seed for this event key and replay the event exactly once.
+        handler.addObserver(ProfileIdentifiedEvent.self) { received in
+            if received.identifier == event.identifier { replayed.fulfill() }
+        }
+
+        await fulfillment(of: [replayed], timeout: 5.0)
+    }
+
+    func test_loadEventsFromStorage_expectReturnsAfterEventsSeeded() async {
+        let event = ProfileIdentifiedEvent(identifier: "explicit-load")
+        let profileLoadCount = Synchronized(0)
+        mockEventStorage.loadEventsClosure = { key in
+            guard key == ProfileIdentifiedEvent.key else { return [] }
+            let currentLoadCount = profileLoadCount.mutating { count in
+                count += 1
+                return count
+            }
+            // Initialization owns the first load. The explicit API call below owns the second.
+            return currentLoadCount == 2 ? [event] : []
+        }
+
+        let handler = makeHandler()
         await handler.loadEventsFromStorage()
 
-        let replayed = XCTestExpectation(description: "persisted event replayed to new observer")
+        let replayed = XCTestExpectation(description: "explicitly loaded event replayed")
+        replayed.assertForOverFulfill = true
         handler.addObserver(ProfileIdentifiedEvent.self) { received in
             if received.identifier == event.identifier { replayed.fulfill() }
         }

--- a/Tests/Common/Util/ThreadUtilTest.swift
+++ b/Tests/Common/Util/ThreadUtilTest.swift
@@ -17,7 +17,7 @@ private final class LegacyThreadUtil: ThreadUtil {
 
 class ThreadUtilTest: UnitTest {
     /// These tests verify queue selection, not dispatch latency. Shared CI runners can delay
-    /// low-priority global queues when the full test suite is running concurrently.
+    /// main-queue and global-queue work when the full test suite is running concurrently.
     private let queueSchedulingTimeout: TimeInterval = 10
 
     func test_runMainActor_expectBlockRunsOnMainThread() {

--- a/Tests/Common/Util/ThreadUtilTest.swift
+++ b/Tests/Common/Util/ThreadUtilTest.swift
@@ -16,6 +16,10 @@ private final class LegacyThreadUtil: ThreadUtil {
 }
 
 class ThreadUtilTest: UnitTest {
+    /// These tests verify queue selection, not dispatch latency. Shared CI runners can delay
+    /// low-priority global queues when the full test suite is running concurrently.
+    private let queueSchedulingTimeout: TimeInterval = 10
+
     func test_runMainActor_expectBlockRunsOnMainThread() {
         let blockExecuted = expectation(description: "main-actor block executed")
 
@@ -24,7 +28,7 @@ class ThreadUtilTest: UnitTest {
             blockExecuted.fulfill()
         }
 
-        wait(for: [blockExecuted], timeout: 1)
+        wait(for: [blockExecuted], timeout: queueSchedulingTimeout)
     }
 
     func test_runUtility_expectBlockRunsOffMainThread() {
@@ -35,7 +39,7 @@ class ThreadUtilTest: UnitTest {
             blockExecuted.fulfill()
         }
 
-        wait(for: [blockExecuted], timeout: 1)
+        wait(for: [blockExecuted], timeout: queueSchedulingTimeout)
     }
 
     func test_defaultScheduling_givenLegacyConformer_expectNewSeamsRemainUsable() {
@@ -50,7 +54,7 @@ class ThreadUtilTest: UnitTest {
             }
         }
 
-        wait(for: [mainActorBlockExecuted], timeout: 1)
+        wait(for: [mainActorBlockExecuted], timeout: queueSchedulingTimeout)
         XCTAssertEqual(threadUtil.runBackgroundCallsCount, 1)
     }
 }

--- a/Tests/Location/LocationServicesImplementationTest.swift
+++ b/Tests/Location/LocationServicesImplementationTest.swift
@@ -41,13 +41,6 @@ struct LocationServicesImplementationTests {
         )
     }
 
-    /// Yields so the fire-and-forget task from requestLocationUpdate() can run (no sleep).
-    private func yieldForLocationTask() async {
-        for _ in 0 ..< 40 {
-            await Task.yield()
-        }
-    }
-
     @Test
     func setLastKnownLocation_givenTrackingDisabled_expectNoTrackCalled() async {
         let pipelineMock = DataPipelineTrackingMock()
@@ -55,7 +48,7 @@ struct LocationServicesImplementationTests {
         let validLocation = CLLocation(latitude: 37.7749, longitude: -122.4194)
 
         service.setLastKnownLocation(validLocation)
-        await yieldForLocationTask()
+        await service.waitForPendingSetLastKnownLocation()
 
         #expect(pipelineMock.trackCallsCount == 0)
     }
@@ -67,7 +60,7 @@ struct LocationServicesImplementationTests {
         let invalidLocation = CLLocation(latitude: 91.0, longitude: 181.0)
 
         service.setLastKnownLocation(invalidLocation)
-        await yieldForLocationTask()
+        await service.waitForPendingSetLastKnownLocation()
 
         #expect(pipelineMock.trackCallsCount == 0)
     }
@@ -81,7 +74,7 @@ struct LocationServicesImplementationTests {
         let validLocation = CLLocation(latitude: expectedLatitude, longitude: expectedLongitude)
 
         service.setLastKnownLocation(validLocation)
-        await yieldForLocationTask()
+        await service.waitForPendingSetLastKnownLocation()
 
         #expect(pipelineMock.trackCallsCount == 1)
         #expect(pipelineMock.trackInvocations.first?.name == "CIO Location Update")
@@ -100,11 +93,14 @@ struct LocationServicesImplementationTests {
 
         service.setLastKnownLocation(location1)
         service.setLastKnownLocation(location2)
-        await yieldForLocationTask()
+        await service.waitForPendingSetLastKnownLocation()
 
         #expect(pipelineMock.trackCallsCount == 1)
         #expect(pipelineMock.trackInvocations.first?.properties["latitude"] as? Double == 37.7749)
         #expect(pipelineMock.trackInvocations.first?.properties["longitude"] as? Double == -122.4194)
+        let lastKnownLocation = await service.getLastKnownLocation()
+        #expect(lastKnownLocation?.latitude == 40.7128)
+        #expect(lastKnownLocation?.longitude == -74.0060)
     }
 
     @Test
@@ -114,7 +110,7 @@ struct LocationServicesImplementationTests {
         let zeroLocation = CLLocation(latitude: 0.0, longitude: 0.0)
 
         service.setLastKnownLocation(zeroLocation)
-        await yieldForLocationTask()
+        await service.waitForPendingSetLastKnownLocation()
 
         #expect(pipelineMock.trackCallsCount == 1)
     }
@@ -126,7 +122,7 @@ struct LocationServicesImplementationTests {
         let negativeLocation = CLLocation(latitude: -33.8688, longitude: 151.2093)
 
         service.setLastKnownLocation(negativeLocation)
-        await yieldForLocationTask()
+        await service.waitForPendingSetLastKnownLocation()
 
         #expect(pipelineMock.trackCallsCount == 1)
         #expect(pipelineMock.trackInvocations.first?.properties["latitude"] as? Double == -33.8688)
@@ -154,7 +150,7 @@ struct LocationServicesImplementationTests {
         )
 
         service.requestLocationUpdate()
-        await yieldForLocationTask()
+        await service.waitForPendingLocationRequest()
 
         #expect(pipelineMock.trackCallsCount == 1)
         #expect(pipelineMock.trackInvocations.first?.properties["latitude"] as? Double == 37.7749)
@@ -173,7 +169,7 @@ struct LocationServicesImplementationTests {
         )
 
         service.requestLocationUpdate()
-        await yieldForLocationTask()
+        await service.waitForPendingLocationRequest()
 
         #expect(pipelineMock.trackCallsCount == 0)
         let requestCount = await mockProvider.requestLocationCallCount
@@ -199,7 +195,7 @@ struct LocationServicesImplementationTests {
         )
 
         service.requestLocationUpdateSilently()
-        await yieldForLocationTask()
+        await service.waitForPendingLocationRequest()
 
         // Silent acquisition ignores the .off tracking mode (geofencing needs a fix even when
         // tracking is off) but must never emit analytics. The fix is readable as last-known.
@@ -218,6 +214,7 @@ struct LocationServicesImplementationTests {
             if await provider.requestLocationCallCount >= 1 { return }
             await Task.yield()
         }
+        Issue.record("Location request never reached the provider")
     }
 
     private var validSnapshot: LocationSnapshot {
@@ -235,9 +232,9 @@ struct LocationServicesImplementationTests {
         service.requestLocationUpdateSilently()
         await waitUntilRequestInFlight(mockProvider)
         service.requestLocationUpdate()
-        await yieldForLocationTask()
+        await service.waitForPendingLocationRequestEntry()
         await mockProvider.releaseHeldRequest()
-        await yieldForLocationTask()
+        await service.waitForPendingLocationRequest()
 
         // One acquisition serves both callers: the silent fix is promoted to a tracked one
         // instead of the tracked request being dropped by the single-request gate.
@@ -257,9 +254,9 @@ struct LocationServicesImplementationTests {
         service.requestLocationUpdate()
         await waitUntilRequestInFlight(mockProvider)
         service.requestLocationUpdateSilently()
-        await yieldForLocationTask()
+        await service.waitForPendingLocationRequestEntry()
         await mockProvider.releaseHeldRequest()
-        await yieldForLocationTask()
+        await service.waitForPendingLocationRequest()
 
         // The reverse overlap needs no upgrade: the tracked result feeds silent consumers too.
         #expect(await mockProvider.requestLocationCallCount == 1)
@@ -277,9 +274,9 @@ struct LocationServicesImplementationTests {
         service.requestLocationUpdateSilently()
         await waitUntilRequestInFlight(mockProvider)
         service.requestLocationUpdate()
-        await yieldForLocationTask()
+        await service.waitForPendingLocationRequestEntry()
         await mockProvider.releaseHeldRequest()
-        await yieldForLocationTask()
+        await service.waitForPendingLocationRequest()
 
         // Under `.off` the tracked request would have been refused outright, so the latched
         // intent must not smuggle a track through the silent request either.
@@ -297,15 +294,15 @@ struct LocationServicesImplementationTests {
         service.requestLocationUpdateSilently()
         await waitUntilRequestInFlight(mockProvider)
         service.requestLocationUpdate()
-        await yieldForLocationTask()
+        await service.waitForPendingLocationRequestEntry()
         await mockProvider.releaseHeldRequest()
-        await yieldForLocationTask()
+        await service.waitForPendingLocationRequest()
 
         // A later silent request must start from a clean slate: the failed request dropped the
         // latched intent (the tracked request would have failed identically).
         await mockProvider.setResult(.success(validSnapshot))
         service.requestLocationUpdateSilently()
-        await yieldForLocationTask()
+        await service.waitForPendingLocationRequest()
 
         #expect(await mockProvider.requestLocationCallCount == 2)
         #expect(pipelineMock.trackCallsCount == 0)
@@ -325,9 +322,9 @@ struct LocationServicesImplementationTests {
         )
 
         service.requestLocationUpdate()
-        await yieldForLocationTask()
+        await service.waitForPendingLocationRequest()
         service.stopLocationUpdates()
-        await yieldForLocationTask()
+        await service.waitForPendingStopLocationUpdates()
 
         let cancelCount = await mockProvider.cancelCallCount
         #expect(cancelCount >= 1)
@@ -350,7 +347,7 @@ struct LocationServicesImplementationTests {
         await service.setUpLifecycleObserver()
 
         stub.simulateDidBecomeActive()
-        await yieldForLocationTask()
+        await service.waitForPendingLocationRequest()
 
         let requestCount = await mockProvider.requestLocationCallCount
         #expect(requestCount >= 1)
@@ -367,7 +364,7 @@ struct LocationServicesImplementationTests {
         await service.setUpLifecycleObserver()
 
         stub.simulateDidEnterBackground()
-        await yieldForLocationTask()
+        await service.waitForPendingStopLocationUpdates()
 
         let cancelCount = await mockProvider.cancelCallCount
         #expect(cancelCount >= 1)
@@ -389,7 +386,7 @@ struct LocationServicesImplementationTests {
             applicationStateProvider: stubState
         )
         await service.setUpLifecycleObserver()
-        await yieldForLocationTask()
+        await service.waitForPendingLocationRequest()
 
         let requestCount = await mockProvider.requestLocationCallCount
         #expect(requestCount >= 1)

--- a/Tests/MessagingInApp/MessagingInAppImplementationTest.swift
+++ b/Tests/MessagingInApp/MessagingInAppImplementationTest.swift
@@ -59,8 +59,6 @@ class MessagingInAppImplementationTest: IntegrationTest {
         expectSdkReset: Bool = false,
         expectScreenViewEvent: Bool = false
     ) -> [XCTestExpectation] {
-        super.setUp(modifyModuleConfig: nil)
-
         var combinedExpectations: [XCTestExpectation] = []
 
         // Set default values on all expectations created in this function.
@@ -95,6 +93,10 @@ class MessagingInAppImplementationTest: IntegrationTest {
             screenViewEventExpectation.fulfill()
         }
         combinedExpectations.append(screenViewEventExpectation)
+
+        // Module initialization can immediately replay cached events. Install every
+        // expectation callback first so a replay cannot race ahead of the test observer.
+        super.setUp(modifyModuleConfig: nil)
 
         return combinedExpectations
     }


### PR DESCRIPTION
## Summary
- serialize fire-and-forget location work so rapid calls preserve caller order
- replace fixed-yield test timing with deterministic joins
- order persisted EventBus seeding with observer registration for each event type
- install MessagingInApp expectations before initialization can replay cached identity

## Root cause
The affected tests depended on unstructured tasks completing within a fixed number of `Task.yield()` calls. Under concurrent CI load, those tasks could still be pending. A second race allowed cached identity replay to occur before the MessagingInApp test installed its callback, or to be seeded twice.

## Validation
- reproduced failures on untouched `main` with the affected test classes running concurrently
- affected Location, EventBus, and MessagingInApp test classes passed 5 concurrent iterations
- the two original incident-shaped tests passed 100 iterations together
- `Customer.io-Package` build-for-testing passed on an iPhone 17 Pro simulator
- repository-pinned SwiftFormat completed
- repository-pinned SwiftLint strict passed with 0 violations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches startup event replay and location update ordering on production paths; behavior is more deterministic but could surface latent ordering assumptions in host apps.
> 
> **Overview**
> Fixes flaky CI by making **async ordering explicit** instead of relying on `Task.yield()` loops or background init races.
> 
> **Event bus:** Persisted events are seeded during init via the same per-event-key registry chain as `addObserver`, so a listener registered right after startup always sees cache seeding before registration and replay. `loadEventsFromStorage()` reuses that path and awaits each load task.
> 
> **Location:** Synchronous APIs (`setLastKnownLocation`, request/stop) chain work through `Synchronized` task tails so rapid host calls keep FIFO order; tests join via `waitForPending*` helpers instead of fixed yields.
> 
> **Tests / CI:** MessagingInApp installs expectation callbacks before `super.setUp()` so cached identity replay cannot beat the observer. Thread util tests use a 10s scheduling timeout on loaded runners. Maestro E2E sets `MAESTRO_DRIVER_STARTUP_TIMEOUT` to 300000ms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbacd7296a92a5f02d8ac9cb39d284e28e8d6c88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->