### PR TITLE
chore: classify and log in-app message failures internally

### DIFF
--- a/Sources/MessagingInApp/Gist/EngineWeb/EngineEventHandler.swift
+++ b/Sources/MessagingInApp/Gist/EngineWeb/EngineEventHandler.swift
@@ -49,6 +49,29 @@ enum EngineEventHandler {
         extractRoute(properties: properties)
     }
 
+    /// Pulls the renderer's own description of a failure out of an `error` event.
+    ///
+    /// The renderer sends `{ target, errorMessage }` — e.g. `Unable to find "step-2" in payload.`
+    /// That string is the only first-hand account of why a message would not render, and it was
+    /// being dropped on the floor.
+    static func getErrorProperties(properties: EngineEventProperties) -> String? {
+        guard let parameters = properties["parameters"] else { return nil }
+
+        let errorMessage = parameters["errorMessage"] as? String
+        let target = parameters["target"] as? String
+
+        switch (errorMessage, target) {
+        case (.some(let message), .some(let target)):
+            return "\(message) (target: \(target))"
+        case (.some(let message), .none):
+            return message
+        case (.none, .some(let target)):
+            return "Engine reported an error for target: \(target)"
+        case (.none, .none):
+            return nil
+        }
+    }
+
     static func getRouteLoadedProperties(properties: EngineEventProperties) -> String? {
         extractRoute(properties: properties)
     }

--- a/Sources/MessagingInApp/Gist/EngineWeb/EngineWeb.swift
+++ b/Sources/MessagingInApp/Gist/EngineWeb/EngineWeb.swift
@@ -27,6 +27,9 @@ public class EngineWeb: NSObject, EngineWebInstance {
     private var _timeoutTimer: Timer?
     private var _elapsedTimer = ElapsedTimer()
 
+    /// How long the engine gets to report `bootstrapped` before the message is treated as failed.
+    static let bootstrapTimeoutSeconds: TimeInterval = 5.0
+
     public weak var delegate: EngineWebDelegate?
     var webView = WKWebView()
 
@@ -86,11 +89,10 @@ public class EngineWeb: NSObject, EngineWebInstance {
 
         if let url = URL(string: messageUrl) {
             _timeoutTimer?.invalidate()
-            _timeoutTimer = Timer.scheduledTimer(timeInterval: 5.0, target: self, selector: #selector(forcedTimeout), userInfo: nil, repeats: false)
+            _timeoutTimer = Timer.scheduledTimer(timeInterval: Self.bootstrapTimeoutSeconds, target: self, selector: #selector(forcedTimeout), userInfo: nil, repeats: false)
             webView.load(URLRequest(url: url))
         } else {
-            logger.logWithModuleTag("Invalid URL: \(messageUrl)", level: .error)
-            delegate?.error()
+            reportFailure(InAppMessageError(reason: .internalError, detail: "Invalid renderer URL: \(messageUrl)"))
         }
     }
 
@@ -126,13 +128,23 @@ public class EngineWeb: NSObject, EngineWebInstance {
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "gist")
     }
 
+    /// Single exit for every failure in this class: classify, log, then tell the delegate.
+    ///
+    /// `MessageManager` owns the resulting `messageLoadingFailed` dispatch — see `forcedTimeout`.
+    private func reportFailure(_ error: InAppMessageError) {
+        logger.logWithModuleTag(
+            "Message \(currentMessage.describeForLogs) failed: \(error.describeForLogs)",
+            level: .error
+        )
+        delegate?.error()
+    }
+
     @objc
     func forcedTimeout() {
-        logger.logWithModuleTag("Timeout triggered for message: \(currentMessage.describeForLogs), triggering message error.", level: .info)
         // Report through the delegate only. `MessageManager` turns this into a single
         // `messageLoadingFailed` dispatch, the same as every other failure site in this class.
         // Dispatching here as well delivered the host's error callback twice for a timeout.
-        delegate?.error()
+        reportFailure(InAppMessageError(reason: .timeout, detail: "Engine did not bootstrap within \(Int(Self.bootstrapTimeoutSeconds))s"))
     }
 }
 
@@ -179,7 +191,10 @@ extension EngineWeb: WKScriptMessageHandler {
                 delegate?.tap(name: tapProperties.name, action: tapProperties.action, system: tapProperties.system)
             }
         case .error:
-            delegate?.error()
+            reportFailure(InAppMessageError(
+                reason: .renderFailed,
+                detail: EngineEventHandler.getErrorProperties(properties: eventProperties)
+            ))
         }
     }
 }
