### PR TITLE
chore(samples): route Live Activity universal-link destinations

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
@@ -125,18 +125,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 }
 
-private extension DeepLinksHandlerUtil {
-    func handleCustomerIODestination(_ url: URL) -> Bool {
-        let scheme = url.scheme?.lowercased()
-        if scheme == "http" || scheme == "https" {
-            return handleUniversalLinkDeepLink(url)
-        }
-        // Returning false lets the SDK open unclaimed app schemes through the system, which
-        // delivers sample-owned URLs such as Live Activity destinations to UIScene.
-        return handleAppSchemeDeepLink(url)
-    }
-}
-
 /*
  The lines of code below are optional and only required if you:
  - want fine-grained control over whether notifications are shown in the foreground

--- a/Apps/APN-UIKit/APN UIKit/SceneDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/SceneDelegate.swift
@@ -92,7 +92,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 routeToLiveActivities()
                 continue
             }
-            _ = deepLinkHandler.handleAppSchemeDeepLink(url)
+            _ = deepLinkHandler.handleCustomerIODestination(url)
         }
     }
 

--- a/Apps/APN-UIKit/APN UIKit/Util/DeepLinksHandlerUtil.swift
+++ b/Apps/APN-UIKit/APN UIKit/Util/DeepLinksHandlerUtil.swift
@@ -15,6 +15,19 @@ protocol DeepLinksHandlerUtil {
     func handleUniversalLinkDeepLink(_ url: URL) -> Bool
 }
 
+extension DeepLinksHandlerUtil {
+    /// Routes a Customer.io deep-link destination through the handler matching its URL scheme.
+    func handleCustomerIODestination(_ url: URL) -> Bool {
+        let scheme = url.scheme?.lowercased()
+        if scheme == "http" || scheme == "https" {
+            return handleUniversalLinkDeepLink(url)
+        }
+        // Returning false lets the SDK open unclaimed app schemes through the system when this
+        // helper is used by SDKConfigBuilder.deepLinkCallback.
+        return handleAppSchemeDeepLink(url)
+    }
+}
+
 // sourcery: InjectRegisterShared = "DeepLinksHandlerUtil"
 class AppDeepLinksHandlerUtil: DeepLinksHandlerUtil {
     private let storage: StorageManager

--- a/Apps/APN-UIKit/APN UIKitTests/APN_UIKitTests.swift
+++ b/Apps/APN-UIKit/APN UIKitTests/APN_UIKitTests.swift
@@ -113,6 +113,73 @@ final class Tests: XCTestCase {
         XCTAssertTrue(handler.handleUniversalLinkDeepLink(URL(string: "https://ciosample.page.link/spm")!))
         wait(for: [notificationExpectation], timeout: 1)
     }
+
+    func testHandleCustomerIODestination_givenUniversalLink_thenPostsDeepLinkRoute() {
+        let storage = StorageManagerStub()
+        storage.userEmailId = "test@example.com"
+        let notificationCenter = NotificationCenter()
+        let notificationExpectation = expectation(description: "Dashboard deep-link route posted")
+        let observer = notificationCenter.addObserver(
+            forName: .showDeepLinkScreenOnDashboard,
+            object: nil,
+            queue: .main
+        ) { notification in
+            XCTAssertEqual(notification.userInfo?["link"] as? String, "/spm")
+            notificationExpectation.fulfill()
+        }
+        defer { notificationCenter.removeObserver(observer) }
+        let handler = AppDeepLinksHandlerUtil(storage: storage, notificationCenter: notificationCenter)
+
+        XCTAssertTrue(handler.handleCustomerIODestination(URL(string: "https://ciosample.page.link/spm")!))
+        wait(for: [notificationExpectation], timeout: 1)
+    }
+
+    func testHandleCustomerIODestination_givenAppScheme_thenPostsSettingsRoute() {
+        let storage = StorageManagerStub()
+        storage.userEmailId = "test@example.com"
+        let notificationCenter = NotificationCenter()
+        let notificationExpectation = expectation(description: "Dashboard settings route posted")
+        let observer = notificationCenter.addObserver(
+            forName: .showSettingsScreenOnDashboard,
+            object: nil,
+            queue: .main
+        ) { notification in
+            XCTAssertEqual(notification.userInfo?["site_id"] as? String, "test")
+            notificationExpectation.fulfill()
+        }
+        defer { notificationCenter.removeObserver(observer) }
+        let handler = AppDeepLinksHandlerUtil(storage: storage, notificationCenter: notificationCenter)
+
+        XCTAssertTrue(handler.handleCustomerIODestination(URL(string: "apn-uikit://settings?site_id=test")!))
+        wait(for: [notificationExpectation], timeout: 1)
+    }
+
+    func testHandleCustomerIODestination_givenForeignScheme_thenReturnsFalse() {
+        let handler = AppDeepLinksHandlerUtil(
+            storage: StorageManagerStub(),
+            notificationCenter: NotificationCenter()
+        )
+
+        XCTAssertFalse(handler.handleCustomerIODestination(URL(string: "mailto:support@example.com")!))
+    }
+
+    func testHandleCustomerIODestination_givenNonMatchingUniversalLink_thenReturnsFalse() {
+        let handler = AppDeepLinksHandlerUtil(
+            storage: StorageManagerStub(),
+            notificationCenter: NotificationCenter()
+        )
+
+        XCTAssertFalse(handler.handleCustomerIODestination(URL(string: "https://example.com/spm")!))
+    }
+
+    func testHandleCustomerIODestination_givenUppercaseHTTPSLink_thenReturnsTrue() {
+        let handler = AppDeepLinksHandlerUtil(
+            storage: StorageManagerStub(),
+            notificationCenter: NotificationCenter()
+        )
+
+        XCTAssertTrue(handler.handleCustomerIODestination(URL(string: "HTTPS://CIOSAMPLE.PAGE.LINK/spm")!))
+    }
 }
 
 private final class StorageManagerStub: StorageManager {

--- a/Tests/Common/SPITests.swift
+++ b/Tests/Common/SPITests.swift
@@ -3,7 +3,7 @@ import SharedTests
 import XCTest
 
 /// Includes compile-time checks and validations for internal APIs marked with `@_spi(Internal)`.
-/// These tests simulate usage by trusted internal consumers (e.g., Flutter or React Native plugins), and verify that default
+/// These tests simulate usage across trusted SDK module boundaries and verify that default
 /// implementations or internal contracts remain safe and stable.
 ///
 /// These tests should NOT be used to validate public-facing API behavior.
@@ -12,7 +12,7 @@ final class SPITests: UnitTest {
     /// Validates that a conforming type does not need to implement the `@_spi(Internal)` method
     /// `setDeepLinkCallback(_:)` directly, and can rely on default implementation provided via protocol extension.
     ///
-    /// This ensures that internal consumers (with SPI access) can conform to `DeepLinkUtil` without
+    /// This ensures that SDK modules with SPI access can conform to `DeepLinkUtil` without
     /// breaking when protocol requirements change.
     func test_DeepLinkUtil_conformance_withDefaultSPIImplementation() {
         class Stub: DeepLinkUtil {

--- a/docs/dev-notes/DEEPLINKS-AND-NOTIFICATIONS.md
+++ b/docs/dev-notes/DEEPLINKS-AND-NOTIFICATIONS.md
@@ -190,7 +190,7 @@ Tier 3: UIKitWrapper.open(url: url)
 ```
 
 **Notes:**
-- Native hosts register `deepLinkCallback` through the public `SDKConfigBuilder.deepLinkCallback(_:)` API. React Native and Flutter wrappers install their native routing adapters through the internal `setDeepLinkCallback(_:)` SPI.
+- Native hosts and the Flutter and React Native wrappers configure deep-link routing through the public `SDKConfigBuilder.deepLinkCallback(_:)` API. During `CustomerIO.initialize`, the SDK transfers that callback into the shared `DeepLinkUtil` through the internal `setDeepLinkCallback(_:)` SPI.
 - Scene-based native apps should prefer `deepLinkCallback`. The SDK cannot forward a URL to an arbitrary `UISceneDelegate` because the host may own more than one scene.
 - `NSUserActivity.webpageURL` only accepts `http`/`https` schemes. App-scheme URLs (e.g. `myapp://`) skip Tier 2 and fall through to `UIApplication.open()`.
 - SDK logs a message at each tier indicating how the deep link was handled (or if no tier handled it).


### PR DESCRIPTION
## Summary

Follow-up to the post-merge review on #1223.

- route APN-UIKit Live Activity redirect destinations through the existing scheme-aware helper, so supported HTTPS universal links work on the shared cold and warm scene path
- keep opened attribution ordering, direct universal-link handling, SDK runtime behavior, and the AppDelegate callback behavior unchanged
- correct the internal note: native hosts, Flutter, and React Native use the public `SDKConfigBuilder.deepLinkCallback`; `CustomerIO.initialize` transfers it through the internal SPI
- add focused coverage for HTTPS, app-scheme, decline, and case-insensitive scheme selection

This intentionally does not add a system-open fallback or a new routing abstraction.

## Validation

- `swiftformat`
- strict `swiftlint`, 0 violations
- APN-UIKit sample simulator build
- `APN UIKitTests/Tests`, 17 passing
- Claude Code Opus pre-change assessment and post-change adversarial review: APPROVE

## Scope

Sample app, focused sample tests, and internal developer notes only. No SDK runtime source changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sample app, tests, and documentation only; no SDK runtime changes.
> 
> **Overview**
> **Live Activity deep links** on the APN-UIKit scene path (cold and warm) now call `handleCustomerIODestination` instead of only `handleAppSchemeDeepLink`, so HTTPS universal links from CIO widget URLs route the same way as the SDK `deepLinkCallback` in `AppDelegate`.
> 
> **Refactor:** `handleCustomerIODestination` moves from a private `AppDelegate` extension into a default implementation on `DeepLinksHandlerUtil`, shared by both entry points.
> 
> **Tests and docs:** New unit tests cover universal links, app schemes, foreign schemes, non-matching hosts, and case-insensitive `https`. Dev notes clarify that native, Flutter, and RN hosts use public `SDKConfigBuilder.deepLinkCallback`, wired into `DeepLinkUtil` at initialize via the internal SPI. SPI test comments are wording-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1419192b225ca2a8201f0e845e8beae65c56c5fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->