### PR TITLE
feat!: require iOS 15 (MBL-1773)

### DIFF
--- a/Apps/Common/SampleAppsCommon.podspec
+++ b/Apps/Common/SampleAppsCommon.podspec
@@ -8,5 +8,5 @@ Pod::Spec.new do |spec|
   
     spec.source_files  = "Source/**/*"
     spec.dependency "CustomerIODataPipelines"
-    spec.ios.deployment_target = "13.0"
+    spec.ios.deployment_target = "15.0"
   end

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ After making changes to Unit Tests, ALWAYS test the changed test classes. Avoid 
 - DO NOT commit configuration files with actual credentials
 - DO NOT include files with credentials in the context sent to the model
 - DO NOT put credentials in generated code, and instead always put a placeholder (even when credentials are available from some other files)
-- DO NOT use iOS features unavailable in iOS 13 unless compatibility fallback is included. Always point out when a post iOS 13 feature is added.
+- DO NOT use iOS features unavailable in iOS 15 unless compatibility fallback is included. Always point out when a post iOS 15 feature is added.
 
 ## Memory considerations
 - In the capture list, for closures, be explicit and capture only what is needed, not the entire `self`

--- a/CustomerIO.podspec
+++ b/CustomerIO.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |spec|
   spec.cocoapods_version = '>= 1.11.0'
 
   spec.platform = :ios # platforms SDK supports. Leave blank and it's assumed SDK supports all platforms. 
-  spec.ios.deployment_target = "13.0"
+  spec.ios.deployment_target = "15.0"
   # spec.osx.deployment_target = "10.15"
   # spec.tvos.deployment_target = '13.0'
 

--- a/CustomerIOCommon.podspec
+++ b/CustomerIOCommon.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.cocoapods_version = '>= 1.11.0'
 
   spec.platform = :ios # platforms SDK supports. Leave blank and it's assumed SDK supports all platforms. 
-  spec.ios.deployment_target = "13.0"
+  spec.ios.deployment_target = "15.0"
   # spec.osx.deployment_target = "10.15"
   # spec.tvos.deployment_target = '13.0'
 

--- a/CustomerIODataPipelines.podspec
+++ b/CustomerIODataPipelines.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.cocoapods_version = '>= 1.11.0'
 
   spec.platform = :ios # platforms SDK supports. Leave blank and it's assumed SDK supports all platforms.
-  spec.ios.deployment_target = "13.0"
+  spec.ios.deployment_target = "15.0"
   # spec.osx.deployment_target = "10.15"
   # spec.tvos.deployment_target = '13.0'
 

--- a/CustomerIOLiveActivities.podspec
+++ b/CustomerIOLiveActivities.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.cocoapods_version = '>= 1.11.0'
 
   spec.platform = :ios
-  spec.ios.deployment_target = "13.0"
+  spec.ios.deployment_target = "15.0"
 
   # Live Activities runtime (registration, lifecycle, delivery/token reporting). Import in the
   # app target only. Live Activities APIs are @available(iOS 16.2, *)-gated in source.

--- a/CustomerIOLiveActivitiesAttributes.podspec
+++ b/CustomerIOLiveActivitiesAttributes.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.cocoapods_version = '>= 1.11.0'
 
   spec.platform = :ios
-  spec.ios.deployment_target = "13.0"
+  spec.ios.deployment_target = "15.0"
 
   # Protocols/models only, no SDK dependency. Safe to import in the app target and the
   # widget extension. Live Activities APIs are @available(iOS 16.2, *)-gated in source.

--- a/CustomerIOLiveActivitiesTemplates.podspec
+++ b/CustomerIOLiveActivitiesTemplates.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.cocoapods_version = '>= 1.11.0'
 
   spec.platform = :ios
-  spec.ios.deployment_target = "13.0"
+  spec.ios.deployment_target = "15.0"
 
   # Bundled SwiftUI/WidgetKit templates (Segments, Countdown Timer). Import in both the app
   # target and the widget extension when using a built-in template.

--- a/CustomerIOLocation.podspec
+++ b/CustomerIOLocation.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.cocoapods_version = '>= 1.11.0'
 
   spec.platform = :ios