@@ -212,27 +227,31 @@ extension EngineWeb: WKNavigationDelegate {
 
             webView.evaluateJavaScript(js) { [weak self] _, error in
                 if let error = error {
-                    self?.logger.logWithModuleTag("JavaScript execution error: \(error)", level: .error)
-                    self?.delegate?.error()
+                    self?.reportFailure(InAppMessageError(
+                        reason: .internalError,
+                        detail: "Configuration injection failed: \(error.localizedDescription)"
+                    ))
                 } else {
                     self?.logger.logWithModuleTag("Configuration injected successfully", level: .info)
                 }
             }
         } catch {
-            logger.logWithModuleTag("Failed to encode configuration: \(error)", level: .error)
-            delegate?.error()
+            reportFailure(InAppMessageError(
+                reason: .internalError,
+                detail: "Failed to encode configuration: \(error.localizedDescription)"
+            ))
         }
     }
 
     public func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
-        delegate?.error()
+        reportFailure(InAppMessageError(reason: .webViewCrashed, detail: "WebView content process terminated"))
     }
 
     public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-        delegate?.error()
+        reportFailure(InAppMessageError(networkError: error))
     }
 
     public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-        delegate?.error()
+        reportFailure(InAppMessageError(networkError: error))
     }
 }

--- a/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
@@ -280,7 +280,14 @@ extension BaseMessageManager: EngineWebDelegate {
     }
 
     public func routeError(route: String) {
-        logger.logWithModuleTag("Error loading message with route: \(route)", level: .error)
+        // The renderer has not emitted `routeError` since the 3.0 bundle, so this path is
+        // effectively unreachable today. Classified anyway so it behaves like the live sites if a
+        // future renderer brings it back.
+        let error = InAppMessageError(reason: .renderFailed, detail: "Failed to load route: \(route)")
+        logger.logWithModuleTag(
+            "Message \(currentMessage.describeForLogs) failed: \(error.describeForLogs)",
+            level: .error
+        )
         inAppMessageManager.dispatch(
             action: .engineAction(
                 action: .messageLoadingFailed(message: currentMessage)

--- a/Sources/MessagingInApp/Type/InAppMessageError.swift
+++ b/Sources/MessagingInApp/Type/InAppMessageError.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Why an in-app message failed to load or render.
+///
+/// The cases are deliberately coarse: each one maps to a different thing an integrator would do
+/// about it — check connectivity, look at a slow renderer, report the message content to us, or
+/// file an SDK bug. Finer detail belongs in ``InAppMessageError/detail``.
+enum InAppMessageErrorReason: String {
+    /// The renderer could not be reached: navigation failed, TLS failed, or the host returned an
+    /// error status.
+    case network
+    /// The renderer was reached but never signalled that it had bootstrapped within the timeout.
+    case timeout
+    /// The renderer loaded and then reported that it could not render the message.
+    case renderFailed
+    /// The WebView's content process died, so the message can never finish.
+    case webViewCrashed
+    /// The SDK itself could not drive the render — a malformed URL, or configuration that would
+    /// not encode or inject.
+    case internalError
+}
+
+/// A single in-app message load/render failure, with as much context as the failing layer had.
+struct InAppMessageError: Error, Equatable {
+    /// The coarse category. Branch on this.
+    let reason: InAppMessageErrorReason
+
+    /// Human-readable detail from the layer that failed — a `WKWebView` error description, or the
+    /// message the renderer itself reported. Free-form and unstable: log it, don't parse it.
+    let detail: String?
+
+    /// The underlying platform error code where the failing layer had one, e.g. an `NSURLError`
+    /// code or an HTTP status. `nil` when the failure carried no numeric code.
+    let code: Int?
+
+    init(reason: InAppMessageErrorReason, detail: String? = nil, code: Int? = nil) {
+        self.reason = reason
+        self.detail = detail
+        self.code = code
+    }
+
+    /// Compact form for logs: `network (-1009): The Internet connection appears to be offline.`
+    var describeForLogs: String {
+        var description = reason.rawValue
+        if let code = code {
+            description += " (\(code))"
+        }
+        if let detail = detail {
+            description += ": \(detail)"
+        }
+        return description
+    }
+}
+
+extension InAppMessageError {
+    /// Builds a `.network` failure from a `WKWebView` navigation error, keeping the underlying
+    /// description and `NSURLError` code that the SDK previously discarded.
+    init(networkError: Error) {
+        let nsError = networkError as NSError
+        self.init(
+            reason: .network,
+            detail: nsError.localizedDescription,
+            code: nsError.code
+        )
+    }
+}

--- a/Tests/MessagingInApp/EngineWeb/InAppMessageErrorTests.swift
+++ b/Tests/MessagingInApp/EngineWeb/InAppMessageErrorTests.swift
@@ -1,0 +1,82 @@
+@testable import CioInternalCommon
+@testable import CioMessagingInApp
+import Foundation
+import SharedTests
+import XCTest
+
+/// Covers the failure detail the SDK now keeps hold of.
+///
+/// Two things used to be discarded outright: the renderer's own `errorMessage` (the only
+/// first-hand account of why a message would not render) and the `NSError` behind a failed
+/// navigation. Both now reach the logs.
+class InAppMessageErrorTests: UnitTest {
+    // MARK: - renderer error payload
+
+    /// Shape the renderer actually sends, e.g. `Unable to find "step-2" in payload.`
+    private func errorEvent(errorMessage: String? = nil, target: String? = nil) -> EngineEventProperties {
+        var parameters: [String: AnyObject] = [:]
+        if let errorMessage = errorMessage {
+            parameters["errorMessage"] = errorMessage as AnyObject
+        }
+        if let target = target {
+            parameters["target"] = target as AnyObject
+        }
+        return ["parameters": parameters as AnyObject]
+    }
+
+    func test_getErrorProperties_givenMessageAndTarget_expectBoth() {
+        let properties = errorEvent(errorMessage: "Unable to find \"step-2\" in payload.", target: "step-2")
+
+        let detail = EngineEventHandler.getErrorProperties(properties: properties)
+
+        XCTAssertEqual(detail, "Unable to find \"step-2\" in payload. (target: step-2)")
+    }
+
+    func test_getErrorProperties_givenMessageOnly_expectMessage() {
+        let detail = EngineEventHandler.getErrorProperties(properties: errorEvent(errorMessage: "Boom"))
+
+        XCTAssertEqual(detail, "Boom")
+    }
+
+    func test_getErrorProperties_givenTargetOnly_expectTargetDescribed() {
+        let detail = EngineEventHandler.getErrorProperties(properties: errorEvent(target: "step-2"))
+
+        XCTAssertEqual(detail, "Engine reported an error for target: step-2")
+    }
+
+    func test_getErrorProperties_givenNeither_expectNil() {
+        XCTAssertNil(EngineEventHandler.getErrorProperties(properties: errorEvent()))
+    }
+
+    func test_getErrorProperties_givenNoParameters_expectNil() {
+        XCTAssertNil(EngineEventHandler.getErrorProperties(properties: [:]))
+    }
+
+    // MARK: - navigation errors
+
+    func test_init_givenNavigationError_expectReasonDetailAndCodeKept() {
+        let underlying = NSError(
+            domain: NSURLErrorDomain,
+            code: NSURLErrorNotConnectedToInternet,
+            userInfo: [NSLocalizedDescriptionKey: "The Internet connection appears to be offline."]
+        )
+
+        let error = InAppMessageError(networkError: underlying)
+
+        XCTAssertEqual(error.reason, .network)
+        XCTAssertEqual(error.detail, "The Internet connection appears to be offline.")
+        XCTAssertEqual(error.code, NSURLErrorNotConnectedToInternet)
+    }
+
+    // MARK: - log formatting
+
+    func test_describeForLogs_givenCodeAndDetail_expectAllThree() {
+        let error = InAppMessageError(reason: .network, detail: "offline", code: -1009)
+
+        XCTAssertEqual(error.describeForLogs, "network (-1009): offline")
+    }
+
+    func test_describeForLogs_givenReasonOnly_expectReason() {
+        XCTAssertEqual(InAppMessageError(reason: .timeout).describeForLogs, "timeout")
+    }
+}


### PR DESCRIPTION
## MBL-2310 · iOS stack — step 2 of 3

| Step | PR | |
| --- | --- | --- |
| 1 | #1231 — `chore:` fire the in-app error callback once on engine timeout |  |
| **2** | **#1237 — `chore:` classify and log in-app message failures internally** | **← you are here** |
| 3 | #1238 — `fix:` surface the failure reason on `errorWithMessage` | cuts the iOS release |

Merge bottom-up. Every `chore:` step is internal only — no public type, no protocol or interface change, and the committed API surface is untouched — so nothing user-visible ships if an unrelated release cuts while they sit on main. The final `fix:` carries the whole feature and is the only step that triggers a release.

**Android mirror:** customerio/customerio-android#823 → customerio/customerio-android#826 → customerio/customerio-android#827 → customerio/customerio-android#828. Both platforms land the same API and must release before the wrapper PRs (Flutter, React Native) can start.

---
Gives every in-app failure a reason and keeps the detail the SDK was throwing away. Internal only — nothing public changes yet.

Stacked on #1231. Groundwork for MBL-2310; the next PR puts the reason on `errorWithMessage`.

### Why

All nine failure sites in `EngineWeb` collapsed into a bare `delegate?.error()`, so why a message failed survived only in whatever each site happened to log. Two of the most useful sources were dropped entirely:

- **The renderer's own `errorMessage`.** The 3.0 bundle sends `{ target, errorMessage }` with the engine `error` event — e.g. `Unable to find "step-2" in payload.` `EngineWeb` discarded `eventProperties`. That string is the only first-hand account of why a message would not render.
- **The `NSError` behind a failed navigation.** `didFail` and `didFailProvisionalNavigation` both received one and ignored it, losing the description and the `NSURLError` code — which is the most likely real-world failure, the renderer being unreachable.

### Change

An internal `InAppMessageError` (`reason`, `detail`, `code`) with five coarse reasons, each mapping to a different thing an integrator would actually do: `network`, `timeout`, `renderFailed`, `webViewCrashed`, `internalError`.

All nine sites now go through one `reportFailure` choke point that classifies and logs before notifying the delegate, so the next PR changes the delegate hand-off in exactly one place. `EngineEventHandler.getErrorProperties` parses the renderer payload. The 5s bootstrap timeout is now a named constant rather than a literal.

`MessageManager.routeError` is classified too, though renderer 3.0 never emits `routeError` — noted in a comment so nobody counts it as live coverage.

### No public API movement

Every new declaration is internal — `InAppMessageError`, `InAppMessageErrorReason`, `getErrorProperties`, and `bootstrapTimeoutSeconds` (a member of a public class, so internal by default). `api-docs/` is untouched. `EngineWebDelegate` is public API, which is exactly why widening it waits for the `fix:` PR.

### Verification

`InAppMessageErrorTests` covers the renderer payload parser across all four combinations of `errorMessage`/`target` plus the no-parameters case, the `NSError` mapping, and log formatting.

`MessagingInAppTests/InAppMessageErrorTests` + `MessagingInAppTests/EngineWebTimeoutTests` — 9 tests, 0 failures. `MessagingInApp` scheme builds clean.
