### PR TITLE
fix(in-app): deallocate subscribers on main thread

### DIFF
--- a/Sources/MessagingInApp/State/InAppMessageManager.swift
+++ b/Sources/MessagingInApp/State/InAppMessageManager.swift
@@ -105,7 +105,9 @@ class InAppMessageStoreManager: InAppMessageManager {
     /// In order to keep the subscriber alive, the caller must keep a strong reference to the subscriber.
     @discardableResult
     func subscribe(subscriber: InAppMessageStoreSubscriber) -> Task<Void, Never> {
-        Task { await store.subscribe(subscriber) }
+        Task { @MainActor [store, subscriber] in
+            await store.subscribe(subscriber)
+        }
     }
 
     /// Subscribe to store updates with given subscriber and comparator.
@@ -120,6 +122,8 @@ class InAppMessageStoreManager: InAppMessageManager {
         comparator: @escaping (InAppMessageState, InAppMessageState) -> Bool,
         subscriber: InAppMessageStoreSubscriber
     ) -> Task<Void, Never> {
-        Task { await self.store.subscribe(subscriber, comparator) }
+        Task { @MainActor [store, subscriber] in
+            await store.subscribe(subscriber, comparator)
+        }
     }
 }

--- a/Sources/MessagingInApp/State/InAppMessageManager.swift
+++ b/Sources/MessagingInApp/State/InAppMessageManager.swift
@@ -95,7 +95,9 @@ class InAppMessageStoreManager: InAppMessageManager {
 
     @discardableResult
     func unsubscribe(subscriber: InAppMessageStoreSubscriber) -> Task<Void, Never> {
-        Task { await store.unsubscribe(subscriber) }
+        Task { @MainActor [store, subscriber] in
+            await store.unsubscribe(subscriber)
+        }
     }
 
     /// Subscribe to store updates with given subscriber.

--- a/Tests/MessagingInApp/State/InAppMessageStateTests.swift
+++ b/Tests/MessagingInApp/State/InAppMessageStateTests.swift
@@ -10,6 +10,19 @@ extension InAppMessageManager {
     }
 }
 
+private final class MainThreadDeinitTrackingSubscriber: InAppMessageStoreSubscriber {
+    private let onDeinit: () -> Void
+
+    init(onDeinit: @escaping () -> Void) {
+        self.onDeinit = onDeinit
+        super.init { _ in }
+    }
+
+    deinit {
+        onDeinit()
+    }
+}
+
 class InAppMessageStateTests: IntegrationTest {
     private struct FetchHarness {
         let gist: Gist
@@ -84,6 +97,26 @@ class InAppMessageStateTests: IntegrationTest {
     override func tearDown() {
         inAppMessageManager = nil
         super.tearDown()
+    }
+
+    @MainActor
+    private func unsubscribeWithTaskAsLastSubscriberOwner(onDeinit: @escaping () -> Void) async -> Task<Void, Never> {
+        let subscriber = MainThreadDeinitTrackingSubscriber(onDeinit: onDeinit)
+
+        await inAppMessageManager.subscribe(comparator: { _, _ in false }, subscriber: subscriber).value
+
+        return inAppMessageManager.unsubscribe(subscriber: subscriber)
+    }
+
+    func test_unsubscribe_whenTaskOwnsLastSubscriberReference_thenDeinitializesSubscriberOnMainThread() async {
+        let deinitExpectation = expectation(description: "Subscriber deinitialized")
+        let unsubscribeTask = await unsubscribeWithTaskAsLastSubscriberOwner {
+            XCTAssertTrue(Thread.isMainThread)
+            deinitExpectation.fulfill()
+        }
+
+        await unsubscribeTask.value
+        await fulfillment(of: [deinitExpectation], timeout: 1)
     }
 
     // MARK: - State Tests

--- a/Tests/MessagingInApp/State/InAppMessageStateTests.swift
+++ b/Tests/MessagingInApp/State/InAppMessageStateTests.swift
@@ -100,6 +100,24 @@ class InAppMessageStateTests: IntegrationTest {
     }
 
     @MainActor
+    private func subscribeWithTaskAsLastSubscriberOwner(onDeinit: @escaping () -> Void) -> Task<Void, Never> {
+        let subscriber = MainThreadDeinitTrackingSubscriber(onDeinit: onDeinit)
+
+        return inAppMessageManager.subscribe(comparator: { _, _ in false }, subscriber: subscriber)
+    }
+
+    func test_subscribe_whenTaskOwnsLastSubscriberReference_thenDeinitializesSubscriberOnMainThread() async {
+        let deinitExpectation = expectation(description: "Subscriber deinitialized")
+        let subscribeTask = await subscribeWithTaskAsLastSubscriberOwner {
+            XCTAssertTrue(Thread.isMainThread)
+            deinitExpectation.fulfill()
+        }
+
+        await subscribeTask.value
+        await fulfillment(of: [deinitExpectation], timeout: 1)
+    }
+
+    @MainActor
     private func unsubscribeWithTaskAsLastSubscriberOwner(onDeinit: @escaping () -> Void) async -> Task<Void, Never> {
         let subscriber = MainThreadDeinitTrackingSubscriber(onDeinit: onDeinit)
 


### PR DESCRIPTION
## Summary

- run in-app subscriber unsubscription on MainActor
- keep the task-owned subscriber and its WebKit-owning object graph on the main thread through final release
- add a regression test that verifies deinitialization happens on the main thread when the task is the last owner

## Validation

- regression test demonstrated failure before the fix and passed afterward
- focused regression test passed 20 repeated iterations
- InAppMessageStateTests passed
- Customer.io-Package build-for-testing passed
- MessagingInApp Debug and Release simulator builds passed
- SwiftLint passed with 0 violations
- APN-UIKit Maestro flow passed on iPhone 17 Pro simulator, iOS 26.5: live modal displayed, Continue dismissed it, and a subsequent custom event persisted with no crash signatures

## Linear

[MBL-2294: Crash on modal in-app message dismiss, WKWebView owning object](https://linear.app/customerio/issue/MBL-2294/crash-on-modal-in-app-message-dismiss-wkwebview-owning-object)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Threading change to all in-app store subscription paths; low behavioral surface area but touches modal/WebKit teardown where incorrect threading previously caused production crashes.
> 
> **Overview**
> Fixes a crash when modal in-app messages are dismissed by ensuring **subscribe** and **unsubscribe** work in `InAppMessageStoreManager` runs on the **main actor**. Those APIs now wrap store calls in `Task { @MainActor [store, subscriber] in ... }` so when the returned `Task` is the last strong owner of a subscriber tied to UI/WebKit, **deinitialization happens on the main thread**.
> 
> Adds regression tests with a deinit-tracking subscriber that assert main-thread teardown when the subscribe or unsubscribe task completes and releases the subscriber.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e171a56da79cac79ddedb056eefe6252f413231. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->