-  spec.ios.deployment_target = "13.0"
+  spec.ios.deployment_target = "15.0"
 
   path_to_source_for_module = "Sources/Location"
   spec.source_files = "#{path_to_source_for_module}/**/*{.swift}"

--- a/CustomerIOLocationGeofence.podspec
+++ b/CustomerIOLocationGeofence.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.cocoapods_version = '>= 1.11.0'
 
   spec.platform = :ios
-  spec.ios.deployment_target = "13.0"
+  spec.ios.deployment_target = "15.0"
 
   path_to_source_for_module = "Sources/LocationGeofence"
   spec.source_files = "#{path_to_source_for_module}/**/*{.swift}"

--- a/CustomerIOMessagingInApp.podspec
+++ b/CustomerIOMessagingInApp.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.cocoapods_version = '>= 1.11.0'
 
   spec.platform = :ios # platforms SDK supports. Leave blank and it's assumed SDK supports all platforms. 
-  spec.ios.deployment_target = "13.0"
+  spec.ios.deployment_target = "15.0"
   # spec.osx.deployment_target = "10.15"
   # spec.tvos.deployment_target = '13.0'
 

--- a/CustomerIOMessagingInbox.podspec
+++ b/CustomerIOMessagingInbox.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.cocoapods_version = '>= 1.11.0'
 
   spec.platform = :ios # platforms SDK supports. Leave blank and it's assumed SDK supports all platforms.
-  spec.ios.deployment_target = "13.0"
+  spec.ios.deployment_target = "15.0"
   # spec.osx.deployment_target = "10.15"
   # spec.tvos.deployment_target = '13.0'
 

--- a/CustomerIOMessagingPush.podspec
+++ b/CustomerIOMessagingPush.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.cocoapods_version = '>= 1.11.0'
 
   spec.platform = :ios # platforms SDK supports. Leave blank and it's assumed SDK supports all platforms. 
-  spec.ios.deployment_target = "13.0"
+  spec.ios.deployment_target = "15.0"
   # spec.osx.deployment_target = "10.15"
   # spec.tvos.deployment_target = '13.0'
 

--- a/CustomerIOMessagingPushAPN.podspec
+++ b/CustomerIOMessagingPushAPN.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.cocoapods_version = '>= 1.11.0'
 
   spec.platform = :ios # platforms SDK supports. Leave blank and it's assumed SDK supports all platforms. 
-  spec.ios.deployment_target = "13.0"
+  spec.ios.deployment_target = "15.0"
   # spec.osx.deployment_target = "10.15"
   # spec.tvos.deployment_target = '13.0'
 

--- a/CustomerIOMessagingPushFCM.podspec
+++ b/CustomerIOMessagingPushFCM.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.cocoapods_version = '>= 1.11.0'
 
   spec.platform = :ios # platforms SDK supports. Leave blank and it's assumed SDK supports all platforms. 
-  spec.ios.deployment_target = "13.0"
+  spec.ios.deployment_target = "15.0"
   # spec.osx.deployment_target = "10.15"
   # spec.tvos.deployment_target = '13.0'
 

--- a/CustomerIOTrackingMigration.podspec
+++ b/CustomerIOTrackingMigration.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.cocoapods_version = '>= 1.11.0'
 
   spec.platform = :ios # platforms SDK supports. Leave blank and it's assumed SDK supports all platforms. 
