### PR TITLE
chore: adopt current UIKit and SwiftUI APIs

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/View/Extension/StringExtension.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/Extension/StringExtension.swift
@@ -15,9 +15,7 @@ extension String {
     }
 
     var isValidUrl: Bool {
-        if let url = NSURL(string: self) {
-            return UIApplication.shared.canOpenURL(url as URL)
-        }
-        return false
+        guard let scheme = URL(string: self)?.scheme else { return false }
+        return !scheme.isEmpty
     }
 }

--- a/Apps/APN-UIKit/APN UIKit/View/Extension/StringExtension.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/Extension/StringExtension.swift
@@ -1,5 +1,4 @@
 import Foundation
-import UIKit
 
 extension String {
     static func generateRandomString(ofLength length: Int = 15) -> Self {
@@ -12,10 +11,5 @@ extension String {
         let emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
         let emailPred = NSPredicate(format: "SELF MATCHES %@", emailRegEx)
         return emailPred.evaluate(with: self)
-    }
-
-    var isValidUrl: Bool {
-        guard let scheme = URL(string: self)?.scheme else { return false }
-        return !scheme.isEmpty
     }
 }

--- a/Apps/CocoaPods-FCM/src/Extensions/ViewExtensions.swift
+++ b/Apps/CocoaPods-FCM/src/Extensions/ViewExtensions.swift
@@ -1,6 +1,18 @@
 import SwiftUI
 
 extension View {
+    @available(iOS 14.0, *)
+    @ViewBuilder
+    func onValueChange<Value: Equatable>(of value: Value, perform action: @escaping (Value) -> Void) -> some View {
+        if #available(iOS 17.0, *) {
+            onChange(of: value) { _, newValue in
+                action(newValue)
+            }
+        } else {
+            onChange(of: value, perform: action)
+        }
+    }
+
     func setBackgroundColor(_ color: Color) -> some View {
         background(AnyView(Capsule().fill(color)))
     }

--- a/Apps/CocoaPods-FCM/src/View/Widget/LabeledTextField.swift
+++ b/Apps/CocoaPods-FCM/src/View/Widget/LabeledTextField.swift
@@ -32,7 +32,7 @@ struct LabeledTextField<InputType: Equatable>: View {
                 .setAppiumId(appiumId)
                 Divider()
             }
-        }.onChange(of: value) { newValue in // If the value changes outside of this View, update the text that the TextField is displaying in the UI.
+        }.onValueChange(of: value) { newValue in // If the value changes outside of this View, update the text that the TextField is displaying in the UI.
             // this helps provide a 2-way sync between the value and the textfield.
             text = valueToText(newValue)
         }.onAppear {

--- a/Apps/CocoaPods-FCM/src/View/Widget/Toast.swift
+++ b/Apps/CocoaPods-FCM/src/View/Widget/Toast.swift
@@ -37,7 +37,7 @@ struct ToastView: View {
                 }
             }
         }
