### PR TITLE
chore(geofence): run movement passes on a fresh fix instead of the manager's cached one

### DIFF
--- a/Sources/LocationGeofence/GeofenceBackgroundTime.swift
+++ b/Sources/LocationGeofence/GeofenceBackgroundTime.swift
@@ -1,0 +1,14 @@
+import CioInternalCommon
+import Foundation
+
+/// Picks the background-task runner for geofence work: a real `UIApplication` assertion in the
+/// app, a no-op where `UIApplication` is unavailable (non-UIKit platforms).
+enum GeofenceBackgroundTime {
+    static func runner(name: String) -> BackgroundTaskRunner {
+        #if canImport(UIKit)
+        UIKitBackgroundTaskRunner(name: name)
+        #else
+        NoBackgroundTaskRunner()
+        #endif
+    }
+}

--- a/Sources/LocationGeofence/GeofenceConstants.swift
+++ b/Sources/LocationGeofence/GeofenceConstants.swift
@@ -34,6 +34,13 @@ enum GeofenceConstants {
     /// Staleness interval (in seconds) after which a server sync is considered stale.
     static let staleSyncInterval: TimeInterval = 24 * 60 * 60
 
+    // Movement passes act on the device's CURRENT position (re-center the trigger, measure
+    // displacement for the refetch tier), but a long-suspended process's cached fix can be frozen
+    // at process start. A cached fix older than `movementFixMaxAge` triggers a one-shot fresh-fix
+    // request; after `movementFixRequestTimeout` the pass falls back to the cached fix.
+    static let movementFixMaxAge: TimeInterval = 30
+    static let movementFixRequestTimeout: TimeInterval = 10
+
     // Sane bounds the SDK coerces server config into, so a misconfigured backend can't push
     // monitoring into a pathological state: a positive out-of-range value clamps to the nearest
     // bound; a non-positive value falls back. (`maxMonitoringDistance` needs no upper bound — a

--- a/Sources/LocationGeofence/GeofenceMonitorBinder.swift
+++ b/Sources/LocationGeofence/GeofenceMonitorBinder.swift
@@ -14,7 +14,8 @@ enum GeofenceMonitorBinder {
     static func bind(
         monitor: GeofenceRegionMonitoring,
         tracker: GeofenceEventTracker,
-        coordinator: GeofenceSyncCoordinator
+        coordinator: GeofenceSyncCoordinator,
+        backgroundTaskRunner: BackgroundTaskRunner = GeofenceBackgroundTime.runner(name: "io.customer.geofence.movement-pass")
     ) {
         monitor.setOnTransition { [weak tracker, weak coordinator] identifier, transition, location in
             // CLLocationManager delivers on main; both handlers below are async with their
@@ -24,7 +25,14 @@ enum GeofenceMonitorBinder {
                 // EXIT is the only registered transition for the movement trigger; the
                 // guard defends against an unexpected ENTER reaching this dispatch.
                 guard transition == .exit, let location else { return }
-                Task { _ = await coordinator?.handleMovement(latitude: location.latitude, longitude: location.longitude) }
+                // The EXIT is consumed once dispatched; a wake window expiring mid-pass would
+                // lose it with no retry, so the pass runs under a background-task assertion.
+                // (The tracker path holds its own inside `trackTransition`.)
+                Task {
+                    await backgroundTaskRunner.withBackgroundTime {
+                        _ = await coordinator?.handleMovement(latitude: location.latitude, longitude: location.longitude)
+                    }
+                }
                 return
             }
             Task { await tracker?.trackTransition(geofenceId: identifier, transition: transition) }

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -132,6 +132,21 @@ extension Logger {
         debug("Movement refresh failed; re-ranking from cache to re-arm the movement trigger", geofenceTag)
     }
 
+    func geofenceMovementFixResolved(ageSeconds: TimeInterval, requested: Bool) {
+        let source = requested ? "freshly requested" : "cached"
+        debug("Movement pass using \(source) fix, age \(String(format: "%.1f", ageSeconds))s", geofenceTag)
+    }
+
+    func geofenceMovementFixStale(ageSeconds: TimeInterval?) {
+        let age = ageSeconds.map { "\(String(format: "%.1f", $0))s old" } ?? "missing"
+        info("Cached fix is \(age); requesting a fresh fix for the movement pass", geofenceTag)
+    }
+
+    func geofenceMovementFixRequestFailed(fallingBackToCached: Bool) {
+        let outcome = fallingBackToCached ? "falling back to the stale cached fix" : "no cached fix to fall back to"
+        info("Fresh-fix request failed or timed out; \(outcome)", geofenceTag)
+    }
+
     func geofenceSyncSupersededByUserChange() {
         info("Sync result discarded: identified user changed during fetch", geofenceTag)
     }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -41,6 +41,8 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
     /// Only for auth status/changes + current-location reads; region monitoring is on `CLMonitor`.
     /// Internal for the `+Registration` extension.
     let authManager: CLLocationManager
+    /// Freshens the fix behind movement-trigger EXIT dispatches (see `MovementFixResolver`).
+    private let movementFixResolver: MovementFixResolver
     private var onTransition: GeofenceTransitionHandler?
     private var onAuthorizationChanged: GeofenceAuthorizationChangedHandler?
     private var onReconciled: GeofenceReconciledHandler?
@@ -97,6 +99,7 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
         self.storage = storage
         self.userDefaults = userDefaults
         self.authManager = CLLocationManager()
+        self.movementFixResolver = MovementFixResolver(logger: logger)
         super.init()
         let mirrored = Set(userDefaults.stringArray(forKey: Self.conditionMirrorKey) ?? [])
         self.knownConditionIdentifiers = mirrored
@@ -259,6 +262,15 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
         // No ownership re-check after the await: the baseline already advanced, so dropping here
         // loses the transition permanently — a sync's stop-all + re-add swap would eat a genuine
         // crossing that raced it. A region truly removed in that window delivers one last gated event.
+        if identifier == GeofenceConstants.movementTriggerIdentifier, transition == .exit {
+            // The movement pass re-centers the trigger and measures displacement at these coords, so
+            // a frozen cached fix pins the whole pipeline to a stale point — freshen it first.
+            // Fire-and-forget so a slow fix can't stall the pending-event drain behind it.
+            movementFixResolver.resolve(cached: bestKnownFix()) { [weak self] location in
+                self?.onTransition?(identifier, transition, location)
+            }
+            return
+        }
         onTransition?(identifier, transition, currentLocationData())
     }
 
@@ -338,23 +350,25 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
         userDefaults.set(knownConditionIdentifiers.sorted(), forKey: Self.conditionMirrorKey)
     }
 
+    /// Newest usable fix across the auth manager's cache and the resolver's requested fixes.
+    /// The manager's cache can freeze at process start on a long-suspended process, so a fresher
+    /// resolver fix must win wherever cached position is read.
+    private func bestKnownFix() -> CLLocation? {
+        let cached = authManager.location.flatMap { CLLocationCoordinate2DIsValid($0.coordinate) ? $0 : nil }
+        guard let resolved = movementFixResolver.latestFix else { return cached }
+        guard let cached else { return resolved }
+        return resolved.timestamp > cached.timestamp ? resolved : cached
+    }
+
     private func currentLocationData() -> LocationData? {
-        guard let location = authManager.location,
-              CLLocationCoordinate2DIsValid(location.coordinate)
-        else {
-            return nil
-        }
+        guard let location = bestKnownFix() else { return nil }
         return LocationData(latitude: location.coordinate.latitude, longitude: location.coordinate.longitude)
     }
 
     /// Whether the device is inside the circle per the last known location; `nil` without a usable
     /// fix. No accuracy padding: a wrong guess costs one corrective event, absorbed by the baseline.
     func isDeviceInside(center: CLLocationCoordinate2D, radius: CLLocationDistance) -> Bool? {
-        guard let location = authManager.location,
-              CLLocationCoordinate2DIsValid(location.coordinate)
-        else {
-            return nil
-        }
+        guard let location = bestKnownFix() else { return nil }
         let centerLocation = CLLocation(latitude: center.latitude, longitude: center.longitude)
         return location.distance(from: centerLocation) <= radius
     }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -99,7 +99,10 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
         self.storage = storage
         self.userDefaults = userDefaults
         self.authManager = CLLocationManager()
-        self.movementFixResolver = MovementFixResolver(logger: logger)
+        self.movementFixResolver = MovementFixResolver(
+            logger: logger,
+            backgroundTaskRunner: GeofenceBackgroundTime.runner(name: "io.customer.geofence.movement-fix")
+        )
         super.init()
         let mirrored = Set(userDefaults.stringArray(forKey: Self.conditionMirrorKey) ?? [])
         self.knownConditionIdentifiers = mirrored

--- a/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
@@ -46,7 +46,10 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
     init(logger: Logger) {
         self.manager = CLLocationManager()
         self.logger = logger
-        self.movementFixResolver = MovementFixResolver(logger: logger)
+        self.movementFixResolver = MovementFixResolver(
+            logger: logger,
+            backgroundTaskRunner: GeofenceBackgroundTime.runner(name: "io.customer.geofence.movement-fix")
+        )
         super.init()
         manager.delegate = self
     }

--- a/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
@@ -26,6 +26,8 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
 
     private let manager: CLLocationManager
     private let logger: Logger
+    /// Freshens the fix behind movement-trigger EXIT dispatches (see `MovementFixResolver`).
+    private let movementFixResolver: MovementFixResolver
     private var onTransition: GeofenceTransitionHandler?
     private var onAuthorizationChanged: GeofenceAuthorizationChangedHandler?
     private var lastLoggedPermissionTier: PermissionTier?
@@ -44,6 +46,7 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
     init(logger: Logger) {
         self.manager = CLLocationManager()
         self.logger = logger
+        self.movementFixResolver = MovementFixResolver(logger: logger)
         super.init()
         manager.delegate = self
     }
@@ -183,7 +186,7 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
             return
         }
         guard ownedRegionIdentifiers.contains(region.identifier) else { return }
-        onTransition?(region.identifier, transition, currentLocationData())
+        dispatchTransition(identifier: region.identifier, transition: transition, capturedLocation: currentLocationData())
     }
 
     private func drainPendingEventsIfReady() {
@@ -194,10 +197,24 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
             while self.onTransition != nil, !self.pendingEvents.isEmpty {
                 let next = self.pendingEvents.removeFirst()
                 guard self.ownedRegionIdentifiers.contains(next.identifier) else { continue }
-                self.onTransition?(next.identifier, next.transition, next.location)
+                self.dispatchTransition(identifier: next.identifier, transition: next.transition, capturedLocation: next.location)
             }
             self.isDrainingPendingEvents = false
         }
