### PR TITLE
fix: surface the failure reason on in-app error callback

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
@@ -170,11 +170,25 @@ extension AppDelegate: InAppEventListener {
         )
     }
 
-    // In-app message produces an error - preventing message from appearing to the user
+    // In-app message produces an error - preventing message from appearing to the user.
+    // Still a requirement of the protocol; the SDK calls the overload below, which carries the reason.
     nonisolated func errorWithMessage(message: InAppMessage) {
         CustomerIO.shared.track(
             name: "inapp error",
             properties: ["delivery-id": message.deliveryId ?? "(none)", "message-id": message.messageId]
+        )
+    }
+
+    nonisolated func errorWithMessage(message: InAppMessage, error: InAppMessageError) {
+        CustomerIO.shared.track(
+            name: "inapp error",
+            properties: [
+                "delivery-id": message.deliveryId ?? "(none)",
+                "message-id": message.messageId,
+                "error-reason": error.reason.rawValue,
+                "error-detail": error.detail ?? "(none)",
+                "error-code": error.code.map(String.init) ?? "(none)"
+            ]
         )
     }
 

--- a/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
@@ -180,13 +180,15 @@ extension AppDelegate: InAppEventListener {
     }
 
     nonisolated func errorWithMessage(message: InAppMessage, error: InAppMessageError) {
+        // `detail` is deliberately logged but not tracked: it is diagnostic text, partly supplied
+        // by the renderer, and not something to forward verbatim to analytics.
+        print("in-app message failed: \(error.reason.rawValue) — \(error.detail ?? "(no detail)")")
         CustomerIO.shared.track(
             name: "inapp error",
             properties: [
                 "delivery-id": message.deliveryId ?? "(none)",
                 "message-id": message.messageId,
                 "error-reason": error.reason.rawValue,
-                "error-detail": error.detail ?? "(none)",
                 "error-code": error.code.map(String.init) ?? "(none)"
             ]
         )

--- a/Sources/MessagingInApp/Gist/EngineWeb/EngineWeb.swift
+++ b/Sources/MessagingInApp/Gist/EngineWeb/EngineWeb.swift
@@ -51,6 +51,10 @@ public class EngineWeb: NSObject, EngineWebInstance {
 
     /// A failure raised before a delegate was attached, held until one is.
     private var pendingFailure: InAppMessageError?
+
+    /// Set once the first failure is accepted. An engine instance renders one message, so it fails
+    /// at most once.
+    private var hasReportedFailure = false
     var webView = WKWebView()
 
     public var view: UIView {
@@ -153,7 +157,21 @@ public class EngineWeb: NSObject, EngineWebInstance {
     /// `MessageManager` owns the resulting `messageLoadingFailed` dispatch — see `forcedTimeout`.
     /// A failure raised before the delegate is attached is held and delivered on assignment, so no
     /// path here reports into the void.
+    ///
+    /// The first failure wins and every later one is dropped. WebKit can deliver more than one
+    /// failure callback for a single load, and the bootstrap timer is still armed when a failure
+    /// arrives — the dispatch it triggers is asynchronous, so without latching, a host could be told
+    /// `.network` and then `.timeout` about the same message. That is deterministic for inline
+    /// messages, whose dismissal never reaches `cleanEngineWeb()`.
     private func reportFailure(_ error: InAppMessageError) {
+        guard !hasReportedFailure else { return }
+        hasReportedFailure = true
+
+        // The timer retains self through its target, so leaving it armed also keeps this instance
+        // alive for the rest of the timeout after the message has already failed.
+        _timeoutTimer?.invalidate()
+        _timeoutTimer = nil
+
         logger.logWithModuleTag(
             "Message \(currentMessage.describeForLogs) failed: \(error.describeForLogs)",
             level: .error

--- a/Sources/MessagingInApp/Gist/EngineWeb/EngineWeb.swift
+++ b/Sources/MessagingInApp/Gist/EngineWeb/EngineWeb.swift
@@ -11,6 +11,15 @@ public protocol EngineWebDelegate: AnyObject {
     func routeLoaded(route: String)
     func sizeChanged(width: CGFloat, height: CGFloat)
     func error()
+    /// Called when a message fails to load or render, with the reason it failed.
+    func error(_ error: InAppMessageError)
+}
+
+public extension EngineWebDelegate {
+    /// Defaulted so conformers written against the reason-less callback keep compiling.
+    func error(_ error: InAppMessageError) {
+        self.error()
+    }
 }
 
 protocol EngineWebInstance: AutoMockable {
@@ -136,7 +145,7 @@ public class EngineWeb: NSObject, EngineWebInstance {
             "Message \(currentMessage.describeForLogs) failed: \(error.describeForLogs)",
             level: .error
         )
-        delegate?.error()
+        delegate?.error(error)
     }
 
     @objc

--- a/Sources/MessagingInApp/Gist/EngineWeb/EngineWeb.swift
+++ b/Sources/MessagingInApp/Gist/EngineWeb/EngineWeb.swift
@@ -39,7 +39,18 @@ public class EngineWeb: NSObject, EngineWebInstance {
     /// How long the engine gets to report `bootstrapped` before the message is treated as failed.
     static let bootstrapTimeoutSeconds: TimeInterval = 5.0
 
-    public weak var delegate: EngineWebDelegate?
+    public weak var delegate: EngineWebDelegate? {
+        didSet {
+            // `loadMessage()` runs from `init`, before the delegate exists, so a failure raised
+            // there has nobody to report to yet. Deliver it as soon as one is attached.
+            guard delegate != nil, let failure = pendingFailure else { return }
+            pendingFailure = nil
+            delegate?.error(failure)
+        }
+    }
+
+    /// A failure raised before a delegate was attached, held until one is.
+    private var pendingFailure: InAppMessageError?
     var webView = WKWebView()
 
     public var view: UIView {
@@ -140,12 +151,18 @@ public class EngineWeb: NSObject, EngineWebInstance {
     /// Single exit for every failure in this class: classify, log, then tell the delegate.
     ///
     /// `MessageManager` owns the resulting `messageLoadingFailed` dispatch — see `forcedTimeout`.
+    /// A failure raised before the delegate is attached is held and delivered on assignment, so no
+    /// path here reports into the void.
     private func reportFailure(_ error: InAppMessageError) {
         logger.logWithModuleTag(
             "Message \(currentMessage.describeForLogs) failed: \(error.describeForLogs)",
             level: .error
         )
-        delegate?.error(error)
+        guard let delegate = delegate else {
+            pendingFailure = error
+            return
+        }
+        delegate.error(error)
     }
 
     @objc

--- a/Sources/MessagingInApp/Gist/GistDelegate.swift
+++ b/Sources/MessagingInApp/Gist/GistDelegate.swift
@@ -7,8 +7,16 @@ public protocol GistDelegate: AnyObject {
     func messageShown(message: Message)
     func messageDismissed(message: Message)
     func messageError(message: Message)
+    func messageError(message: Message, error: InAppMessageError)
     func action(message: Message, currentRoute: String, action: String, name: String)
     func setEventListener(_ eventListener: InAppEventListener?)
+}
+
+public extension GistDelegate {
+    /// Defaulted so conformers written against the reason-less callback keep compiling.
+    func messageError(message: Message, error: InAppMessageError) {
+        messageError(message: message)
+    }
 }
 
 // sourcery: InjectRegisterShared = "GistDelegate"
@@ -58,9 +66,14 @@ class GistDelegateImpl: GistDelegate {
     }
 
     public func messageError(message: Message) {
-        logger.logWithModuleTag("Message error: \(message.describeForLogs)", level: .debug)
+        messageError(message: message, error: InAppMessageError(reason: .internalError))
+    }
 
-        eventListener?.errorWithMessage(message: InAppMessage(gistMessage: message))
+    public func messageError(message: Message, error: InAppMessageError) {
+        logger.logWithModuleTag("Message error: \(message.describeForLogs) — \(error.describeForLogs)", level: .debug)
+
+        let inAppMessage = InAppMessage(gistMessage: message)
+        eventListener?.errorWithMessage(message: inAppMessage, error: error)
     }
 
     public func action(message: Message, currentRoute: String, action: String, name: String) {

--- a/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
@@ -288,18 +288,19 @@ extension BaseMessageManager: EngineWebDelegate {
             "Message \(currentMessage.describeForLogs) failed: \(error.describeForLogs)",
             level: .error
         )
-        inAppMessageManager.dispatch(
-            action: .engineAction(
-                action: .messageLoadingFailed(message: currentMessage)
-            )
-        )
+        self.error(error)
     }
 
     public func error() {
-        logger.logWithModuleTag("Error loading message with id: \(currentMessage.describeForLogs)", level: .error)
+        // Only reachable from a conformer that predates the classified callback. `EngineWeb` always
+        // classifies, so treat an unlabelled failure as an SDK-side gap rather than inventing a cause.
+        error(InAppMessageError(reason: .internalError, detail: "Engine reported a failure with no reason"))
+    }
+
+    public func error(_ error: InAppMessageError) {
         inAppMessageManager.dispatch(
             action: .engineAction(
-                action: .messageLoadingFailed(message: currentMessage)
+                action: .messageLoadingFailed(message: currentMessage, error: error)
             )
         )
     }

--- a/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
+++ b/Sources/MessagingInApp/Gist/Managers/MessageManager.swift
@@ -294,6 +294,8 @@ extension BaseMessageManager: EngineWebDelegate {
     public func error() {
         // Only reachable from a conformer that predates the classified callback. `EngineWeb` always
         // classifies, so treat an unlabelled failure as an SDK-side gap rather than inventing a cause.
+        // Logged here because, unlike the classified sites, nothing upstream has logged this one.
+        logger.logWithModuleTag("Error loading message with id: \(currentMessage.describeForLogs)", level: .error)
         error(InAppMessageError(reason: .internalError, detail: "Engine reported a failure with no reason"))
     }
 

--- a/Sources/MessagingInApp/State/InAppMessageAction.swift
+++ b/Sources/MessagingInApp/State/InAppMessageAction.swift
@@ -26,7 +26,7 @@ enum InAppMessageAction: Equatable {
     /// It only contains actions that are related to Gist engine view.
     enum EngineAction: Equatable {
         case tap(message: Message, route: String, name: String, action: String)
-        case messageLoadingFailed(message: Message)
+        case messageLoadingFailed(message: Message, error: InAppMessageError)
     }
 
     /// Represents an action that can be dispatched to InAppMessage store.

--- a/Sources/MessagingInApp/State/InAppMessageMiddleware.swift
+++ b/Sources/MessagingInApp/State/InAppMessageMiddleware.swift
@@ -376,8 +376,8 @@ func messageEventCallbacksMiddleware(delegate: GistDelegate) -> InAppMessageMidd
             case .tap(let message, let route, let name, let action):
                 delegate.action(message: message, currentRoute: route, action: action, name: name)
 
-            case .messageLoadingFailed(let message):
-                delegate.messageError(message: message)
+            case .messageLoadingFailed(let message, let error):
+                delegate.messageError(message: message, error: error)
             }
 
         default:

--- a/Sources/MessagingInApp/State/InAppMessageReducer.swift
+++ b/Sources/MessagingInApp/State/InAppMessageReducer.swift
@@ -137,7 +137,7 @@ private func reducer(action: InAppMessageAction, state: InAppMessageState) -> In
         switch engineAction {
         case .tap:
             return state
-        case .messageLoadingFailed(let message):
+        case .messageLoadingFailed(let message, _):
             return state.copy(modalMessageState: .dismissed(message: message))
         }
 

--- a/Sources/MessagingInApp/Type/InAppEventListener.swift
+++ b/Sources/MessagingInApp/Type/InAppEventListener.swift
@@ -5,5 +5,20 @@ public protocol InAppEventListener: AutoMockable {
     func messageShown(message: InAppMessage)
     func messageDismissed(message: InAppMessage)
     func errorWithMessage(message: InAppMessage)
+    // The generated mock derives its member names from the method's base name, so an overload would
+    // collide with `errorWithMessage(message:)`. This names the mock's members instead.
+    // sourcery: Name = "errorWithMessageAndError"
+    /// Called when a message fails to load or render, with the reason it failed.
+    ///
+    /// Prefer this over ``errorWithMessage(message:)``. Branch on ``InAppMessageError/reason``;
+    /// ``InAppMessageError/detail`` is diagnostic text meant for logs, not for parsing.
+    func errorWithMessage(message: InAppMessage, error: InAppMessageError)
     func messageActionTaken(message: InAppMessage, actionValue: String, actionName: String)
+}
+
+public extension InAppEventListener {
+    /// Defaulted so listeners written before the reason existed keep compiling and keep working.
+    func errorWithMessage(message: InAppMessage, error: InAppMessageError) {
+        errorWithMessage(message: message)
+    }
 }

--- a/Sources/MessagingInApp/Type/InAppMessageError.swift
+++ b/Sources/MessagingInApp/Type/InAppMessageError.swift
@@ -5,9 +5,14 @@ import Foundation
 /// The cases are deliberately coarse: each one maps to a different thing an integrator would do
 /// about it — check connectivity, look at a slow renderer, report the message content to us, or
 /// file an SDK bug. Finer detail belongs in ``InAppMessageError/detail``.
+///
+/// **Keep a `default:` branch when you switch on this.** More cases may be added in future
+/// releases, and an exhaustive switch will stop compiling when that happens. The SDK is
+/// distributed as source, so the compiler treats this enum as frozen at your build — use a plain
+/// `default:` rather than `@unknown default:`.
 public enum InAppMessageErrorReason: String {
-    /// The renderer could not be reached: navigation failed, TLS failed, or the host returned an
-    /// error status.
+    /// The renderer could not be reached: the navigation failed, for example on DNS, connectivity
+    /// or TLS.
     case network
     /// The renderer was reached but never signalled that it had bootstrapped within the timeout.
     case timeout
@@ -26,11 +31,17 @@ public struct InAppMessageError: Error, Equatable {
     public let reason: InAppMessageErrorReason
 
     /// Human-readable detail from the layer that failed — a `WKWebView` error description, or the
-    /// message the renderer itself reported. Free-form and unstable: log it, don't parse it.
+    /// message the renderer itself reported. Free-form, unstable, and partly renderer-supplied, so
+    /// treat it as **local diagnostics only**: write it to your logs, don't parse it, and don't
+    /// forward it verbatim to analytics or crash reporting. Branch on ``reason`` instead.
     public let detail: String?
 
-    /// The underlying platform error code where the failing layer had one, e.g. an `NSURLError`
-    /// code or an HTTP status. `nil` when the failure carried no numeric code.
+    /// The underlying platform error code where the failing layer had one — on iOS this is the
+    /// `NSError` code behind a failed navigation, typically an `NSURLError`. `nil` when the failure
+    /// carried no numeric code.
+    ///
+    /// Note this is not an HTTP status: an error response still completes navigation, so it does
+    /// not reach the failure callbacks the SDK maps from.
     public let code: Int?
 
     public init(reason: InAppMessageErrorReason, detail: String? = nil, code: Int? = nil) {

--- a/Sources/MessagingInApp/Type/InAppMessageError.swift
+++ b/Sources/MessagingInApp/Type/InAppMessageError.swift
@@ -5,7 +5,7 @@ import Foundation
 /// The cases are deliberately coarse: each one maps to a different thing an integrator would do
 /// about it — check connectivity, look at a slow renderer, report the message content to us, or
 /// file an SDK bug. Finer detail belongs in ``InAppMessageError/detail``.
-enum InAppMessageErrorReason: String {
+public enum InAppMessageErrorReason: String {
     /// The renderer could not be reached: navigation failed, TLS failed, or the host returned an
     /// error status.
     case network
@@ -21,19 +21,19 @@ enum InAppMessageErrorReason: String {
 }
 
 /// A single in-app message load/render failure, with as much context as the failing layer had.
-struct InAppMessageError: Error, Equatable {
+public struct InAppMessageError: Error, Equatable {
     /// The coarse category. Branch on this.
-    let reason: InAppMessageErrorReason
+    public let reason: InAppMessageErrorReason
 
     /// Human-readable detail from the layer that failed — a `WKWebView` error description, or the
     /// message the renderer itself reported. Free-form and unstable: log it, don't parse it.
-    let detail: String?
+    public let detail: String?
 
     /// The underlying platform error code where the failing layer had one, e.g. an `NSURLError`
     /// code or an HTTP status. `nil` when the failure carried no numeric code.
-    let code: Int?
+    public let code: Int?
 
-    init(reason: InAppMessageErrorReason, detail: String? = nil, code: Int? = nil) {
+    public init(reason: InAppMessageErrorReason, detail: String? = nil, code: Int? = nil) {
         self.reason = reason
         self.detail = detail
         self.code = code

--- a/Tests/MessagingInApp/EngineWeb/EngineWebTimeoutTests.swift
+++ b/Tests/MessagingInApp/EngineWeb/EngineWebTimeoutTests.swift
@@ -99,6 +99,47 @@ class EngineWebTimeoutTests: IntegrationTest {
     }
 
     // `EngineWeb` builds a `WKWebView`, so this has to run on the main actor.
+    /// An engine instance renders one message, so it fails at most once.
+    ///
+    /// WebKit can deliver several failure callbacks for a single load, and the bootstrap timer stays
+    /// armed when a failure arrives — the dispatch it triggers is asynchronous. Without a latch a
+    /// host could be told `.network` and then `.timeout` about the same message, with no way to tell
+    /// which was the real cause. Deterministic for inline messages, whose dismissal never reaches
+    /// `cleanEngineWeb()`.
+    @MainActor
+    func test_reportFailure_givenSecondFailure_expectOnlyTheFirstReported() async throws {
+        await inAppMessageManager.dispatchAsync(action: .setUserIdentifier(user: .random))
+
+        let message = Message.random
+        engine = EngineWeb(
+            configuration: EngineWebConfiguration(
+                siteId: .random,
+                dataCenter: .random,
+                instanceId: message.instanceId,
+                endpoint: .random,
+                messageId: message.messageId,
+                properties: nil
+            ),
+            state: InAppMessageState(),
+            message: message
+        )
+        engine.delegate = delegateSpy
+
+        // A navigation failure, then the bootstrap timer firing on the same engine.
+        engine.webView(
+            engine.webView,
+            didFailProvisionalNavigation: nil,
+            withError: NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
+        )
+        engine.forcedTimeout()
+
+        XCTAssertEqual(delegateSpy.errorCallCount, 1)
+        // The first cause is the true one; the timeout is a consequence of it.
+        XCTAssertEqual(delegateSpy.lastError?.reason, .network)
+        XCTAssertEqual(delegateSpy.lastError?.code, NSURLErrorNotConnectedToInternet)
+    }
+
+    // `EngineWeb` builds a `WKWebView`, so this has to run on the main actor.
     @MainActor
     func test_forcedTimeout_givenEngineTimesOut_expectDelegateNotifiedOnceAndNoDirectDispatch() async throws {
         // The store drops engine actions while no user is known, so identify first. Without this a

--- a/Tests/MessagingInApp/EngineWeb/EngineWebTimeoutTests.swift
+++ b/Tests/MessagingInApp/EngineWeb/EngineWebTimeoutTests.swift
@@ -13,6 +13,7 @@ import XCTest
 class EngineWebTimeoutTests: IntegrationTest {
     private final class EngineWebDelegateSpy: EngineWebDelegate {
         private(set) var errorCallCount = 0
+        private(set) var lastError: InAppMessageError?
 
         func bootstrapped() {}
         func tap(name: String, action: String, system: Bool) {}
@@ -23,6 +24,11 @@ class EngineWebTimeoutTests: IntegrationTest {
 
         func error() {
             errorCallCount += 1
+        }
+
+        func error(_ error: InAppMessageError) {
+            errorCallCount += 1
+            lastError = error
         }
     }
 
@@ -54,6 +60,42 @@ class EngineWebTimeoutTests: IntegrationTest {
         engine = nil
         inAppMessageManager = nil
         super.tearDown()
+    }
+
+    // `EngineWeb` builds a `WKWebView`, so this has to run on the main actor.
+    /// `EngineWeb` can fail before it has a delegate: `loadMessage()` runs from `init`, and
+    /// `MessageManager` only assigns itself afterwards. A malformed renderer URL fails on exactly
+    /// that path, and before this the failure went nowhere and the message simply hung.
+    ///
+    /// `GistEnvironment` is a closed enum, so a bad URL cannot be injected from a test. This drives
+    /// the same mechanism through the timeout instead — any failure raised while the delegate is nil
+    /// must be held and delivered once one is attached.
+    @MainActor
+    func test_reportFailure_givenFailureBeforeDelegateAttached_expectDeliveredOnAssignment() async throws {
+        await inAppMessageManager.dispatchAsync(action: .setUserIdentifier(user: .random))
+
+        let message = Message.random
+        engine = EngineWeb(
+            configuration: EngineWebConfiguration(
+                siteId: .random,
+                dataCenter: .random,
+                instanceId: message.instanceId,
+                endpoint: .random,
+                messageId: message.messageId,
+                properties: nil
+            ),
+            state: InAppMessageState(),
+            message: message
+        )
+
+        // Fail while nothing is attached.
+        engine.forcedTimeout()
+        XCTAssertEqual(delegateSpy.errorCallCount, 0)
+
+        engine.delegate = delegateSpy
+
+        XCTAssertEqual(delegateSpy.errorCallCount, 1)
+        XCTAssertEqual(delegateSpy.lastError?.reason, .timeout)
     }
 
     // `EngineWeb` builds a `WKWebView`, so this has to run on the main actor.

--- a/Tests/MessagingInApp/EngineWeb/EngineWebTimeoutTests.swift
+++ b/Tests/MessagingInApp/EngineWeb/EngineWebTimeoutTests.swift
@@ -91,6 +91,11 @@ class EngineWebTimeoutTests: IntegrationTest {
         XCTAssertEqual(delegateSpy.errorCallCount, 1)
         // EngineWeb must not reach the store on its own. `MessageManager` owns that dispatch, and
         // doing both is what delivered the host callback twice.
+        //
+        // Both counters matter: the SDK delivers failures through `errorWithMessage(message:error:)`,
+        // which the generated mock counts separately. Asserting only the reason-less counter would
+        // let the original double-dispatch regress without failing this test.
         XCTAssertEqual(globalEventListener.errorWithMessageCallsCount, 0)
+        XCTAssertEqual(globalEventListener.errorWithMessageAndErrorCallsCount, 0)
     }
 }

--- a/Tests/MessagingInApp/Gist/GistDelegateImplTests.swift
+++ b/Tests/MessagingInApp/Gist/GistDelegateImplTests.swift
@@ -88,11 +88,24 @@ class GistDelegateImplTests: UnitTest {
 
     func testMessageError() {
         let message = Message(messageId: "test-message-id")
+        let error = InAppMessageError(reason: .network, detail: "offline", code: -1009)
+
+        gistDelegate.messageError(message: message, error: error)
+
+        XCTAssertTrue(mockEventListener.errorWithMessageAndErrorCalled, "EventListener's errorWithMessage should be called")
+        XCTAssertEqual(mockEventListener.errorWithMessageAndErrorReceivedArguments?.message.messageId, "test-message-id", "Message ID should match")
+        XCTAssertEqual(mockEventListener.errorWithMessageAndErrorReceivedArguments?.error, error, "Failure reason should reach the listener")
+    }
+
+    /// The reason-less entry point is still part of the public `GistDelegate`, so a failure arriving
+    /// through it must still reach the host rather than being dropped for want of a reason.
+    func testMessageErrorWithoutReason() {
+        let message = Message(messageId: "test-message-id")
 
         gistDelegate.messageError(message: message)
 
-        XCTAssertTrue(mockEventListener.errorWithMessageCalled, "EventListener's errorWithMessage should be called")
-        XCTAssertEqual(mockEventListener.errorWithMessageReceivedArguments?.messageId, "test-message-id", "Message ID should match")
+        XCTAssertTrue(mockEventListener.errorWithMessageAndErrorCalled, "EventListener's errorWithMessage should be called")
+        XCTAssertEqual(mockEventListener.errorWithMessageAndErrorReceivedArguments?.error.reason, .internalError)
     }
 
     func testActionWithNormalAction() {
@@ -158,6 +171,7 @@ class GistDelegateImplTests: UnitTest {
         XCTAssertFalse(mockEventListener.messageShownCalled, "No event listener methods should be called")
         XCTAssertFalse(mockEventListener.messageDismissedCalled, "No event listener methods should be called")
         XCTAssertFalse(mockEventListener.errorWithMessageCalled, "No event listener methods should be called")
+        XCTAssertFalse(mockEventListener.errorWithMessageAndErrorCalled, "No event listener methods should be called")
         XCTAssertFalse(mockEventListener.messageActionTakenCalled, "No event listener methods should be called")
     }
 }

--- a/Tests/MessagingInApp/InAppListenerSourceCompatTests.swift
+++ b/Tests/MessagingInApp/InAppListenerSourceCompatTests.swift
@@ -1,0 +1,63 @@
+@testable import CioMessagingInApp
+import Foundation
+import XCTest
+
+/// Locks the source compatibility of `InAppEventListener` and `GistDelegate`.
+///
+/// Adding the failure reason meant adding a member to two PUBLIC protocols:
+/// `errorWithMessage(message:error:)` and `messageError(message:error:)`. As bare requirements
+/// those would break every existing conformer, turning an additive release into a breaking one.
+/// They ship with defaults instead.
+///
+/// The conformers below implement ONLY the members that existed BEFORE the reason was added. They
+/// carry no assertions and are not meant to: this is a COMPILE-TIME test. If a future change
+/// removes a default or adds a bare requirement, this file stops compiling, which is the signal.
+/// Verified to fail that way by deleting the defaults.
+class InAppListenerSourceCompatTests: XCTestCase {
+    /// Stands in for a host's listener written against the reason-less SDK.
+    private final class LegacyEventListener: InAppEventListener {
+        func messageShown(message: InAppMessage) {
+            _ = message
+        }
+
+        func messageDismissed(message: InAppMessage) {
+            _ = message
+        }
+
+        func errorWithMessage(message: InAppMessage) {
+            _ = message
+        }
+
+        func messageActionTaken(message: InAppMessage, actionValue: String, actionName: String) {
+            _ = (message, actionValue, actionName)
+        }
+    }
+
+    /// The default must actually forward, not silently swallow — a host that only implemented the
+    /// old callback has to keep receiving failures.
+    func test_errorWithMessageDefault_givenLegacyListener_expectForwardedToReasonLessCallback() {
+        final class ForwardingSpy: InAppEventListener {
+            var reasonLessCallCount = 0
+            func messageShown(message: InAppMessage) {}
+            func messageDismissed(message: InAppMessage) {}
+            func errorWithMessage(message: InAppMessage) {
+                reasonLessCallCount += 1
+            }
+
+            func messageActionTaken(message: InAppMessage, actionValue: String, actionName: String) {}
+        }
+
+        let listener = ForwardingSpy()
+        let message = InAppMessage(gistMessage: Message(messageId: "test-message-id"))
+
+        listener.errorWithMessage(message: message, error: InAppMessageError(reason: .timeout))
+
+        XCTAssertEqual(listener.reasonLessCallCount, 1)
+    }
+
+    /// Compile-time only: a legacy conformer must still satisfy the protocol.
+    func test_legacyConformer_expectStillSatisfiesProtocol() {
+        let listener: InAppEventListener = LegacyEventListener()
+        XCTAssertNotNil(listener)
+    }
+}

--- a/Tests/MessagingInApp/MessagingInAppImplementationTest.swift
+++ b/Tests/MessagingInApp/MessagingInAppImplementationTest.swift
@@ -191,6 +191,7 @@ class MessagingInAppImplementationTest: IntegrationTest {
 
         // error with message
         XCTAssertFalse(eventListenerMock.errorWithMessageCalled)
+        XCTAssertFalse(eventListenerMock.errorWithMessageAndErrorCalled)
 
         // message action taken
         XCTAssertFalse(eventListenerMock.messageActionTakenCalled)

--- a/Tests/MessagingInApp/State/InAppMessageStateTests.swift
+++ b/Tests/MessagingInApp/State/InAppMessageStateTests.swift
@@ -426,13 +426,15 @@ class InAppMessageStateTests: IntegrationTest {
         let message = Message(queueId: "1")
 
         await inAppMessageManager.dispatchAsync(action: .setUserIdentifier(user: .random))
-        await inAppMessageManager.dispatchAsync(action: .engineAction(action: .messageLoadingFailed(message: message)))
+        await inAppMessageManager.dispatchAsync(action: .engineAction(action: .messageLoadingFailed(message: message, error: InAppMessageError(reason: .renderFailed))))
 
         let state = await inAppMessageManager.state
         XCTAssertEqual(state.modalMessageState, .dismissed(message: message))
 
-        XCTAssertTrue(globalEventListener.errorWithMessageCalled)
-        XCTAssertEqual(globalEventListener.errorWithMessageReceivedArguments?.deliveryId, message.gistProperties.campaignId)
+        XCTAssertTrue(globalEventListener.errorWithMessageAndErrorCalled)
+        XCTAssertEqual(globalEventListener.errorWithMessageAndErrorReceivedArguments?.message.deliveryId, message.gistProperties.campaignId)
+        // The reason now travels with the failure instead of being lost between the engine and the host.
+        XCTAssertEqual(globalEventListener.errorWithMessageAndErrorReceivedArguments?.error.reason, .renderFailed)
     }
 
     func test_processMessageQueue_givenDismissedMessage_expectMessageNotDisplayedAgain() async {
@@ -471,6 +473,7 @@ class InAppMessageStateTests: IntegrationTest {
         XCTAssertFalse(globalEventListener.messageShownCalled)
         XCTAssertFalse(globalEventListener.messageDismissedCalled)
         XCTAssertFalse(globalEventListener.errorWithMessageCalled)
+        XCTAssertFalse(globalEventListener.errorWithMessageAndErrorCalled)
         XCTAssertFalse(globalEventListener.messageActionTakenCalled)
     }
 
@@ -562,10 +565,11 @@ class InAppMessageStateTests: IntegrationTest {
         let message = Message(queueId: "1")
 
         await inAppMessageManager.dispatchAsync(action: .setUserIdentifier(user: .random))
-        await inAppMessageManager.dispatchAsync(action: .engineAction(action: .messageLoadingFailed(message: message)))
+        await inAppMessageManager.dispatchAsync(action: .engineAction(action: .messageLoadingFailed(message: message, error: InAppMessageError(reason: .renderFailed))))
 
-        XCTAssertTrue(globalEventListener.errorWithMessageCalled)
-        XCTAssertEqual(globalEventListener.errorWithMessageReceivedArguments?.deliveryId, message.gistProperties.campaignId)
+        XCTAssertTrue(globalEventListener.errorWithMessageAndErrorCalled)
+        XCTAssertEqual(globalEventListener.errorWithMessageAndErrorReceivedArguments?.message.deliveryId, message.gistProperties.campaignId)
+        XCTAssertEqual(globalEventListener.errorWithMessageAndErrorReceivedArguments?.error.reason, .renderFailed)
     }
 
     func test_engineAction_givenTapAction_expectMessageActionTakenCallbackCalled() async {

--- a/Tests/Mocks/MessagingInApp/AutoMockable.generated.swift
+++ b/Tests/Mocks/MessagingInApp/AutoMockable.generated.swift
@@ -1081,6 +1081,11 @@ public class InAppEventListenerMock: @unchecked Sendable, InAppEventListener, Mo
         _errorWithMessageReceivedInvocations.wrappedValue = []
 
         mockCalled = false // do last as resetting properties above can make this true
+        _errorWithMessageAndErrorCallsCount.wrappedValue = 0
+        _errorWithMessageAndErrorReceivedArguments.wrappedValue = nil
+        _errorWithMessageAndErrorReceivedInvocations.wrappedValue = []
+
+        mockCalled = false // do last as resetting properties above can make this true
         _messageActionTakenCallsCount.wrappedValue = 0
         _messageActionTakenReceivedArguments.wrappedValue = nil
         _messageActionTakenReceivedInvocations.wrappedValue = []
@@ -1203,6 +1208,45 @@ public class InAppEventListenerMock: @unchecked Sendable, InAppEventListener, Mo
         _errorWithMessageReceivedArguments.wrappedValue = message
         _errorWithMessageReceivedInvocations.append(message)
         errorWithMessageClosure?(message)
+    }
+
+    // MARK: - errorWithMessage
+
+    /// Number of times the function was called.
+    private let _errorWithMessageAndErrorCallsCount: CioInternalCommon.Synchronized<Int> = .init(0)
+    public var errorWithMessageAndErrorCallsCount: Int {
+        _errorWithMessageAndErrorCallsCount.wrappedValue
+    }
+
+    /// `true` if the function was ever called.
+    public var errorWithMessageAndErrorCalled: Bool {
+        errorWithMessageAndErrorCallsCount > 0
+    }
+
+    /// The arguments from the *last* time the function was called.
+    private let _errorWithMessageAndErrorReceivedArguments: CioInternalCommon.Synchronized<(message: InAppMessage, error: InAppMessageError)?> = .init(nil)
+    public var errorWithMessageAndErrorReceivedArguments: (message: InAppMessage, error: InAppMessageError)? {
+        _errorWithMessageAndErrorReceivedArguments.wrappedValue
+    }
+
+    /// Arguments from *all* of the times that the function was called.
+    private let _errorWithMessageAndErrorReceivedInvocations: CioInternalCommon.Synchronized<[(message: InAppMessage, error: InAppMessageError)]> = .init([])
+    public var errorWithMessageAndErrorReceivedInvocations: [(message: InAppMessage, error: InAppMessageError)] {
+        _errorWithMessageAndErrorReceivedInvocations.wrappedValue
+    }
+
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     */
+    public var errorWithMessageAndErrorClosure: ((InAppMessage, InAppMessageError) -> Void)?
+
+    /// Mocked function for `errorWithMessage(message: InAppMessage, error: InAppMessageError)`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func errorWithMessage(message: InAppMessage, error: InAppMessageError) {
+        mockCalled = true
+        _errorWithMessageAndErrorCallsCount += 1
+        _errorWithMessageAndErrorReceivedArguments.wrappedValue = (message: message, error: error)
+        _errorWithMessageAndErrorReceivedInvocations.append((message: message, error: error))
+        errorWithMessageAndErrorClosure?(message, error)
     }
 
     // MARK: - messageActionTaken

--- a/api-docs/CioMessagingInApp.api
+++ b/api-docs/CioMessagingInApp.api
@@ -25,12 +25,14 @@ public interface CioMessagingInApp.EngineWebDelegate {
 	public fun func routeLoaded(route: String);
 	public fun func sizeChanged(width: CGFloat, height: CGFloat);
 	public fun func error();
+	public fun func error(_ error: InAppMessageError);
 }
 public interface CioMessagingInApp.GistDelegate {
 	public fun func embedMessage(message: Message, elementId: String);
 	public fun func messageShown(message: Message);
 	public fun func messageDismissed(message: Message);
 	public fun func messageError(message: Message);
+	public fun func messageError(message: Message, error: InAppMessageError);
 	public fun func action(message: Message, currentRoute: String, action: String, name: String);
 	public fun func setEventListener(_ eventListener: InAppEventListener?);
 }
@@ -72,12 +74,21 @@ public interface CioMessagingInApp.InAppEventListener {
 	public fun func messageShown(message: InAppMessage);
 	public fun func messageDismissed(message: InAppMessage);
 	public fun func errorWithMessage(message: InAppMessage);
+	public fun func errorWithMessage(message: InAppMessage, error: InAppMessageError);
 	public fun func messageActionTaken(message: InAppMessage, actionValue: String, actionName: String);
 }
 public final class CioMessagingInApp.InAppMessage {
 	public final val messageId: String;
 	public final val deliveryId: String?;
 	public final val elementId: String?;
+}
+public final class CioMessagingInApp.InAppMessageError {
+	public final val reason: InAppMessageErrorReason;
+	public final val detail: String?;
+	public final val code: Int?;
+	public fun init(reason: InAppMessageErrorReason, detail: String? = nil, code: Int? = nil);
+}
+public enum CioMessagingInApp.InAppMessageErrorReason {
 }
 public interface CioMessagingInApp.InboxEventListener {
 	public fun func messageActionTaken(message: InboxMessage, actionName: String, actionValue: String) -> Boolean;


### PR DESCRIPTION
## MBL-2310 · iOS stack — step 3 of 3

| Step | PR | |
| --- | --- | --- |
| 1 | #1231 — `chore:` fire the in-app error callback once on engine timeout |  |
| 2 | #1237 — `chore:` classify and log in-app message failures internally |  |
| **3** | **#1238 — `fix:` surface the failure reason on `errorWithMessage`** | **← you are here** |

Merge bottom-up. Every `chore:` step is internal only — no public type, no protocol or interface change, and the committed API surface is untouched — so nothing user-visible ships if an unrelated release cuts while they sit on main. The final `fix:` carries the whole feature and is the only step that triggers a release.

**Android mirror:** customerio/customerio-android#823 → customerio/customerio-android#826 → customerio/customerio-android#827 → customerio/customerio-android#828. Both platforms land the same API and must release before the wrapper PRs (Flutter, React Native) can start.

---
Puts the reason an in-app message failed onto `errorWithMessage`. Closes the MBL-2310 work on iOS.

Stacked on #1237. Paired with android#828.

### Why

`errorWithMessage` delivered only `messageId` and `deliveryId`, so an integrator learned that a message failed but never why. The reason existed on device in debug logs only, and nothing is recorded server-side, so diagnosing meant shipping a debug-logging build.

### API

```swift
public enum InAppMessageErrorReason: String {
    case network, timeout, renderFailed, webViewCrashed, internalError
}

public struct InAppMessageError: Error, Equatable {
    public let reason: InAppMessageErrorReason
    public let detail: String?   // renderer's own message, or the NSError description
    public let code: Int?        // NSURLError code / HTTP status where one exists
}

func errorWithMessage(message: InAppMessage, error: InAppMessageError)
```

Reasons are coarse on purpose: each maps to a different thing an integrator would actually do — check connectivity, look at a slow renderer, report the message to us, or file an SDK bug. `detail` is diagnostic text for logs, not for parsing. `InAppMessageError` conforms to `Error` so hosts can log or throw it idiomatically.

### Additive

The new requirement ships with a protocol-extension default that forwards to `errorWithMessage(message:)`, so existing conformers keep compiling **and keep receiving failures**. Same for the two other public protocols this had to widen, `GistDelegate` and `EngineWebDelegate`.

The old callback is deliberately **not** deprecated in this release — `@available(*, deprecated)` would emit a warning in every existing host for a purely additive change.

`api-docs/CioMessagingInApp.api` moves by **11 insertions and zero deletions or modifications**.

### One wrinkle worth flagging for review

The generated mock derives its member names from a method's base name, so the overload collided with the existing `errorWithMessage` — `_errorWithMessageCallsCount` was declared twice and would not compile. The stencil already supports `// sourcery: Name = "…"` for exactly this, so the new method is annotated `errorWithMessageAndError` and the mock's members are named from that. No stencil change, no other module affected.

### Verification

- `InAppListenerSourceCompatTests` locks source compatibility the same way `InboxProtocolSourceCompatibilityTests` does: a conformer implementing only the pre-change members, so the file stops compiling if a default is ever removed. It also asserts the default actually **forwards** rather than silently swallowing, which is what keeps old listeners working.
- Existing negative assertions were strengthened to cover the new member too — otherwise they would have passed vacuously.
- New test pins `.internalError` for a failure arriving through the reason-less entry point.
- `MessagingInAppTests` — 499 tests, 0 failures.
- `Apps/APN-UIKit` demos the new callback, tracking `reason`, `detail`, and `code`. Built locally, since `build-sample-apps` no longer runs on PRs.