-        .onChange(of: message) { message in
+        .onValueChange(of: message) { message in
             if let message = message, !message.isEmpty {
                 timer.start(interval: duration) {
                     self.message = nil

--- a/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
@@ -224,10 +224,13 @@ extension BaseMessageManager: EngineWebDelegate {
         let encodedUrl = URL(string: originalAction.percentEncode(character: "#")) ?? url
         if let page = encodedUrl.queryParameters?["url"],
            let pageUrl = URL(string: page) {
-            UIApplication.shared.open(pageUrl, options: [:]) { [weak self] didOpen in
+            let logger = logger
+            let message = currentMessage.describeForLogs
+            let scheme = pageUrl.scheme ?? "none"
+            UIApplication.shared.open(pageUrl, options: [:]) { didOpen in
                 guard !didOpen else { return }
-                self?.logger.logWithModuleTag(
-                    "Unable to open in-app message page action.",
+                logger.logWithModuleTag(
+                    "Unable to open in-app message page action. Message: \(message), scheme: \(scheme).",
                     level: .error
                 )
             }

--- a/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
@@ -230,12 +230,14 @@ extension BaseMessageManager: EngineWebDelegate {
             let logger = logger
             let message = currentMessage.describeForLogs
             let scheme = pageUrl.scheme ?? "none"
-            UIApplication.shared.open(pageUrl, options: [:]) { didOpen in
-                guard !didOpen else { return }
-                logger.logWithModuleTag(
-                    "Unable to open in-app message page action. Message: \(message), scheme: \(scheme).",
-                    level: .error
-                )
+            threadUtil.runMain {
+                UIApplication.shared.open(pageUrl, options: [:]) { didOpen in
+                    guard !didOpen else { return }
+                    logger.logWithModuleTag(
+                        "Unable to open in-app message page action. Message: \(message), scheme: \(scheme).",
+                        level: .error
+                    )
+                }
             }
         }
     }

--- a/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
@@ -223,9 +223,14 @@ extension BaseMessageManager: EngineWebDelegate {
         // Encode '#' in url action string and creates encoded URL to handle fragments
         let encodedUrl = URL(string: originalAction.percentEncode(character: "#")) ?? url
         if let page = encodedUrl.queryParameters?["url"],
-           let pageUrl = URL(string: page),
-           UIApplication.shared.canOpenURL(pageUrl) {
-            UIApplication.shared.open(pageUrl)
+           let pageUrl = URL(string: page) {
+            UIApplication.shared.open(pageUrl, options: [:]) { [weak self] didOpen in
+                guard !didOpen else { return }
+                self?.logger.logWithModuleTag(
+                    "Unable to open in-app message page action.",
+                    level: .error
+                )
+            }
         }
     }
 

--- a/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
@@ -224,6 +224,9 @@ extension BaseMessageManager: EngineWebDelegate {
         let encodedUrl = URL(string: originalAction.percentEncode(character: "#")) ?? url
         if let page = encodedUrl.queryParameters?["url"],
            let pageUrl = URL(string: page) {
+            // `canOpenURL` returns false for schemes omitted from the host's
+            // `LSApplicationQueriesSchemes`, even when the system can open them. Attempt the
+            // configured action directly and use the completion result as the source of truth.
             let logger = logger
             let message = currentMessage.describeForLogs
             let scheme = pageUrl.scheme ?? "none"

--- a/Sources/MessagingInApp/Gist/Views/GistModalViewController.swift
+++ b/Sources/MessagingInApp/Gist/Views/GistModalViewController.swift
@@ -54,10 +54,11 @@ class GistModalViewController: UIViewController, GistViewDelegate, DoNotTrackScr
     func sizeChanged(message: Message, width: CGFloat, height: CGFloat) {
         currentHeight = height
         view.setNeedsUpdateConstraints()
+        view.setNeedsLayout()
     }
 
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
         updateConstraintConstants()
     }
 

--- a/Sources/MessagingInApp/Gist/Views/GistModalViewController.swift
+++ b/Sources/MessagingInApp/Gist/Views/GistModalViewController.swift
@@ -53,7 +53,7 @@ class GistModalViewController: UIViewController, GistViewDelegate, DoNotTrackScr
 
     func sizeChanged(message: Message, width: CGFloat, height: CGFloat) {
         currentHeight = height
-        updateViewConstraints()
+        view.setNeedsUpdateConstraints()
     }
 
     override func viewDidLayoutSubviews() {

--- a/Sources/MessagingInApp/Gist/Views/GistModalViewController.swift
+++ b/Sources/MessagingInApp/Gist/Views/GistModalViewController.swift
@@ -53,18 +53,12 @@ class GistModalViewController: UIViewController, GistViewDelegate, DoNotTrackScr
 
     func sizeChanged(message: Message, width: CGFloat, height: CGFloat) {
         currentHeight = height
-        view.setNeedsUpdateConstraints()
         view.setNeedsLayout()
     }
 
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         updateConstraintConstants()
-    }
-
-    override func updateViewConstraints() {
-        updateConstraintConstants()
-        super.updateViewConstraints()
     }
 
     private func updateConstraintConstants() {

--- a/Sources/MessagingInApp/Gist/Views/GistModalViewController.swift
+++ b/Sources/MessagingInApp/Gist/Views/GistModalViewController.swift
@@ -67,14 +67,15 @@ class GistModalViewController: UIViewController, GistViewDelegate, DoNotTrackScr
     }
 
     private func updateConstraintConstants() {
-        guard heightConstraint != nil, widthConstraint != nil else { return }
+        guard let heightConstraint, let widthConstraint else { return }
 
-        if currentHeight > view.frame.height {
-            heightConstraint.constant = view.frame.height
-        } else {
-            heightConstraint.constant = currentHeight
+        let targetHeight = min(currentHeight, view.frame.height)
+        if heightConstraint.constant != targetHeight {
+            heightConstraint.constant = targetHeight
         }
-        widthConstraint.constant = view.frame.width
+        if widthConstraint.constant != view.frame.width {
+            widthConstraint.constant = view.frame.width
+        }
     }
 
     func action(message: Message, currentRoute: String, action: String, name: String) {}

--- a/Sources/MessagingInApp/Gist/Views/GistModalViewController.swift
+++ b/Sources/MessagingInApp/Gist/Views/GistModalViewController.swift
@@ -15,6 +15,19 @@ class GistModalViewController: UIViewController, GistViewDelegate, DoNotTrackScr
         heightConstraint,
         bottomConstraint: NSLayoutConstraint!
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        if #available(iOS 17.0, *) {
+            registerForTraitChanges([
+                UITraitHorizontalSizeClass.self,
+                UITraitVerticalSizeClass.self
+            ]) { (viewController: GistModalViewController, _: UITraitCollection) in
+                viewController.updateViewConstraints()
+            }
+        }
+    }
+
     func setup(position: MessagePosition) {
         gistView.delegate = self
         self.position = position
@@ -57,8 +70,11 @@ class GistModalViewController: UIViewController, GistViewDelegate, DoNotTrackScr
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        updateViewConstraints()
         super.traitCollectionDidChange(previousTraitCollection)
+
+        if #unavailable(iOS 17.0) {
+            updateViewConstraints()
+        }
     }
 
     override func updateViewConstraints() {

--- a/Sources/MessagingInApp/Gist/Views/GistModalViewController.swift
+++ b/Sources/MessagingInApp/Gist/Views/GistModalViewController.swift
@@ -15,19 +15,6 @@ class GistModalViewController: UIViewController, GistViewDelegate, DoNotTrackScr
         heightConstraint,
         bottomConstraint: NSLayoutConstraint!
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        if #available(iOS 17.0, *) {
-            registerForTraitChanges([
-                UITraitHorizontalSizeClass.self,
-                UITraitVerticalSizeClass.self
-            ]) { (viewController: GistModalViewController, _: UITraitCollection) in
-                viewController.updateViewConstraints()
-            }
-        }
-    }
-
     func setup(position: MessagePosition) {
         gistView.delegate = self
         self.position = position
@@ -69,22 +56,25 @@ class GistModalViewController: UIViewController, GistViewDelegate, DoNotTrackScr
         updateViewConstraints()
     }
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if #unavailable(iOS 17.0) {
-            updateViewConstraints()
-        }
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        updateConstraintConstants()
     }
 
     override func updateViewConstraints() {
+        updateConstraintConstants()
+        super.updateViewConstraints()
+    }
+
+    private func updateConstraintConstants() {
+        guard heightConstraint != nil, widthConstraint != nil else { return }
+
         if currentHeight > view.frame.height {
             heightConstraint.constant = view.frame.height
         } else {
             heightConstraint.constant = currentHeight
         }
         widthConstraint.constant = view.frame.width
-        super.updateViewConstraints()
     }
 
     func action(message: Message, currentRoute: String, action: String, name: String) {}

--- a/Sources/MessagingInApp/Gist/Views/GistView.swift
+++ b/Sources/MessagingInApp/Gist/Views/GistView.swift
@@ -24,11 +24,19 @@ public class GistView: UIView {
         self.message = message
         addSubview(engineView)
         engineView.autoresizingMask = [.flexibleWidth, .flexibleHeight, .flexibleBottomMargin, .flexibleRightMargin]
+
+        if #available(iOS 17.0, *) {
+            registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (view: GistView, _: UITraitCollection) in
+                view.onTraitCollectionChange?(view.traitCollection)
+            }
+        }
     }
 
     override public func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        if traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
+
+        if #unavailable(iOS 17.0),
+           traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
             onTraitCollectionChange?(traitCollection)
         }
     }

--- a/Sources/MessagingInApp/Gist/Views/GistView.swift
+++ b/Sources/MessagingInApp/Gist/Views/GistView.swift
@@ -19,12 +19,24 @@ public class GistView: UIView {
     var onTraitCollectionChange: ((UITraitCollection) -> Void)?
     var message: Message?
 
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
+        registerForInterfaceStyleChanges()
+    }
+
+    public required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        registerForInterfaceStyleChanges()
+    }
+
     convenience init(message: Message, engineView: UIView) {
-        self.init()
+        self.init(frame: .zero)
         self.message = message
         addSubview(engineView)
         engineView.autoresizingMask = [.flexibleWidth, .flexibleHeight, .flexibleBottomMargin, .flexibleRightMargin]
+    }
 