+    }
+
+    /// Movement-trigger EXITs re-center the trigger and measure displacement at the attached
+    /// coords, so a frozen cached fix pins the whole pipeline to a stale point — freshen it first,
+    /// keeping the captured location only as the fallback. Fire-and-forget so a slow fix can't
+    /// stall the pending-event drain behind it. Business events keep the captured location.
+    private func dispatchTransition(identifier: String, transition: GeofenceTransition, capturedLocation: LocationData?) {
+        if identifier == GeofenceConstants.movementTriggerIdentifier, transition == .exit {
+            movementFixResolver.resolve(cached: bestKnownFix()) { [weak self] location in
+                self?.onTransition?(identifier, transition, location ?? capturedLocation)
+            }
+            return
+        }
+        onTransition?(identifier, transition, capturedLocation)
     }
 
     func locationManager(_ manager: CLLocationManager, monitoringDidFailFor region: CLRegion?, withError error: Error) {
@@ -253,12 +270,17 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
         }
     }
 
+    /// Newest usable fix across the manager's cache and the resolver's requested fixes — the
+    /// manager's cache can freeze at process start on a long-suspended process.
+    private func bestKnownFix() -> CLLocation? {
+        let cached = manager.location.flatMap { CLLocationCoordinate2DIsValid($0.coordinate) ? $0 : nil }
+        guard let resolved = movementFixResolver.latestFix else { return cached }
+        guard let cached else { return resolved }
+        return resolved.timestamp > cached.timestamp ? resolved : cached
+    }
+
     private func currentLocationData() -> LocationData? {
-        guard let location = manager.location,
-              CLLocationCoordinate2DIsValid(location.coordinate)
-        else {
-            return nil
-        }
+        guard let location = bestKnownFix() else { return nil }
         return LocationData(latitude: location.coordinate.latitude, longitude: location.coordinate.longitude)
     }
 }

