### PR TITLE
ci: stop building sample apps on PRs, skip CI for docs-only changes

### DIFF
--- a/.github/workflows/build-sample-apps.yml
+++ b/.github/workflows/build-sample-apps.yml
@@ -1,10 +1,14 @@
 name: Build sample apps
 
 on:
-  pull_request: # build sample apps for every commit pushed to an open pull request (including drafts)
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
   push:
     branches: [ main, feature/* ]
-  workflow_dispatch: # allow manual run     
+    paths-ignore:
+      - '**/*.md'
+  workflow_dispatch: # allow manual run
     inputs:
       use_latest_sdk_version:
         description: "Whether to build sample apps with the latest SDK version (newest tag)."
@@ -17,41 +21,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # 1) Update PR comment (optional) - only runs if event is a pull_request
-  update-pr-comment:
-    if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
-    permissions: # to be able to comment on PR
-      pull-requests: write
-    outputs:
-      comment-id: ${{ steps.create-comment.outputs.comment-id }}
-    steps:
-      - name: Find existing PR comment
-        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
-        id: existing-comment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: <!-- sample app builds -->
-
-      - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
-        id: create-comment
-        with:
-          comment-id: ${{ steps.existing-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            <!-- sample app builds -->
-            # Sample app builds 📱
-
-            Below you will find the list of the latest versions of the sample apps. 
-            It's recommended to always download the latest builds to test this PR accurately.
-          edit-mode: replace # replace the existing comment with new content since we are creating new builds 
-
-  # 2) Call the reusable workflow to build all sample apps
+  # 1) Build and publish sample apps to Firebase App Distribution.
+  # Skipped on pull_request: reviewing a PR doesn't need a published distributable
+  # build, and the 2-job matrix (APN-UIKit + CocoaPods-FCM) was contending with
+  # Lint/Tests/Maestro E2E for the same limited macOS runner pool on every PR push.
+  # Still runs on push to main/feature branches, and on-demand via workflow_dispatch.
   build-sample-apps:
-    if: ${{ always() }}
-    needs: [ update-pr-comment ]
+    if: ${{ github.event_name != 'pull_request' }}
     uses: ./.github/workflows/reusable_build_sample_apps.yml
     with:
       # If manual run AND user sets 'use_latest_sdk_version' to true, get the new tag.
@@ -68,7 +44,9 @@ jobs:
       SAMPLE_APPS_INSTRUCTIONS_GUIDE_LINK: ${{ secrets.SAMPLE_APPS_INSTRUCTIONS_GUIDE_LINK }}
       SLACK_NOTIFY_RELEASES_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFY_RELEASES_WEBHOOK_URL }}
 
-  # 3) Generate SDK size reports or other tasks
+  # 2) Generate SDK size reports. Kept on pull_request: this is the single job that
+  # surfaces the binary-size diff vs. main on every PR, separate from (and much
+  # cheaper than) the sample-app build matrix above.
   generate-sdk-size-reports:
     runs-on: macos-26
     permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,9 @@
 name: Lint
 
-on: [pull_request]
+on:
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   lint:

--- a/.github/workflows/maestro-e2e.yml
+++ b/.github/workflows/maestro-e2e.yml
@@ -1,7 +1,9 @@
 name: Maestro SDK E2E
 
 on:
-  pull_request: {}
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
   workflow_dispatch:
     inputs:
       profile:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,9 @@
 name: Tests
 
-on: 
+on:
   pull_request:
+    paths-ignore:
+      - '**/*.md'
   push:
     branches: [main] # code coverage reporting needs to be on main so all PRs can compare against it. 
 


### PR DESCRIPTION
## Why
PR CI was slow because `Build sample apps` runs its full 2-job Firebase-distribution build matrix (APN-UIKit + CocoaPods-FCM, both `macos-26`) on every PR push, in parallel with Lint/Tests/Maestro E2E — all competing for the same limited macOS runner pool. On #1226 (a docs-only change) `test` and `lint` sat QUEUED for 10+ minutes waiting for a runner, not because the jobs themselves were slow.

## What changed
- `build-sample-apps.yml`: the sample-app build/publish job now skips on `pull_request` (`if: github.event_name != 'pull_request'`). It already runs on push to `main`/`feature/*`, so PR-time publishing to Firebase App Distribution was redundant. Removed the now-dead `update-pr-comment` job that only made sense alongside it.
  - Kept `generate-sdk-size-reports` running on PRs — it's a single job (not a 2-job matrix) and it's what surfaces the binary-size diff vs. main on every PR, so removing `pull_request` entirely would have silently killed that signal too.
- Added `paths-ignore: ['**/*.md']` to `lint.yml`, `test.yml`, `maestro-e2e.yml`, and `build-sample-apps.yml` so a docs-only PR (like #1226) doesn't trigger a full iOS build/test/E2E pipeline at all.

## Net effect
2 fewer macOS jobs contending for runners on every PR push, and zero CI on markdown-only PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI trigger and job gating only; no application or SDK runtime behavior changes, with the tradeoff that PRs no longer publish Firebase sample builds until merge or manual dispatch.
> 
> **Overview**
> **Reduces macOS runner contention on PRs** by no longer running the Firebase App Distribution sample-app matrix (`APN-UIKit` + `CocoaPods-FCM`) on `pull_request`. That job now runs only on push to `main`/`feature/*` and `workflow_dispatch`. The **`update-pr-comment`** job that posted “Sample app builds” links on PRs was removed with it.
> 
> **PRs still get SDK binary size feedback** via the standalone `generate-sdk-size-reports` job, which posts the size diff comment without the heavy distributable builds.
> 
> **Docs-only PRs skip most CI**: `paths-ignore: '**/*.md'` was added on `pull_request` for **Lint**, **Tests**, **Maestro E2E**, and **Build sample apps**, so markdown-only changes do not queue full iOS lint/test/E2E (or the size workflow when only `.md` files change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 696a332896084ab2b73e7ef81e826ebd1dd63880. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->