+    private func registerForInterfaceStyleChanges() {
         if #available(iOS 17.0, *) {
             registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (view: GistView, _: UITraitCollection) in
                 view.onTraitCollectionChange?(view.traitCollection)

--- a/Sources/MessagingInApp/Gist/Views/GistView.swift
+++ b/Sources/MessagingInApp/Gist/Views/GistView.swift
@@ -19,11 +19,13 @@ public class GistView: UIView {
     var onTraitCollectionChange: ((UITraitCollection) -> Void)?
     var message: Message?
 
+    /// Creates a Gist view with the specified frame.
     override public init(frame: CGRect) {
         super.init(frame: frame)
         registerForInterfaceStyleChanges()
     }
 
+    /// Creates a Gist view from an archived interface description.
     public required init?(coder: NSCoder) {
         super.init(coder: coder)
         registerForInterfaceStyleChanges()

--- a/Sources/MessagingInbox/NotificationInboxOverlay.swift
+++ b/Sources/MessagingInbox/NotificationInboxOverlay.swift
@@ -84,13 +84,13 @@ public struct NotificationInboxOverlay: View {
             model.stop()
         }
         // If the inbox transitions to hidden while the sheet is open, dismiss it so it doesn't linger.
-        .onChange(of: model.showsChrome) { visible in
+        .onValueChange(of: model.showsChrome) { visible in
             if !visible { isInboxPresented = false }
         }
         // Auto-mark-opened (item 8): keep marking later snapshots only while the sheet is presented
         // AND the app is active. SwiftUI does not call `onDisappear` merely because the app moves to
         // the background, so lifecycle notifications close that gap.
-        .onChange(of: isInboxPresented) { _ in
+        .onValueChange(of: isInboxPresented) { _ in
             updateAutoMarkState()
         }
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)) { _ in
@@ -124,6 +124,20 @@ public struct NotificationInboxOverlay: View {
                 isApplicationActive: UIApplication.shared.applicationState == .active
             )
         )
+    }
+}
+
+private extension View {
+    @available(iOS 14.0, *)
+    @ViewBuilder
+    func onValueChange<Value: Equatable>(of value: Value, perform action: @escaping (Value) -> Void) -> some View {
+        if #available(iOS 17.0, *) {
+            onChange(of: value) { _, newValue in
+                action(newValue)
+            }
+        } else {
+            onChange(of: value, perform: action)
+        }
     }
 }
 