--- a/Sources/LocationGeofence/Monitor/MovementFixResolver.swift
+++ b/Sources/LocationGeofence/Monitor/MovementFixResolver.swift
@@ -1,0 +1,132 @@
+import CioInternalCommon
+import CoreLocation
+import Foundation
+
+/// Ensures the fix attached to a movement-trigger EXIT is fresh before it drives a sync pass.
+///
+/// `CLLocationManager.location` on a long-suspended process can stay frozen at the fix cached
+/// around process start, anchoring every movement pass (re-rank point, trigger re-center, the
+/// moved-beyond check) to a stale position for a whole trip. A cached fix older than
+/// `GeofenceConstants.movementFixMaxAge` triggers a one-shot request; on failure or after
+/// `movementFixRequestTimeout` the pass falls back to the cached fix, so it is never worse off
+/// than without the resolver. Concurrent resolutions coalesce onto one in-flight request, and
+/// `latestFix` retains the freshest delivered fix for the monitor's other cached-fix reads.
+///
+/// Owns its manager instead of routing through the Location module's provider: on a wrapper cold
+/// wake `CustomerIO.initialize` has not run, and movement passes must work in exactly that state.
+@MainActor
+final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDelegate {
+    private let logger: Logger
+    private let maxAge: TimeInterval
+    private let requestTimeout: TimeInterval
+
+    /// Created lazily so tests using the `requestFreshFix` seam never touch CoreLocation.
+    private lazy var manager: CLLocationManager = {
+        let manager = CLLocationManager()
+        manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+        manager.delegate = self
+        return manager
+    }()
+
+    /// Freshest fix this resolver has received, retained even when it arrives after a timeout.
+    private(set) var latestFix: CLLocation?
+    private var pendingCompletions: [(LocationData?) -> Void] = []
+    /// Newest cached fix seen while a request is in flight — the fallback on failure/timeout.
+    private var fallbackFix: CLLocation?
+    private var timeoutTask: Task<Void, Never>?
+
+    /// Test seam: replaces the manager's one-shot request. Tests inject this and then feed
+    /// `handleResolvedFix` / `handleRequestFailure` directly.
+    var requestFreshFix: (() -> Void)?
+
+    init(
+        logger: Logger,
+        maxAge: TimeInterval = GeofenceConstants.movementFixMaxAge,
+        requestTimeout: TimeInterval = GeofenceConstants.movementFixRequestTimeout
+    ) {
+        self.logger = logger
+        self.maxAge = maxAge
+        self.requestTimeout = requestTimeout
+    }
+
+    deinit {
+        timeoutTask?.cancel()
+    }
+
+    /// Completes with a fix no older than `maxAge` when one can be obtained, exactly once per call.
+    /// `cached` should be the caller's best currently-known fix.
+    func resolve(cached: CLLocation?, completion: @escaping (LocationData?) -> Void) {
+        let age = cached.map { -$0.timestamp.timeIntervalSinceNow }
+        if let cached, let age, age <= maxAge {
+            logger.geofenceMovementFixResolved(ageSeconds: age, requested: false)
+            completion(locationData(from: cached))
+            return
+        }
+        logger.geofenceMovementFixStale(ageSeconds: age)
+        if let cached, fallbackFix.map({ cached.timestamp > $0.timestamp }) ?? true {
+            fallbackFix = cached
+        }
+        pendingCompletions.append(completion)
+        guard pendingCompletions.count == 1 else { return }
+        startTimeout()
+        if let requestFreshFix {
+            requestFreshFix()
+        } else {
+            manager.requestLocation()
+        }
+    }
+
+    // MARK: - CLLocationManagerDelegate
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let fix = locations.last, CLLocationCoordinate2DIsValid(fix.coordinate) else { return }
+        handleResolvedFix(fix)
+    }
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        handleRequestFailure()
+    }
+
+    // MARK: - Internal (also the test seam's feed points)
+
+    func handleResolvedFix(_ fix: CLLocation) {
+        if latestFix.map({ fix.timestamp > $0.timestamp }) ?? true {
+            latestFix = fix
+        }
+        guard !pendingCompletions.isEmpty else { return }
+        logger.geofenceMovementFixResolved(ageSeconds: -fix.timestamp.timeIntervalSinceNow, requested: true)
+        completeAll(with: locationData(from: fix))
+    }
+
+    func handleRequestFailure() {
+        guard !pendingCompletions.isEmpty else { return }
+        logger.geofenceMovementFixRequestFailed(fallingBackToCached: fallbackFix != nil)
+        completeAll(with: fallbackFix.map(locationData(from:)))
+    }
+
+    // MARK: - Private
+
+    private func startTimeout() {
+        timeoutTask?.cancel()
+        timeoutTask = Task { @MainActor [weak self, requestTimeout] in
+            try? await Task.sleep(nanoseconds: UInt64(requestTimeout * 1000000000))
+            guard !Task.isCancelled else { return }
+            self?.handleRequestFailure()
+        }
+    }
+
+    private func completeAll(with location: LocationData?) {
+        timeoutTask?.cancel()
+        timeoutTask = nil
+        fallbackFix = nil
+        let completions = pendingCompletions
+        pendingCompletions = []
+        for completion in completions {
+            completion(location)
+        }
+    }
+
+    private func locationData(from fix: CLLocation) -> LocationData {
+        LocationData(latitude: fix.coordinate.latitude, longitude: fix.coordinate.longitude)
+    }
+}

