### PR TITLE
docs: define Xcode 27 delivery and review order

### DIFF
--- a/docs/dev-notes/IOS27-DELIVERY-AND-REVIEW-PLAN.md
+++ b/docs/dev-notes/IOS27-DELIVERY-AND-REVIEW-PLAN.md
@@ -18,14 +18,15 @@ Keep released SDK behavior unchanged while adding continuous Xcode 27 compile ev
 | Order | PR | Target | What it changes | Release effect |
 | --- | --- | --- | --- | --- |
 | 1 | [mobile-ci-tools #15](https://github.com/customerio/mobile-ci-tools/pull/15) | `main` | Shared toolchain report and major-version validation | No SDK release |
-| 2 | [Flutter #388](https://github.com/customerio/customerio-flutter/pull/388) | `main` | Pins both sample apps to Flutter 3.44.8, the first stable version with the Xcode 27 lipo fix | No package release; keep a `ci:` or `chore:` title |
-| 3 | [iOS #1208](https://github.com/customerio/customerio-ios/pull/1208) | `main` | Normalizes generated CocoaPods sample targets for Xcode 27 | No SDK release; retitle from `fix:` to `ci:` before merge |
-| 4 | [Flutter #389](https://github.com/customerio/customerio-flutter/pull/389) | `main` | Applies the same normalization to the Flutter CocoaPods sample | No package release; retitle from `fix:` to `ci:` before merge |
-| 5 | [iOS #1213](https://github.com/customerio/customerio-ios/pull/1213) | `main`, after #1208 | Xcode 26.6 and Xcode 27 matrix for APN/SwiftPM and FCM/CocoaPods | No SDK release |
-| 6 | [Flutter #392](https://github.com/customerio/customerio-flutter/pull/392) | `main`, after #388 and #389 | Xcode 26.6 and Xcode 27 matrix for Flutter SwiftPM and CocoaPods | No package release |
-| 7 | [Expo #389](https://github.com/customerio/customerio-expo-plugin/pull/389) | `main`, after mobile-ci-tools #15 | Adds Xcode 27 APN/FCM cells to the existing latest-Expo PR matrix | No package release |
+| 2 | [Flutter #393](https://github.com/customerio/customerio-flutter/pull/393) | `main` | Keeps the ordinary floating-Flutter checks deterministic after Flutter 3.47 and fails API extraction closed | No package release |
+| 3 | [Flutter #388](https://github.com/customerio/customerio-flutter/pull/388) | `main` | Pins both sample apps to Flutter 3.44.8, the first stable version with the Xcode 27 lipo fix | No package release; keep a `ci:` or `chore:` title |
+| 4 | [iOS #1208](https://github.com/customerio/customerio-ios/pull/1208) | `main` | Normalizes generated CocoaPods sample targets for Xcode 27 | No SDK release; keep a `ci:` title |
+| 5 | [Flutter #389](https://github.com/customerio/customerio-flutter/pull/389) | `main` | Applies the same normalization to the Flutter CocoaPods sample | No package release; keep a `ci:` title |
+| 6 | [iOS #1213](https://github.com/customerio/customerio-ios/pull/1213) | `main`, after #1208 | Xcode 26.6 and Xcode 27 matrix for APN/SwiftPM and FCM/CocoaPods | No SDK release |
+| 7 | [Flutter #392](https://github.com/customerio/customerio-flutter/pull/392) | `main`, after #393, #388, and #389 | Xcode 26.6 and Xcode 27 matrix for Flutter SwiftPM and CocoaPods | No package release |
+| 8 | [Expo #389](https://github.com/customerio/customerio-expo-plugin/pull/389) | `main`, after mobile-ci-tools #15 | Adds Xcode 27 APN/FCM cells to the existing latest-Expo PR matrix | No package release |
 
-Orders 2 through 4 are independent after review and may merge in parallel. After their prerequisites merge, rebase #1213 and #392 onto current `main`, retarget them to `main`, and delete Flutter's temporary `codex/mbl-2248-flutter-xcode27-prereqs` branch. After mobile-ci-tools #15 merges, update every consumer to its final merge commit SHA.
+Orders 2 through 5 are independent after review and may merge in parallel. After their prerequisites merge, rebase #1213 and #392 onto current `main`, retarget them to `main`, and delete Flutter's temporary `codex/mbl-2248-flutter-xcode27-prereqs` branch. After mobile-ci-tools #15 merges, update every consumer to its final merge commit SHA.
 
 These CI and sample-tooling PRs may merge directly to `main`. A feature branch would add coordination cost without protecting users because they contain no production runtime behavior and their semantic titles must not request a package release.
 

--- a/docs/dev-notes/IOS27-DELIVERY-AND-REVIEW-PLAN.md
+++ b/docs/dev-notes/IOS27-DELIVERY-AND-REVIEW-PLAN.md
@@ -2,66 +2,71 @@
 
 ## Goal
 
-Keep released SDK behavior unchanged while adding continuous Xcode 27 compile evidence. Runtime lifecycle changes ship later as one complete, backward-compatible feature, after native ownership and wrapper forwarding are proven together.
+Add continuous Xcode 27 compile evidence without changing released SDK behavior. Runtime lifecycle work ships later as one complete backward-compatible feature after native ownership and wrapper forwarding are proven together.
 
-## CI design reviewers should expect
+## Permanent CI design
 
-- The supported Xcode 26.x cell remains blocking.
-- The floating Xcode 27 preview cell runs the same fixture and is non-blocking until Xcode 27 is stable.
-- One shared `mobile-ci-tools` action records the hosted image, macOS, architecture, Xcode build, SDKs, and runtimes. SDK repositories do not copy exact-beta guards.
-- Exact beta-image validation is retained only in clearly labeled test-only PRs.
-- Expo preview cells run only in pull-request compatibility CI. They do not gate npm release.
-- When Xcode 27 is stable, replace the preview runner/version, make the cells blocking, and remove preview-specific wording.
+- Stable controls run the same fixture on `macos-26` with Xcode 26.6 and are blocking when the path-scoped workflow runs.
+- Preview cells run on the floating `xcode-27` hosted label. The setup action leaves the image-bundled Xcode selected, then the shared reporter fails closed unless Xcode and the iOS SDK are major version 27.
+- Preview cells use `continue-on-error: true` and must not be configured as required branch-protection checks. Path-scoped stable checks also need an always-run fallback before they can be universally required.
+- New matrices pin `report-toolchain/v1` to an immutable `mobile-ci-tools` commit. Existing release/test workflows that reference other `mobile-ci-tools` actions through `@main` are outside this rollout and are not repinned.
+- Exact beta-image validation remains only in clearly titled test-only PRs. It is point-in-time diagnostic evidence, not permanent CI.
+- When Xcode 27 becomes stable, replace `xcode-27` with the supported stable runner/version, make those cells blocking, and remove preview wording.
 
 ## Merge order
 
-| Order | PR | Target | What it changes | Release effect |
-| --- | --- | --- | --- | --- |
-| 1 | [mobile-ci-tools #15](https://github.com/customerio/mobile-ci-tools/pull/15) | `main` | Shared toolchain report and major-version validation | No SDK release |
-| 2 | [Flutter #393](https://github.com/customerio/customerio-flutter/pull/393) | `main` | Keeps the ordinary floating-Flutter checks deterministic after Flutter 3.47 and fails API extraction closed | No package release |
-| 3 | [Flutter #388](https://github.com/customerio/customerio-flutter/pull/388) | `main` | Pins both sample apps to Flutter 3.44.8, the first stable version with the Xcode 27 lipo fix | No package release; keep a `ci:` or `chore:` title |
-| 4 | [iOS #1208](https://github.com/customerio/customerio-ios/pull/1208) | `main` | Normalizes generated CocoaPods sample targets for Xcode 27 | No SDK release; keep a `ci:` title |
-| 5 | [Flutter #389](https://github.com/customerio/customerio-flutter/pull/389) | `main` | Applies the same normalization to the Flutter CocoaPods sample | No package release; keep a `ci:` title |
-| 6 | [iOS #1213](https://github.com/customerio/customerio-ios/pull/1213) | `main`, after #1208 | Xcode 26.6 and Xcode 27 matrix for APN/SwiftPM and FCM/CocoaPods | No SDK release |
-| 7 | [Flutter #392](https://github.com/customerio/customerio-flutter/pull/392) | `main`, after #393, #388, and #389 | Xcode 26.6 and Xcode 27 matrix for Flutter SwiftPM and CocoaPods | No package release |
-| 8 | [Expo #389](https://github.com/customerio/customerio-expo-plugin/pull/389) | `main`, after mobile-ci-tools #15 | Adds Xcode 27 APN/FCM cells to the existing latest-Expo PR matrix | No package release |
+| Order | PR | Current base | Must merge first | Final target and purpose | Release effect |
+| --- | --- | --- | --- | --- | --- |
+| 1 | [mobile-ci-tools #15](https://github.com/customerio/mobile-ci-tools/pull/15) | `main` | None | `main`: add the shared reporter as a new action | No SDK release |
+| 2 | [Flutter #393](https://github.com/customerio/customerio-flutter/pull/393) | `main` | None | `main`: keep floating-Flutter CI deterministic | No package release |
+| 3 | [Flutter #388](https://github.com/customerio/customerio-flutter/pull/388) | `main` | None | `main`: pin samples to Flutter 3.44.8 with the Xcode 27 lipo fix | No package release |
+| 4 | [iOS #1208](https://github.com/customerio/customerio-ios/pull/1208) | `main` | None | `main`: normalize generated CocoaPods sample targets | No SDK release |
+| 5 | [Flutter #389](https://github.com/customerio/customerio-flutter/pull/389) | `main` | None | `main`: normalize the Flutter CocoaPods sample | No package release |
+| 6 | [Expo #389](https://github.com/customerio/customerio-expo-plugin/pull/389) | `main` | mobile-ci-tools #15 | `main`: add stable/preview APN and FCM cells | No package release |
+| 7 | [iOS #1213](https://github.com/customerio/customerio-ios/pull/1213) | `codex/mbl-2278-cocoapods-target-normalization` | mobile-ci-tools #15, iOS #1208 | Rebase and retarget to `main`: add native APN and FCM stable/preview cells | No SDK release |
+| 8 | [Flutter #392](https://github.com/customerio/customerio-flutter/pull/392) | `codex/mbl-2248-flutter-xcode27-prereqs` | mobile-ci-tools #15, Flutter #393, Flutter #388, Flutter #389 | Rebase and retarget to `main`: add SwiftPM and CocoaPods stable/preview cells | No package release |
 
-Orders 2 through 5 are independent after review and may merge in parallel. After their prerequisites merge, rebase #1213 and #392 onto current `main`, retarget them to `main`, and delete Flutter's temporary `codex/mbl-2248-flutter-xcode27-prereqs` branch. After mobile-ci-tools #15 merges, update every consumer to its final merge commit SHA.
+Orders 2 through 5 are independent and may merge in parallel. Use squash merge with the reviewed `ci:` or `chore:` title. This matters because semantic-release runs on `main`; preserving a release-bearing `feat:` or `fix:` commit from branch history could publish a package.
 
-These CI and sample-tooling PRs may merge directly to `main`. A feature branch would add coordination cost without protecting users because they contain no production runtime behavior and their semantic titles must not request a package release.
+After mobile-ci-tools #15 squash-merges, update only these three new reporter references to its final merge SHA: Expo #389, iOS #1213, and Flutter #392. Rerun their matrices. Do not repo-wide repin unrelated existing `mobile-ci-tools@main` consumers. The action is additive, so rollback before consumer merge is simply reverting #15; after a consumer matrix merges, revert that matrix first.
+
+After the other prerequisites merge, rebase iOS #1213 and Flutter #392 onto current `main`, retarget them to `main`, and rerun exact-head checks. Delete Flutter's temporary `codex/mbl-2248-flutter-xcode27-prereqs` branch after #392 is retargeted.
+
+These CI and sample-tooling PRs may merge directly to `main` because they do not change published runtime code and their squash titles do not request a semantic release. No feature branch is required for this CI rollout.
 
 ## Test-only PRs, never merge
 
 | PR | Purpose | Close when |
 | --- | --- | --- |
-| [iOS #1205](https://github.com/customerio/customerio-ios/pull/1205) | Exact Xcode 27 beta 4 native baseline | #1213 has retained hosted stable/preview evidence |
-| [Flutter #386](https://github.com/customerio/customerio-flutter/pull/386) | Exact beta baseline and original Flutter lipo diagnosis | #392 has retained hosted evidence |
-| [Expo #386](https://github.com/customerio/customerio-expo-plugin/pull/386) | Exact beta Expo 57 FCM baseline | Expo #389 has retained hosted evidence |
+| [iOS #1205](https://github.com/customerio/customerio-ios/pull/1205) | Exact Xcode 27 beta 4 native baseline | iOS #1213 records retained stable/preview evidence |
+| [Flutter #386](https://github.com/customerio/customerio-flutter/pull/386) | Exact beta baseline and original Flutter lipo diagnosis | Flutter #392 records retained stable/preview evidence |
+| [Expo #386](https://github.com/customerio/customerio-expo-plugin/pull/386) | Exact beta Expo 57 FCM baseline | Expo #389 records retained stable/preview evidence |
 
-These PRs intentionally pin a moving preview image. Keep their run links for diagnosis, then close them without merging.
+Before closing a test-only PR, copy its exact run/job IDs, image/Xcode build, result, and diagnostic conclusion into the corresponding mergeable PR body. Do not rely on expiring Actions logs or artifacts as the only durable record.
 
 ## Runtime lifecycle work is a later release
 
-Do not merge the lifecycle runtime PRs merely because the CI matrix is green. CI compilation proves source compatibility, not callback ownership or delivery.
+Compile matrices prove source compatibility only. They do not prove callback ownership, delivery, or backward compatibility, so lifecycle runtime PRs remain draft.
 
-The runtime release sequence is:
+Runtime release order:
 
-1. Correct and freeze the lifecycle contract, including explicit host topology and callback-seat rules.
-2. Complete the native coordinator and notification-delegate composition on a native integration branch.
-3. Prove backward compatibility for existing AppDelegate-only hosts and correctness for scene-based hosts.
-4. Publish a native beta and validate real wrapper consumers against it.
-5. Re-vendor the final contract into Flutter, Expo, and React Native, then capture supported lifecycle paths.
-6. Merge one complete native release-bearing PR to `main`, release native, update wrappers to the released native version, and release each wrapper independently.
+1. Correct and freeze the lifecycle contract with explicit host topology and callback-seat rules.
+2. Complete the native coordinator and notification-delegate composition on an integration branch.
+3. Prove AppDelegate-only backward compatibility and scene-based correctness.
+4. Publish the complete native candidate from the repository's `beta` prerelease branch and validate real wrapper consumers against it.
+5. Re-vendor the final contract into Flutter, Expo, and React Native and capture supported lifecycle paths.
+6. Squash-merge one complete native release-bearing PR to `main`, release native, then update and release each wrapper independently.
 
-Current lifecycle PRs remain draft until that sequence is satisfied. In particular, native delegate-composition PR #1211 and the obsolete contract/wrapper heads must resolve their adversarial-review blockers before they are merge candidates.
+Native delegate-composition PR [#1211](https://github.com/customerio/customerio-ios/pull/1211) and the current contract/wrapper drafts are not merge candidates until their recorded adversarial-review blockers are resolved.
 
-## Required review gate for every mergeable PR
+## Required gate before removing draft status
 
-- Exact head and base are recorded.
-- Stable and preview cells exercise the intended same fixture.
-- Stable cells are green.
-- Preview failures, if any, are classified as toolchain, fixture-preparation, or SDK compile failures.
-- Release workflows and semantic titles do not publish a package for CI-only changes.
-- Generated lockfiles and sample projects have no unexplained churn.
-- A fresh Claude Opus adversarial review returns an actual verdict on the exact head. A timeout, quota failure, or empty output is not acceptance.
-- All actionable findings are reproduced, reconciled, and re-reviewed before draft removal.
+- Record the exact head and current base in the PR body.
+- Confirm the stable and preview cells exercise the same fixture and dependency setup.
+- Require green stable cells. Classify any preview failure as toolchain, fixture-setup, or SDK-compile failure.
+- Confirm release workflows and squash titles do not request a package release.
+- Confirm generated locks and sample projects have no unexplained churn.
+- Run the Customer.io source-command review manually with Claude Opus against the exact head. Record the substantive verdict in the PR body; empty output, timeout, or quota failure is not acceptance.
+- Reproduce and reconcile every actionable finding, then obtain an exact-head ACCEPT or a documented independent dismissal with evidence.
+
+Delete this dev note after all three permanent matrices merge and the three test-only PRs close.

--- a/docs/dev-notes/IOS27-DELIVERY-AND-REVIEW-PLAN.md
+++ b/docs/dev-notes/IOS27-DELIVERY-AND-REVIEW-PLAN.md
@@ -65,7 +65,7 @@ This gate applies to Expo #389, iOS #1213, and Flutter #392. Lifecycle PRs are a
 
 - Record the exact head and current base in the PR body.
 - Confirm the stable and preview cells exercise the same fixture and dependency setup.
-- Require green stable cells. Classify any preview failure as toolchain, fixture-setup, or SDK-compile failure. Record a toolchain or fixture-setup failure in the PR body as non-blocking evidence. Record an SDK-compile failure and file a tracked source-compatibility issue; the additive matrix may still merge because preview cells are explicitly non-blocking.
+- Require stable cells that actually ran on the exact head and are green. A skipped or filtered-out stable job is not evidence and must be rerun. Classify any preview failure as toolchain, fixture-setup, or SDK-compile failure. Record a toolchain or fixture-setup failure in the PR body as non-blocking evidence. Record an SDK-compile failure and file a tracked source-compatibility issue; the additive matrix may still merge because preview cells are explicitly non-blocking.
 - Confirm release workflows and squash titles do not request a package release.
 - Confirm generated locks and sample projects have no unexplained churn.
 - Run the Customer.io source-command review manually with Claude Opus against the exact head. Record the substantive verdict in the PR body; empty output, timeout, or quota failure is not acceptance.

--- a/docs/dev-notes/IOS27-DELIVERY-AND-REVIEW-PLAN.md
+++ b/docs/dev-notes/IOS27-DELIVERY-AND-REVIEW-PLAN.md
@@ -6,10 +6,10 @@ Add continuous Xcode 27 compile evidence without changing released SDK behavior.
 
 ## Permanent CI design
 
-- Stable controls run the same fixture on `macos-26` with Xcode 26.6 and are blocking when the path-scoped workflow runs.
-- Preview cells run on the floating `xcode-27` hosted label. The setup action leaves the image-bundled Xcode selected, then the shared reporter fails closed unless Xcode and the iOS SDK are major version 27.
-- Preview cells use `continue-on-error: true` and must not be configured as required branch-protection checks. Path-scoped stable checks also need an always-run fallback before they can be universally required.
-- New matrices pin `customerio/mobile-ci-tools/github-actions/ios/report-toolchain/v1@<merge-sha>` to an immutable commit. Existing release/test workflows that reference other `mobile-ci-tools` actions through `@main` are outside this rollout and are not repinned.
+- Existing stable CI remains the blocking release gate and is not duplicated by this rollout.
+- New preview jobs run nightly on the floating `xcode-27` hosted label. The setup action leaves the image-bundled Xcode selected, then the shared reporter fails closed unless Xcode and the iOS SDK are major version 27.
+- Preview jobs use `continue-on-error: true` and must not be configured as required branch-protection checks.
+- The new workflows reference the first-party reporter as `customerio/mobile-ci-tools/github-actions/ios/report-toolchain/v1@main`, matching existing Customer.io usage. Breaking reporter changes require a new versioned action path.
 - Exact beta-image validation remains only in clearly titled test-only PRs. It is point-in-time diagnostic evidence, not permanent CI.
 - When Xcode 27 becomes stable, replace `xcode-27` with the supported stable runner/version, make those cells blocking, and remove preview wording.
 
@@ -22,13 +22,13 @@ Add continuous Xcode 27 compile evidence without changing released SDK behavior.
 | 3 | [Flutter #388](https://github.com/customerio/customerio-flutter/pull/388) | `main` | None | `main`: pin samples to Flutter 3.44.8 with the Xcode 27 lipo fix | No package release |
 | 4 | [iOS #1208](https://github.com/customerio/customerio-ios/pull/1208) | `main` | None | `main`: normalize generated CocoaPods sample targets | No SDK release |
 | 5 | [Flutter #389](https://github.com/customerio/customerio-flutter/pull/389) | `main` | None | `main`: normalize the Flutter CocoaPods sample | No package release |
-| 6 | [Expo #389](https://github.com/customerio/customerio-expo-plugin/pull/389) | `main` | mobile-ci-tools #15 | `main`: add stable/preview APN and FCM cells | No package release |
-| 7 | [iOS #1213](https://github.com/customerio/customerio-ios/pull/1213) | `codex/mbl-2278-cocoapods-target-normalization` | mobile-ci-tools #15, iOS #1208 | Rebase and retarget to `main`: add native APN and FCM stable/preview cells | No SDK release |
-| 8 | [Flutter #392](https://github.com/customerio/customerio-flutter/pull/392) | `codex/mbl-2248-flutter-xcode27-prereqs` | mobile-ci-tools #15, Flutter #393, Flutter #388, Flutter #389 | Rebase and retarget to `main`: add SwiftPM and CocoaPods stable/preview cells | No package release |
+| 6 | [Expo #389](https://github.com/customerio/customerio-expo-plugin/pull/389) | `main` | mobile-ci-tools #15 | `main`: add nightly Xcode 27 APN and FCM jobs | No package release |
+| 7 | [iOS #1213](https://github.com/customerio/customerio-ios/pull/1213) | `codex/mbl-2278-cocoapods-target-normalization` | mobile-ci-tools #15, iOS #1208 | Rebase and retarget to `main`: add nightly native APN and FCM jobs | No SDK release |
+| 8 | [Flutter #392](https://github.com/customerio/customerio-flutter/pull/392) | `codex/mbl-2248-flutter-xcode27-prereqs` | mobile-ci-tools #15, Flutter #393, Flutter #388, Flutter #389 | Rebase and retarget to `main`: add nightly SwiftPM and CocoaPods jobs | No package release |
 
 Orders 2 through 5 are independent and may merge in parallel. Use squash merge with the reviewed `ci:` or `chore:` title. This matters because semantic-release runs on `main`; preserving a release-bearing `feat:` or `fix:` commit from branch history could publish a package.
 
-After mobile-ci-tools #15 squash-merges, update only these three new reporter references to its final merge SHA: Expo #389, iOS #1213, and Flutter #392. Rerun their matrices. Do not repo-wide repin unrelated existing `mobile-ci-tools@main` consumers. The action is additive, so rollback before consumer merge is simply reverting #15; after a consumer matrix merges, revert that matrix first.
+Mobile-ci-tools #15 is merged. Expo #389, iOS #1213, and Flutter #392 use the reporter from `@main`, consistent with existing first-party action references. The action is additive, so rollback before consumer merge is simply reverting #15; after a consumer workflow merges, revert that workflow first.
 
 After the other prerequisites merge, rebase iOS #1213 and Flutter #392 onto current `main`, retarget them to `main`, and rerun exact-head checks. Delete Flutter's temporary `codex/mbl-2248-flutter-xcode27-prereqs` branch after #392 is retargeted.
 
@@ -64,8 +64,8 @@ Native delegate-composition PR [#1211](https://github.com/customerio/customerio-
 This gate applies to Expo #389, iOS #1213, and Flutter #392. Lifecycle PRs are additionally gated by the runtime release order above.
 
 - Record the exact head and current base in the PR body.
-- Confirm the stable and preview cells exercise the same fixture and dependency setup.
-- Require stable cells that actually ran on the exact head and are green. A skipped or filtered-out stable job is not evidence and must be forced to run on the exact head through `workflow_dispatch` or an always-run fallback. Classify any preview failure as toolchain, fixture-setup, or SDK-compile failure. Record a toolchain or fixture-setup failure in the PR body as non-blocking evidence. Record an SDK-compile failure and file a tracked source-compatibility issue; the additive matrix may still merge because preview cells are explicitly non-blocking.
+- Confirm the existing stable workflow and new preview job exercise the same fixture and dependency shape.
+- Require the existing stable workflow to be green on the exact head. Classify any preview failure as toolchain, fixture-setup, or SDK-compile failure. Record a toolchain or fixture-setup failure in the PR body as non-blocking evidence. Record an SDK-compile failure and file a tracked source-compatibility issue; the additive preview workflow may still merge because preview jobs are explicitly non-blocking.
 - Confirm release workflows and squash titles do not request a package release.
 - Confirm generated locks and sample projects have no unexplained churn.
 - Run the Customer.io source-command review manually with Claude Opus against the exact head. Record the substantive verdict in the PR body; empty output, timeout, or quota failure is not acceptance.

--- a/docs/dev-notes/IOS27-DELIVERY-AND-REVIEW-PLAN.md
+++ b/docs/dev-notes/IOS27-DELIVERY-AND-REVIEW-PLAN.md
@@ -9,7 +9,7 @@ Add continuous Xcode 27 compile evidence without changing released SDK behavior.
 - Stable controls run the same fixture on `macos-26` with Xcode 26.6 and are blocking when the path-scoped workflow runs.
 - Preview cells run on the floating `xcode-27` hosted label. The setup action leaves the image-bundled Xcode selected, then the shared reporter fails closed unless Xcode and the iOS SDK are major version 27.
 - Preview cells use `continue-on-error: true` and must not be configured as required branch-protection checks. Path-scoped stable checks also need an always-run fallback before they can be universally required.
-- New matrices pin `report-toolchain/v1` to an immutable `mobile-ci-tools` commit. Existing release/test workflows that reference other `mobile-ci-tools` actions through `@main` are outside this rollout and are not repinned.
+- New matrices pin `customerio/mobile-ci-tools/github-actions/ios/report-toolchain/v1@<merge-sha>` to an immutable commit. Existing release/test workflows that reference other `mobile-ci-tools` actions through `@main` are outside this rollout and are not repinned.
 - Exact beta-image validation remains only in clearly titled test-only PRs. It is point-in-time diagnostic evidence, not permanent CI.
 - When Xcode 27 becomes stable, replace `xcode-27` with the supported stable runner/version, make those cells blocking, and remove preview wording.
 
@@ -61,9 +61,11 @@ Native delegate-composition PR [#1211](https://github.com/customerio/customerio-
 
 ## Required gate before removing draft status
 
+This gate applies to Expo #389, iOS #1213, and Flutter #392. Lifecycle PRs are additionally gated by the runtime release order above.
+
 - Record the exact head and current base in the PR body.
 - Confirm the stable and preview cells exercise the same fixture and dependency setup.
-- Require green stable cells. Classify any preview failure as toolchain, fixture-setup, or SDK-compile failure.
+- Require green stable cells. Classify any preview failure as toolchain, fixture-setup, or SDK-compile failure. Record a toolchain or fixture-setup failure in the PR body as non-blocking evidence. Record an SDK-compile failure and file a tracked source-compatibility issue; the additive matrix may still merge because preview cells are explicitly non-blocking.
 - Confirm release workflows and squash titles do not request a package release.
 - Confirm generated locks and sample projects have no unexplained churn.
 - Run the Customer.io source-command review manually with Claude Opus against the exact head. Record the substantive verdict in the PR body; empty output, timeout, or quota failure is not acceptance.

--- a/docs/dev-notes/IOS27-DELIVERY-AND-REVIEW-PLAN.md
+++ b/docs/dev-notes/IOS27-DELIVERY-AND-REVIEW-PLAN.md
@@ -1,0 +1,66 @@
+# Xcode 27 delivery and PR review plan
+
+## Goal
+
+Keep released SDK behavior unchanged while adding continuous Xcode 27 compile evidence. Runtime lifecycle changes ship later as one complete, backward-compatible feature, after native ownership and wrapper forwarding are proven together.
+
+## CI design reviewers should expect
+
+- The supported Xcode 26.x cell remains blocking.
+- The floating Xcode 27 preview cell runs the same fixture and is non-blocking until Xcode 27 is stable.
+- One shared `mobile-ci-tools` action records the hosted image, macOS, architecture, Xcode build, SDKs, and runtimes. SDK repositories do not copy exact-beta guards.
+- Exact beta-image validation is retained only in clearly labeled test-only PRs.
+- Expo preview cells run only in pull-request compatibility CI. They do not gate npm release.
+- When Xcode 27 is stable, replace the preview runner/version, make the cells blocking, and remove preview-specific wording.
+
+## Merge order
+
+| Order | PR | Target | What it changes | Release effect |
+| --- | --- | --- | --- | --- |
+| 1 | [mobile-ci-tools #15](https://github.com/customerio/mobile-ci-tools/pull/15) | `main` | Shared toolchain report and major-version validation | No SDK release |
+| 2 | [Flutter #388](https://github.com/customerio/customerio-flutter/pull/388) | `main` | Pins both sample apps to Flutter 3.44.8, the first stable version with the Xcode 27 lipo fix | No package release; keep a `ci:` or `chore:` title |
+| 3 | [iOS #1208](https://github.com/customerio/customerio-ios/pull/1208) | `main` | Normalizes generated CocoaPods sample targets for Xcode 27 | No SDK release; retitle from `fix:` to `ci:` before merge |
+| 4 | [Flutter #389](https://github.com/customerio/customerio-flutter/pull/389) | `main` | Applies the same normalization to the Flutter CocoaPods sample | No package release; retitle from `fix:` to `ci:` before merge |
+| 5 | [iOS #1213](https://github.com/customerio/customerio-ios/pull/1213) | `main`, after #1208 | Xcode 26.6 and Xcode 27 matrix for APN/SwiftPM and FCM/CocoaPods | No SDK release |
+| 6 | [Flutter #392](https://github.com/customerio/customerio-flutter/pull/392) | `main`, after #388 and #389 | Xcode 26.6 and Xcode 27 matrix for Flutter SwiftPM and CocoaPods | No package release |
+| 7 | [Expo #389](https://github.com/customerio/customerio-expo-plugin/pull/389) | `main`, after mobile-ci-tools #15 | Adds Xcode 27 APN/FCM cells to the existing latest-Expo PR matrix | No package release |
+
+Orders 2 through 4 are independent after review and may merge in parallel. After their prerequisites merge, rebase #1213 and #392 onto current `main`, retarget them to `main`, and delete Flutter's temporary `codex/mbl-2248-flutter-xcode27-prereqs` branch. After mobile-ci-tools #15 merges, update every consumer to its final merge commit SHA.
+
+These CI and sample-tooling PRs may merge directly to `main`. A feature branch would add coordination cost without protecting users because they contain no production runtime behavior and their semantic titles must not request a package release.
+
+## Test-only PRs, never merge
+
+| PR | Purpose | Close when |
+| --- | --- | --- |
+| [iOS #1205](https://github.com/customerio/customerio-ios/pull/1205) | Exact Xcode 27 beta 4 native baseline | #1213 has retained hosted stable/preview evidence |
+| [Flutter #386](https://github.com/customerio/customerio-flutter/pull/386) | Exact beta baseline and original Flutter lipo diagnosis | #392 has retained hosted evidence |
+| [Expo #386](https://github.com/customerio/customerio-expo-plugin/pull/386) | Exact beta Expo 57 FCM baseline | Expo #389 has retained hosted evidence |
+
+These PRs intentionally pin a moving preview image. Keep their run links for diagnosis, then close them without merging.
+
+## Runtime lifecycle work is a later release
+
+Do not merge the lifecycle runtime PRs merely because the CI matrix is green. CI compilation proves source compatibility, not callback ownership or delivery.
+
+The runtime release sequence is:
+
+1. Correct and freeze the lifecycle contract, including explicit host topology and callback-seat rules.
+2. Complete the native coordinator and notification-delegate composition on a native integration branch.
+3. Prove backward compatibility for existing AppDelegate-only hosts and correctness for scene-based hosts.
+4. Publish a native beta and validate real wrapper consumers against it.
+5. Re-vendor the final contract into Flutter, Expo, and React Native, then capture supported lifecycle paths.
+6. Merge one complete native release-bearing PR to `main`, release native, update wrappers to the released native version, and release each wrapper independently.
+
+Current lifecycle PRs remain draft until that sequence is satisfied. In particular, native delegate-composition PR #1211 and the obsolete contract/wrapper heads must resolve their adversarial-review blockers before they are merge candidates.
+
+## Required review gate for every mergeable PR
+
+- Exact head and base are recorded.
+- Stable and preview cells exercise the intended same fixture.
+- Stable cells are green.
+- Preview failures, if any, are classified as toolchain, fixture-preparation, or SDK compile failures.
+- Release workflows and semantic titles do not publish a package for CI-only changes.
+- Generated lockfiles and sample projects have no unexplained churn.
+- A fresh Claude Opus adversarial review returns an actual verdict on the exact head. A timeout, quota failure, or empty output is not acceptance.
+- All actionable findings are reproduced, reconciled, and re-reviewed before draft removal.

--- a/docs/dev-notes/IOS27-DELIVERY-AND-REVIEW-PLAN.md
+++ b/docs/dev-notes/IOS27-DELIVERY-AND-REVIEW-PLAN.md
@@ -65,7 +65,7 @@ This gate applies to Expo #389, iOS #1213, and Flutter #392. Lifecycle PRs are a
 
 - Record the exact head and current base in the PR body.
 - Confirm the stable and preview cells exercise the same fixture and dependency setup.
-- Require stable cells that actually ran on the exact head and are green. A skipped or filtered-out stable job is not evidence and must be rerun. Classify any preview failure as toolchain, fixture-setup, or SDK-compile failure. Record a toolchain or fixture-setup failure in the PR body as non-blocking evidence. Record an SDK-compile failure and file a tracked source-compatibility issue; the additive matrix may still merge because preview cells are explicitly non-blocking.
+- Require stable cells that actually ran on the exact head and are green. A skipped or filtered-out stable job is not evidence and must be forced to run on the exact head through `workflow_dispatch` or an always-run fallback. Classify any preview failure as toolchain, fixture-setup, or SDK-compile failure. Record a toolchain or fixture-setup failure in the PR body as non-blocking evidence. Record an SDK-compile failure and file a tracked source-compatibility issue; the additive matrix may still merge because preview cells are explicitly non-blocking.
 - Confirm release workflows and squash titles do not request a package release.
 - Confirm generated locks and sample projects have no unexplained churn.
 - Run the Customer.io source-command review manually with Claude Opus against the exact head. Record the substantive verdict in the PR body; empty output, timeout, or quota failure is not acceptance.


### PR DESCRIPTION
## Summary

- defines the rollout architecture: existing stable CI remains the blocking release gate, while Xcode 27 runs as separate nightly preview monitoring
- records the exact PR merge order, current bases, final targets, and dependencies
- records first-party use of the path-versioned mobile-ci-tools reporter through `@main`
- separates mergeable CI/sample tooling from exact-beta test-only evidence
- defines squash/release semantics, rollback order, durable evidence, and the later native-beta/runtime path

## Review result

- Customer.io Claude Opus execution-contract review initially rejected ambiguous dependency, release, and evidence wording
- every P1/P2 was reconciled and re-reviewed
- final exact-head verdict: ACCEPT, no findings

## Validation

- `git diff --check`
- previous exact-head Xcode 26.6 sample builds and automated checks were green
- local SwiftLint hook is currently blocked by a SourceKitten `sourcekitdInProc` load crash; hosted lint is the authoritative check

## Release impact

Documentation only. No SDK behavior or package release.

Delete this dev note after the three nightly preview workflows merge and the three test-only PRs close.