--- a/Sources/MessagingInbox/NotificationInboxView.swift
+++ b/Sources/MessagingInbox/NotificationInboxView.swift
@@ -18,7 +18,7 @@ import UIKit
 ///
 /// ## Usage
 /// ```swift
-/// NavigationView { NotificationInboxView() }
+/// NotificationInboxView()
 /// ```
 @available(iOS 13.0, *)
 public struct NotificationInboxView: View {

--- a/api-docs/CioMessagingInApp.api
+++ b/api-docs/CioMessagingInApp.api
@@ -47,6 +47,8 @@ public final class CioMessagingInApp.GistProperties {
 public final class CioMessagingInApp.GistView {
 	public var delegate: (any GistViewDelegate)?;
 	public var lifecycleDelegate: (any GistViewLifecycleDelegate)?;
+	public fun override init(frame: CGRect);
+	public fun required init?(coder: NSCoder);
 	public fun override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?);
 	public fun override func removeFromSuperview();
 }


### PR DESCRIPTION
## Summary

- replace the `canOpenURL` preflight with direct open-result handling for in-app page actions
- adopt iOS 17 trait and SwiftUI change-observation APIs with iOS 13-16 fallbacks
- update the affected sample and inbox snippets and remove one unused sample helper
- regenerate the `CioMessagingInApp` API baseline for the explicit `GistView` initializers

The page-action change is intentional. `canOpenURL` returns `false` for schemes omitted from the host app's `LSApplicationQueriesSchemes`, even when `open` can handle them. The SDK now attempts the action and logs a contextual, non-PII error only when the system reports failure.

This PR does not change scene selection, multi-window ownership, or inactive-message behavior.

## Validation

- strict SwiftLint and SwiftFormat
- full `Customer.io-Package` simulator build
- focused `GistViewLifecycleDelegateTests`
- APN-UIKit and CocoaPods-FCM sample simulator builds
- regenerated API baselines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches in-app page-action deep-link handling and UI layout/trait APIs, which are user-facing and timing-sensitive, though changes are guarded with iOS version fallbacks and completion-based error logging.
> 
> **Overview**
> Adopts current iOS APIs across the in-app messaging SDK and sample apps, with iOS 13–16 fallbacks where needed.
> 
> The most notable behavior change is in `MessageManager.handleGistLoadPageAction`: it no longer preflights page-action URLs with `canOpenURL` and instead calls `UIApplication.shared.open` directly, using the completion handler to log a non-PII error if the system reports failure. This avoids false negatives for schemes missing from the host app's `LSApplicationQueriesSchemes`.
> 
> SwiftUI change observation is unified through a new `onValueChange` helper that uses the iOS 17 two-parameter `onChange` signature while falling back to the older API. UIKit layout and trait handling is updated in `GistModalViewController` and `GistView` to use `viewWillLayoutSubviews`, explicit initializers, and `registerForTraitChanges` on iOS 17. The APN-UIKit sample drops an unused URL-validation helper, and the `CioMessagingInApp` API baseline is regenerated for the new `GistView` initializers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2095f16c0daa908b088a468d52a1fdcf2c1394e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->