### PR TITLE
chore(geofence): refuse OS transitions a fresh fix geometrically contradicts

### DIFF
--- a/Sources/LocationGeofence/GeofenceConstants.swift
+++ b/Sources/LocationGeofence/GeofenceConstants.swift
@@ -47,8 +47,9 @@ enum GeofenceConstants {
 
     /// How long after a condition's (re)add the contradiction gate vets its events. The daemon's
     /// belief replays land 0.003–3.3 s after the add (measured across every reproduction); the
-    /// window adds slack for pipeline-drain latency. Events outside it are never gated, so a
-    /// normal crossing is never delayed by a fix request nor at any risk of refusal.
+    /// window adds slack for pipeline-drain latency. Events dated outside the window — before the
+    /// re-add began or beyond this bound after it (see `ConditionReadd.replayWindowCovers`) — are
+    /// never gated, so a normal crossing is never delayed by a fix request nor at any risk of refusal.
     static let contradictionGateReplayWindow: TimeInterval = 10
 
     // Sane bounds the SDK coerces server config into, so a misconfigured backend can't push

--- a/Sources/LocationGeofence/GeofenceConstants.swift
+++ b/Sources/LocationGeofence/GeofenceConstants.swift
@@ -41,6 +41,16 @@ enum GeofenceConstants {
     static let movementFixMaxAge: TimeInterval = 30
     static let movementFixRequestTimeout: TimeInterval = 10
 
+    // Floor on the baseline-heal ambiguity margin (meters): a fix closer than this to the fence
+    // edge never synthesizes a crossing, even when it reports better accuracy.
+    static let baselineHealMinEdgeMargin: Double = 20
+
+    /// How long after a condition's (re)add the contradiction gate vets its events. The daemon's
+    /// belief replays land 0.003–3.3 s after the add (measured across every reproduction); the
+    /// window adds slack for pipeline-drain latency. Events outside it are never gated, so a
+    /// normal crossing is never delayed by a fix request nor at any risk of refusal.
+    static let contradictionGateReplayWindow: TimeInterval = 10
+
     // Sane bounds the SDK coerces server config into, so a misconfigured backend can't push
     // monitoring into a pathological state: a positive out-of-range value clamps to the nearest
     // bound; a non-positive value falls back. (`maxMonitoringDistance` needs no upper bound — a

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -142,6 +142,10 @@ extension Logger {
         info("Cached fix is \(age); requesting a fresh fix for the movement pass", geofenceTag)
     }
 
+    func geofenceEventRefusedByContradiction(identifier: String, transition: GeofenceTransition, distanceFromCenter: Double, radius: Double, accuracy: Double) {
+        info("Refused OS \(transition.rawValue) for region \(identifier): a fresh fix contradicts it (distance \(Int(distanceFromCenter)) m, radius \(Int(radius)) m, accuracy \(Int(accuracy)) m)", geofenceTag)
+    }
+
     func geofenceMovementFixRequestFailed(fallingBackToCached: Bool) {
         let outcome = fallingBackToCached ? "falling back to the stale cached fix" : "no cached fix to fall back to"
         info("Fresh-fix request failed or timed out; \(outcome)", geofenceTag)

--- a/Sources/LocationGeofence/Monitor/BaselineHealDecision.swift
+++ b/Sources/LocationGeofence/Monitor/BaselineHealDecision.swift
@@ -1,0 +1,35 @@
+import CioInternalCommon
+import Foundation
+
+/// Decides whether a sync pass should synthesize a crossing for an already-registered region whose
+/// stored dedup baseline contradicts the pass's fix.
+///
+/// iOS region monitoring is conservative about promoting crossings from coarse passive fixes — a
+/// device can dwell well inside an armed fence without the OS ever generating the enter (observed
+/// on device, 2026-08-08). The sync pass carries a fresh, actively-requested fix; when that fix
+/// places the device unambiguously on the other side of the fence from the stored baseline, the
+/// crossing genuinely happened and the OS missed it — deliver it ourselves.
+///
+/// Guards, all of which SKIP the heal (today's behavior) rather than risk a fabricated event:
+/// - the fix must be recent (a stale fix says where the device was, not where it is), and
+/// - the fix's distance from the fence EDGE must exceed its horizontal accuracy (with a floor
+///   against over-optimistic accuracy values) — inside the ambiguity band, no verdict.
+enum BaselineHealDecision {
+    /// The transition to synthesize, or `nil` to leave the baseline alone.
+    static func synthesizedTransition(
+        distanceFromCenter: Double,
+        radius: Double,
+        horizontalAccuracy: Double,
+        fixAge: TimeInterval,
+        lastState: GeofenceTransition?
+    ) -> GeofenceTransition? {
+        guard let lastState else { return nil }
+        guard fixAge >= 0, fixAge <= GeofenceConstants.movementFixMaxAge else { return nil }
+        guard horizontalAccuracy > 0 else { return nil }
+        let edgeDistance = distanceFromCenter - radius
+        let margin = max(horizontalAccuracy, GeofenceConstants.baselineHealMinEdgeMargin)
+        guard abs(edgeDistance) > margin else { return nil }
+        let actual: GeofenceTransition = edgeDistance < 0 ? .enter : .exit
+        return actual == lastState ? nil : actual
+    }
+}

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+ContradictionGate.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+ContradictionGate.swift
@@ -1,0 +1,67 @@
+import CioInternalCommon
+import CoreLocation
+import Foundation
+
+/// Contradiction gate for OS-delivered transitions, split out to keep the monitor's event
+/// plumbing readable (same convention as `+Registration`).
+///
+/// CLMonitor re-adds (registration, adopt, rearm) replay the daemon's per-identifier belief as an
+/// immediate event computed WITHOUT a fresh evaluation. The belief can be stale by hours
+/// (crossings observed while the app was dead), predate the install (it persists across
+/// uninstalls), or default to unsatisfied for never-seen identifiers — producing false enters for
+/// far fences and false-exit storms when registering while inside (both field-observed; the
+/// daemon's own re-evaluation follows ~3 s later, measured).
+///
+/// The gate therefore vets only events landing inside a short window after our own (re)add of
+/// that identifier — where belief replays live — and refuses one that a fresh fix unambiguously
+/// contradicts, BEFORE the dedup baseline advances, so the daemon's re-evaluation lands as a
+/// duplicate against the untouched baseline and is absorbed silently. Everything outside the
+/// window flows exactly as before: a normal crossing is never delayed by a fix request, and a
+/// legitimate in-window corrective (rearm/wedged-crossing recovery) agrees with the fix and
+/// passes. Undecidable fixes — none, stale, or within the ambiguity margin — fail OPEN.
+@available(iOS 17.0, *)
+extension CLMonitorGeofenceMonitor {
+    /// True when the event lands inside the identifier's replay window AND a trustworthy fix
+    /// confidently contradicts it (`BaselineHealDecision` with `lastState` = the incoming
+    /// transition — a non-nil result means the fix says the opposite of what the OS delivered).
+    func isEventContradictedByFreshFix(identifier: String, transition: GeofenceTransition) async -> Bool {
+        guard let readdedAt = conditionReaddTimestamps[identifier],
+              Date().timeIntervalSince(readdedAt) <= GeofenceConstants.contradictionGateReplayWindow,
+              let condition = registeredConditions[identifier]
+        else { return false }
+        let gateFix = await resolveGateFix()
+        guard let gateFix, CLLocationCoordinate2DIsValid(gateFix.coordinate) else { return false }
+        let center = CLLocation(latitude: condition.center.latitude, longitude: condition.center.longitude)
+        let distanceFromCenter = gateFix.distance(from: center)
+        guard BaselineHealDecision.synthesizedTransition(
+            distanceFromCenter: distanceFromCenter,
+            radius: condition.radius,
+            horizontalAccuracy: gateFix.horizontalAccuracy,
+            fixAge: -gateFix.timestamp.timeIntervalSinceNow,
+            lastState: transition
+        ) != nil else { return false }
+        logger.geofenceEventRefusedByContradiction(
+            identifier: identifier,
+            transition: transition,
+            distanceFromCenter: distanceFromCenter,
+            radius: condition.radius,
+            accuracy: gateFix.horizontalAccuracy
+        )
+        return true
+    }
+
+    /// Freshest fix obtainable for the gate: reuses the movement resolver (one-shot request when
+    /// the cache is stale, coalesced across concurrent events — a replay burst re-adds many
+    /// conditions at once and every event shares one resolution — cached-fix fallback on timeout).
+    /// A cached fix is acceptable as-is: the gate only runs moments after an add that itself
+    /// positioned the staging off the same cache, so it cannot meaningfully predate the state the
+    /// event claims. Returns via `bestKnownFix()` so the freshest of the cache and the request
+    /// wins; the caller's decision applies the fix-age guard to the result.
+    private func resolveGateFix() async -> CLLocation? {
+        await withCheckedContinuation { continuation in
+            movementFixResolver.resolve(cached: bestKnownFix()) { [weak self] _ in
+                continuation.resume(returning: self?.bestKnownFix())
+            }
+        }
+    }
+}

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+ContradictionGate.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+ContradictionGate.swift
@@ -23,9 +23,23 @@ import Foundation
 extension CLMonitorGeofenceMonitor {
     /// A drained (re)add: when it landed at the OS and the circle it imposed there.
     struct ConditionReadd {
-        let date: Date
+        /// Stamped before the remove/add pair is issued. A replay is created by the add, so no
+        /// replay can be dated earlier — while an event dated before it (e.g. a catch-up buffered
+        /// in `pendingEvents` across the re-add) is provably not this add's replay.
+        let start: Date
+        /// Stamped after `add` returned; the replay window extends from here. Kept separate from
+        /// `start` because a replay can be dated inside the remove→add gap, before `add` returns.
+        let added: Date
         let center: LocationData
         let radius: Double
+
+        /// Whether an event's date falls inside this add's replay window. Both bounds matter:
+        /// without the lower one, any event dated before the add — however old — would be gated
+        /// and judged against geometry that may postdate it.
+        func replayWindowCovers(_ eventDate: Date) -> Bool {
+            eventDate >= start &&
+                eventDate.timeIntervalSince(added) <= GeofenceConstants.contradictionGateReplayWindow
+        }
     }
 
     /// True when the event lands inside the identifier's replay window AND a trustworthy fix
@@ -36,11 +50,11 @@ extension CLMonitorGeofenceMonitor {
     /// computed on the old circle must still be judged against the old circle.
     /// The window compares the EVENT's date to the add, not the processing time: an event can sit
     /// in `pendingEvents` until the bootstrap binds the handler, and a belief replay must stay
-    /// gated no matter how late it drains — while a real crossing minutes after the add stays
-    /// ungated no matter how fast it is processed.
+    /// gated no matter how late it drains — while a real crossing dated outside the window, before
+    /// the add or minutes after it, stays ungated no matter when it is processed.
     func isEventContradictedByFreshFix(identifier: String, transition: GeofenceTransition, eventDate: Date) async -> Bool {
         guard let readd = conditionReadds[identifier],
-              eventDate.timeIntervalSince(readd.date) <= GeofenceConstants.contradictionGateReplayWindow
+              readd.replayWindowCovers(eventDate)
         else { return false }
         let gateFix = await resolveGateFix()
         guard let gateFix, CLLocationCoordinate2DIsValid(gateFix.coordinate) else { return false }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+ContradictionGate.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+ContradictionGate.swift
@@ -78,17 +78,38 @@ extension CLMonitorGeofenceMonitor {
     }
 
     /// Freshest fix obtainable for the gate: reuses the movement resolver (one-shot request when
-    /// the cache is stale, coalesced across concurrent events — a replay burst re-adds many
-    /// conditions at once and every event shares one resolution — cached-fix fallback on timeout).
+    /// the cache is stale, cached-fix fallback on timeout). In a replay burst the FIRST event pays
+    /// at most one request and every later event reads the fix it delivered from the cache — the
+    /// events loop awaits `process` serially, so the resolver's in-flight coalescing never engages
+    /// and repeated requests would stack instead. When an attempt fails to produce a fresh fix,
+    /// that failure is remembered for `movementFixMaxAge` and later events skip straight to the
+    /// cache (failing open, exactly as the timed-out attempt did) — otherwise a burst with no fix
+    /// obtainable would stall the single event consumer for one timeout per gated event. A late
+    /// fix from the failed request still reaches `latestFix` and serves the rest of the burst.
     /// A cached fix is acceptable as-is: the gate only runs moments after an add that itself
     /// positioned the staging off the same cache, so it cannot meaningfully predate the state the
     /// event claims. Returns via `bestKnownFix()` so the freshest of the cache and the request
     /// wins; the caller's decision applies the fix-age guard to the result.
     private func resolveGateFix() async -> CLLocation? {
-        await withCheckedContinuation { continuation in
+        if Self.gateFixRequestBlocked(failedAt: gateFixRequestFailedAt, now: Date()) {
+            return bestKnownFix()
+        }
+        let fix: CLLocation? = await withCheckedContinuation { continuation in
             movementFixResolver.resolve(cached: bestKnownFix()) { [weak self] _ in
                 continuation.resume(returning: self?.bestKnownFix())
             }
         }
+        let isFresh = fix.map { -$0.timestamp.timeIntervalSinceNow <= GeofenceConstants.movementFixMaxAge } ?? false
+        gateFixRequestFailedAt = isFresh ? nil : Date()
+        return fix
+    }
+
+    /// Whether a new gate-fix request is skipped because the last one recently came back without
+    /// a fresh fix. Blocked for `movementFixMaxAge` after the failure: within it a re-request at
+    /// the same conditions is unlikely to fare better, and a late fix from the failed request
+    /// still lands in `latestFix` where the cache read picks it up.
+    nonisolated static func gateFixRequestBlocked(failedAt: Date?, now: Date) -> Bool {
+        guard let failedAt else { return false }
+        return now.timeIntervalSince(failedAt) < GeofenceConstants.movementFixMaxAge
     }
 }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+ContradictionGate.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+ContradictionGate.swift
@@ -21,21 +21,30 @@ import Foundation
 /// passes. Undecidable fixes — none, stale, or within the ambiguity margin — fail OPEN.
 @available(iOS 17.0, *)
 extension CLMonitorGeofenceMonitor {
+    /// A drained (re)add: when it landed at the OS and the circle it imposed there.
+    struct ConditionReadd {
+        let date: Date
+        let center: LocationData
+        let radius: Double
+    }
+
     /// True when the event lands inside the identifier's replay window AND a trustworthy fix
     /// confidently contradicts it (`BaselineHealDecision` with `lastState` = the incoming
     /// transition — a non-nil result means the fix says the opposite of what the OS delivered).
+    /// Geometry comes from the drained add's stamp, not `registeredConditions`: that map updates
+    /// synchronously when a reshape is staged, so during its staging→drain gap an event the OS
+    /// computed on the old circle must still be judged against the old circle.
     func isEventContradictedByFreshFix(identifier: String, transition: GeofenceTransition) async -> Bool {
-        guard let readdedAt = conditionReaddTimestamps[identifier],
-              Date().timeIntervalSince(readdedAt) <= GeofenceConstants.contradictionGateReplayWindow,
-              let condition = registeredConditions[identifier]
+        guard let readd = conditionReadds[identifier],
+              Date().timeIntervalSince(readd.date) <= GeofenceConstants.contradictionGateReplayWindow
         else { return false }
         let gateFix = await resolveGateFix()
         guard let gateFix, CLLocationCoordinate2DIsValid(gateFix.coordinate) else { return false }
-        let center = CLLocation(latitude: condition.center.latitude, longitude: condition.center.longitude)
+        let center = CLLocation(latitude: readd.center.latitude, longitude: readd.center.longitude)
         let distanceFromCenter = gateFix.distance(from: center)
         guard BaselineHealDecision.synthesizedTransition(
             distanceFromCenter: distanceFromCenter,
-            radius: condition.radius,
+            radius: readd.radius,
             horizontalAccuracy: gateFix.horizontalAccuracy,
             fixAge: -gateFix.timestamp.timeIntervalSinceNow,
             lastState: transition
@@ -44,7 +53,7 @@ extension CLMonitorGeofenceMonitor {
             identifier: identifier,
             transition: transition,
             distanceFromCenter: distanceFromCenter,
-            radius: condition.radius,
+            radius: readd.radius,
             accuracy: gateFix.horizontalAccuracy
         )
         return true

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+ContradictionGate.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+ContradictionGate.swift
@@ -34,9 +34,13 @@ extension CLMonitorGeofenceMonitor {
     /// Geometry comes from the drained add's stamp, not `registeredConditions`: that map updates
     /// synchronously when a reshape is staged, so during its staging→drain gap an event the OS
     /// computed on the old circle must still be judged against the old circle.
-    func isEventContradictedByFreshFix(identifier: String, transition: GeofenceTransition) async -> Bool {
+    /// The window compares the EVENT's date to the add, not the processing time: an event can sit
+    /// in `pendingEvents` until the bootstrap binds the handler, and a belief replay must stay
+    /// gated no matter how late it drains — while a real crossing minutes after the add stays
+    /// ungated no matter how fast it is processed.
+    func isEventContradictedByFreshFix(identifier: String, transition: GeofenceTransition, eventDate: Date) async -> Bool {
         guard let readd = conditionReadds[identifier],
-              Date().timeIntervalSince(readd.date) <= GeofenceConstants.contradictionGateReplayWindow
+              eventDate.timeIntervalSince(readd.date) <= GeofenceConstants.contradictionGateReplayWindow
         else { return false }
         let gateFix = await resolveGateFix()
         guard let gateFix, CLLocationCoordinate2DIsValid(gateFix.coordinate) else { return false }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Rearm.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Rearm.swift
@@ -34,7 +34,7 @@ extension CLMonitorGeofenceMonitor {
                     radius: radius
                 )
                 await monitor.add(condition, identifier: identifier, assuming: record.lastState == .enter ? .satisfied : .unsatisfied)
-                self.conditionReaddTimestamps[identifier] = Date()
+                self.conditionReadds[identifier] = ConditionReadd(date: Date(), center: center, radius: radius)
                 // Recorded per identifier rather than in one pass at the end: an `.unmonitored` for
                 // one of these can land between two iterations, and it must be able to take the
                 // identifier back out.

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Rearm.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Rearm.swift
@@ -34,6 +34,7 @@ extension CLMonitorGeofenceMonitor {
                     radius: radius
                 )
                 await monitor.add(condition, identifier: identifier, assuming: record.lastState == .enter ? .satisfied : .unsatisfied)
+                self.conditionReaddTimestamps[identifier] = Date()
                 // Recorded per identifier rather than in one pass at the end: an `.unmonitored` for
                 // one of these can land between two iterations, and it must be able to take the
                 // identifier back out.

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Rearm.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Rearm.swift
@@ -28,13 +28,14 @@ extension CLMonitorGeofenceMonitor {
                 guard let record = records[identifier],
                       let center = record.center, let radius = record.radius
                 else { continue }
+                let readdStart = Date()
                 await monitor.remove(identifier)
                 let condition = CLMonitor.CircularGeographicCondition(
                     center: CLLocationCoordinate2D(latitude: center.latitude, longitude: center.longitude),
                     radius: radius
                 )
                 await monitor.add(condition, identifier: identifier, assuming: record.lastState == .enter ? .satisfied : .unsatisfied)
-                self.conditionReadds[identifier] = ConditionReadd(date: Date(), center: center, radius: radius)
+                self.conditionReadds[identifier] = ConditionReadd(start: readdStart, added: Date(), center: center, radius: radius)
                 // Recorded per identifier rather than in one pass at the end: an `.unmonitored` for
                 // one of these can land between two iterations, and it must be able to take the
                 // identifier back out.

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
@@ -94,7 +94,11 @@ extension CLMonitorGeofenceMonitor {
             await monitor.remove(identifier)
             let condition = CLMonitor.CircularGeographicCondition(center: coordinate, radius: clampedRadius)
             await monitor.add(condition, identifier: identifier, assuming: assumedState)
-            self.conditionReaddTimestamps[identifier] = Date()
+            self.conditionReadds[identifier] = ConditionReadd(
+                date: Date(),
+                center: LocationData(latitude: coordinate.latitude, longitude: coordinate.longitude),
+                radius: clampedRadius
+            )
             self.knownConditionIdentifiers.insert(identifier)
             self.persistConditionMirror()
         }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
@@ -94,6 +94,7 @@ extension CLMonitorGeofenceMonitor {
             await monitor.remove(identifier)
             let condition = CLMonitor.CircularGeographicCondition(center: coordinate, radius: clampedRadius)
             await monitor.add(condition, identifier: identifier, assuming: assumedState)
+            self.conditionReaddTimestamps[identifier] = Date()
             self.knownConditionIdentifiers.insert(identifier)
             self.persistConditionMirror()
         }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
@@ -91,11 +91,13 @@ extension CLMonitorGeofenceMonitor {
             // and reporting no error, so the identifier is cleared first. Keyed on the OS rather
             // than on this process's bookkeeping, which can be missing an identifier the OS still
             // holds. Removing one the OS does not hold is a no-op.
+            let readdStart = Date()
             await monitor.remove(identifier)
             let condition = CLMonitor.CircularGeographicCondition(center: coordinate, radius: clampedRadius)
             await monitor.add(condition, identifier: identifier, assuming: assumedState)
             self.conditionReadds[identifier] = ConditionReadd(
-                date: Date(),
+                start: readdStart,
+                added: Date(),
                 center: LocationData(latitude: coordinate.latitude, longitude: coordinate.longitude),
                 radius: clampedRadius
             )

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -67,10 +67,13 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
     /// Conditions the OS stopped monitoring since their last registration. The next registration
     /// reseeds their stored baseline instead of preserving it — see `recordMonitorRegistration`.
     var conditionsNeedingBaselineReseed: Set<String> = []
-    /// When each condition was last (re)added at the OS, stamped at the add's drain time. The
-    /// contradiction gate only vets events landing shortly after an add — the daemon's belief
-    /// replays — so this is the gate's applicability check (see `+ContradictionGate`).
-    var conditionReaddTimestamps: [String: Date] = [:]
+    /// When each condition was last (re)added at the OS and the circle that add imposed, stamped
+    /// at the add's drain time. The contradiction gate only vets events landing shortly after an
+    /// add — the daemon's belief replays — and judges them against this geometry, NOT the staged
+    /// `registeredConditions` entry: a reshape updates that map synchronously, so during its
+    /// staging→drain gap an event computed on the old circle would otherwise be judged against
+    /// the new one (see `+ContradictionGate`).
+    var conditionReadds: [String: ConditionReadd] = [:]
 
     /// The circle a condition was added with.
     struct RegisteredCondition: Equatable {
@@ -247,6 +250,7 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
             logger.geofenceMonitorStoppedMonitoringRegion(identifier)
             knownConditionIdentifiers.remove(identifier)
             registeredConditions.removeValue(forKey: identifier)
+            conditionReadds.removeValue(forKey: identifier)
             // Whichever registration comes next must reseed the baseline rather than preserve it.
             // The clear below only covers the case where none comes: a re-registration with the same
             // circle preserves the stored state by design, and after the OS gave up that state is no

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -273,7 +273,7 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
         // Runs BEFORE the baseline advance below: a refused event must leave the stored baseline
         // untouched so the daemon's own re-evaluation dedups against it (see `+ContradictionGate`).
         if identifier != GeofenceConstants.movementTriggerIdentifier,
-           await isEventContradictedByFreshFix(identifier: identifier, transition: transition) {
+           await isEventContradictedByFreshFix(identifier: identifier, transition: transition, eventDate: event.date) {
             return
         }
         guard case .deliver = await storage.recordMonitorEvent(transition, forIdentifier: identifier) else { return }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -42,7 +42,8 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
     /// Internal for the `+Registration` extension.
     let authManager: CLLocationManager
     /// Freshens the fix behind movement-trigger EXIT dispatches (see `MovementFixResolver`).
-    private let movementFixResolver: MovementFixResolver
+    /// Internal (not private) for the `+ContradictionGate` extension's gate-fix resolution.
+    let movementFixResolver: MovementFixResolver
     private var onTransition: GeofenceTransitionHandler?
     private var onAuthorizationChanged: GeofenceAuthorizationChangedHandler?
     private var onReconciled: GeofenceReconciledHandler?
@@ -66,6 +67,10 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
     /// Conditions the OS stopped monitoring since their last registration. The next registration
     /// reseeds their stored baseline instead of preserving it — see `recordMonitorRegistration`.
     var conditionsNeedingBaselineReseed: Set<String> = []
+    /// When each condition was last (re)added at the OS, stamped at the add's drain time. The
+    /// contradiction gate only vets events landing shortly after an add — the daemon's belief
+    /// replays — so this is the gate's applicability check (see `+ContradictionGate`).
+    var conditionReaddTimestamps: [String: Date] = [:]
 
     /// The circle a condition was added with.
     struct RegisteredCondition: Equatable {
@@ -261,6 +266,12 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
         @unknown default:
             return
         }
+        // Runs BEFORE the baseline advance below: a refused event must leave the stored baseline
+        // untouched so the daemon's own re-evaluation dedups against it (see `+ContradictionGate`).
+        if identifier != GeofenceConstants.movementTriggerIdentifier,
+           await isEventContradictedByFreshFix(identifier: identifier, transition: transition) {
+            return
+        }
         guard case .deliver = await storage.recordMonitorEvent(transition, forIdentifier: identifier) else { return }
         // No ownership re-check after the await: the baseline already advanced, so dropping here
         // loses the transition permanently — a sync's stop-all + re-add swap would eat a genuine
@@ -355,8 +366,9 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
 
     /// Newest usable fix across the auth manager's cache and the resolver's requested fixes.
     /// The manager's cache can freeze at process start on a long-suspended process, so a fresher
-    /// resolver fix must win wherever cached position is read.
-    private func bestKnownFix() -> CLLocation? {
+    /// resolver fix must win wherever cached position is read. Internal (not private) for the
+    /// `+ContradictionGate` extension's gate-fix resolution.
+    func bestKnownFix() -> CLLocation? {
         let cached = authManager.location.flatMap { CLLocationCoordinate2DIsValid($0.coordinate) ? $0 : nil }
         guard let resolved = movementFixResolver.latestFix else { return cached }
         guard let cached else { return resolved }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -74,6 +74,10 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
     /// staging→drain gap an event computed on the old circle would otherwise be judged against
     /// the new one (see `+ContradictionGate`).
     var conditionReadds: [String: ConditionReadd] = [:]
+    /// When the last gate-fix request completed without producing a fresh fix. While recent, the
+    /// gate reads the cache instead of requesting again — see `resolveGateFix`. Internal (not
+    /// private) for the `+ContradictionGate` extension.
+    var gateFixRequestFailedAt: Date?
 
     /// The circle a condition was added with.
     struct RegisteredCondition: Equatable {

--- a/Tests/LocationGeofence/Geofence/Monitor/BaselineHealDecisionTests.swift
+++ b/Tests/LocationGeofence/Geofence/Monitor/BaselineHealDecisionTests.swift
@@ -1,0 +1,76 @@
+@testable import CioInternalCommon
+@testable import CioLocationGeofence
+import Foundation
+import Testing
+
+@Suite("BaselineHealDecision")
+struct BaselineHealDecisionTests {
+    private func decide(
+        distanceFromCenter: Double,
+        radius: Double = 1000,
+        horizontalAccuracy: Double = 30,
+        fixAge: TimeInterval = 5,
+        lastState: GeofenceTransition? = .exit
+    ) -> GeofenceTransition? {
+        BaselineHealDecision.synthesizedTransition(
+            distanceFromCenter: distanceFromCenter,
+            radius: radius,
+            horizontalAccuracy: horizontalAccuracy,
+            fixAge: fixAge,
+            lastState: lastState
+        )
+    }
+
+    @Test
+    func synthesizedTransition_givenConfidentlyInsideWithExitBaseline_expectEnter() {
+        #expect(decide(distanceFromCenter: 350) == .enter)
+    }
+
+    @Test
+    func synthesizedTransition_givenConfidentlyOutsideWithEnterBaseline_expectExit() {
+        #expect(decide(distanceFromCenter: 1500, lastState: .enter) == .exit)
+    }
+
+    @Test
+    func synthesizedTransition_givenBaselineAgreesWithFix_expectNil() {
+        #expect(decide(distanceFromCenter: 350, lastState: .enter) == nil)
+        #expect(decide(distanceFromCenter: 1500, lastState: .exit) == nil)
+    }
+
+    @Test
+    func synthesizedTransition_givenFixInsideAmbiguityBand_expectNil() {
+        // 20m inside the edge with 30m accuracy: could be either side.
+        #expect(decide(distanceFromCenter: 980) == nil)
+        // 25m outside the edge with 30m accuracy, enter baseline: same band.
+        #expect(decide(distanceFromCenter: 1025, lastState: .enter) == nil)
+    }
+
+    @Test
+    func synthesizedTransition_givenOverOptimisticAccuracy_expectFloorApplied() {
+        // 15m inside the edge; accuracy claims 5m but the 20m floor rejects the verdict.
+        #expect(decide(distanceFromCenter: 985, horizontalAccuracy: 5) == nil)
+        // 25m inside the edge clears the floor with the same claimed accuracy.
+        #expect(decide(distanceFromCenter: 975, horizontalAccuracy: 5) == .enter)
+    }
+
+    @Test
+    func synthesizedTransition_givenStaleFix_expectNil() {
+        #expect(decide(distanceFromCenter: 350, fixAge: 31) == nil)
+    }
+
+    @Test
+    func synthesizedTransition_givenFutureTimestampedFix_expectNil() {
+        #expect(decide(distanceFromCenter: 350, fixAge: -2) == nil)
+    }
+
+    @Test
+    func synthesizedTransition_givenInvalidAccuracy_expectNil() {
+        #expect(decide(distanceFromCenter: 350, horizontalAccuracy: 0) == nil)
+        #expect(decide(distanceFromCenter: 350, horizontalAccuracy: -1) == nil)
+    }
+
+    @Test
+    func synthesizedTransition_givenNoBaseline_expectNil() {
+        #expect(decide(distanceFromCenter: 350, lastState: nil) == nil)
+    }
+}

--- a/Tests/LocationGeofence/Geofence/Monitor/ContradictionGateDecisionTests.swift
+++ b/Tests/LocationGeofence/Geofence/Monitor/ContradictionGateDecisionTests.swift
@@ -144,4 +144,30 @@ struct ContradictionGateDecisionTests {
         let readd = makeReadd(start: start, added: added)
         #expect(!readd.replayWindowCovers(added.addingTimeInterval(GeofenceConstants.contradictionGateReplayWindow + 0.1)))
     }
+
+    // MARK: - Gate-fix request cooldown (one attempt per burst)
+
+    @available(iOS 17.0, *)
+    @Test
+    func gateFixRequest_givenRecentFailedAttempt_expectBlocked() {
+        // A burst with no fix obtainable must pay at most one request timeout, not one per event —
+        // the events loop is serial, so repeated requests would stall it for their sum.
+        let failedAt = Date()
+        #expect(CLMonitorGeofenceMonitor.gateFixRequestBlocked(failedAt: failedAt, now: failedAt.addingTimeInterval(1)))
+        #expect(CLMonitorGeofenceMonitor.gateFixRequestBlocked(
+            failedAt: failedAt,
+            now: failedAt.addingTimeInterval(GeofenceConstants.movementFixMaxAge - 1)
+        ))
+    }
+
+    @available(iOS 17.0, *)
+    @Test
+    func gateFixRequest_givenNoOrExpiredFailure_expectAllowed() {
+        let failedAt = Date()
+        #expect(!CLMonitorGeofenceMonitor.gateFixRequestBlocked(failedAt: nil, now: failedAt))
+        #expect(!CLMonitorGeofenceMonitor.gateFixRequestBlocked(
+            failedAt: failedAt,
+            now: failedAt.addingTimeInterval(GeofenceConstants.movementFixMaxAge)
+        ))
+    }
 }

--- a/Tests/LocationGeofence/Geofence/Monitor/ContradictionGateDecisionTests.swift
+++ b/Tests/LocationGeofence/Geofence/Monitor/ContradictionGateDecisionTests.swift
@@ -91,4 +91,57 @@ struct ContradictionGateDecisionTests {
         #expect(!refuses(incoming: .enter, distanceFromCenter: 7787, horizontalAccuracy: -1))
         #expect(!refuses(incoming: .enter, distanceFromCenter: 7787, horizontalAccuracy: 0))
     }
+
+    // MARK: - Replay window bounds (which events the gate vets at all)
+
+    @available(iOS 17.0, *)
+    private func makeReadd(start: Date, added: Date) -> CLMonitorGeofenceMonitor.ConditionReadd {
+        CLMonitorGeofenceMonitor.ConditionReadd(
+            start: start,
+            added: added,
+            center: LocationData(latitude: 0, longitude: 0),
+            radius: 500
+        )
+    }
+
+    @available(iOS 17.0, *)
+    @Test
+    func replayWindow_givenEventDatedBeforeReaddStart_expectNotCovered() {
+        // A catch-up buffered in `pendingEvents` across the re-add predates it — provably not this
+        // add's replay, and must never be judged against the geometry this add imposed.
+        let start = Date()
+        let readd = makeReadd(start: start, added: start.addingTimeInterval(0.05))
+        #expect(!readd.replayWindowCovers(start.addingTimeInterval(-0.001)))
+        #expect(!readd.replayWindowCovers(start.addingTimeInterval(-3600)))
+    }
+
+    @available(iOS 17.0, *)
+    @Test
+    func replayWindow_givenEventDatedInsideRemoveAddGap_expectCovered() {
+        // A replay can be stamped before `add` returns, so the window opens at the remove, not at
+        // the add's return — a bare non-negative check against `added` would leak these.
+        let start = Date()
+        let readd = makeReadd(start: start, added: start.addingTimeInterval(0.05))
+        #expect(readd.replayWindowCovers(start))
+        #expect(readd.replayWindowCovers(start.addingTimeInterval(0.02)))
+    }
+
+    @available(iOS 17.0, *)
+    @Test
+    func replayWindow_givenEventWithinWindowAfterAdd_expectCovered() {
+        let start = Date()
+        let added = start.addingTimeInterval(0.05)
+        let readd = makeReadd(start: start, added: added)
+        #expect(readd.replayWindowCovers(added.addingTimeInterval(3.3)))
+        #expect(readd.replayWindowCovers(added.addingTimeInterval(GeofenceConstants.contradictionGateReplayWindow)))
+    }
+
+    @available(iOS 17.0, *)
+    @Test
+    func replayWindow_givenEventBeyondWindow_expectNotCovered() {
+        let start = Date()
+        let added = start.addingTimeInterval(0.05)
+        let readd = makeReadd(start: start, added: added)
+        #expect(!readd.replayWindowCovers(added.addingTimeInterval(GeofenceConstants.contradictionGateReplayWindow + 0.1)))
+    }
 }

--- a/Tests/LocationGeofence/Geofence/Monitor/ContradictionGateDecisionTests.swift
+++ b/Tests/LocationGeofence/Geofence/Monitor/ContradictionGateDecisionTests.swift
@@ -1,0 +1,94 @@
+@testable import CioInternalCommon
+@testable import CioLocationGeofence
+import Foundation
+import Testing
+
+/// Pins the contradiction gate's decision semantics. The gate reuses
+/// `BaselineHealDecision.synthesizedTransition` with `lastState` set to the INCOMING OS
+/// transition: a non-nil result means a fresh gated fix unambiguously says the opposite of what
+/// the OS delivered, so the event is refused before the dedup baseline advances. These tests
+/// document that reuse from the gate's perspective — refusal must trigger only on confident
+/// geometric contradiction, and every undecidable input must fail open (deliver).
+@Suite("ContradictionGateDecision")
+struct ContradictionGateDecisionTests {
+    /// Mirrors the gate's call in `CLMonitorGeofenceMonitor.process(event:)`.
+    private func refuses(
+        incoming: GeofenceTransition,
+        distanceFromCenter: Double,
+        radius: Double = 500,
+        horizontalAccuracy: Double = 10,
+        fixAge: TimeInterval = 2
+    ) -> Bool {
+        BaselineHealDecision.synthesizedTransition(
+            distanceFromCenter: distanceFromCenter,
+            radius: radius,
+            horizontalAccuracy: horizontalAccuracy,
+            fixAge: fixAge,
+            lastState: incoming
+        ) != nil
+    }
+
+    // MARK: - Confident contradictions refuse (the two field-observed damage classes)
+
+    @Test
+    func gate_givenEnterWithFixFarOutside_expectRefusal() {
+        // The Saleem/Baba-Sweets class: stale daemon belief replays an enter kilometres away.
+        #expect(refuses(incoming: .enter, distanceFromCenter: 7787))
+    }
+
+    @Test
+    func gate_givenExitWithFixDeepInside_expectRefusal() {
+        // The login-inside-fences class: default-unsatisfied belief replays an exit at the center.
+        #expect(refuses(incoming: .exit, distanceFromCenter: 0))
+    }
+
+    @Test
+    func gate_givenEnterJustBeyondMargin_expectRefusal() {
+        // Edge distance 31 m outside with margin max(10, 20) = 20 → confident contradiction.
+        #expect(refuses(incoming: .enter, distanceFromCenter: 531))
+    }
+
+    // MARK: - Agreement and ambiguity deliver
+
+    @Test
+    func gate_givenEnterWithFixInside_expectDelivery() {
+        // Legitimate corrective (rearm/wedged-crossing recovery): fix agrees with the event.
+        #expect(!refuses(incoming: .enter, distanceFromCenter: 100))
+    }
+
+    @Test
+    func gate_givenExitWithFixOutside_expectDelivery() {
+        #expect(!refuses(incoming: .exit, distanceFromCenter: 1200))
+    }
+
+    @Test
+    func gate_givenFixWithinMarginBand_expectDelivery() {
+        // A boundary crossing sits within accuracy of the edge — never refused.
+        #expect(!refuses(incoming: .enter, distanceFromCenter: 515))
+        #expect(!refuses(incoming: .exit, distanceFromCenter: 485))
+    }
+
+    @Test
+    func gate_givenAccuracyWiderThanDiscrepancy_expectDelivery() {
+        // 80 m outside the edge but a 100 m-accuracy fix cannot contradict confidently.
+        #expect(!refuses(incoming: .enter, distanceFromCenter: 580, horizontalAccuracy: 100))
+    }
+
+    // MARK: - Untrustworthy fixes fail open
+
+    @Test
+    func gate_givenStaleFix_expectDelivery() {
+        #expect(!refuses(incoming: .enter, distanceFromCenter: 7787, fixAge: GeofenceConstants.movementFixMaxAge + 1))
+    }
+
+    @Test
+    func gate_givenFutureTimestampedFix_expectDelivery() {
+        #expect(!refuses(incoming: .enter, distanceFromCenter: 7787, fixAge: -1))
+    }
+
+    @Test
+    func gate_givenInvalidAccuracy_expectDelivery() {
+        #expect(!refuses(incoming: .enter, distanceFromCenter: 7787, horizontalAccuracy: -1))
+        #expect(!refuses(incoming: .enter, distanceFromCenter: 7787, horizontalAccuracy: 0))
+    }
+}


### PR DESCRIPTION
## What

Refuses an OS-delivered geofence transition when it lands inside a short window after our own (re)add of that condition AND a fresh fix confidently contradicts it. Events outside the window are untouched.

## Why

CLMonitor keeps a per-identifier belief that survives app uninstalls and re-evaluates lazily. On every add (first registration, launch adopt, rearm), the daemon instantly replays that belief against our staged `assuming:` — **without a fresh evaluation** — and its own real evaluation follows only ~3 s later. When the belief is wrong (stale by hours from crossings observed while the app was dead, left over from a previous install, or the default "unsatisfied" for never-seen identifiers), that replay is delivered as a real transition:

- false ENTER for a fence 7.8 km away on a fresh install's first sync (field, twice: two different fences on two days, one of them registered mid-drive);
- false enters for two fences 1.1 km / 5.4 km away on a plain cold-launch adopt after 22 h suspended (field);
- false-EXIT storm when a user's first login happens inside fences — 6 fences ⇒ 12 junk CDP events in 3 s (deterministic sim repro).

Each false event also flips the dedup baseline, so the *next real* crossing of that fence is swallowed as a duplicate. Reproduced deterministically on simulator (~90 s/cycle); every alternative SDK-side cause was eliminated by instrumentation before pinning the mechanism.

## How

- The monitor stamps each condition's (re)add — when it began, when the add returned, and the circle it imposed. The gate vets only events dated inside `[start, added + contradictionGateReplayWindow]` (10 s; measured replays land 0.003–3.3 s after the add) — a normal crossing, before the re-add or after the window, is never delayed by a fix request nor at any risk of refusal.
- In-window events are checked against a fresh fix via `BaselineHealDecision` (introduced here) with `lastState` = the incoming transition: non-nil means the fix says the opposite, beyond `max(horizontalAccuracy, 20 m)` from the edge. Refusal happens BEFORE the baseline advances, so the daemon's own ~3 s re-evaluation lands as a duplicate against the untouched baseline and is absorbed — net zero events, baseline stays true.
- Legitimate in-window correctives (recovery of a crossing the OS observed but never delivered) agree with the fix and pass unchanged.
- Fail-open everywhere: no fix, stale fix, coarse accuracy, or within the ambiguity margin ⇒ deliver. A real event is never dropped for lack of a fix.

## Verification

- **State-space model v8.2** (125,952 paths per arm over belief × truth × baseline × assuming × fix-availability × heal × buffered pre-add catch-ups): zero fabricated deliveries whenever a usable fix exists (no-gate delivers 1,312 in the same paths); out-of-window crossings provably untouched; every single-crossing in-window refusal recovered; exactly-once and baseline convergence hold. The model earned its keep twice: it caught that a fix predating a fast real crossing could refuse it (fixed by the replay-window design), and end-to-end rig runs caught a burst-ordering hole in an earlier guard implementation (fixed and re-proven).
- **Simulator rig, end-to-end on this exact code**: false-exit storm at first-login-inside — 6/6 refused, all 6 real initial enters delivered; false-enter burst on reinstall-far — 6/6 refused, zero events tracked; real drive-through crossings delivered normally.
- 347/347 LocationGeofence tests, including 16 gate-decision tests pinning refusal/fail-open/window/cooldown semantics.
- The production incidents above were each cleaned up minutes later by the baseline heal — this PR stops them at the source instead.

## Notes

- No public API changes. CLMonitor path (iOS 18+) only; the classic path's exposure is unverified (no field observation there).
- Accepted residue, by design: with no usable fix the gate fails open (a replay can pass); a real round trip completed entirely inside the 10 s window and judged only by a pre-crossing cached fix can be suppressed (same class of quick round trips circles already miss natively).
- Shares `BaselineHealDecision.swift` (+ tests and margin constant) with the baseline-heal PR (#1219), which uses the same primitive for the opposite failure (deliver what the OS wrongly withheld). Both PRs are self-contained; whichever merges second gets a trivial rebase and its diff shrinks by that file.
- Integration note with #1218 (foreground rearm): that PR adds a third re-add site, which must also stamp the replay window — a one-line addition for whichever of the two merges second (verified on the combined field build).
- Follow-up tracked separately: launch adopts can run twice back-to-back (reconcile rewire), doubling replay opportunities — a recency gate there is a cheap independent hardening.

## Review round (2026-08-25)

Two review findings, both confirmed against the code and fixed in separate commits:

- **Replay window had no lower bound** — any event dated before the re-add (negative delta) qualified for gating, so a genuine catch-up buffered in `pendingEvents` across an adopt re-add could be refused off a cached pre-crossing fix, and its refusal would dedup away the paired corrective. The stamp now records a start taken *before* the remove/add pair (a bare non-negative check against the add's return would leak replays stamped inside the remove→add gap) and the window is two-sided. Model v8.2 adds the buffered-catch-up class as a new dimension: the two-sided window refuses none of them, and an upper-only negative control fails exactly there — the model is provably sensitive to the bound.
- **Serial fix resolution could stall the event consumer** — the events loop awaits `process` serially, so the resolver's in-flight coalescing never engages; with no usable fix obtainable, each fence in a burst started its own 10 s request. A resolution that comes back without a fresh fix is now remembered for `movementFixMaxAge`: a burst pays at most one request and later events fail open immediately (a late fix from that request still reaches the cache and serves them).

Re-validated end-to-end on this exact code: false-enter burst 6/6 refused (refusals 2 ms apart — one shared fix, no repeated requests); false-exit storm 6/6 refused with all 6 real initial enters delivered; real drive-in delivered all 6 enters untouched; fresh-install-inside produced zero junk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core geofence event delivery and dedup baseline timing on CLMonitor; incorrect gating could suppress real crossings or let false replays through when fixes are unavailable (designed to fail open).
> 
> **Overview**
> Adds a **contradiction gate** on the CLMonitor path so OS transitions that are really stale daemon “belief replays” right after a condition (re)add can be dropped before the dedup baseline advances.
> 
> Each registration/rearm now records a **`ConditionReadd`** stamp (timing + circle geometry). For **10s** after an add, events dated in that replay window can be vetted with a fresh location fix (reusing **`MovementFixResolver`**, with one request per burst and fail-open on missing/stale/coarse fixes). **`BaselineHealDecision`** decides whether the fix unambiguously disagrees with the incoming enter/exit (edge distance beyond `max(accuracy, 20m)`); if so the event is refused and logged, leaving the baseline intact so the daemon’s later re-evaluation dedups silently. Events outside the window, the movement trigger, and ambiguous geometry behave as before.
> 
> New unit tests cover heal/gate geometry, replay-window bounds, and gate-fix request cooldown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5542eebf20492ed54e6143d7276a6ee331b6a66e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



