### PR TITLE
refactor: remove obsolete iOS compatibility paths (MBL-2279)

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/View/InboxViewController.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/InboxViewController.swift
@@ -49,7 +49,6 @@ class InboxViewController: BaseViewController, UITableViewDelegate, UITableViewD
 
     /// Pushes the visual message list as a dedicated screen, without the floating bell or sheet.
     @objc private func presentVisualInboxDemo() {
-        guard #available(iOS 13.0, *) else { return }
         let host = UIHostingController(rootView: VisualInboxScreen())
         host.title = "Visual Inbox"
         navigationController?.pushViewController(host, animated: true)
@@ -257,7 +256,6 @@ private extension InboxViewController {
 // MARK: - VisualInboxOverlayScreen
 
 /// Dedicated-screen integration of the visual Inbox message list.
-@available(iOS 13.0, *)
 private struct VisualInboxScreen: View {
     var body: some View {
         ZStack {

--- a/Apps/APN-UIKit/APN UIKit/View/location/LocationTestViewController+CLLocationManagerDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/location/LocationTestViewController+CLLocationManagerDelegate.swift
@@ -22,18 +22,16 @@ extension LocationTestViewController: @MainActor CLLocationManagerDelegate {
 
     /// Returns a short label for the device location source.
     /// Core Location can provide location from GPS, Wi‑Fi, cell, or a combination; the public API does not expose which.
-    /// We only get simulation and accessory info on iOS 15+.
+    /// The supported deployment target exposes simulation and accessory information.
     private func deviceLocationSourceName(for location: CLLocation) -> String {
-        if #available(iOS 15.0, *) {
-            guard let sourceInfo = location.sourceInformation else {
-                return "Device"
-            }
-            if sourceInfo.isSimulatedBySoftware {
-                return "Device (Simulated)"
-            }
-            if sourceInfo.isProducedByAccessory {
-                return "Device (Accessory)"
-            }
+        guard let sourceInfo = location.sourceInformation else {
+            return "Device"
+        }
+        if sourceInfo.isSimulatedBySoftware {
+            return "Device (Simulated)"
+        }
+        if sourceInfo.isProducedByAccessory {
+            return "Device (Accessory)"
         }
         return "Device"
     }
@@ -47,16 +45,8 @@ extension LocationTestViewController: @MainActor CLLocationManagerDelegate {
     /// when permission lands in a granted state — it bootstraps geofence sync from the current
     /// location without emitting a `CIO Location Update` analytics event (unlike
     /// `requestLocationUpdate()`). Safe to invoke on every delegate firing.
-    @available(iOS 14.0, *)
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         let status = manager.authorizationStatus
-        if status == .authorizedWhenInUse || status == .authorizedAlways {
-            CustomerIO.geofence.refreshFromCurrentLocation()
-        }
-        handleAuthorizationChange(status)
-    }
-
-    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
         if status == .authorizedWhenInUse || status == .authorizedAlways {
             CustomerIO.geofence.refreshFromCurrentLocation()
         }

--- a/Apps/APN-UIKit/APN UIKit/View/location/LocationTestViewController+Location.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/location/LocationTestViewController+Location.swift
@@ -84,11 +84,7 @@ extension LocationTestViewController {
     }
 
     func currentAuthorizationStatus() -> CLAuthorizationStatus {
-        if #available(iOS 14.0, *) {
-            return locationManager.authorizationStatus
-        } else {
-            return CLLocationManager.authorizationStatus()
-        }
+        locationManager.authorizationStatus
     }
 
     func setLocation(latitude: Double, longitude: Double, sourceName: String? = nil) {
@@ -117,12 +113,7 @@ extension LocationTestViewController {
     }
 
     func requestCurrentLocation() {
-        let status: CLAuthorizationStatus
-        if #available(iOS 14.0, *) {
-            status = locationManager.authorizationStatus
-        } else {
-            status = CLLocationManager.authorizationStatus()
-        }
+        let status = locationManager.authorizationStatus
 
         switch status {
         case .notDetermined:
@@ -153,12 +144,7 @@ extension LocationTestViewController {
 
     /// Asks for location permission if needed, then asks the SDK to request a single location update.
     func requestSdkLocationUpdateOnce() {
-        let status: CLAuthorizationStatus
-        if #available(iOS 14.0, *) {
-            status = locationManager.authorizationStatus
-        } else {
-            status = CLLocationManager.authorizationStatus()
-        }
+        let status = locationManager.authorizationStatus
 
         switch status {
         case .notDetermined:

--- a/Apps/APN-UIKit/APN UIKitUITests/APN_UIKitUITests.swift
+++ b/Apps/APN-UIKit/APN UIKitUITests/APN_UIKitUITests.swift
@@ -23,11 +23,9 @@ final class UITests: XCTestCase {
     }
 
     func testLaunchPerformance() throws {
-        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
-            // This measures how long it takes to launch your application.
-            measure(metrics: [XCTApplicationLaunchMetric()]) {
-                XCUIApplication().launch()
-            }
+        // This measures how long it takes to launch your application.
+        measure(metrics: [XCTApplicationLaunchMetric()]) {
+            XCUIApplication().launch()
         }
     }
 }

--- a/Sources/Common/Util/SystemLogger.swift
+++ b/Sources/Common/Util/SystemLogger.swift
@@ -17,13 +17,8 @@ public class SystemLoggerImpl: SystemLogger {
         #if canImport(os)
         // Unified logging for Swift. https://www.avanderlee.com/workflow/oslog-unified-logging/
         // This means we can view logs in xcode console + Console app.
-        if #available(iOS 14, *) {
-            let logger = os.Logger(subsystem: logSubsystem, category: logCategory)
-            logger.log(level: level.osLogLevel, "\(message, privacy: .public)")
-        } else {
-            let logger = OSLog(subsystem: logSubsystem, category: logCategory)
-            os_log("%{public}@", log: logger, type: level.osLogLevel, message)
-        }
+        let logger = os.Logger(subsystem: logSubsystem, category: logCategory)
+        logger.log(level: level.osLogLevel, "\(message, privacy: .public)")
         #else
         // At this time, Linux cannot use `os.log` or `OSLog`. Instead, use: https://github.com/apple/swift-log/
         // As we don't officially support Linux at this time, no need to add a dependency to the project.

--- a/Sources/DataPipeline/Plugins/AutoTrackingScreenViews.swift
+++ b/Sources/DataPipeline/Plugins/AutoTrackingScreenViews.swift
@@ -212,7 +212,7 @@ extension UIViewController {
     private func getActiveRootViewController() -> UIViewController? {
         if let viewController = UIApplication.shared.delegate?.window??.rootViewController {
             return viewController
-        } else if #available(iOS 13.0, *) {
+        } else {
             for scene in UIApplication.shared.connectedScenes {
                 if scene.activationState == .foregroundActive, let windowScene = scene as? UIWindowScene {
                     if let sceneDelegate = windowScene.delegate as? UIWindowSceneDelegate {
@@ -222,10 +222,6 @@ extension UIViewController {
                     }
                 }
             }
-        } else { // keyWindow is deprecated in iOS 13.0*
-            #if os(iOS)
-            return UIApplication.shared.keyWindow?.rootViewController
-            #endif
         }
 
         return nil

--- a/Sources/Location/CoreLocationProvider.swift
+++ b/Sources/Location/CoreLocationProvider.swift
@@ -71,11 +71,7 @@ actor CoreLocationProvider: NSObject, CLLocationManagerDelegate, LocationProvidi
     private func currentAuthorizationStatus() async -> AuthorizationSnapshot {
         let m = manager
         let clStatus: CLAuthorizationStatus = await MainActor.run {
-            if #available(iOS 14.0, *) {
-                return m.authorizationStatus
-            } else {
-                return CLLocationManager.authorizationStatus()
-            }
+            m.authorizationStatus
         }
         return AuthorizationSnapshot(status: authorizationStatusFromCL(clStatus))
     }

--- a/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
@@ -207,7 +207,7 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
         logger.geofenceMonitoringFailed(region: identifier, error: error)
     }
 
-    // iOS 14+ fires this on delegate set with the current status, and again on every change.
+    // Core Location fires this on delegate set with the current status, and again on every change.
     // We surface it to callers so the bootstrap can re-attempt registration when permission
     // improves mid-process (the initial fire after delegate-set is harmless — the bootstrap
     // already read the current status synchronously before installing the handler).
@@ -246,11 +246,7 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
     }
 
     private func currentAuthorizationStatus() -> CLAuthorizationStatus {
-        if #available(iOS 14.0, *) {
-            return manager.authorizationStatus
-        } else {
-            return CLLocationManager.authorizationStatus()
-        }
+        manager.authorizationStatus
     }
 
     private func currentLocationData() -> LocationData? {
@@ -279,7 +275,7 @@ extension DIGraphShared {
         let overridden: GeofenceRegionMonitoring? = getOverriddenInstance()
         if let overridden { return overridden }
         // iOS 18+ uses the CLMonitor-backed monitor: only there does `CLServiceSession` provide a
-        // documented way to keep background event delivery alive. iOS 13–17 keep the classic
+        // documented way to keep background event delivery alive. iOS 15–17 keep the classic
         // CLLocationManager monitor — the region APIs are deprecated on 17 but still deliver
         // reliably in the background (OS relaunch), whereas iOS 17 CLMonitor has no session and
         // no dependable background story. Revisit lowering this to 17 only if it proves reliable.

--- a/Sources/MessagingInApp/Gist/Managers/ModalViewManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/ModalViewManager.swift
@@ -118,12 +118,10 @@ class ModalViewManager {
 
     private func getUIWindow() -> UIWindow {
         var modalWindow = UIWindow(frame: UIScreen.main.bounds)
-        if #available(iOS 13.0, *) {
-            for connectedScene in UIApplication.shared.connectedScenes
-                where connectedScene.activationState == .foregroundActive {
-                if let windowScene = connectedScene as? UIWindowScene {
-                    modalWindow = UIWindow(windowScene: windowScene)
-                }
+        for connectedScene in UIApplication.shared.connectedScenes
+            where connectedScene.activationState == .foregroundActive {
+            if let windowScene = connectedScene as? UIWindowScene {
+                modalWindow = UIWindow(windowScene: windowScene)
             }
         }
         modalWindow.windowLevel = .normal

--- a/Sources/MessagingInApp/Gist/Network/SSE/AsyncStreamBackport.swift
+++ b/Sources/MessagingInApp/Gist/Network/SSE/AsyncStreamBackport.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Backport of `AsyncStream.makeStream()` for iOS 13+.
+/// Backport of `AsyncStream.makeStream()` for the SDK's iOS 15 deployment target.
 ///
 /// `AsyncStream.makeStream()` was introduced in iOS 17 and provides a way to create
 /// an AsyncStream and access its continuation separately. This is useful when you need

--- a/Sources/MessagingInApp/Gist/Network/SSE/HeartbeatTimer.swift
+++ b/Sources/MessagingInApp/Gist/Network/SSE/HeartbeatTimer.swift
@@ -65,7 +65,7 @@ actor HeartbeatTimer: HeartbeatTimerProtocol {
 
         currentTimerTask = Task { [weak self, generation, clampedTimeout] in
             do {
-                // Task.sleep with nanoseconds required for iOS 13+ compatibility
+                // The duration-based Task.sleep API is unavailable at the iOS 15 deployment target.
                 try await Task.sleep(nanoseconds: nanoseconds)
 
                 // Check cancellation after sleep completes

--- a/Sources/MessagingInApp/Gist/Network/SSE/SseService.swift
+++ b/Sources/MessagingInApp/Gist/Network/SSE/SseService.swift
@@ -69,8 +69,8 @@ actor SseService: SseServiceProtocol {
 
         logger.logWithModuleTag("SseService: Connecting to \(url.absoluteString)", level: .info)
 
-        // Create stream and continuation separately to avoid race conditions
-        // (Using backport for iOS 13+ compatibility; native makeStream() requires iOS 17+)
+        // Create stream and continuation separately to avoid race conditions. The backport remains
+        // necessary at the iOS 15 floor because native makeStream() requires iOS 17+.
         let (stream, continuation) = AsyncStreamBackport.makeStream(of: SseEvent.self)
 
         // Create event handler with continuation

--- a/Sources/MessagingInApp/Views/SwiftUIInline.swift
+++ b/Sources/MessagingInApp/Views/SwiftUIInline.swift
@@ -117,8 +117,7 @@ struct InlineMessageUIViewRepresentable: UIViewRepresentable {
     }
 }
 
-// UIActivityIndicatorView to use in SwiftUI.
-// Must use this because SwiftUI activity indicator was introduced in iOS 14.
+// Keep the large UIKit spinner so SwiftUI and UIKit inline-message loading states have matching size.
 struct ActivityIndicator: UIViewRepresentable {
     func makeUIView(context: Context) -> UIActivityIndicatorView {
         let indicator = UIActivityIndicatorView(style: .large)

--- a/Sources/MessagingInbox/InboxActionNavigator.swift
+++ b/Sources/MessagingInbox/InboxActionNavigator.swift
@@ -7,7 +7,6 @@ import UIKit
 /// a protocol so ``NotificationInboxView`` can be exercised — including its navigate/dismiss ordering
 /// and host-interception paths — without `DIGraphShared` or live UIKit, keeping the shared graph at
 /// the module boundary with constructor injection below it (per the SDK DI guidelines).
-@available(iOS 13.0, *)
 protocol InboxActionNavigating {
     /// Open an external URL (web parity `openUrl`) — the system browser or whichever app claims it.
     func openExternalURL(_ url: URL)
@@ -17,7 +16,6 @@ protocol InboxActionNavigating {
 }
 
 /// Production ``InboxActionNavigating`` backed by the SDK's shared `DeepLinkUtil` and `UIApplication`.
-@available(iOS 13.0, *)
 struct DefaultInboxActionNavigator: InboxActionNavigating {
     private let deepLinkUtil: DeepLinkUtil
 

--- a/Sources/MessagingInbox/InboxActionResolution.swift
+++ b/Sources/MessagingInbox/InboxActionResolution.swift
@@ -7,7 +7,6 @@ import Foundation
 /// Mirrors the web SDK's `InboxActionConfig` (gist-web `inbox-component-manager.handleInboxAction`):
 /// `{ behavior, action, name, dismiss, newTab }`. `newTab` is web-only (open in a new browser tab)
 /// and is not modeled here — native always opens externally.
-@available(iOS 13.0, *)
 struct InboxActionResolution: Equatable {
     /// The action `behavior` from the message's `properties[actionName]`. Matches the web enum
     /// `InboxActionBehavior` (minus `dismiss`, which is resolved before this type is built).

--- a/Sources/MessagingInbox/InboxBellIcon.swift
+++ b/Sources/MessagingInbox/InboxBellIcon.swift
@@ -13,7 +13,6 @@ import SwiftUI
 /// Path parsing is delegated to the vendored `SVGPath` (see `Vendor/SVGPath`), which robustly handles
 /// the full SVG path grammar. This type only extracts the `<path d="…">` elements + `viewBox` from the
 /// markup and combines the paths.
-@available(iOS 13.0, *)
 struct InboxBellGlyph {
     /// One `<path>` element: its geometry (in viewBox coordinates) + the fill rule to apply to IT.
     struct Subpath {
@@ -123,7 +122,6 @@ struct InboxBellGlyph {
 ///
 /// The caller fills each sub-path with `FillStyle(eoFill: subpath.usesEvenOddFill)` so the SVG's own
 /// declared `fill-rule` is honored per-path (MBL-2123) rather than assuming even-odd.
-@available(iOS 13.0, *)
 struct InboxBellIcon: Shape {
     /// One sub-path from the glyph (viewBox coordinates). Rendered as its own filled shape.
     let subpath: Path

--- a/Sources/MessagingInbox/InboxBellPosition.swift
+++ b/Sources/MessagingInbox/InboxBellPosition.swift
@@ -8,7 +8,6 @@ import SwiftUI
 ///
 /// The raw values are the exact strings the backend/web SDK emit (gist-web `positionStyles`):
 /// `bottom-right` / `bottom-left` / `top-right` / `top-left`, with `bottom-right` as the default.
-@available(iOS 13.0, *)
 enum InboxBellPosition: String {
     case bottomRight = "bottom-right"
     case bottomLeft = "bottom-left"

--- a/Sources/MessagingInbox/InboxChromeColors.swift
+++ b/Sources/MessagingInbox/InboxChromeColors.swift
@@ -13,7 +13,6 @@ import SwiftUI
 ///      palette (`patterns.modes.dark` is OPTIONAL; absent in most workspaces),
 ///   2. `patterns.inbox.*` — the workspace's configured (light) inbox chrome,
 ///   3. a SwiftUI/system default (`Color.accentColor` / `Color(.systemBackground)` / `Color.red` …).
-@available(iOS 13.0, *)
 struct ResolvedInboxColors {
     let bellBackground: Color
     let bellIcon: Color
@@ -82,10 +81,8 @@ struct ResolvedInboxColors {
     }
 }
 
-/// Parses branding hex color strings into SwiftUI colors. iOS 13-safe: builds `Color` directly from
-/// sRGB components (no `UIColor(_:)`/`Color` round-trip, which is iOS 14+) and computes luminance from
-/// the same components.
-@available(iOS 13.0, *)
+/// Parses branding hex color strings directly from sRGB components so color construction and
+/// luminance calculations use the same normalized values.
 enum InboxColorParser {
     /// Normalized sRGB components parsed from a hex string.
     private struct RGBA {

--- a/Sources/MessagingInbox/NotificationInboxBell.swift
+++ b/Sources/MessagingInbox/NotificationInboxBell.swift
@@ -17,11 +17,10 @@ import SwiftUI
 /// ```swift
 /// NotificationInboxBell { showInbox = true }
 /// ```
-@available(iOS 13.0, *)
 public struct NotificationInboxBell: View {
-    /// Owns the model for standalone use. `@State` rather than `@ObservedObject` so SwiftUI keeps the
-    /// instance across view reconstruction; `@StateObject` is iOS 14+ and this view is public on
-    /// iOS 13. See ``NotificationInboxView`` for the full rationale.
+    /// Owns the model for standalone use. `@State` intentionally preserves the existing ownership
+    /// behavior; `@ObservedObject` would not own the value and could replace a started model during
+    /// parent updates. Moving to another ownership wrapper requires separate lifecycle validation.
     @State private var model = VisualInboxModel()
 
     private let onTap: () -> Void
@@ -39,7 +38,6 @@ public struct NotificationInboxBell: View {
 
 /// Renders the bell for a model it does not own. Always constructed with an explicit model — either
 /// the shared one from ``NotificationInboxOverlay`` or the one ``NotificationInboxBell`` owns.
-@available(iOS 13.0, *)
 struct InboxBellView: View {
     @ObservedObject private var model: VisualInboxModel
 
@@ -107,7 +105,6 @@ struct InboxBellView: View {
                 }
             }
         })
-        // `.accessibility(label:)` is the iOS 13-safe form; `.accessibilityLabel` is iOS 14+.
         .accessibility(label: Text(showsUnreadCount ? "Notifications, \(model.unopenedCount) unread" : "Notifications"))
     }
 
@@ -138,7 +135,6 @@ struct InboxBellView: View {
 
 /// Starts/stops the shared model only when this view owns the lifecycle. Centralizes the
 /// `onAppear`/`onDisappear` so the bell and panel can each conditionally drive it.
-@available(iOS 13.0, *)
 struct LifecycleModifier: ViewModifier {
     @ObservedObject var model: VisualInboxModel
     let enabled: Bool

--- a/Sources/MessagingInbox/NotificationInboxView.swift
+++ b/Sources/MessagingInbox/NotificationInboxView.swift
@@ -20,15 +20,11 @@ import UIKit
 /// ```swift
 /// NavigationView { NotificationInboxView() }
 /// ```
-@available(iOS 13.0, *)
 public struct NotificationInboxView: View {
-    /// Owns the model for standalone embedding.
-    ///
-    /// `@State` rather than `@ObservedObject`: `@ObservedObject` does not own its value, so a parent
-    /// update could hand the view a brand-new model after the original had already started its
-    /// lifecycle — losing load state, dedupe guards, and in-flight work. `@StateObject` would be the
-    /// natural owner but is iOS 14+, and this view is public on iOS 13. `VisualInboxModel.init` has no
-    /// side effects (work begins in `start()`), so the instances SwiftUI discards are inert.
+    /// Owns the model for standalone embedding. `@State` intentionally preserves the existing
+    /// ownership behavior; `@ObservedObject` would not own the value and could replace a started
+    /// model during parent updates, losing load state, dedupe guards, and in-flight work. Moving to
+    /// another ownership wrapper requires separate lifecycle validation.
     @State private var model = VisualInboxModel()
 
     /// Creates a standalone inbox list backed by the SDK's shared Visual Inbox data layer.
@@ -41,7 +37,6 @@ public struct NotificationInboxView: View {
 
 /// Renders the inbox list for a model it does not own. Always constructed with an explicit model —
 /// either the shared one from ``NotificationInboxOverlay`` or the one ``NotificationInboxView`` owns.
-@available(iOS 13.0, *)
 struct InboxListView: View {
     @ObservedObject private var model: VisualInboxModel
 
@@ -145,8 +140,6 @@ struct InboxListView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if model.messages.isEmpty {
             // idle/loading (pre-first-snapshot or fetch in progress) → spinner, not the empty copy.
-            // `InboxLoadingSpinner` (UIKit) instead of SwiftUI `ProgressView`, which is iOS 14+ while
-            // this view is public on iOS 13.
             VStack {
                 Spacer()
                 InboxLoadingSpinner()
@@ -278,9 +271,8 @@ struct InboxListView: View {
     }
 }
 
-/// iOS 13-compatible loading spinner. SwiftUI's `ProgressView` is iOS 14+, but ``NotificationInboxView``
-/// is public on iOS 13, so the loading state wraps UIKit's `UIActivityIndicatorView` instead.
-@available(iOS 13.0, *)
+/// Preserves the standalone inbox list's existing medium UIKit loading indicator. Migrating to a
+/// different SwiftUI loading view requires separate visual validation.
 private struct InboxLoadingSpinner: UIViewRepresentable {
     func makeUIView(context: Context) -> UIActivityIndicatorView {
         let indicator = UIActivityIndicatorView(style: .medium)

--- a/Sources/MessagingInbox/VisualInboxMessageRow.swift
+++ b/Sources/MessagingInbox/VisualInboxMessageRow.swift
@@ -7,9 +7,8 @@ import SwiftUI
 
 /// A single inbox message rendered via Jist (item 7).
 ///
-/// Jist (`JistView`) is available at the iOS 13 floor: the renderer handles its iOS-15-only needs
-/// internally via runtime backports (AsyncImage / AttributedString), so no host-side gating is needed.
-@available(iOS 13.0, *)
+/// Jist (`JistView`) supports the SDK's deployment target, so no host-side availability gating is
+/// needed.
 struct VisualInboxMessageRow: View {
     let message: VisualInboxMessageSnapshot
     /// The message's `properties` already decoded into Jist data by `VisualInboxModel` (decoded once

--- a/Sources/MessagingInbox/VisualInboxModel.swift
+++ b/Sources/MessagingInbox/VisualInboxModel.swift
@@ -15,7 +15,6 @@ import SwiftUI
 ///
 /// Thread safety: `@MainActor` so all `@Published` mutations happen on the main thread; the
 /// provider calls are `async` and hop back to the main actor before publishing.
-@available(iOS 13.0, *)
 @MainActor
 final class VisualInboxModel: ObservableObject {
     /// Current visibility/loading state from the data layer. Drives which chrome is shown.

--- a/Sources/MessagingPush/Integration/CioNotificationCenterDelegate.swift
+++ b/Sources/MessagingPush/Integration/CioNotificationCenterDelegate.swift
@@ -41,11 +41,7 @@ open class CioNotificationCenterDelegate: NSObject, UNUserNotificationCenterDele
         }
 
         if config?().showPushAppInForeground ?? false {
-            if #available(iOS 14.0, *) {
-                completionHandler([.list, .banner, .badge, .sound])
-            } else {
-                completionHandler([.alert, .badge, .sound])
-            }
+            completionHandler([.list, .banner, .badge, .sound])
         } else {
             completionHandler([])
         }

--- a/Tests/MessagingInbox/InboxBellIconTests.swift
+++ b/Tests/MessagingInbox/InboxBellIconTests.swift
@@ -6,7 +6,6 @@ import XCTest
 /// Coverage for the branding-SVG bell glyph (`InboxBellGlyph.build` extraction via vendored SVGPath +
 /// `InboxBellIcon` fit) and the branding-driven bell position mapping — the pure, non-SwiftUI-rendered
 /// pieces of the overlay, unit-testable without a host.
-@available(iOS 13.0, *)
 final class InboxBellIconTests: XCTestCase {
     // MARK: - InboxBellGlyph / InboxBellIcon (branding SVG → fitted Shape)
 

--- a/Tests/MessagingInbox/VisualInboxModelTests.swift
+++ b/Tests/MessagingInbox/VisualInboxModelTests.swift
@@ -11,7 +11,6 @@ import XCTest
 /// ``VisualInboxModel``: the read-only message/unopened-count API (item 9), the load → refresh
 /// publish cycle (item 11), and the auto-mark-opened dedupe guard (item 8). These tests drive the
 /// model against a hand-written fake provider.
-@available(iOS 13.0, *)
 @MainActor
 final class VisualInboxModelTests: XCTestCase {
     // MARK: - refresh / read-only API (items 9, 11)
@@ -424,8 +423,8 @@ final class VisualInboxModelTests: XCTestCase {
         let model = VisualInboxModel(provider: provider)
         await model.refresh()
 
-        // Jist renders at the iOS 13 floor, so the no-template skip applies on every version:
-        // "b" has no matching template and is filtered out.
+        // Jist supports the SDK's deployment target, so the no-template skip applies on every
+        // supported version: "b" has no matching template and is filtered out.
         XCTAssertEqual(model.renderableMessages.map(\.id), ["a"])
     }
 
@@ -523,7 +522,6 @@ final class VisualInboxModelTests: XCTestCase {
 
 /// Hand-written fake of the `@_spi(VisualInbox)` `VisualInboxProvider`. Avoids the auto-generated
 /// mock pipeline so this test target needs no sourcery config.
-@available(iOS 13.0, *)
 private final class FakeVisualInboxProvider: VisualInboxProvider, @unchecked Sendable {
     var stubState: VisualInboxState = .idle
     var stubMessages: [VisualInboxMessageSnapshot] = []

--- a/Tests/MessagingInbox/VisualInboxSnapshotTests.swift
+++ b/Tests/MessagingInbox/VisualInboxSnapshotTests.swift
@@ -9,7 +9,6 @@ import XCTest
 /// EQUAL and was dropped by `emitSnapshot` — leaving the overlay rendering stale Jist rows/theme.
 /// These tests pin that such render-payload changes now count as DIFFERENT (so they're emitted),
 /// while truly-identical snapshots still compare equal (so genuine dupes are still dropped).
-@available(iOS 13.0, *)
 final class VisualInboxSnapshotTests: XCTestCase {
     private func snapshot(
         state: VisualInboxState = .visible(messageCount: 1),

--- a/Tests/MessagingPush/Integration/CioNotificationCenterDelegateTests.swift
+++ b/Tests/MessagingPush/Integration/CioNotificationCenterDelegateTests.swift
@@ -81,11 +81,7 @@ class CioNotificationCenterDelegateTests: XCTestCase {
         XCTAssertFalse(mockNotificationCenterDelegate.willPresentNotificationCalled)
         XCTAssertTrue(completionHandlerCalled)
 
-        if #available(iOS 14.0, *) {
-            XCTAssertEqual(presentationOptions, [.list, .banner, .badge, .sound])
-        } else {
-            XCTAssertEqual(presentationOptions, [.alert, .badge, .sound])
-        }
+        XCTAssertEqual(presentationOptions, [.list, .banner, .badge, .sound])
     }
 
     func testUserNotificationCenterWillPresent_whenWrappedDelegateCallsCompletionHandlerAsync_thenCompletionHandlerIsCalledExactlyOnce() {
@@ -194,11 +190,7 @@ class CioNotificationCenterDelegateTests: XCTestCase {
             withCompletionHandler: { options in presentationOptions = options }
         )
 
-        if #available(iOS 14.0, *) {
-            XCTAssertEqual(presentationOptions, [.list, .banner, .badge, .sound])
-        } else {
-            XCTAssertEqual(presentationOptions, [.alert, .badge, .sound])
-        }
+        XCTAssertEqual(presentationOptions, [.list, .banner, .badge, .sound])
     }
 
     // MARK: - openSettingsFor

--- a/Tests/MessagingPush/NSE/NSEPushCoordinatorTests.swift
+++ b/Tests/MessagingPush/NSE/NSEPushCoordinatorTests.swift
@@ -7,7 +7,6 @@ import SharedTests
 import UserNotifications
 import XCTest
 
-@available(iOS 13.0, *)
 class NSEPushCoordinatorTests: UnitTest {
     private var contentHandlerInvocations: [UNNotificationContent]!
     private var deliveryTrackingMock: RichPushDeliveryTrackingMock!


### PR DESCRIPTION
## Summary
- remove source compatibility branches that became unreachable after the iOS 15 floor
- preserve public APIs, lifecycle ownership, push routing, and Inbox visual/ownership behavior
- keep the change stacked on the coordinated iOS 15 floor PR #1206

## Validation
- full package build-for-testing passed on Xcode 26.6
- focused changed-module tests passed: deployment manifest 1, DataPipeline 11, Location 17, Geofence 5, MessagingInbox 58, MessagingPush 22
- APN UIKit sample build passed
- strict SwiftLint passed with 0 violations across 719 files
- API docs and diff checks passed
- Claude Opus adversarial review accepted the corrected boundary; independent root review confirmed no lifecycle ownership or routing changes

## Residual boundary
The launch-performance UI test bundle compiled, but local execution hung while Xcode materialized a debugger-version worker and was interrupted after 212 seconds. This is not claimed as runtime evidence.

Linear: MBL-2279