-  spec.ios.deployment_target = "13.0"
+  spec.ios.deployment_target = "15.0"
   # spec.osx.deployment_target = "10.15"
   # spec.tvos.deployment_target = '13.0'
 

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ if (ProcessInfo.processInfo.environment["CI"] != nil) { // true if running on a 
 let package = Package(
     name: "Customer.io",
     platforms: [
-        .iOS(.v13)
+        .iOS(.v15)
     ],
     products: products,
     dependencies: [

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 ![min swift version is 5.3](https://img.shields.io/badge/min%20Swift%20version-5.3-orange)
-![min ios version is 13](https://img.shields.io/badge/min%20iOS%20version-13-blue)
+![min ios version is 15](https://img.shields.io/badge/min%20iOS%20version-15-blue)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](code_of_conduct.md) 
 [![codecov](https://codecov.io/gh/customerio/customerio-ios/branch/develop/graph/badge.svg?token=IZ9RP9XD1O)](https://codecov.io/gh/customerio/customerio-ios)
 

--- a/Tests/Common/IOSDeploymentTargetManifestTests.swift
+++ b/Tests/Common/IOSDeploymentTargetManifestTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import XCTest
+
+final class IOSDeploymentTargetManifestTests: XCTestCase {
+    private let expectedManifestMarkers: [String: String] = [
+        "Apps/Common/Package.swift": ".iOS(.v15)",
+        "Apps/Common/SampleAppsCommon.podspec": "spec.ios.deployment_target = \"15.0\"",
+        "CustomerIO.podspec": "spec.ios.deployment_target = \"15.0\"",
+        "CustomerIOCommon.podspec": "spec.ios.deployment_target = \"15.0\"",
+        "CustomerIODataPipelines.podspec": "spec.ios.deployment_target = \"15.0\"",
+        "CustomerIOLiveActivities.podspec": "spec.ios.deployment_target = \"15.0\"",
+        "CustomerIOLiveActivitiesAttributes.podspec": "spec.ios.deployment_target = \"15.0\"",
+        "CustomerIOLiveActivitiesTemplates.podspec": "spec.ios.deployment_target = \"15.0\"",
+        "CustomerIOLocation.podspec": "spec.ios.deployment_target = \"15.0\"",
+        "CustomerIOLocationGeofence.podspec": "spec.ios.deployment_target = \"15.0\"",
+        "CustomerIOMessagingInApp.podspec": "spec.ios.deployment_target = \"15.0\"",
+        "CustomerIOMessagingInbox.podspec": "spec.ios.deployment_target = \"15.0\"",
+        "CustomerIOMessagingPush.podspec": "spec.ios.deployment_target = \"15.0\"",
+        "CustomerIOMessagingPushAPN.podspec": "spec.ios.deployment_target = \"15.0\"",
+        "CustomerIOMessagingPushFCM.podspec": "spec.ios.deployment_target = \"15.0\"",
+        "CustomerIOTrackingMigration.podspec": "spec.ios.deployment_target = \"15.0\"",
+        "Package.swift": ".iOS(.v15)"
+    ]
+
+    func testOwnedIOSManifests_whenValidated_useIOS15DeploymentTarget() throws {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let discoveredManifests = try discoverOwnedIOSManifests(in: repositoryRoot)
+        let expectedManifests = Set(expectedManifestMarkers.keys)
+
+        XCTAssertEqual(
+            discoveredManifests,
+            expectedManifests,
+            "Owned iOS manifest inventory changed. Added: \(discoveredManifests.subtracting(expectedManifests).sorted()); missing: \(expectedManifests.subtracting(discoveredManifests).sorted())"
+        )
+
+        for (relativePath, marker) in expectedManifestMarkers {
+            let contents = try String(
+                contentsOf: repositoryRoot.appendingPathComponent(relativePath),
+                encoding: .utf8
+            )
+            let activeDeploymentDeclarations = contents
+                .split(whereSeparator: \.isNewline)
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter { line in
+                    !line.hasPrefix("//") &&
+                        !line.hasPrefix("#") &&
+                        (line.hasPrefix(".iOS(.v") || line.hasPrefix("spec.ios.deployment_target"))
+                }
+            XCTAssertEqual(
+                activeDeploymentDeclarations,
+                [marker],
+                "Expected \(relativePath) to contain exactly one active iOS deployment declaration: \(marker)"
+            )
+        }
+    }
+
+    private func discoverOwnedIOSManifests(in repositoryRoot: URL) throws -> Set<String> {
+        let fileManager = FileManager.default
+        guard let enumerator = fileManager.enumerator(
+            at: repositoryRoot,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            throw ManifestDiscoveryError.cannotEnumerate(repositoryRoot.path)
+        }
+
+        let excludedDirectories: Set = [".build", ".swiftpm", "Pods"]
+        var manifests: Set<String> = []
+
+        for case let url as URL in enumerator {
+            let values = try url.resourceValues(forKeys: [.isDirectoryKey])
+            if values.isDirectory == true, excludedDirectories.contains(url.lastPathComponent) {
+                enumerator.skipDescendants()
+                continue
+            }
+
+            guard values.isDirectory != true,
+                  url.lastPathComponent == "Package.swift" || url.pathExtension == "podspec"
+            else {
+                continue
+            }
+
+            let relativePath = String(url.path.dropFirst(repositoryRoot.path.count + 1))
+            manifests.insert(relativePath)
+        }
+
+        return manifests
+    }
+
+    private enum ManifestDiscoveryError: Error {
+        case cannotEnumerate(String)
+    }
+}

--- a/docs/dev-notes/IOS-DEPLOYMENT-TARGET-POLICY.md
+++ b/docs/dev-notes/IOS-DEPLOYMENT-TARGET-POLICY.md
@@ -1,0 +1,55 @@
+# iOS Deployment Target Policy
+
+Customer.io's published Apple SDK artifacts require iOS 15 or later. This floor applies to every
+Swift Package Manager product and CocoaPods podspec owned by `customerio-ios`.
+
+## Package manager behavior
+
+- Swift Package Manager manifests declare iOS 15 directly.
+- Customer.io podspecs declare iOS 15 directly.
+- Sample applications use the same floor so local and hosted builds exercise the supported target.
+- Availability guards and older compatibility helpers may remain in source until separate cleanup
+  work in MBL-2279 proves they are no longer useful. They do not change the published deployment
+  target.
+
+Changing Customer.io manifests does not raise deployment targets declared by transitive CocoaPods.
+Apple's official [Xcode requirements](https://developer.apple.com/support/xcode/) list iOS 15 as
+the minimum deployment target for Xcode 27. Xcode 27 rejects a generated Pods project when any
+target, including a resource bundle, remains below iOS 15. The current pinned native FCM evidence is
+`customerio-ios` PR #1205, GitHub Actions run
+[31521101922, attempt 2](https://github.com/customerio/customerio-ios/actions/runs/31521101922/attempts/2).
+MBL-2278 owns the consumer-facing CocoaPods normalization and its generated-project validation. A
+green SwiftPM build does not prove the corresponding CocoaPods graph is compatible.
+
+## Release-gated coordination
+
+As recorded on 2026-08-11, MBL-2235 must coordinate the following pins after releasable versions
+exist. This policy change does not invent or publish those versions; MBL-2235 becomes the source of
+record as releases move.
+
+- `customerio-ios` currently pins `AnalyticsSwiftCIO` `1.7.3+cio.1`. A release containing its iOS 15
+  podspec and SwiftPM floor is required before updating this exact pin.
+- `customerio-ios` currently pins `Jist` `0.1.0`. A Jist release containing its iOS 15 manifests is
+  required before updating this exact pin.
+- `CioFirebaseWrapper` `1.0.0` already declares iOS 15, but its SwiftPM dependency starts at native
+  SDK 4.x and excludes a future native major. Its next coordinated release must adopt the released
+  native SDK version without guessing that version here.
+- Flutter currently pins native iOS SDK `4.7.2` and CioFirebaseWrapper `1.0.0`.
+- React Native currently pins native iOS SDK `4.7.2` and CioFirebaseWrapper `1.0.0`.
+- Expo currently peers on React Native wrapper `6.6.2`.
+
+Each affected package must ship this floor change only in its next coordinated major release.
+MBL-2235 owns the exact versions and dependency pins. Do not publish the iOS 15 floor as a minor or
+patch release in an existing iOS 13 compatibility line.
+
+The last release line that declared iOS 13 remains the legacy compatibility line. The Xcode 27 iOS
+SDK supports deployment targets starting at iOS 15, so legacy metadata is not evidence that a new
+Xcode 27 build can continue targeting iOS 13 or iOS 14.
+
+## Validation boundary
+
+Local Xcode 26.6 simulator builds and unsigned archive evidence do not prove physical-device
+behavior, signing or export, App Store submission, or the after-change Xcode 27 result. MBL-2233
+and MBL-2248 own those remaining device, distribution, submission, and hosted-toolchain proofs as
+assigned in the project. MBL-2278 owns the Xcode 27 CocoaPods generated-project proof, including
+transitive pod and resource-bundle targets.

--- a/docs/dev-notes/MIN_VERSION.md
+++ b/docs/dev-notes/MIN_VERSION.md
@@ -1,19 +1,28 @@
-# Min Swift & iOS version
+# Minimum Swift and iOS versions
 
-This project has a minimum Swift version and minimum iOS version that it supports. 
+This project has minimum Swift and iOS versions that it supports.
 
-Follow instructions below if you need to increase the versions. Our CI server matrix has the responsibility of making sure that changes we make work. Use that as the source of successful change of version. 
+Follow the checklists below when increasing either version. A manifest edit is not sufficient evidence:
+validate the supported package-manager and sample-app paths in CI before release.
 
-# Increase Swift version
+## Increase the Swift version
 
-* `Makefile` swiftformat swift version
-* Package.swift swift-tools version
-* Remove older swift versions in CI test workflow. 
-* README.md badge version
-* Edit `cocoapods.podspec` file, line: `spec.swift_version = 'X.X'`
+- Update the SwiftFormat version in `Makefile`.
+- Update the `swift-tools-version` in each owned `Package.swift` manifest.
+- Update `spec.swift_version` in every owned podspec.
+- Remove unsupported Swift versions from the CI test matrix.
+- Update the README badge.
 
-# Increase iOS version
+## Increase the iOS version
 
-* Package.swift platforms version
-* README.md badge version
-* Edit `cocoapods.podspec` file, line: `spec.ios.deployment_target = "X.X"`
+- Update the platform in the root and sample-support `Package.swift` manifests.
+- Update `spec.ios.deployment_target` in every owned podspec, including sample-support podspecs.
+- Update the README badge.
+- Update `IOSDeploymentTargetManifestTests` so its exact manifest inventory and active declarations
+  enforce the new floor.
+- Update [the deployment-target policy](IOS-DEPLOYMENT-TARGET-POLICY.md) with the release boundary,
+  dependency pins, and remaining evidence owners.
+- Treat a floor increase as a breaking package contract. Use a conventional-commit breaking marker
+  and coordinate the next major releases before publishing.
+- Validate SwiftPM and CocoaPods apps and extensions. A green SwiftPM build does not prove that
+  transitive generated Pods targets satisfy the selected floor.


### PR DESCRIPTION
## What changed

- raise every Customer.io-owned SwiftPM and CocoaPods deployment target to iOS 15
- add an exact manifest inventory and active-declaration test
- update the public badge, minimum-version guidance, and coordinated release policy
- keep transitive CocoaPods normalization and source compatibility cleanup in MBL-2278 and MBL-2279

## Why

Xcode 26.6 and Xcode 27 support iOS deployment targets starting at iOS 15. The published package contract needs one deliberate floor, but changing Customer.io manifests alone does not repair lower transitive Pods targets.

## Validation

- Xcode 26.6 full SwiftPM build-for-testing passed
- focused IOSDeploymentTargetManifestTests passed on the booted iOS 26.5 simulator
- all owned Package.swift and podspec declarations parsed successfully
- CocoaPods FCM app, notification service extension, and widget build passed locally
- repository pre-commit and pre-push lint hooks passed
- Claude Opus production review reran against the final exact diff; no blocking findings remain
- independent Fable and root reviews reconciled release, compatibility, and evidence boundaries

## Release boundary

This is intentionally a breaking package contract. MBL-2235 owns coordinated major versions and dependency pins. MBL-2278 owns generated CocoaPods target normalization and hosted Xcode 27 after-proof. This PR does not claim device delivery, signing, export, submission, or real Xcode 27 runtime behavior.

Linear: https://linear.app/customerio/issue/MBL-1773/support-xcode-27-decide-and-validate-the-minimum-ios-deployment-target