--- a/Sources/LocationGeofence/Monitor/MovementFixResolver.swift
+++ b/Sources/LocationGeofence/Monitor/MovementFixResolver.swift
@@ -19,6 +19,7 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
     private let logger: Logger
     private let maxAge: TimeInterval
     private let requestTimeout: TimeInterval
+    private let backgroundTaskRunner: BackgroundTaskRunner
 
     /// Created lazily so tests using the `requestFreshFix` seam never touch CoreLocation.
     private lazy var manager: CLLocationManager = {
@@ -34,6 +35,9 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
     /// Newest cached fix seen while a request is in flight — the fallback on failure/timeout.
     private var fallbackFix: CLLocation?
     private var timeoutTask: Task<Void, Never>?
+    /// Completed when the in-flight request resolves, releasing its background-time window.
+    /// One signal per request cycle, so a window can never outlive its own cycle.
+    private var currentRequestSignal: RequestCompletionSignal?
 
     /// Test seam: replaces the manager's one-shot request. Tests inject this and then feed
     /// `handleResolvedFix` / `handleRequestFailure` directly.
@@ -42,15 +46,18 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
     init(
         logger: Logger,
         maxAge: TimeInterval = GeofenceConstants.movementFixMaxAge,
-        requestTimeout: TimeInterval = GeofenceConstants.movementFixRequestTimeout
+        requestTimeout: TimeInterval = GeofenceConstants.movementFixRequestTimeout,
+        backgroundTaskRunner: BackgroundTaskRunner = NoBackgroundTaskRunner()
     ) {
         self.logger = logger
         self.maxAge = maxAge
         self.requestTimeout = requestTimeout
+        self.backgroundTaskRunner = backgroundTaskRunner
     }
 
     deinit {
         timeoutTask?.cancel()
+        currentRequestSignal?.complete()
     }
 
     /// Completes with a fix no older than `maxAge` when one can be obtained, exactly once per call.
@@ -69,6 +76,7 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
         pendingCompletions.append(completion)
         guard pendingCompletions.count == 1 else { return }
         startTimeout()
+        holdBackgroundTimeUntilCompletion()
         if let requestFreshFix {
             requestFreshFix()
         } else {
@@ -79,7 +87,16 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
     // MARK: - CLLocationManagerDelegate
 
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        guard let fix = locations.last, CLLocationCoordinate2DIsValid(fix.coordinate) else { return }
+        guard let fix = locations.last, CLLocationCoordinate2DIsValid(fix.coordinate),
+              fix.horizontalAccuracy > 0
+        else { return }
+        // Core Location can echo a cached location as a new manager's first delivery. A fix as
+        // stale as the one that prompted the request must not complete the pass as "fresh" —
+        // keep waiting; the timeout falls back if nothing recent arrives.
+        guard -fix.timestamp.timeIntervalSinceNow <= maxAge else {
+            recordDeliveredFix(fix)
+            return
+        }
         handleResolvedFix(fix)
     }
 
@@ -90,9 +107,7 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
     // MARK: - Internal (also the test seam's feed points)
 
     func handleResolvedFix(_ fix: CLLocation) {
-        if latestFix.map({ fix.timestamp > $0.timestamp }) ?? true {
-            latestFix = fix
-        }
+        recordDeliveredFix(fix)
         guard !pendingCompletions.isEmpty else { return }
         logger.geofenceMovementFixResolved(ageSeconds: -fix.timestamp.timeIntervalSinceNow, requested: true)
         completeAll(with: locationData(from: fix))
@@ -106,6 +121,12 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
 
     // MARK: - Private
 
+    private func recordDeliveredFix(_ fix: CLLocation) {
+        if latestFix.map({ fix.timestamp > $0.timestamp }) ?? true {
+            latestFix = fix
+        }
+    }
+
     private func startTimeout() {
         timeoutTask?.cancel()
         timeoutTask = Task { @MainActor [weak self, requestTimeout] in
@@ -115,10 +136,24 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
         }
     }
 
+    /// A region wake grants only a short execution window, and the request may consume most of it
+    /// before the movement pass even starts. Holding a background-task assertion for the life of
+    /// the request keeps the no-drop guarantee from depending on the wake window's leftovers.
+    private func holdBackgroundTimeUntilCompletion() {
+        let signal = RequestCompletionSignal()
+        currentRequestSignal = signal
+        let runner = backgroundTaskRunner
+        Task {
+            await runner.withBackgroundTime { await signal.wait() }
+        }
+    }
+
     private func completeAll(with location: LocationData?) {
         timeoutTask?.cancel()
         timeoutTask = nil
         fallbackFix = nil
+        currentRequestSignal?.complete()
+        currentRequestSignal = nil
         let completions = pendingCompletions
         pendingCompletions = []
         for completion in completions {
@@ -128,5 +163,37 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
 
     private func locationData(from fix: CLLocation) -> LocationData {
         LocationData(latitude: fix.coordinate.latitude, longitude: fix.coordinate.longitude)
+    }
+}
+
+/// Awaitable one-shot completion flag. `wait()` returns when `complete()` has been called,
+/// regardless of order; both are safe from any thread and idempotent.
+private final class RequestCompletionSignal: Sendable {
+    private struct State {
+        var isCompleted = false
+        var continuation: CheckedContinuation<Void, Never>?
+    }
+
+    private let state = Synchronized<State>(State())
+
+    func complete() {
+        let continuation = state.mutating { state -> CheckedContinuation<Void, Never>? in
+            state.isCompleted = true
+            let pending = state.continuation
+            state.continuation = nil
+            return pending
+        }
+        continuation?.resume()
+    }
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            let resumeNow = state.mutating { state -> Bool in
+                if state.isCompleted { return true }
+                state.continuation = continuation
+                return false
+            }
+            if resumeNow { continuation.resume() }
+        }
     }
 }

--- a/Tests/LocationGeofence/Geofence/Monitor/MovementFixResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Monitor/MovementFixResolverTests.swift
@@ -12,18 +12,24 @@ struct MovementFixResolverTests {
     private func makeResolver(
         maxAge: TimeInterval = 30,
         requestTimeout: TimeInterval = 30,
+        backgroundTaskRunner: BackgroundTaskRunner = NoBackgroundTaskRunner(),
         onRequest: @escaping () -> Void = {}
     ) -> MovementFixResolver {
-        let resolver = MovementFixResolver(logger: LoggerMock(), maxAge: maxAge, requestTimeout: requestTimeout)
+        let resolver = MovementFixResolver(
+            logger: LoggerMock(),
+            maxAge: maxAge,
+            requestTimeout: requestTimeout,
+            backgroundTaskRunner: backgroundTaskRunner
+        )
         resolver.requestFreshFix = onRequest
         return resolver
     }
 
-    private func makeFix(latitude: Double = 31.0, longitude: Double = 74.0, ageSeconds: TimeInterval) -> CLLocation {
+    private func makeFix(latitude: Double = 31.0, longitude: Double = 74.0, ageSeconds: TimeInterval, accuracy: Double = 10) -> CLLocation {
         CLLocation(
             coordinate: CLLocationCoordinate2D(latitude: latitude, longitude: longitude),
             altitude: 0,
-            horizontalAccuracy: 10,
+            horizontalAccuracy: accuracy,
             verticalAccuracy: 10,
             timestamp: Date(timeIntervalSinceNow: -ageSeconds)
         )
@@ -170,5 +176,78 @@ struct MovementFixResolverTests {
 
         resolver.handleResolvedFix(makeFix(latitude: 32.2, ageSeconds: 0))
         #expect(received.map(\.?.latitude) == [32.1, 32.2])
+    }
+
+    @Test
+    func didUpdateLocations_givenStaleEchoedFix_expectKeptWaitingUntilFreshFix() {
+        let resolver = makeResolver()
+        var received: [LocationData?] = []
+
+        resolver.resolve(cached: nil) { received.append($0) }
+        // Core Location echoing a cached (stale) location must not complete the pass...
+        resolver.locationManager(CLLocationManager(), didUpdateLocations: [
+            makeFix(latitude: 31.9, ageSeconds: 120)
+        ])
+        #expect(received.isEmpty)
+        // ...but it is still retained for the monitor's newest-fix reads.
+        #expect(resolver.latestFix?.coordinate.latitude == 31.9)
+
+        resolver.locationManager(CLLocationManager(), didUpdateLocations: [
+            makeFix(latitude: 32.4, ageSeconds: 1)
+        ])
+        #expect(received.map(\.?.latitude) == [32.4])
+    }
+
+    @Test
+    func didUpdateLocations_givenInvalidAccuracy_expectIgnoredEntirely() {
+        let resolver = makeResolver()
+        var received: [LocationData?] = []
+
+        resolver.resolve(cached: nil) { received.append($0) }
+        resolver.locationManager(CLLocationManager(), didUpdateLocations: [
+            makeFix(latitude: 31.9, ageSeconds: 0, accuracy: -1)
+        ])
+        #expect(received.isEmpty)
+        #expect(resolver.latestFix == nil)
+
+        resolver.locationManager(CLLocationManager(), didUpdateLocations: [
+            makeFix(latitude: 32.6, ageSeconds: 0)
+        ])
+        #expect(received.map(\.?.latitude) == [32.6])
+    }
+
+    @Test
+    func resolve_givenStaleCachedFix_expectBackgroundTimeHeldUntilCompletion() async {
+        let runner = BackgroundTaskRunnerSpy()
+        let resolver = makeResolver(backgroundTaskRunner: runner)
+        var received: [LocationData?] = []
+
+        resolver.resolve(cached: makeFix(ageSeconds: 120)) { received.append($0) }
+        for _ in 0 ..< 200 {
+            if runner.started.wrappedValue == 1 { break }
+            try? await Task.sleep(nanoseconds: 5000000)
+        }
+        #expect(runner.started.wrappedValue == 1)
+        #expect(runner.finished.wrappedValue == 0)
+
+        resolver.handleResolvedFix(makeFix(latitude: 32.7, ageSeconds: 0))
+        for _ in 0 ..< 200 {
+            if runner.finished.wrappedValue == 1 { break }
+            try? await Task.sleep(nanoseconds: 5000000)
+        }
+        #expect(runner.finished.wrappedValue == 1)
+        #expect(received.map(\.?.latitude) == [32.7])
+    }
+}
+
+/// Records entry/exit of the background-time window so tests can assert it brackets the request.
+private final class BackgroundTaskRunnerSpy: BackgroundTaskRunner, @unchecked Sendable {
+    let started = Synchronized(0)
+    let finished = Synchronized(0)
+
+    func withBackgroundTime(_ work: @Sendable () async -> Void) async {
+        started.mutating { $0 += 1 }
+        await work()
+        finished.mutating { $0 += 1 }
     }
 }

--- a/Tests/LocationGeofence/Geofence/Monitor/MovementFixResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Monitor/MovementFixResolverTests.swift
@@ -1,0 +1,174 @@
+@testable import CioInternalCommon
+@testable import CioInternalCommonMocks
+@testable import CioLocationGeofence
+import CoreLocation
+import Foundation
+import SharedTests
+import Testing
+
+@Suite("MovementFixResolver")
+@MainActor
+struct MovementFixResolverTests {
+    private func makeResolver(
+        maxAge: TimeInterval = 30,
+        requestTimeout: TimeInterval = 30,
+        onRequest: @escaping () -> Void = {}
+    ) -> MovementFixResolver {
+        let resolver = MovementFixResolver(logger: LoggerMock(), maxAge: maxAge, requestTimeout: requestTimeout)
+        resolver.requestFreshFix = onRequest
+        return resolver
+    }
+
+    private func makeFix(latitude: Double = 31.0, longitude: Double = 74.0, ageSeconds: TimeInterval) -> CLLocation {
+        CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: latitude, longitude: longitude),
+            altitude: 0,
+            horizontalAccuracy: 10,
+            verticalAccuracy: 10,
+            timestamp: Date(timeIntervalSinceNow: -ageSeconds)
+        )
+    }
+
+    @Test
+    func resolve_givenFreshCachedFix_expectImmediateCompletionWithoutRequest() {
+        var requestCount = 0
+        let resolver = makeResolver(onRequest: { requestCount += 1 })
+        var received: [LocationData?] = []
+
+        resolver.resolve(cached: makeFix(latitude: 31.5, ageSeconds: 5)) { received.append($0) }
+
+        #expect(received.map(\.?.latitude) == [31.5])
+        #expect(requestCount == 0)
+    }
+
+    @Test
+    func resolve_givenStaleCachedFix_expectRequestThenCompletionWithFreshFix() {
+        var requestCount = 0
+        let resolver = makeResolver(onRequest: { requestCount += 1 })
+        var received: [LocationData?] = []
+
+        resolver.resolve(cached: makeFix(latitude: 31.1, ageSeconds: 120)) { received.append($0) }
+        #expect(received.isEmpty)
+        #expect(requestCount == 1)
+
+        resolver.handleResolvedFix(makeFix(latitude: 31.9, ageSeconds: 0))
+        #expect(received.map(\.?.latitude) == [31.9])
+    }
+
+    @Test
+    func resolve_givenNoCachedFix_expectRequestAndNilOnFailure() {
+        var requestCount = 0
+        let resolver = makeResolver(onRequest: { requestCount += 1 })
+        var received: [LocationData?] = []
+
+        resolver.resolve(cached: nil) { received.append($0) }
+        #expect(requestCount == 1)
+
+        resolver.handleRequestFailure()
+        #expect(received.count == 1)
+        #expect(received[0] == nil)
+    }
+
+    @Test
+    func resolve_givenStaleCachedFixAndFailure_expectFallbackToStaleFix() {
+        let resolver = makeResolver()
+        var received: [LocationData?] = []
+
+        resolver.resolve(cached: makeFix(latitude: 31.2, ageSeconds: 120)) { received.append($0) }
+        resolver.handleRequestFailure()
+
+        #expect(received.map(\.?.latitude) == [31.2])
+    }
+
+    @Test
+    func resolve_givenConcurrentResolutions_expectSingleRequestAndBothComplete() {
+        var requestCount = 0
+        let resolver = makeResolver(onRequest: { requestCount += 1 })
+        var first: [LocationData?] = []
+        var second: [LocationData?] = []
+
+        resolver.resolve(cached: makeFix(ageSeconds: 120)) { first.append($0) }
+        resolver.resolve(cached: makeFix(ageSeconds: 90)) { second.append($0) }
+        #expect(requestCount == 1)
+
+        resolver.handleResolvedFix(makeFix(latitude: 32.0, ageSeconds: 0))
+        #expect(first.map(\.?.latitude) == [32.0])
+        #expect(second.map(\.?.latitude) == [32.0])
+    }
+
+    @Test
+    func resolve_givenTimeout_expectFallbackCompletionExactlyOnce() async {
+        let resolver = makeResolver(requestTimeout: 0.05)
+        var received: [LocationData?] = []
+
+        resolver.resolve(cached: makeFix(latitude: 31.3, ageSeconds: 120)) { received.append($0) }
+
+        for _ in 0 ..< 200 {
+            if !received.isEmpty { break }
+            try? await Task.sleep(nanoseconds: 10000000)
+        }
+        #expect(received.map(\.?.latitude) == [31.3])
+
+        // A fix landing after the timeout must not re-complete, only refresh `latestFix`.
+        resolver.handleResolvedFix(makeFix(latitude: 32.5, ageSeconds: 0))
+        #expect(received.count == 1)
+        #expect(resolver.latestFix?.coordinate.latitude == 32.5)
+    }
+
+    @Test
+    func resolve_givenNewerCachedFixWhileRequestInFlight_expectFallbackToNewestCached() {
+        let resolver = makeResolver()
+        var first: [LocationData?] = []
+        var second: [LocationData?] = []
+
+        resolver.resolve(cached: makeFix(latitude: 31.6, ageSeconds: 120)) { first.append($0) }
+        resolver.resolve(cached: makeFix(latitude: 31.7, ageSeconds: 90)) { second.append($0) }
+        resolver.handleRequestFailure()
+
+        #expect(first.map(\.?.latitude) == [31.7])
+        #expect(second.map(\.?.latitude) == [31.7])
+    }
+
+    @Test
+    func didUpdateLocations_givenInvalidCoordinate_expectIgnoredUntilValidFix() {
+        let resolver = makeResolver()
+        var received: [LocationData?] = []
+
+        resolver.resolve(cached: nil) { received.append($0) }
+        resolver.locationManager(CLLocationManager(), didUpdateLocations: [
+            makeFix(latitude: 200.0, longitude: 200.0, ageSeconds: 0)
+        ])
+        #expect(received.isEmpty)
+
+        resolver.locationManager(CLLocationManager(), didUpdateLocations: [
+            makeFix(latitude: 31.8, ageSeconds: 0)
+        ])
+        #expect(received.map(\.?.latitude) == [31.8])
+    }
+
+    @Test
+    func latestFix_givenOlderDeliveredFix_expectNewestRetained() {
+        let resolver = makeResolver()
+
+        resolver.handleResolvedFix(makeFix(latitude: 31.4, ageSeconds: 10))
+        resolver.handleResolvedFix(makeFix(latitude: 31.5, ageSeconds: 60))
+
+        #expect(resolver.latestFix?.coordinate.latitude == 31.4)
+    }
+
+    @Test
+    func resolve_givenSecondResolveAfterCompletion_expectNewRequestCycle() {
+        var requestCount = 0
+        let resolver = makeResolver(onRequest: { requestCount += 1 })
+        var received: [LocationData?] = []
+
+        resolver.resolve(cached: makeFix(ageSeconds: 120)) { received.append($0) }
+        resolver.handleResolvedFix(makeFix(latitude: 32.1, ageSeconds: 0))
+
+        resolver.resolve(cached: makeFix(ageSeconds: 120)) { received.append($0) }
+        #expect(requestCount == 2)
+
+        resolver.handleResolvedFix(makeFix(latitude: 32.2, ageSeconds: 0))
+        #expect(received.map(\.?.latitude) == [32.1, 32.2])
+    }
+}


### PR DESCRIPTION
## Problem

`CLLocationManager.location` in a long-suspended process can remain frozen at the fix cached around process start. Movement passes (triggered by movement-trigger EXITs) read that property directly, so every pass in such a process runs against the same stale coordinates:

- the local re-rank evaluates candidates from the wrong point,
- the movement trigger re-centers where the device is not,
- the moved-beyond check never observes real displacement, so the remote refetch can starve for the duration of the trip — geofences beyond the cached window are not discovered until the next app open or cold wake.

The condition requires one process instance to stay suspended-alive across the trip; a cold wake reseeds the cache and is unaffected. Confirmed on device via registration state: the trigger was re-registered at coordinates bit-identical to the trip-start fix across multiple passes.

## Fix

New `MovementFixResolver` (internal): movement-trigger EXITs resolve their fix before dispatch.

- Cached fix ≤ 30 s old → used as-is, no request. (The common case: on an instrumented device drive, all passes hit this branch.)
- Older or missing → one one-shot `requestLocation()` (hundred-meter accuracy) on a resolver-owned manager. A delivered fix is accepted only when it is itself recent with valid accuracy — Core Location can echo a cached location as a new manager's first delivery, and a fix as stale as the one that prompted the request must not complete the pass as fresh. On failure or 10 s timeout the pass falls back to the cached fix.

Both monitors also prefer the newest known fix (manager cache vs. resolver's last delivered fix) for event locations and the inside/outside staging check.

Design constraints:

- **A pass is never dropped or stalled**: dispatch is fire-and-forget, every path completes (fresh, fallback, or the pre-existing nil behavior), and the pending-event drain is never blocked.
- **Worst case is the previous behavior**: request failure/timeout yields exactly what the code did before this change.
- **No posture change**: no continuous location updates, no background-mode additions; at most one one-shot request per movement pass, only when the cache is stale.
- **The wake window can't cut the pass short**: a background-task assertion is held for the life of the fresh-fix request, and the movement pass runs under its own — the trigger EXIT is consumed once dispatched, so a wake window expiring mid-pass would otherwise lose it with no retry.
- The resolver owns its `CLLocationManager` because movement passes must work on wrapper cold wakes, where the Location module is not initialized.
- Fix age is logged on every movement pass, so staleness frequency is measurable in the field.

No public API changes.

## Validation

- 13 unit tests on the resolver covering every branch (fresh/stale, failure fallback, fallback newest-wins, timeout exactly-once with late-delivery retention, coalescing concurrent resolutions into one request, invalid-coordinate guard, stale-echo rejection, invalid-accuracy rejection, background-window held until completion, repeat cycles). Full LocationGeofenceTests: 322/322.
- Simulator end-to-end on both monitor paths: CLMonitor (iOS 26) and classic `CLLocationManager` regions (iOS 17.5) — driven routes with movement cycles, all enter/exit events delivered exactly once at a local mock CDP (10 transitions, 0 duplicates), registration diffs steady at `+1/-0`.
- The stale branch was additionally exercised on-simulator with forced-stale builds: real `requestLocation()` issued and the freshly delivered fix used by the pass; with the recency guard forced to reject every delivery, the pass completed through the timeout fallback instead of stalling.
- Instrumented device drive on a build containing this change: movement cycles, background remote refreshes, and event delivery all healthy; every pass logged its fix age.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core geofence background delivery and location sourcing on cold wake; behavior is designed to match or improve on the prior fallback path, but incorrect fix freshness logic could still mis-rank or delay sync.
> 
> **Overview**
> Fixes movement geofence passes using **stale** `CLLocationManager.location` after a long-suspended process, which could starve remote refetches for an entire trip.
> 
> Introduces **`MovementFixResolver`**: on movement-trigger EXIT, uses a cache ≤30s old as-is; otherwise issues a one-shot `requestLocation()` (with stale-echo and accuracy guards), coalesces concurrent resolves, and falls back to cached fix on failure or 10s timeout. Both monitors route EXIT through the resolver (fire-and-forget so pending-event drains are not blocked) and **`bestKnownFix()`** so resolver fixes beat a frozen manager cache for other reads.
> 
> **`GeofenceBackgroundTime`** selects UIKit vs no-op background runners; **`GeofenceMonitorBinder`** wraps `handleMovement` in a background-task assertion so wake windows cannot drop the pass mid-flight; the resolver holds a separate assertion for the fresh-fix request. Adds movement-fix logging and 13 unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1657d3126b58562482f1c43d5d707a5dd912ce08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

