### PR TITLE
chore(geofence): read the v2 polygon wire contract

### DIFF
--- a/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
@@ -312,10 +312,7 @@ extension GeofenceApiRegion {
         guard let region = PolygonRegion(vertices: positions),
               region.vertices.count <= GeofenceConstants.maxPolygonVertexCount
         else { return nil }
-        let coverageBound = coveringRadius + max(
-            GeofenceConstants.polygonCoverageSlackMeters,
-            coveringRadius * GeofenceConstants.polygonCoverageSlackFraction
-        )
+        let coverageBound = coveringRadius + GeofenceConstants.polygonCoverageSlackMeters
         guard region.vertices.allSatisfy({ vertex in
             coveringCenter.distance(from: CLLocation(latitude: vertex.latitude, longitude: vertex.longitude)) <= coverageBound
         }) else { return nil }

--- a/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
@@ -44,7 +44,7 @@ private struct LenientRegion: Decodable {
 
 /// Why a region on the wire never became a monitorable fence.
 enum GeofenceRegionDropReason: String, Error {
-    case unknownShape = "unrecognized shape"
+    case unknownShape = "unrecognized or inconsistent shape"
     case unusableCircle = "invalid coordinates or radius"
     case unusablePolygon = "missing or undecodable polygon geometry"
 }
@@ -265,6 +265,11 @@ extension GeofenceApiRegion {
         let resolved: ResolvedGeometry?
         let dropReason: GeofenceRegionDropReason
         switch shape?.lowercased() {
+        case nil where geometry != nil || enclosingCircle != nil:
+            // Polygon fields with no discriminator: the payload describes something this decoder
+            // cannot name. Falling through to the flat circle fields would monitor a shape the
+            // server never described. Android drops the same combination.
+            return .failure(.unknownShape)
         case nil, "circle":
             resolved = resolvedCircle()
             dropReason = .unusableCircle

--- a/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
@@ -323,7 +323,8 @@ extension GeofenceApiRegion {
     }
 
     /// Decodes the ring into the kernel's canonical (unclosed) vertices so the cache stores one
-    /// representation. Only what building the region needs — the server validates the geometry.
+    /// representation. Validates here rather than at every use: the degeneracy checks are O(n²) and
+    /// a region is rebuilt per wake and per evaluation, so this is the one place they can run once.
     private static func polygonVertices(_ ring: [[Double]]) -> [LocationData]? {
         var positions: [LocationData] = []
         positions.reserveCapacity(ring.count)
@@ -332,7 +333,7 @@ extension GeofenceApiRegion {
             guard position.count >= 2 else { return nil }
             positions.append(LocationData(latitude: position[1], longitude: position[0]))
         }
-        return PolygonRegion(vertices: positions)?.vertices
+        return PolygonRegion(validating: positions)?.vertices
     }
 
     private static func resolveTransitionTypes(_ raw: [String]?) -> Set<GeofenceTransition> {

--- a/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
@@ -81,6 +81,10 @@ struct GeofenceApiRegion: Decodable {
     /// The circle the server guarantees contains the polygon — the shape actually registered at
     /// the OS as the wake trigger.
     let enclosingCircle: GeofenceApiEnclosingCircle?
+    /// Whether the payload carried a non-null `geometry` or `enclosing_circle` at all, which is not
+    /// the same as either having decoded: both use `try?`, so a malformed value becomes `nil` and
+    /// would otherwise be indistinguishable from a v1 circle.
+    var carriesPolygonFields: Bool = false
     let externalId: String?
     let transitionTypes: [String]?
     /// Wire format is milliseconds since epoch.
@@ -131,6 +135,7 @@ extension GeofenceApiRegion {
         self.radius = try container.decodeIfPresent(Double.self, forKey: .radius)
         self.geometry = try? container.decodeIfPresent(GeofenceApiGeometry.self, forKey: .geometry)
         self.enclosingCircle = try? container.decodeIfPresent(GeofenceApiEnclosingCircle.self, forKey: .enclosingCircle)
+        self.carriesPolygonFields = container.holdsValue(forKey: .geometry) || container.holdsValue(forKey: .enclosingCircle)
         self.externalId = try container.decodeIfPresent(String.self, forKey: .externalId)
         self.transitionTypes = try container.decodeIfPresent([String].self, forKey: .transitionTypes)
         self.lastUpdated = try container.decodeIfPresent(Double.self, forKey: .lastUpdated)
@@ -167,6 +172,12 @@ private extension KeyedDecodingContainer {
         guard let raw = try? decode([String: LenientMetadataValue].self, forKey: key) else { return nil }
         let filtered = raw.compactMapValues(\.value)
         return filtered.isEmpty ? nil : filtered
+    }
+
+    /// Whether the key is present with a non-null value, regardless of whether that value decodes
+    /// into the type the field expects.
+    func holdsValue(forKey key: Key) -> Bool {
+        contains(key) && ((try? decodeNil(forKey: key)) == false)
     }
 
     /// Absent or null → nil, so a not-yet-rolled-out field is treated as "no value" rather than throwing.
@@ -265,10 +276,11 @@ extension GeofenceApiRegion {
         let resolved: ResolvedGeometry?
         let dropReason: GeofenceRegionDropReason
         switch shape?.lowercased() {
-        case nil where geometry != nil || enclosingCircle != nil:
+        case nil where carriesPolygonFields:
             // Polygon fields with no discriminator: the payload describes something this decoder
             // cannot name. Falling through to the flat circle fields would monitor a shape the
-            // server never described. Android drops the same combination.
+            // server never described. Android drops the same combination. Keyed on the fields being
+            // PRESENT, not on their having decoded — a malformed one is still a claim of a polygon.
             return .failure(.unknownShape)
         case nil, "circle":
             resolved = resolvedCircle()

--- a/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
@@ -7,7 +7,46 @@ import Foundation
 /// gradually; per-field fallbacks live in `toDomain`.
 struct GeofenceApiResponse: Decodable {
     let config: GeofenceApiConfig?
+    /// How many regions the payload carried, including any that failed to decode. `geofences`
+    /// alone cannot tell "the server sent none" from "none of them survived".
+    let receivedRegionCount: Int
     let geofences: [GeofenceApiRegion]
+
+    private enum CodingKeys: String, CodingKey {
+        case config, geofences
+    }
+
+    /// One malformed region must not cost the whole response, so regions are decoded leniently and
+    /// the bad ones skipped.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.config = try container.decodeIfPresent(GeofenceApiConfig.self, forKey: .config)
+        let lenient = try container.decodeIfPresent([LenientRegion].self, forKey: .geofences) ?? []
+        self.receivedRegionCount = lenient.count
+        self.geofences = lenient.compactMap(\.region)
+    }
+
+    init(config: GeofenceApiConfig?, geofences: [GeofenceApiRegion]) {
+        self.config = config
+        self.geofences = geofences
+        self.receivedRegionCount = geofences.count
+    }
+}
+
+/// Decodes a region without ever throwing, so one bad element cannot fail the array around it.
+private struct LenientRegion: Decodable {
+    let region: GeofenceApiRegion?
+
+    init(from decoder: Decoder) throws {
+        self.region = try? GeofenceApiRegion(from: decoder)
+    }
+}
+
+/// Why a region on the wire never became a monitorable fence.
+enum GeofenceRegionDropReason: String, Error {
+    case unknownShape = "unrecognized shape"
+    case unusableCircle = "invalid coordinates or radius"
+    case unusablePolygon = "missing or undecodable polygon geometry"
 }
 
 struct GeofenceApiConfig: Decodable {
@@ -69,9 +108,7 @@ struct GeofenceApiGeometry: Decodable, Equatable {
 struct GeofenceApiEnclosingCircle: Decodable, Equatable {
     let latitude: Double
     let longitude: Double
-    /// Unpadded canonical radius: the smallest circle the server will claim contains the polygon.
-    /// Any platform margin is added when registering with the OS, never here — the coverage check
-    /// has to run against the value the server actually guaranteed.
+    /// The smallest circle the server claims contains the polygon, registered with the OS as-is.
     let baseRadiusM: Double
 }
 
@@ -151,13 +188,15 @@ extension GeofenceApiResponse {
 
     /// Regions the OS would reject (non-positive radius, out-of-range coordinates) are dropped
     /// here so one bad server region costs itself, not a nearest-selection slot or the whole sync.
-    func toDomainRegions(onInvalidRegion: (String) -> Void = { _ in }) -> [Geofence] {
+    func toDomainRegions(onInvalidRegion: (String, GeofenceRegionDropReason) -> Void = { _, _ in }) -> [Geofence] {
         geofences.compactMap { region in
-            guard let domain = region.toDomain() else {
-                onInvalidRegion(region.id)
+            switch region.toDomain() {
+            case .success(let domain):
+                return domain
+            case .failure(let reason):
+                onInvalidRegion(region.id, reason)
                 return nil
             }
-            return domain
         }
     }
 }
@@ -222,18 +261,21 @@ extension GeofenceApiRegion {
     /// defaults to epoch when missing so callers can compare without unwrapping. `name` is `nil`
     /// when the server omits it (or sends an empty string), so the domain value is always either
     /// `nil` or non-empty.
-    func toDomain() -> Geofence? {
+    func toDomain() -> Result<Geofence, GeofenceRegionDropReason> {
         let resolved: ResolvedGeometry?
+        let dropReason: GeofenceRegionDropReason
         switch shape?.lowercased() {
         case nil, "circle":
             resolved = resolvedCircle()
+            dropReason = .unusableCircle
         case "polygon":
             resolved = resolvedPolygon()
+            dropReason = .unusablePolygon
         default:
-            resolved = nil
+            return .failure(.unknownShape)
         }
-        guard let resolved else { return nil }
-        return Geofence(
+        guard let resolved else { return .failure(dropReason) }
+        return .success(Geofence(
             id: id,
             latitude: resolved.center.latitude,
             longitude: resolved.center.longitude,
@@ -244,7 +286,7 @@ extension GeofenceApiRegion {
             geosetIds: geosetIds ?? [],
             metadata: Self.cappedMetadata(metadata),
             vertices: resolved.vertices
-        )
+        ))
     }
 
     /// What the monitors need regardless of shape: the circle to register, plus the polygon that
@@ -272,11 +314,7 @@ extension GeofenceApiRegion {
         else { return nil }
         let center = CLLocationCoordinate2D(latitude: enclosingCircle.latitude, longitude: enclosingCircle.longitude)
         guard CLLocationCoordinate2DIsValid(center) else { return nil }
-        guard let vertices = Self.validatedPolygonVertices(
-            geometry.coordinates[0],
-            coveringCenter: CLLocation(latitude: center.latitude, longitude: center.longitude),
-            coveringRadius: enclosingCircle.baseRadiusM
-        ) else { return nil }
+        guard let vertices = Self.polygonVertices(geometry.coordinates[0]) else { return nil }
         return ResolvedGeometry(
             center: LocationData(latitude: center.latitude, longitude: center.longitude),
             radius: enclosingCircle.baseRadiusM,
@@ -284,39 +322,17 @@ extension GeofenceApiRegion {
         )
     }
 
-    /// The polygon acceptance rules, in validation order; failing any drops the whole region
-    /// ("no illusions" — a broken polygon must cost itself, never masquerade as its circle):
-    /// - every position is `[longitude, latitude]`, optionally with a third elevation element the
-    ///   GeoJSON spec allows and we ignore;
-    /// - every position is a valid coordinate;
-    /// - the kernel accepts the ring (≥3 distinct vertices after unclosing the closed ring);
-    /// - the distinct vertex count is within `maxPolygonVertexCount`, counted after unclosing so it
-    ///   matches the server's cap on *unique* vertices;
-    /// - the covering guarantee holds: every vertex within the enclosing radius (+ slack) of its
-    ///   center. Vertices inside a convex circle imply the whole polygon is inside, so this fully
-    ///   defends "enclosing-circle exit ⇒ polygon exit" against a server that miscomputed it.
-    /// Returns the kernel's canonical (unclosed) vertices so the cache stores one representation.
-    private static func validatedPolygonVertices(
-        _ ring: [[Double]],
-        coveringCenter: CLLocation,
-        coveringRadius: Double
-    ) -> [LocationData]? {
+    /// Decodes the ring into the kernel's canonical (unclosed) vertices so the cache stores one
+    /// representation. Only what building the region needs — the server validates the geometry.
+    private static func polygonVertices(_ ring: [[Double]]) -> [LocationData]? {
         var positions: [LocationData] = []
         positions.reserveCapacity(ring.count)
         for position in ring {
+            // GeoJSON positions are [longitude, latitude], plus an elevation we ignore.
             guard position.count >= 2 else { return nil }
-            let coordinate = CLLocationCoordinate2D(latitude: position[1], longitude: position[0])
-            guard CLLocationCoordinate2DIsValid(coordinate) else { return nil }
             positions.append(LocationData(latitude: position[1], longitude: position[0]))
         }
-        guard let region = PolygonRegion(vertices: positions),
-              region.vertices.count <= GeofenceConstants.maxPolygonVertexCount
-        else { return nil }
-        let coverageBound = coveringRadius + GeofenceConstants.polygonCoverageSlackMeters
-        guard region.vertices.allSatisfy({ vertex in
-            coveringCenter.distance(from: CLLocation(latitude: vertex.latitude, longitude: vertex.longitude)) <= coverageBound
-        }) else { return nil }
-        return region.vertices
+        return PolygonRegion(vertices: positions)?.vertices
     }
 
     private static func resolveTransitionTypes(_ raw: [String]?) -> Set<GeofenceTransition> {

--- a/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
@@ -28,9 +28,20 @@ struct GeofenceApiPlatformConfig: Decodable {
 struct GeofenceApiRegion: Decodable {
     let id: String
     let name: String?
-    let latitude: Double
-    let longitude: Double
-    let radius: Double
+    /// `"circle"` or `"polygon"`; absent means circle, which is what v1 payloads look like. An
+    /// unrecognized value drops the region — a shape we don't understand must never quietly fall
+    /// back to whatever circle fields happen to be present.
+    let shape: String?
+    /// Circle geometry, present on a circle region. A polygon region carries `enclosingCircle`
+    /// instead, so these are optional and their absence is resolved per shape rather than thrown.
+    let latitude: Double?
+    let longitude: Double?
+    let radius: Double?
+    /// GeoJSON boundary of a polygon region.
+    let geometry: GeofenceApiGeometry?
+    /// The circle the server guarantees contains the polygon — the shape actually registered at
+    /// the OS as the wake trigger.
+    let enclosingCircle: GeofenceApiEnclosingCircle?
     let externalId: String?
     let transitionTypes: [String]?
     /// Wire format is milliseconds since epoch.
@@ -43,9 +54,31 @@ struct GeofenceApiRegion: Decodable {
     let metadata: [String: GeofenceMetadataValue]?
 }
 
+/// GeoJSON geometry of a polygon region. Decoded with `try?` at the region level, so a geometry we
+/// can't read becomes `nil` and drops just this region instead of failing the whole response.
+struct GeofenceApiGeometry: Decodable, Equatable {
+    /// Must be `Polygon`. `MultiPolygon` and anything else drops the region.
+    let type: String
+    /// GeoJSON rings, each an array of `[longitude, latitude]` positions — longitude FIRST, which
+    /// is the opposite of every other coordinate pair in this SDK. Ring 0 is the outer boundary and
+    /// the contract guarantees exactly one; further rings would be holes, which we don't support.
+    let coordinates: [[[Double]]]
+}
+
+/// The server-computed circle containing a polygon.
+struct GeofenceApiEnclosingCircle: Decodable, Equatable {
+    let latitude: Double
+    let longitude: Double
+    /// Unpadded canonical radius: the smallest circle the server will claim contains the polygon.
+    /// Any platform margin is added when registering with the OS, never here — the coverage check
+    /// has to run against the value the server actually guaranteed.
+    let baseRadiusM: Double
+}
+
 extension GeofenceApiRegion {
     private enum CodingKeys: String, CodingKey {
-        case id, name, latitude, longitude, radius, externalId, transitionTypes, lastUpdated, geosetIds, metadata
+        case id, name, shape, latitude, longitude, radius, geometry, enclosingCircle, externalId,
+             transitionTypes, lastUpdated, geosetIds, metadata
     }
 
     /// `id` and `geoset_ids` are `int64` on the wire but strings in some mocked/legacy payloads;
@@ -55,9 +88,12 @@ extension GeofenceApiRegion {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.id = try container.decodeStringOrInt(forKey: .id)
         self.name = try container.decodeIfPresent(String.self, forKey: .name)
-        self.latitude = try container.decode(Double.self, forKey: .latitude)
-        self.longitude = try container.decode(Double.self, forKey: .longitude)
-        self.radius = try container.decode(Double.self, forKey: .radius)
+        self.shape = try container.decodeIfPresent(String.self, forKey: .shape)
+        self.latitude = try container.decodeIfPresent(Double.self, forKey: .latitude)
+        self.longitude = try container.decodeIfPresent(Double.self, forKey: .longitude)
+        self.radius = try container.decodeIfPresent(Double.self, forKey: .radius)
+        self.geometry = try? container.decodeIfPresent(GeofenceApiGeometry.self, forKey: .geometry)
+        self.enclosingCircle = try? container.decodeIfPresent(GeofenceApiEnclosingCircle.self, forKey: .enclosingCircle)
         self.externalId = try container.decodeIfPresent(String.self, forKey: .externalId)
         self.transitionTypes = try container.decodeIfPresent([String].self, forKey: .transitionTypes)
         self.lastUpdated = try container.decodeIfPresent(Double.self, forKey: .lastUpdated)
@@ -179,27 +215,111 @@ private extension Comparable {
 }
 
 extension GeofenceApiRegion {
-    /// `nil` when the region violates the monitors' registration preconditions (radius must be
-    /// positive, coordinates in range). Empty / nil / all-unknown `transition_types` fall back to
+    /// `nil` when the region can't be registered as described: an unrecognized `shape`, a circle
+    /// missing or misreporting its geometry, or a polygon whose ring or enclosing circle fails the
+    /// acceptance rules below. Empty / nil / all-unknown `transition_types` fall back to
     /// `[.enter, .exit]`; a mix of valid + unknown keeps just the valid subset. `lastUpdated`
     /// defaults to epoch when missing so callers can compare without unwrapping. `name` is `nil`
     /// when the server omits it (or sends an empty string), so the domain value is always either
     /// `nil` or non-empty.
     func toDomain() -> Geofence? {
-        guard radius > 0,
-              CLLocationCoordinate2DIsValid(CLLocationCoordinate2D(latitude: latitude, longitude: longitude))
-        else { return nil }
+        let resolved: ResolvedGeometry?
+        switch shape?.lowercased() {
+        case nil, "circle":
+            resolved = resolvedCircle()
+        case "polygon":
+            resolved = resolvedPolygon()
+        default:
+            resolved = nil
+        }
+        guard let resolved else { return nil }
         return Geofence(
             id: id,
-            latitude: latitude,
-            longitude: longitude,
-            radius: radius,
+            latitude: resolved.center.latitude,
+            longitude: resolved.center.longitude,
+            radius: resolved.radius,
             name: name.flatMap { $0.isEmpty ? nil : $0 },
             transitionTypes: Self.resolveTransitionTypes(transitionTypes),
             lastUpdated: lastUpdated.map { Date(timeIntervalSince1970: $0 / 1000) } ?? Date(timeIntervalSince1970: 0),
             geosetIds: geosetIds ?? [],
-            metadata: Self.cappedMetadata(metadata)
+            metadata: Self.cappedMetadata(metadata),
+            vertices: resolved.vertices
         )
+    }
+
+    /// What the monitors need regardless of shape: the circle to register, plus the polygon that
+    /// membership is decided against when there is one.
+    private struct ResolvedGeometry {
+        let center: LocationData
+        let radius: Double
+        let vertices: [LocationData]?
+    }
+
+    private func resolvedCircle() -> ResolvedGeometry? {
+        guard let latitude, let longitude, let radius, radius > 0,
+              CLLocationCoordinate2DIsValid(CLLocationCoordinate2D(latitude: latitude, longitude: longitude))
+        else { return nil }
+        return ResolvedGeometry(
+            center: LocationData(latitude: latitude, longitude: longitude), radius: radius, vertices: nil
+        )
+    }
+
+    private func resolvedPolygon() -> ResolvedGeometry? {
+        guard let geometry, let enclosingCircle,
+              geometry.type.caseInsensitiveCompare("Polygon") == .orderedSame,
+              geometry.coordinates.count == 1,
+              enclosingCircle.baseRadiusM > 0
+        else { return nil }
+        let center = CLLocationCoordinate2D(latitude: enclosingCircle.latitude, longitude: enclosingCircle.longitude)
+        guard CLLocationCoordinate2DIsValid(center) else { return nil }
+        guard let vertices = Self.validatedPolygonVertices(
+            geometry.coordinates[0],
+            coveringCenter: CLLocation(latitude: center.latitude, longitude: center.longitude),
+            coveringRadius: enclosingCircle.baseRadiusM
+        ) else { return nil }
+        return ResolvedGeometry(
+            center: LocationData(latitude: center.latitude, longitude: center.longitude),
+            radius: enclosingCircle.baseRadiusM,
+            vertices: vertices
+        )
+    }
+
+    /// The polygon acceptance rules, in validation order; failing any drops the whole region
+    /// ("no illusions" — a broken polygon must cost itself, never masquerade as its circle):
+    /// - every position is `[longitude, latitude]`, optionally with a third elevation element the
+    ///   GeoJSON spec allows and we ignore;
+    /// - every position is a valid coordinate;
+    /// - the kernel accepts the ring (≥3 distinct vertices after unclosing the closed ring);
+    /// - the distinct vertex count is within `maxPolygonVertexCount`, counted after unclosing so it
+    ///   matches the server's cap on *unique* vertices;
+    /// - the covering guarantee holds: every vertex within the enclosing radius (+ slack) of its
+    ///   center. Vertices inside a convex circle imply the whole polygon is inside, so this fully
+    ///   defends "enclosing-circle exit ⇒ polygon exit" against a server that miscomputed it.
+    /// Returns the kernel's canonical (unclosed) vertices so the cache stores one representation.
+    private static func validatedPolygonVertices(
+        _ ring: [[Double]],
+        coveringCenter: CLLocation,
+        coveringRadius: Double
+    ) -> [LocationData]? {
+        var positions: [LocationData] = []
+        positions.reserveCapacity(ring.count)
+        for position in ring {
+            guard position.count >= 2 else { return nil }
+            let coordinate = CLLocationCoordinate2D(latitude: position[1], longitude: position[0])
+            guard CLLocationCoordinate2DIsValid(coordinate) else { return nil }
+            positions.append(LocationData(latitude: position[1], longitude: position[0]))
+        }
+        guard let region = PolygonRegion(vertices: positions),
+              region.vertices.count <= GeofenceConstants.maxPolygonVertexCount
+        else { return nil }
+        let coverageBound = coveringRadius + max(
+            GeofenceConstants.polygonCoverageSlackMeters,
+            coveringRadius * GeofenceConstants.polygonCoverageSlackFraction
+        )
+        guard region.vertices.allSatisfy({ vertex in
+            coveringCenter.distance(from: CLLocation(latitude: vertex.latitude, longitude: vertex.longitude)) <= coverageBound
+        }) else { return nil }
+        return region.vertices
     }
 
     private static func resolveTransitionTypes(_ raw: [String]?) -> Set<GeofenceTransition> {

--- a/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
@@ -44,7 +44,13 @@ private struct LenientRegion: Decodable {
 
 /// Why a region on the wire never became a monitorable fence.
 enum GeofenceRegionDropReason: String, Error {
-    case unknownShape = "unrecognized or inconsistent shape"
+    /// The server named a shape this version does not implement — a workspace that has moved on.
+    /// Exempt from the all-regions-dropped guard: an old SDK must stop monitoring geometry it can
+    /// no longer describe, rather than holding the last set it understood forever.
+    case unknownShape = "unrecognized shape"
+    /// The server named NO shape but sent polygon fields anyway. That is a malformed payload, not
+    /// a workspace on a newer shape, so it counts as unreadable and preserves the cache.
+    case undescribedShape = "shape missing but polygon fields present"
     case unusableCircle = "invalid coordinates or radius"
     case unusablePolygon = "missing or undecodable polygon geometry"
 }
@@ -281,7 +287,11 @@ extension GeofenceApiRegion {
             // cannot name. Falling through to the flat circle fields would monitor a shape the
             // server never described. Android drops the same combination. Keyed on the fields being
             // PRESENT, not on their having decoded — a malformed one is still a claim of a polygon.
-            return .failure(.unknownShape)
+            //
+            // Distinct from `unknownShape`: a NAMED shape we do not implement means the workspace
+            // moved on and stale monitors should go, whereas a missing name is a broken payload and
+            // must not be allowed to clear the cache.
+            return .failure(.undescribedShape)
         case nil, "circle":
             resolved = resolvedCircle()
             dropReason = .unusableCircle

--- a/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
@@ -44,12 +44,11 @@ private struct LenientRegion: Decodable {
 
 /// Why a region on the wire never became a monitorable fence.
 enum GeofenceRegionDropReason: String, Error {
-    /// The server named a shape this version does not implement — a workspace that has moved on.
-    /// Exempt from the all-regions-dropped guard: an old SDK must stop monitoring geometry it can
-    /// no longer describe, rather than holding the last set it understood forever.
+    /// A shape the server NAMED that this version cannot monitor. The workspace moved on, so this
+    /// is the one reason exempt from the all-dropped guard: stale monitors should go with it.
     case unknownShape = "unrecognized shape"
-    /// The server named NO shape but sent polygon fields anyway. That is a malformed payload, not
-    /// a workspace on a newer shape, so it counts as unreadable and preserves the cache.
+    /// No shape named, but polygon fields present — a malformed payload, so it counts as unreadable
+    /// and the cache survives.
     case undescribedShape = "shape missing but polygon fields present"
     case unusableCircle = "invalid coordinates or radius"
     case unusablePolygon = "missing or undecodable polygon geometry"
@@ -281,16 +280,15 @@ extension GeofenceApiRegion {
     func toDomain() -> Result<Geofence, GeofenceRegionDropReason> {
         let resolved: ResolvedGeometry?
         let dropReason: GeofenceRegionDropReason
-        switch shape?.lowercased() {
+        // Blank or padded is a serialization slip, not a shape the server named — left distinct it
+        // would reach `default`, the one branch the all-dropped guard exempts, and clear the cache.
+        let named = shape?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        switch named?.isEmpty == true ? nil : named {
         case nil where carriesPolygonFields:
             // Polygon fields with no discriminator: the payload describes something this decoder
             // cannot name. Falling through to the flat circle fields would monitor a shape the
             // server never described. Android drops the same combination. Keyed on the fields being
             // PRESENT, not on their having decoded — a malformed one is still a claim of a polygon.
-            //
-            // Distinct from `unknownShape`: a NAMED shape we do not implement means the workspace
-            // moved on and stale monitors should go, whereas a missing name is a broken payload and
-            // must not be allowed to clear the cache.
             return .failure(.undescribedShape)
         case nil, "circle":
             resolved = resolvedCircle()

--- a/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiResponse.swift
@@ -89,7 +89,7 @@ struct GeofenceApiRegion: Decodable {
     /// Whether the payload carried a non-null `geometry` or `enclosing_circle` at all, which is not
     /// the same as either having decoded: both use `try?`, so a malformed value becomes `nil` and
     /// would otherwise be indistinguishable from a v1 circle.
-    var carriesPolygonFields: Bool = false
+    let carriesPolygonFields: Bool
     let externalId: String?
     let transitionTypes: [String]?
     /// Wire format is milliseconds since epoch.

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
@@ -33,13 +33,10 @@ extension GeofenceSyncCoordinatorImpl {
         }
 
         let parsedConfig = response.toDomainConfig()
-        let regions = response.toDomainRegions(onInvalidRegion: { logger.geofenceInvalidRegionDropped($0, reason: $1) })
-        // A response whose regions all failed to resolve is a broken payload, not "this user has no
-        // geofences": reading it as the latter wipes the cache and deregisters everything. An
-        // actually empty list still applies normally.
-        if regions.isEmpty, response.receivedRegionCount > 0 {
-            logger.geofenceAllRegionsDropped(count: response.receivedRegionCount)
-            return .failure(.fetchFailed(.decoding))
+        let regions: [Geofence]
+        switch readableRegions(from: response) {
+        case .success(let value): regions = value
+        case .failure(let error): return .failure(error)
         }
         let effectiveConfig = parsedConfig ?? cachedConfig ?? .fallback
         let anchor = LocationData(latitude: latitude, longitude: longitude)
@@ -111,6 +108,29 @@ extension GeofenceSyncCoordinatorImpl {
         )
         logger.geofenceSyncCompleted(registeredCount: nearest.count, movementTriggerRegistered: registerMovementTrigger)
         return .success(())
+    }
+
+    /// Decodes the response's regions, or fails when the payload turns out to be unreadable rather
+    /// than empty. A response whose regions we could not READ is a broken payload, not "this user
+    /// has no geofences": reading it as the latter wipes the cache and deregisters everything. A
+    /// workspace that has moved entirely to a shape this SDK does not support is the opposite case
+    /// — the response read fine and nothing in it is monitorable, so failing forever would freeze
+    /// stale fences behind a refresh that can never succeed. An actually empty list applies
+    /// normally.
+    private func readableRegions(from response: GeofenceApiResponse) -> Result<[Geofence], GeofenceSyncError> {
+        var unreadableCount = 0
+        let regions = response.toDomainRegions(onInvalidRegion: { id, reason in
+            logger.geofenceInvalidRegionDropped(id, reason: reason)
+            // A shape we understood and declined is not a payload we failed to read.
+            if reason != .unknownShape { unreadableCount += 1 }
+        })
+        // Regions lost at JSON decode never reach `toDomainRegions` — it maps over what survived —
+        // so they have to be counted from the arrival tally instead. A wrong-typed radius or
+        // timestamp lands here, and it is unreadable in exactly the sense that matters.
+        let decodeLosses = response.receivedRegionCount - response.geofences.count
+        guard regions.isEmpty, unreadableCount + decodeLosses > 0 else { return .success(regions) }
+        logger.geofenceAllRegionsDropped(count: response.receivedRegionCount)
+        return .failure(.fetchFailed(.decoding))
     }
 
     /// A sign-out/switch can land anywhere inside a gated operation, and the `reset()` it triggers

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
@@ -33,7 +33,14 @@ extension GeofenceSyncCoordinatorImpl {
         }
 
         let parsedConfig = response.toDomainConfig()
-        let regions = response.toDomainRegions(onInvalidRegion: { logger.geofenceInvalidRegionDropped($0) })
+        let regions = response.toDomainRegions(onInvalidRegion: { logger.geofenceInvalidRegionDropped($0, reason: $1) })
+        // A response whose regions all failed to resolve is a broken payload, not "this user has no
+        // geofences": reading it as the latter wipes the cache and deregisters everything. An
+        // actually empty list still applies normally.
+        if regions.isEmpty, response.receivedRegionCount > 0 {
+            logger.geofenceAllRegionsDropped(count: response.receivedRegionCount)
+            return .failure(.fetchFailed(.decoding))
+        }
         let effectiveConfig = parsedConfig ?? cachedConfig ?? .fallback
         let anchor = LocationData(latitude: latitude, longitude: longitude)
         let nearest = distanceFilter.nearest(regions, to: anchor, limit: effectiveConfig.maxBusinessGeofences, maxDistance: effectiveConfig.maxMonitoringDistance)

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
@@ -121,7 +121,11 @@ extension GeofenceSyncCoordinatorImpl {
         var unreadableCount = 0
         let regions = response.toDomainRegions(onInvalidRegion: { id, reason in
             logger.geofenceInvalidRegionDropped(id, reason: reason)
-            // A shape we understood and declined is not a payload we failed to read.
+            // A shape the server NAMED and this version does not implement is not a payload we
+            // failed to read — the workspace moved on and the stale monitors should go with it.
+            // Everything else counts, `undescribedShape` included: polygon fields with no
+            // discriminator is a malformed response, and letting it clear the cache is the same
+            // defect as letting a decode failure clear it.
             if reason != .unknownShape { unreadableCount += 1 }
         })
         // Regions lost at JSON decode never reach `toDomainRegions` — it maps over what survived —

--- a/Sources/LocationGeofence/GeofenceConstants.swift
+++ b/Sources/LocationGeofence/GeofenceConstants.swift
@@ -83,12 +83,11 @@ enum GeofenceConstants {
     // have rejected; keep the two in step, and never set this below the server's value or we would
     // drop fences the server considers valid.
     static let maxPolygonVertexCount = 500
-    static let polygonCoverageSlackMeters = 1.0
 
-    /// Additional coverage slack as a fraction of the covering radius, to absorb the difference
-    /// between the earth model the server computed the circle with and the WGS84 ellipsoid
-    /// `CLLocation.distance` measures against. Measured at 11 m on a 7.9 km fence — far past a flat
-    /// one-metre slack, and a failed coverage check DROPS the region, so a legitimately-covering
-    /// circle would silently make the fence not exist.
-    static let polygonCoverageSlackFraction = 0.005
+    /// Slack on the coverage check, absorbing only the numerical difference between the server's
+    /// WGS84 spheroidal distances (PostGIS `geography`) and the WGS84 ellipsoid `CLLocation.distance`
+    /// measures against — the two agree on the earth model, so the residual is rounding, not geometry.
+    /// A failed coverage check DROPS the region, so this errs generous: too tight and a legitimately
+    /// covering circle silently makes the fence not exist.
+    static let polygonCoverageSlackMeters = 1.0
 }

--- a/Sources/LocationGeofence/GeofenceConstants.swift
+++ b/Sources/LocationGeofence/GeofenceConstants.swift
@@ -76,4 +76,19 @@ enum GeofenceConstants {
     // drop valid data; per-value size is left to the server.
     static let maxMetadataCount = 100
     static let maxMetadataPayloadBytes = 100 * 1024 // ~20× the server's 5 KB total
+
+    // Polygon geofences. Server contract: a polygon fence carries a GeoJSON ring plus an enclosing
+    // circle the server GUARANTEES contains it. The SDK still defends both. The vertex cap mirrors
+    // the server's own cap on unique vertices, so it only ever catches a payload the server should
+    // have rejected; keep the two in step, and never set this below the server's value or we would
+    // drop fences the server considers valid.
+    static let maxPolygonVertexCount = 500
+    static let polygonCoverageSlackMeters = 1.0
+
+    /// Additional coverage slack as a fraction of the covering radius, to absorb the difference
+    /// between the earth model the server computed the circle with and the WGS84 ellipsoid
+    /// `CLLocation.distance` measures against. Measured at 11 m on a 7.9 km fence — far past a flat
+    /// one-metre slack, and a failed coverage check DROPS the region, so a legitimately-covering
+    /// circle would silently make the fence not exist.
+    static let polygonCoverageSlackFraction = 0.005
 }

--- a/Sources/LocationGeofence/GeofenceConstants.swift
+++ b/Sources/LocationGeofence/GeofenceConstants.swift
@@ -76,18 +76,4 @@ enum GeofenceConstants {
     // drop valid data; per-value size is left to the server.
     static let maxMetadataCount = 100
     static let maxMetadataPayloadBytes = 100 * 1024 // ~20× the server's 5 KB total
-
-    // Polygon geofences. Server contract: a polygon fence carries a GeoJSON ring plus an enclosing
-    // circle the server GUARANTEES contains it. The SDK still defends both. The vertex cap mirrors
-    // the server's own cap on unique vertices, so it only ever catches a payload the server should
-    // have rejected; keep the two in step, and never set this below the server's value or we would
-    // drop fences the server considers valid.
-    static let maxPolygonVertexCount = 500
-
-    /// Slack on the coverage check, absorbing only the numerical difference between the server's
-    /// WGS84 spheroidal distances (PostGIS `geography`) and the WGS84 ellipsoid `CLLocation.distance`
-    /// measures against — the two agree on the earth model, so the residual is rounding, not geometry.
-    /// A failed coverage check DROPS the region, so this errs generous: too tight and a legitimately
-    /// covering circle silently makes the fence not exist.
-    static let polygonCoverageSlackMeters = 1.0
 }

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -5,9 +5,17 @@ import Foundation
 private let geofenceTag = "Geofence"
 
 extension Logger {
-    func geofenceInvalidRegionDropped(_ identifier: String) {
+    func geofenceInvalidRegionDropped(_ identifier: String, reason: GeofenceRegionDropReason) {
         error(
-            "Geofence '\(identifier)' dropped — invalid coordinates or radius, not registerable with the OS",
+            "Geofence '\(identifier)' dropped — \(reason.rawValue), not registerable with the OS",
+            geofenceTag,
+            nil
+        )
+    }
+
+    func geofenceAllRegionsDropped(count: Int) {
+        error(
+            "All \(count) region(s) in the response were unusable — treating as a fetch failure so the cache survives",
             geofenceTag,
             nil
         )

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -7,7 +7,7 @@ private let geofenceTag = "Geofence"
 extension Logger {
     func geofenceInvalidRegionDropped(_ identifier: String, reason: GeofenceRegionDropReason) {
         error(
-            "Geofence '\(identifier)' dropped — \(reason.rawValue), not registerable with the OS",
+            "Geofence '\(identifier)' dropped — \(reason.rawValue)",
             geofenceTag,
             nil
         )

--- a/Tests/LocationGeofence/Geofence/Api/GeofenceApiResponseTests.swift
+++ b/Tests/LocationGeofence/Geofence/Api/GeofenceApiResponseTests.swift
@@ -264,7 +264,7 @@ struct GeofenceApiResponseTests {
         """
         let response = try decode(json)
         var droppedIds: [String] = []
-        let regions = response.toDomainRegions(onInvalidRegion: { droppedIds.append($0) })
+        let regions = response.toDomainRegions(onInvalidRegion: { id, _ in droppedIds.append(id) })
 
         #expect(regions.map(\.id) == ["good"])
         #expect(droppedIds == ["bad"])
@@ -438,5 +438,63 @@ struct GeofenceApiResponseTests {
         }
         #expect(totalBytes <= GeofenceConstants.maxMetadataPayloadBytes)
         #expect(metadata.count < generated) // byte budget dropped some
+    }
+
+    // MARK: - One bad region must not cost the response
+
+    @Test
+    func decode_givenOneWrongTypedRegion_expectOthersSurvive() throws {
+        let json = """
+        {"geofences":[
+          {"id":"good","latitude":1,"longitude":2,"radius":100},
+          {"id":"bad","latitude":1,"longitude":2,"radius":"not-a-number"},
+          {"id":"alsoGood","latitude":3,"longitude":4,"radius":200}
+        ]}
+        """
+        let response = try decode(json)
+        #expect(response.receivedRegionCount == 3)
+        #expect(response.toDomainRegions().map(\.id) == ["good", "alsoGood"])
+    }
+
+    /// Distinguishes "the server sent none" from "none of them decoded" — the caller wipes the
+    /// cache on the first and must not on the second.
+    @Test
+    func decode_givenEveryRegionWrongTyped_expectCountPreservedAndListEmpty() throws {
+        let json = """
+        {"geofences":[
+          {"id":"a","latitude":1,"longitude":2,"radius":"nope"},
+          {"id":"b","latitude":"nope","longitude":2,"radius":100}
+        ]}
+        """
+        let response = try decode(json)
+        #expect(response.receivedRegionCount == 2)
+        #expect(response.geofences.isEmpty)
+    }
+
+    @Test
+    func decode_givenGenuinelyEmptyList_expectZeroReceived() throws {
+        let response = try decode("{\"geofences\":[]}")
+        #expect(response.receivedRegionCount == 0)
+    }
+
+    @Test
+    func toDomainRegions_givenUnknownShape_expectShapeReasonReported() throws {
+        let json = """
+        {"geofences":[{"id":"weird","shape":"hexagon","latitude":1,"longitude":2,"radius":100}]}
+        """
+        var reasons: [String: GeofenceRegionDropReason] = [:]
+        let regions = try decode(json).toDomainRegions(onInvalidRegion: { reasons[$0] = $1 })
+        #expect(regions.isEmpty)
+        #expect(reasons["weird"] == .unknownShape)
+    }
+
+    @Test
+    func toDomainRegions_givenUnusableCircle_expectCircleReasonReported() throws {
+        let json = """
+        {"geofences":[{"id":"c","latitude":91,"longitude":2,"radius":100}]}
+        """
+        var reasons: [String: GeofenceRegionDropReason] = [:]
+        _ = try decode(json).toDomainRegions(onInvalidRegion: { reasons[$0] = $1 })
+        #expect(reasons["c"] == .unusableCircle)
     }
 }

--- a/Tests/LocationGeofence/Geofence/Api/GeofencePolygonDecodeTests.swift
+++ b/Tests/LocationGeofence/Geofence/Api/GeofencePolygonDecodeTests.swift
@@ -1,0 +1,287 @@
+@testable import CioInternalCommon
+@testable import CioLocationGeofence
+import Foundation
+import Testing
+
+/// Contract tests for polygon geofences at the API boundary: a `shape` discriminator, a GeoJSON
+/// ring and an enclosing circle on the wire, canonicalized kernel vertices in the domain, and the
+/// "no illusions" rule — a region we can't read as described is dropped entirely, never degraded
+/// to whatever circle fields happen to be present.
+@Suite("GeofencePolygonDecode")
+struct GeofencePolygonDecodeTests {
+    private let decoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.keyDecodingStrategy = .convertFromSnakeCase
+        return d
+    }()
+
+    private func decode(_ json: String) throws -> GeofenceApiResponse {
+        try decoder.decode(GeofenceApiResponse.self, from: Data(json.utf8))
+    }
+
+    private static let centre = (latitude: 31.36896, longitude: 74.169508)
+
+    /// 400 m square around the centre, closed, longitude-first — the cross-SDK fixture family.
+    private static let squareRing = """
+    [[
+      [74.1674038, 31.3671634],
+      [74.1716122, 31.3671634],
+      [74.1716122, 31.3707566],
+      [74.1674038, 31.3707566],
+      [74.1674038, 31.3671634]
+    ]]
+    """
+
+    private func circleJson(id: Int = 1, radius: Double = 300, shape: String? = "circle") -> String {
+        let shapeField = shape.map { "\"shape\": \"\($0)\", " } ?? ""
+        return """
+        {"id": \(id), \(shapeField)"latitude": \(Self.centre.latitude),
+         "longitude": \(Self.centre.longitude), "radius": \(radius)}
+        """
+    }
+
+    private func polygonJson(
+        id: Int = 1,
+        radius: Double = 300,
+        type: String = "Polygon",
+        ring: String? = squareRing,
+        enclosingCircle: Bool = true
+    ) -> String {
+        let geometry = ring.map { "\"geometry\": {\"type\": \"\(type)\", \"coordinates\": \($0)}" }
+        let circle = enclosingCircle
+            ? """
+            "enclosing_circle": {"latitude": \(Self.centre.latitude),
+             "longitude": \(Self.centre.longitude), "base_radius_m": \(radius)}
+            """
+            : nil
+        let fields = ["\"id\": \(id)", "\"shape\": \"polygon\""] + [geometry, circle].compactMap { $0 }
+        return "{\(fields.joined(separator: ","))}"
+    }
+
+    private func responseJson(_ regions: [String]) -> String {
+        "{\"geofences\":[\(regions.joined(separator: ","))]}"
+    }
+
+    /// A ring of `count` distinct positions well inside the enclosing circle, so a cap test fails
+    /// on the cap and not incidentally on the coverage guarantee.
+    private static func ringInsideCircle(count: Int) -> String {
+        let positions = (0 ..< count).map { i -> String in
+            let angle = 2 * Double.pi * Double(i) / Double(count)
+            return "[\(centre.longitude + 0.0009 * sin(angle)), \(centre.latitude + 0.0008 * cos(angle))]"
+        }
+        return "[[\(positions.joined(separator: ","))]]"
+    }
+
+    // MARK: - Circles
+
+    @Test
+    func toDomain_givenShapeCircle_expectCircleGeofence() throws {
+        let regions = try decode(responseJson([circleJson()])).toDomainRegions()
+        #expect(regions.count == 1)
+        #expect(regions[0].vertices == nil)
+        #expect(regions[0].polygonRegion == nil)
+    }
+
+    /// v1 payloads carry no `shape` at all; they must keep decoding as circles.
+    @Test
+    func toDomain_givenNoShapeKey_expectCircleGeofence() throws {
+        let regions = try decode(responseJson([circleJson(shape: nil)])).toDomainRegions()
+        #expect(regions.count == 1)
+        #expect(regions[0].vertices == nil)
+    }
+
+    /// A shape from a future server must not be silently monitored as its circle fields.
+    @Test
+    func toDomain_givenUnknownShape_expectRegionDroppedNotCircled() throws {
+        let response = try decode(responseJson([circleJson(shape: "corridor"), circleJson(id: 2)]))
+        var invalidIds: [String] = []
+        let regions = response.toDomainRegions(onInvalidRegion: { invalidIds.append($0) })
+        #expect(regions.map(\.id) == ["2"])
+        #expect(invalidIds == ["1"])
+    }
+
+    // MARK: - Valid polygons
+
+    @Test
+    func toDomain_givenValidSquare_expectPolygonGeofence() throws {
+        let regions = try decode(responseJson([polygonJson()])).toDomainRegions()
+        #expect(regions.count == 1)
+        #expect(regions[0].vertices?.count == 4)
+        #expect(regions[0].radius == 300)
+        let polygon = try #require(regions[0].polygonRegion)
+        #expect(polygon.contains(LocationData(latitude: Self.centre.latitude, longitude: Self.centre.longitude)))
+        #expect(!polygon.contains(LocationData(latitude: 31.38, longitude: Self.centre.longitude)))
+    }
+
+    /// Longitude comes first on the wire. If the two were ever swapped the ring would land off the
+    /// coast of Somalia, so assert the decoded corner rather than just the count.
+    @Test
+    func toDomain_givenGeoJsonOrdering_expectLongitudeFirst() throws {
+        let regions = try decode(responseJson([polygonJson()])).toDomainRegions()
+        let first = try #require(regions[0].vertices?.first)
+        #expect(abs(first.latitude - 31.3671634) < 1e-9)
+        #expect(abs(first.longitude - 74.1674038) < 1e-9)
+    }
+
+    @Test
+    func toDomain_givenClosedRing_expectUnclosedCanonicalVertices() throws {
+        let regions = try decode(responseJson([polygonJson()])).toDomainRegions()
+        #expect(regions[0].vertices?.count == 4)
+    }
+
+    /// GeoJSON positions may carry a third elevation element; it is not ours to reject.
+    @Test
+    func toDomain_givenPositionsWithElevation_expectAccepted() throws {
+        let ring = """
+        [[
+          [74.1674038, 31.3671634, 210.0],
+          [74.1716122, 31.3671634, 210.0],
+          [74.1716122, 31.3707566, 210.0],
+          [74.1674038, 31.3707566, 210.0]
+        ]]
+        """
+        let regions = try decode(responseJson([polygonJson(ring: ring)])).toDomainRegions()
+        #expect(regions.count == 1)
+        #expect(regions[0].vertices?.count == 4)
+    }
+
+    @Test
+    func toDomain_givenVertexCountAtCap_expectAccepted() throws {
+        let ring = Self.ringInsideCircle(count: GeofenceConstants.maxPolygonVertexCount)
+        let regions = try decode(responseJson([polygonJson(ring: ring)])).toDomainRegions()
+        #expect(regions.count == 1)
+    }
+
+    // MARK: - "No illusions": unusable polygons drop the region
+
+    @Test
+    func toDomain_givenMultiPolygonType_expectRegionDropped() throws {
+        let response = try decode(responseJson([polygonJson(type: "MultiPolygon")]))
+        #expect(response.toDomainRegions().isEmpty)
+    }
+
+    /// Extra rings are holes. Honouring only the outer ring would report someone standing in a
+    /// hole as inside the fence, so the fence is dropped instead.
+    @Test
+    func toDomain_givenMultipleRings_expectRegionDropped() throws {
+        let withHole = """
+        [[
+          [74.1674038, 31.3671634], [74.1716122, 31.3671634],
+          [74.1716122, 31.3707566], [74.1674038, 31.3707566]
+        ],[
+          [74.1690000, 31.3685000], [74.1700000, 31.3685000],
+          [74.1700000, 31.3695000], [74.1690000, 31.3695000]
+        ]]
+        """
+        let response = try decode(responseJson([polygonJson(ring: withHole)]))
+        #expect(response.toDomainRegions().isEmpty)
+    }
+
+    @Test
+    func toDomain_givenMissingGeometry_expectRegionDropped() throws {
+        let response = try decode(responseJson([polygonJson(ring: nil)]))
+        #expect(response.toDomainRegions().isEmpty)
+    }
+
+    @Test
+    func toDomain_givenMissingEnclosingCircle_expectRegionDropped() throws {
+        let response = try decode(responseJson([polygonJson(enclosingCircle: false)]))
+        #expect(response.toDomainRegions().isEmpty)
+    }
+
+    @Test
+    func toDomain_givenWrongTypedGeometry_expectRegionDroppedNotCircled() throws {
+        let broken = """
+        {"id": 1, "shape": "polygon", "geometry": "not-a-geometry",
+         "enclosing_circle": {"latitude": \(Self.centre.latitude),
+          "longitude": \(Self.centre.longitude), "base_radius_m": 300}}
+        """
+        let response = try decode(responseJson([broken, circleJson(id: 2)]))
+        var invalidIds: [String] = []
+        let regions = response.toDomainRegions(onInvalidRegion: { invalidIds.append($0) })
+        #expect(regions.map(\.id) == ["2"])
+        #expect(invalidIds == ["1"])
+    }
+
+    @Test
+    func toDomain_givenPositionMissingCoordinate_expectRegionDropped() throws {
+        let ring = "[[[74.1674038, 31.3671634], [74.1716122], [74.1716122, 31.3707566]]]"
+        let response = try decode(responseJson([polygonJson(ring: ring)]))
+        #expect(response.toDomainRegions().isEmpty)
+    }
+
+    @Test
+    func toDomain_givenFewerThanThreeDistinctVertices_expectRegionDropped() throws {
+        let ring = """
+        [[[74.1674038, 31.3671634], [74.1716122, 31.3707566], [74.1674038, 31.3671634]]]
+        """
+        let response = try decode(responseJson([polygonJson(ring: ring)]))
+        #expect(response.toDomainRegions().isEmpty)
+    }
+
+    @Test
+    func toDomain_givenVertexCountOverCap_expectRegionDropped() throws {
+        let ring = Self.ringInsideCircle(count: GeofenceConstants.maxPolygonVertexCount + 1)
+        let response = try decode(responseJson([polygonJson(ring: ring)]))
+        #expect(response.toDomainRegions().isEmpty)
+    }
+
+    @Test
+    func toDomain_givenInvalidCoordinate_expectRegionDropped() throws {
+        let ring = """
+        [[[74.1674038, 95.0], [74.1716122, 31.3671634], [74.1716122, 31.3707566]]]
+        """
+        let response = try decode(responseJson([polygonJson(ring: ring)]))
+        #expect(response.toDomainRegions().isEmpty)
+    }
+
+    @Test
+    func toDomain_givenVertexOutsideEnclosingCircle_expectRegionDropped() throws {
+        // The square's corners sit ~283 m from the centre; a 200 m "enclosing" circle violates the
+        // server guarantee, and enclosing-exit ⇒ polygon-exit rests on it, so the region is dropped.
+        let response = try decode(responseJson([polygonJson(radius: 200)]))
+        #expect(response.toDomainRegions().isEmpty)
+    }
+
+    @Test
+    func toDomain_givenEnclosingCircleExactlyAtCorners_expectAccepted() throws {
+        // Corner distance ≈282.8 m; radius 283 must accept. The slack absorbs earth-model drift
+        // between the server's computation and WGS84 on device, not real violations.
+        let response = try decode(responseJson([polygonJson(radius: 283)]))
+        #expect(response.toDomainRegions().count == 1)
+    }
+
+    // MARK: - Cache round-trip
+
+    @Test
+    func geofenceCodable_givenPolygon_expectVerticesSurviveRoundTrip() throws {
+        let original = Geofence(
+            id: "7",
+            latitude: Self.centre.latitude,
+            longitude: Self.centre.longitude,
+            radius: 283,
+            name: "poly",
+            transitionTypes: [.enter, .exit],
+            lastUpdated: Date(timeIntervalSince1970: 1000),
+            vertices: [
+                LocationData(latitude: 31.3671634, longitude: 74.1674038),
+                LocationData(latitude: 31.3671634, longitude: 74.1716122),
+                LocationData(latitude: 31.3707566, longitude: 74.1716122)
+            ]
+        )
+        let decoded = try JSONDecoder().decode(Geofence.self, from: JSONEncoder().encode(original))
+        #expect(decoded == original)
+        #expect(decoded.polygonRegion != nil)
+    }
+
+    @Test
+    func geofenceDecode_givenLegacyCacheWithoutVertices_expectCircleGeofence() throws {
+        let legacy = """
+        {"id":"7","latitude":31.36896,"longitude":74.169508,"radius":283,
+         "transitionTypes":["enter","exit"],"lastUpdated":0}
+        """
+        let decoded = try JSONDecoder().decode(Geofence.self, from: Data(legacy.utf8))
+        #expect(decoded.vertices == nil)
+        #expect(decoded.polygonRegion == nil)
+    }
+}

--- a/Tests/LocationGeofence/Geofence/Api/GeofencePolygonDecodeTests.swift
+++ b/Tests/LocationGeofence/Geofence/Api/GeofencePolygonDecodeTests.swift
@@ -193,6 +193,33 @@ struct GeofencePolygonDecodeTests {
         #expect(reasons["1"] == .unknownShape)
     }
 
+    /// `geometry` and `enclosing_circle` decode with `try?`, so a malformed one becomes nil. Keyed
+    /// on the decoded value the region would read as a plain v1 circle and be monitored as one.
+    @Test
+    func toDomain_givenUndecodablePolygonFieldsWithoutShape_expectRegionDropped() throws {
+        let malformed = """
+        {"id": 1, "latitude": \(Self.centre.latitude), "longitude": \(Self.centre.longitude),
+         "radius": 300, "geometry": "not-an-object"}
+        """
+        var reasons: [String: GeofenceRegionDropReason] = [:]
+        let regions = try decode(responseJson([malformed])).toDomainRegions(onInvalidRegion: { reasons[$0] = $1 })
+        #expect(regions.isEmpty)
+        #expect(reasons["1"] == .unknownShape)
+    }
+
+    /// An explicit null is the server saying "no polygon here", which a v1 circle payload may carry
+    /// once the field ships. It must stay a circle.
+    @Test
+    func toDomain_givenNullPolygonFieldsWithoutShape_expectCircleAccepted() throws {
+        let nulled = """
+        {"id": 1, "latitude": \(Self.centre.latitude), "longitude": \(Self.centre.longitude),
+         "radius": 300, "geometry": null, "enclosing_circle": null}
+        """
+        let regions = try decode(responseJson([nulled])).toDomainRegions()
+        #expect(regions.count == 1)
+        #expect(regions.first?.vertices == nil)
+    }
+
     @Test
     func toDomain_givenMultiPolygonType_expectRegionDropped() throws {
         let response = try decode(responseJson([polygonJson(type: "MultiPolygon")]))

--- a/Tests/LocationGeofence/Geofence/Api/GeofencePolygonDecodeTests.swift
+++ b/Tests/LocationGeofence/Geofence/Api/GeofencePolygonDecodeTests.swift
@@ -245,10 +245,21 @@ struct GeofencePolygonDecodeTests {
 
     @Test
     func toDomain_givenEnclosingCircleExactlyAtCorners_expectAccepted() throws {
-        // Corner distance ≈282.8 m; radius 283 must accept. The slack absorbs earth-model drift
-        // between the server's computation and WGS84 on device, not real violations.
+        // Corner distance ≈282.8 m; radius 283 must accept. The slack absorbs rounding between the
+        // server's spheroidal distances and WGS84 on device, not real violations.
         let response = try decode(responseJson([polygonJson(radius: 283)]))
         #expect(response.toDomainRegions().count == 1)
+    }
+
+    @Test
+    func toDomain_givenLargeFenceVertexPastFlatSlack_expectRegionDropped() throws {
+        // Both sides measure on WGS84, so the slack is a flat metre and does NOT scale with radius:
+        // a vertex 15 m outside a 7.9 km circle is a real coverage violation, not drift.
+        let ring = """
+        [[[74.169508, 31.440346], [74.1675080, 31.3669600], [74.1715080, 31.3669600]]]
+        """
+        let response = try decode(responseJson([polygonJson(radius: 7900, ring: ring)]))
+        #expect(response.toDomainRegions().isEmpty)
     }
 
     // MARK: - Cache round-trip

--- a/Tests/LocationGeofence/Geofence/Api/GeofencePolygonDecodeTests.swift
+++ b/Tests/LocationGeofence/Geofence/Api/GeofencePolygonDecodeTests.swift
@@ -154,6 +154,27 @@ struct GeofencePolygonDecodeTests {
 
     // MARK: - "No illusions": unusable polygons drop the region
 
+    /// End-to-end at the API boundary: a bow-tie reaching the cache would fire enters for ground
+    /// the polygon never covered, so it must not survive decode.
+    @Test
+    func toDomain_givenSelfIntersectingRing_expectRegionDropped() throws {
+        let bowtie = """
+        [[[74.1674038, 31.3671634], [74.1716122, 31.3707566],
+          [74.1716122, 31.3671634], [74.1674038, 31.3707566]]]
+        """
+        let response = try decode(responseJson([polygonJson(ring: bowtie)]))
+        #expect(response.toDomainRegions().isEmpty)
+    }
+
+    @Test
+    func toDomain_givenZeroAreaRing_expectRegionDropped() throws {
+        let line = """
+        [[[74.1674038, 31.3671634], [74.1674038, 31.3681634], [74.1674038, 31.3691634]]]
+        """
+        let response = try decode(responseJson([polygonJson(ring: line)]))
+        #expect(response.toDomainRegions().isEmpty)
+    }
+
     @Test
     func toDomain_givenMultiPolygonType_expectRegionDropped() throws {
         let response = try decode(responseJson([polygonJson(type: "MultiPolygon")]))

--- a/Tests/LocationGeofence/Geofence/Api/GeofencePolygonDecodeTests.swift
+++ b/Tests/LocationGeofence/Geofence/Api/GeofencePolygonDecodeTests.swift
@@ -96,7 +96,7 @@ struct GeofencePolygonDecodeTests {
     func toDomain_givenUnknownShape_expectRegionDroppedNotCircled() throws {
         let response = try decode(responseJson([circleJson(shape: "corridor"), circleJson(id: 2)]))
         var invalidIds: [String] = []
-        let regions = response.toDomainRegions(onInvalidRegion: { invalidIds.append($0) })
+        let regions = response.toDomainRegions(onInvalidRegion: { id, _ in invalidIds.append(id) })
         #expect(regions.map(\.id) == ["2"])
         #expect(invalidIds == ["1"])
     }
@@ -147,9 +147,8 @@ struct GeofencePolygonDecodeTests {
     }
 
     @Test
-    func toDomain_givenVertexCountAtCap_expectAccepted() throws {
-        let ring = Self.ringInsideCircle(count: GeofenceConstants.maxPolygonVertexCount)
-        let regions = try decode(responseJson([polygonJson(ring: ring)])).toDomainRegions()
+    func toDomain_givenLargeRing_expectAccepted() throws {
+        let regions = try decode(responseJson([polygonJson(ring: Self.ringInsideCircle(count: 500))])).toDomainRegions()
         #expect(regions.count == 1)
     }
 
@@ -199,7 +198,7 @@ struct GeofencePolygonDecodeTests {
         """
         let response = try decode(responseJson([broken, circleJson(id: 2)]))
         var invalidIds: [String] = []
-        let regions = response.toDomainRegions(onInvalidRegion: { invalidIds.append($0) })
+        let regions = response.toDomainRegions(onInvalidRegion: { id, _ in invalidIds.append(id) })
         #expect(regions.map(\.id) == ["2"])
         #expect(invalidIds == ["1"])
     }
@@ -220,11 +219,11 @@ struct GeofencePolygonDecodeTests {
         #expect(response.toDomainRegions().isEmpty)
     }
 
-    /// The cap is stated in UNIQUE vertices, so a ring that only exceeds it by repeating positions
-    /// is one the server considers valid — dropping it would make the fence silently not exist.
+    /// Repeated positions collapse to the kernel's canonical unclosed ring, so the cache stores one
+    /// representation regardless of how the server spelled the boundary.
     @Test
-    func toDomain_givenDuplicatesPushingRingPastCap_expectAccepted() throws {
-        let unique = GeofenceConstants.maxPolygonVertexCount
+    func toDomain_givenRepeatedPositions_expectCollapsedToUnique() throws {
+        let unique = 500
         let response = try decode(responseJson([
             polygonJson(ring: Self.ringInsideCircle(count: unique, repeatingFirstPosition: true))
         ]))
@@ -232,49 +231,6 @@ struct GeofencePolygonDecodeTests {
         let regions = response.toDomainRegions()
         #expect(regions.count == 1)
         #expect(regions.first?.vertices?.count == unique)
-    }
-
-    @Test
-    func toDomain_givenVertexCountOverCap_expectRegionDropped() throws {
-        let ring = Self.ringInsideCircle(count: GeofenceConstants.maxPolygonVertexCount + 1)
-        let response = try decode(responseJson([polygonJson(ring: ring)]))
-        #expect(response.toDomainRegions().isEmpty)
-    }
-
-    @Test
-    func toDomain_givenInvalidCoordinate_expectRegionDropped() throws {
-        let ring = """
-        [[[74.1674038, 95.0], [74.1716122, 31.3671634], [74.1716122, 31.3707566]]]
-        """
-        let response = try decode(responseJson([polygonJson(ring: ring)]))
-        #expect(response.toDomainRegions().isEmpty)
-    }
-
-    @Test
-    func toDomain_givenVertexOutsideEnclosingCircle_expectRegionDropped() throws {
-        // The square's corners sit ~283 m from the centre; a 200 m "enclosing" circle violates the
-        // server guarantee, and enclosing-exit ⇒ polygon-exit rests on it, so the region is dropped.
-        let response = try decode(responseJson([polygonJson(radius: 200)]))
-        #expect(response.toDomainRegions().isEmpty)
-    }
-
-    @Test
-    func toDomain_givenEnclosingCircleExactlyAtCorners_expectAccepted() throws {
-        // Corner distance ≈282.8 m; radius 283 must accept. The slack absorbs rounding between the
-        // server's spheroidal distances and WGS84 on device, not real violations.
-        let response = try decode(responseJson([polygonJson(radius: 283)]))
-        #expect(response.toDomainRegions().count == 1)
-    }
-
-    @Test
-    func toDomain_givenLargeFenceVertexPastFlatSlack_expectRegionDropped() throws {
-        // Both sides measure on WGS84, so the slack is a flat metre and does NOT scale with radius:
-        // a vertex 15 m outside a 7.9 km circle is a real coverage violation, not drift.
-        let ring = """
-        [[[74.169508, 31.440346], [74.1675080, 31.3669600], [74.1715080, 31.3669600]]]
-        """
-        let response = try decode(responseJson([polygonJson(radius: 7900, ring: ring)]))
-        #expect(response.toDomainRegions().isEmpty)
     }
 
     // MARK: - Cache round-trip

--- a/Tests/LocationGeofence/Geofence/Api/GeofencePolygonDecodeTests.swift
+++ b/Tests/LocationGeofence/Geofence/Api/GeofencePolygonDecodeTests.swift
@@ -175,6 +175,24 @@ struct GeofencePolygonDecodeTests {
         #expect(response.toDomainRegions().isEmpty)
     }
 
+    /// A payload carrying polygon fields but no `shape` is inconsistent, not a v1 circle. Taking
+    /// the flat circle fields there would monitor a shape the server never described; Android drops
+    /// the same combination.
+    @Test
+    func toDomain_givenPolygonFieldsWithoutShape_expectRegionDropped() throws {
+        let inconsistent = """
+        {"id": 1, "latitude": \(Self.centre.latitude), "longitude": \(Self.centre.longitude),
+         "radius": 300,
+         "geometry": {"type": "Polygon", "coordinates": \(Self.squareRing)},
+         "enclosing_circle": {"latitude": \(Self.centre.latitude),
+          "longitude": \(Self.centre.longitude), "base_radius_m": 300}}
+        """
+        var reasons: [String: GeofenceRegionDropReason] = [:]
+        let regions = try decode(responseJson([inconsistent])).toDomainRegions(onInvalidRegion: { reasons[$0] = $1 })
+        #expect(regions.isEmpty)
+        #expect(reasons["1"] == .unknownShape)
+    }
+
     @Test
     func toDomain_givenMultiPolygonType_expectRegionDropped() throws {
         let response = try decode(responseJson([polygonJson(type: "MultiPolygon")]))

--- a/Tests/LocationGeofence/Geofence/Api/GeofencePolygonDecodeTests.swift
+++ b/Tests/LocationGeofence/Geofence/Api/GeofencePolygonDecodeTests.swift
@@ -64,11 +64,12 @@ struct GeofencePolygonDecodeTests {
 
     /// A ring of `count` distinct positions well inside the enclosing circle, so a cap test fails
     /// on the cap and not incidentally on the coverage guarantee.
-    private static func ringInsideCircle(count: Int) -> String {
-        let positions = (0 ..< count).map { i -> String in
+    private static func ringInsideCircle(count: Int, repeatingFirstPosition: Bool = false) -> String {
+        var positions = (0 ..< count).map { i -> String in
             let angle = 2 * Double.pi * Double(i) / Double(count)
             return "[\(centre.longitude + 0.0009 * sin(angle)), \(centre.latitude + 0.0008 * cos(angle))]"
         }
+        if repeatingFirstPosition, let first = positions.first { positions.insert(first, at: 1) }
         return "[[\(positions.joined(separator: ","))]]"
     }
 
@@ -217,6 +218,20 @@ struct GeofencePolygonDecodeTests {
         """
         let response = try decode(responseJson([polygonJson(ring: ring)]))
         #expect(response.toDomainRegions().isEmpty)
+    }
+
+    /// The cap is stated in UNIQUE vertices, so a ring that only exceeds it by repeating positions
+    /// is one the server considers valid — dropping it would make the fence silently not exist.
+    @Test
+    func toDomain_givenDuplicatesPushingRingPastCap_expectAccepted() throws {
+        let unique = GeofenceConstants.maxPolygonVertexCount
+        let response = try decode(responseJson([
+            polygonJson(ring: Self.ringInsideCircle(count: unique, repeatingFirstPosition: true))
+        ]))
+
+        let regions = response.toDomainRegions()
+        #expect(regions.count == 1)
+        #expect(regions.first?.vertices?.count == unique)
     }
 
     @Test

--- a/Tests/LocationGeofence/Geofence/Api/GeofencePolygonDecodeTests.swift
+++ b/Tests/LocationGeofence/Geofence/Api/GeofencePolygonDecodeTests.swift
@@ -193,6 +193,25 @@ struct GeofencePolygonDecodeTests {
         #expect(reasons["1"] == .undescribedShape)
     }
 
+    /// An empty or whitespace `shape` is a serialization slip, not a shape the server named. As a
+    /// distinct string it would reach `default` and report `unknownShape` — the one reason the
+    /// all-dropped guard exempts — so a payload of these would clear the whole fence set. Both
+    /// forms must route as if the discriminator were absent.
+    @Test(arguments: ["\"\"", "\" \"", "\"  circle \""])
+    func toDomain_givenBlankOrPaddedShape_expectRoutedAsIfAbsent(shapeJson: String) throws {
+        let withPolygonFields = """
+        {"id": 1, "shape": \(shapeJson),
+         "latitude": \(Self.centre.latitude), "longitude": \(Self.centre.longitude), "radius": 300,
+         "geometry": {"type": "Polygon", "coordinates": \(Self.squareRing)}}
+        """
+        var reasons: [String: GeofenceRegionDropReason] = [:]
+        let regions = try decode(responseJson([withPolygonFields]))
+            .toDomainRegions(onInvalidRegion: { reasons[$0] = $1 })
+        // Either it resolves (padded "circle") or it drops under a reason that COUNTS as unreadable.
+        #expect(reasons["1"] != .unknownShape, "blank/padded shape must not take the exempt branch")
+        if regions.isEmpty { #expect(reasons["1"] == .undescribedShape) }
+    }
+
     /// `geometry` and `enclosing_circle` decode with `try?`, so a malformed one becomes nil. Keyed
     /// on the decoded value the region would read as a plain v1 circle and be monitored as one.
     @Test

--- a/Tests/LocationGeofence/Geofence/Api/GeofencePolygonDecodeTests.swift
+++ b/Tests/LocationGeofence/Geofence/Api/GeofencePolygonDecodeTests.swift
@@ -190,7 +190,7 @@ struct GeofencePolygonDecodeTests {
         var reasons: [String: GeofenceRegionDropReason] = [:]
         let regions = try decode(responseJson([inconsistent])).toDomainRegions(onInvalidRegion: { reasons[$0] = $1 })
         #expect(regions.isEmpty)
-        #expect(reasons["1"] == .unknownShape)
+        #expect(reasons["1"] == .undescribedShape)
     }
 
     /// `geometry` and `enclosing_circle` decode with `try?`, so a malformed one becomes nil. Keyed
@@ -204,7 +204,7 @@ struct GeofencePolygonDecodeTests {
         var reasons: [String: GeofenceRegionDropReason] = [:]
         let regions = try decode(responseJson([malformed])).toDomainRegions(onInvalidRegion: { reasons[$0] = $1 })
         #expect(regions.isEmpty)
-        #expect(reasons["1"] == .unknownShape)
+        #expect(reasons["1"] == .undescribedShape)
     }
 
     /// An explicit null is the server saying "no polygon here", which a v1 circle payload may carry

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -81,9 +81,21 @@ struct GeofenceSyncCoordinatorTests {
             GeofenceApiRegion(
                 id: region.id,
                 name: region.name,
-                latitude: region.latitude,
-                longitude: region.longitude,
-                radius: region.radius,
+                shape: region.vertices == nil ? "circle" : "polygon",
+                latitude: region.vertices == nil ? region.latitude : nil,
+                longitude: region.vertices == nil ? region.longitude : nil,
+                radius: region.vertices == nil ? region.radius : nil,
+                geometry: region.vertices.map { ring in
+                    GeofenceApiGeometry(
+                        type: "Polygon",
+                        coordinates: [ring.map { [$0.longitude, $0.latitude] }]
+                    )
+                },
+                enclosingCircle: region.vertices == nil ? nil : GeofenceApiEnclosingCircle(
+                    latitude: region.latitude,
+                    longitude: region.longitude,
+                    baseRadiusM: region.radius
+                ),
                 externalId: nil,
                 transitionTypes: region.transitionTypes.map(\.rawValue),
                 lastUpdated: region.lastUpdated.timeIntervalSince1970,

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -517,6 +517,57 @@ struct GeofenceSyncCoordinatorTests {
         #expect(setup.monitor.startedRegions.isEmpty)
     }
 
+    /// The loss that never reaches `toDomainRegions`: a region rejected at JSON decode is compacted
+    /// out of `geofences` before the domain mapping runs, so no drop callback fires for it. It is
+    /// still an unreadable payload, and treating it as "no geofences" wipes the cache.
+    ///
+    /// Built through `JSONDecoder` deliberately — the memberwise init sets `receivedRegionCount`
+    /// from the surviving array, so it cannot express "one arrived, none survived".
+    @Test
+    func refresh_givenEveryRegionLostAtJsonDecode_expectFetchFailureAndCacheKept() async throws {
+        let storage = makeStorage()
+        await storage.setCachedGeofences([makeRegion(id: "kept", latitude: 37.7749, longitude: -122.4194)])
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let payload = #"{"geofences":[{"id":{},"latitude":1,"longitude":2,"radius":100}]}"#
+        let response = try decoder.decode(GeofenceApiResponse.self, from: Data(payload.utf8))
+        #expect(response.receivedRegionCount == 1)
+        #expect(response.geofences.isEmpty)
+        let api = GeofenceApiServiceMock()
+        api.fetchNearbyGeofencesClosure = { _, _, completion in completion(.success(response)) }
+
+        let setup = makeCoordinator(api: api, storage: storage)
+        let result = await setup.coordinator.refresh(latitude: 37.7749, longitude: -122.4194)
+
+        #expect(result.errorOrNil == .fetchFailed(.decoding))
+        #expect(await storage.getCachedGeofences().map(\.id) == ["kept"])
+    }
+
+    /// A workspace whose fences have all moved to a shape this SDK cannot monitor is the opposite
+    /// of a broken payload: the response read fine and there is genuinely nothing here for us.
+    /// Failing would freeze the previous fences in place with a refresh that can never succeed.
+    @Test
+    func refresh_givenEveryRegionAnUnsupportedShape_expectAppliedAsEmpty() async {
+        let storage = makeStorage()
+        await storage.setCachedGeofences([makeRegion(id: "stale", latitude: 37.7749, longitude: -122.4194)])
+        let futureShape = GeofenceApiRegion(
+            id: "future", name: nil, shape: "corridor",
+            latitude: 37.7749, longitude: -122.4194, radius: 100,
+            geometry: nil, enclosingCircle: nil, externalId: nil,
+            transitionTypes: nil, lastUpdated: nil, geosetIds: nil, metadata: nil
+        )
+        let api = GeofenceApiServiceMock()
+        api.fetchNearbyGeofencesClosure = { _, _, completion in
+            completion(.success(GeofenceApiResponse(config: nil, geofences: [futureShape])))
+        }
+
+        let setup = makeCoordinator(api: api, storage: storage)
+        let result = await setup.coordinator.refresh(latitude: 37.7749, longitude: -122.4194)
+
+        #expect(result.errorOrNil == nil)
+        #expect(await storage.getCachedGeofences().isEmpty)
+    }
+
     @Test
     func refresh_givenEmptyServerResponse_expectMovementTriggerStillRegistered() async {
         let storage = makeStorage()

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -491,6 +491,32 @@ struct GeofenceSyncCoordinatorTests {
         #expect(movementTrigger?.transitionTypes == [.exit])
     }
 
+    /// A payload whose regions all fail to resolve is a broken response, not a geofence-free area:
+    /// treating it as the latter would wipe the cache and deregister every fence the user has.
+    @Test
+    func refresh_givenEveryRegionUnusable_expectFetchFailureAndCacheKept() async {
+        let storage = makeStorage()
+        await storage.setCachedGeofences([makeRegion(id: "kept", latitude: 37.7749, longitude: -122.4194)])
+        let unusable = GeofenceApiRegion(
+            id: "broken", name: nil, shape: "circle",
+            latitude: 91, longitude: 2, radius: 100,
+            geometry: nil, enclosingCircle: nil, externalId: nil,
+            transitionTypes: nil, lastUpdated: nil, geosetIds: nil, metadata: nil
+        )
+        let api = GeofenceApiServiceMock()
+        api.fetchNearbyGeofencesClosure = { _, _, completion in
+            completion(.success(GeofenceApiResponse(config: nil, geofences: [unusable])))
+        }
+
+        let setup = makeCoordinator(api: api, storage: storage)
+        let result = await setup.coordinator.refresh(latitude: 37.7749, longitude: -122.4194)
+
+        #expect(result.errorOrNil == .fetchFailed(.decoding))
+        let cached = await storage.getCachedGeofences()
+        #expect(cached.map(\.id) == ["kept"])
+        #expect(setup.monitor.startedRegions.isEmpty)
+    }
+
     @Test
     func refresh_givenEmptyServerResponse_expectMovementTriggerStillRegistered() async {
         let storage = makeStorage()

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -543,6 +543,29 @@ struct GeofenceSyncCoordinatorTests {
         #expect(await storage.getCachedGeofences().map(\.id) == ["kept"])
     }
 
+    /// Polygon fields with no shape discriminator is a MALFORMED payload, not a workspace that has
+    /// moved to a shape we cannot monitor — so it must preserve the cache, the way a decode loss
+    /// does. Both used to report `unknownShape`, which the all-dropped guard exempts, so this
+    /// payload cleared every fence the user had. Reproduction supplied by @Shahroz16 in review.
+    @Test
+    func refresh_givenPolygonFieldsWithoutShape_expectFetchFailureAndCacheKept() async throws {
+        let storage = makeStorage()
+        await storage.setCachedGeofences([makeRegion(id: "kept", latitude: 37.7749, longitude: -122.4194)])
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let payload = #"{"geofences":[{"id":"broken","latitude":1,"longitude":2,"radius":100,"geometry":{}}]}"#
+        let response = try decoder.decode(GeofenceApiResponse.self, from: Data(payload.utf8))
+        let api = GeofenceApiServiceMock()
+        api.fetchNearbyGeofencesClosure = { _, _, completion in completion(.success(response)) }
+
+        let setup = makeCoordinator(api: api, storage: storage)
+        let result = await setup.coordinator.refresh(latitude: 37.7749, longitude: -122.4194)
+
+        #expect(result.errorOrNil == .fetchFailed(.decoding))
+        #expect(await storage.getCachedGeofences().map(\.id) == ["kept"])
+        #expect(setup.monitor.startedRegions.isEmpty)
+    }
+
     /// A workspace whose fences have all moved to a shape this SDK cannot monitor is the opposite
     /// of a broken payload: the response read fine and there is genuinely nothing here for us.
     /// Failing would freeze the previous fences in place with a refresh that can never succeed.

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -96,6 +96,7 @@ struct GeofenceSyncCoordinatorTests {
                     longitude: region.longitude,
                     baseRadiusM: region.radius
                 ),
+                carriesPolygonFields: region.vertices != nil,
                 externalId: nil,
                 transitionTypes: region.transitionTypes.map(\.rawValue),
                 lastUpdated: region.lastUpdated.timeIntervalSince1970,
@@ -500,7 +501,7 @@ struct GeofenceSyncCoordinatorTests {
         let unusable = GeofenceApiRegion(
             id: "broken", name: nil, shape: "circle",
             latitude: 91, longitude: 2, radius: 100,
-            geometry: nil, enclosingCircle: nil, externalId: nil,
+            geometry: nil, enclosingCircle: nil, carriesPolygonFields: false, externalId: nil,
             transitionTypes: nil, lastUpdated: nil, geosetIds: nil, metadata: nil
         )
         let api = GeofenceApiServiceMock()
@@ -576,7 +577,7 @@ struct GeofenceSyncCoordinatorTests {
         let futureShape = GeofenceApiRegion(
             id: "future", name: nil, shape: "corridor",
             latitude: 37.7749, longitude: -122.4194, radius: 100,
-            geometry: nil, enclosingCircle: nil, externalId: nil,
+            geometry: nil, enclosingCircle: nil, carriesPolygonFields: false, externalId: nil,
             transitionTypes: nil, lastUpdated: nil, geosetIds: nil, metadata: nil
         )
         let api = GeofenceApiServiceMock()

--- a/Tests/LocationGeofence/Geometry/NiagaraFixtureTests.swift
+++ b/Tests/LocationGeofence/Geometry/NiagaraFixtureTests.swift
@@ -1,0 +1,86 @@
+@testable import CioInternalCommon
+@testable import CioLocationGeofence
+import CoreLocation
+import Foundation
+import Testing
+
+@Suite("Niagara fixture")
+struct NiagaraFixtureTests {
+    /// Closed ring as supplied; the kernel unclosees it.
+    private static let ring = [
+        (43.2620, -79.0750), (43.2600, -79.0200), (43.2200, -79.0550), (43.1600, -79.0550),
+        (43.1500, -79.1200), (43.1800, -79.1800), (43.2300, -79.1500), (43.2620, -79.0750)
+    ].map { LocationData(latitude: $0.0, longitude: $0.1) }
+
+    /// Minimum enclosing circle of the ring, radius from a SPHERICAL model — 7864 m, where WGS84
+    /// measures 7875.3 to the farthest vertex. Deliberately the pessimistic value: the proportional
+    /// coverage slack exists so a server using a different earth model doesn't get its region
+    /// dropped, and this fixture is what proves it.
+    private static let covering = (latitude: 43.219062, longitude: -79.099117, radius: 7864.0)
+
+    @Test
+    func niagaraRing_expectAcceptedByKernel() {
+        let region = PolygonRegion(vertices: Self.ring)
+        #expect(region != nil)
+        #expect(region?.vertices.count == 7)
+    }
+
+    @Test
+    func niagaraRing_expectAcceptedByApiValidation() {
+        let api = GeofenceApiRegion(
+            id: "niagara", name: "Niagara-on-the-Lake", shape: "polygon",
+            latitude: nil, longitude: nil, radius: nil,
+            geometry: GeofenceApiGeometry(
+                type: "Polygon",
+                // GeoJSON is longitude-first, and the ring stays closed on the wire.
+                coordinates: [Self.ring.map { [$0.longitude, $0.latitude] }]
+            ),
+            enclosingCircle: GeofenceApiEnclosingCircle(
+                latitude: Self.covering.latitude,
+                longitude: Self.covering.longitude,
+                baseRadiusM: Self.covering.radius
+            ),
+            externalId: nil, transitionTypes: nil, lastUpdated: nil, geosetIds: nil, metadata: nil
+        )
+        let domain = api.toDomain()
+        #expect(domain != nil)
+        #expect(domain?.vertices?.count == 7)
+        #expect(domain?.polygonRegion != nil)
+    }
+
+    /// Well inside the town: the verdict must be decisive at any realistic accuracy.
+    @Test
+    func niagaraRing_expectInteriorPointDecisivelyInside() {
+        let region = PolygonRegion(vertices: Self.ring)
+        let inland = LocationData(latitude: 43.2050, longitude: -79.1050)
+        let signed = region?.signedEdgeDistance(to: inland) ?? 0
+        #expect(region?.contains(inland) == true)
+        #expect(signed > 0)
+        // Decisive past any realistic fix accuracy, so the membership layer can act on it.
+        #expect(signed > 65)
+    }
+
+    /// The reflex notch: inside the covering circle, outside the town. A convex hull would
+    /// wrongly call this inside, which is the whole reason the ring cannot be convexified.
+    @Test
+    func niagaraRing_expectNotchPointOutside() {
+        let region = PolygonRegion(vertices: Self.ring)
+        let notch = LocationData(latitude: 43.2350, longitude: -79.0300)
+        let coveringCentre = LocationData(latitude: Self.covering.latitude, longitude: Self.covering.longitude)
+        let distanceFromCentre = notch.distanceTo(coveringCentre)
+
+        #expect(distanceFromCentre < Self.covering.radius)
+        #expect(region?.contains(notch) == false)
+        #expect((region?.signedEdgeDistance(to: notch) ?? 0) < 0)
+    }
+}
+
+private extension LocationData {
+    func distanceTo(_ other: LocationData) -> Double {
+        let r = 6371000.0
+        let lat0 = (latitude + other.latitude) / 2 * .pi / 180
+        let dx = r * (longitude - other.longitude) * .pi / 180 * cos(lat0)
+        let dy = r * (latitude - other.latitude) * .pi / 180
+        return (dx * dx + dy * dy).squareRoot()
+    }
+}

--- a/Tests/LocationGeofence/Geometry/NiagaraFixtureTests.swift
+++ b/Tests/LocationGeofence/Geometry/NiagaraFixtureTests.swift
@@ -13,12 +13,8 @@ struct NiagaraFixtureTests {
     ].map { LocationData(latitude: $0.0, longitude: $0.1) }
 
     /// Minimum enclosing circle of the ring, radius measured on WGS84 — the farthest vertex sits
-    /// 7877.1 m out, which is what the server computes (PostGIS `geography`) and what
-    /// `CLLocation.distance` measures here. A spherical model puts the same circle at 7864 m, 13 m
-    /// short; `niagaraRing_expectSphericalRadiusRejected` pins that we depend on the WGS84 value.
+    /// 7877.1 m out, which is what the server computes (PostGIS `geography`).
     private static let covering = (latitude: 43.219062, longitude: -79.099117, radius: 7878.0)
-
-    private static let sphericalCoveringRadius = 7864.0
 
     @Test
     func niagaraRing_expectAcceptedByKernel() {
@@ -44,18 +40,10 @@ struct NiagaraFixtureTests {
     }
 
     @Test
-    func niagaraRing_expectAcceptedByApiValidation() {
-        let domain = Self.apiRegion(coveringRadius: Self.covering.radius).toDomain()
-        #expect(domain != nil)
-        #expect(domain?.vertices?.count == 7)
-        #expect(domain?.polygonRegion != nil)
-    }
-
-    /// The coverage slack is a flat metre and does not scale, so a circle sized on the wrong earth
-    /// model no longer squeaks through: it fails coverage and the region is dropped outright.
-    @Test
-    func niagaraRing_expectSphericalRadiusRejected() {
-        #expect(Self.apiRegion(coveringRadius: Self.sphericalCoveringRadius).toDomain() == nil)
+    func niagaraRing_expectDecodedFromWire() throws {
+        let domain = try #require(try? Self.apiRegion(coveringRadius: Self.covering.radius).toDomain().get())
+        #expect(domain.vertices?.count == 7)
+        #expect(domain.polygonRegion != nil)
     }
 
     /// Well inside the town: the verdict must be decisive at any realistic accuracy.

--- a/Tests/LocationGeofence/Geometry/NiagaraFixtureTests.swift
+++ b/Tests/LocationGeofence/Geometry/NiagaraFixtureTests.swift
@@ -12,11 +12,13 @@ struct NiagaraFixtureTests {
         (43.1500, -79.1200), (43.1800, -79.1800), (43.2300, -79.1500), (43.2620, -79.0750)
     ].map { LocationData(latitude: $0.0, longitude: $0.1) }
 
-    /// Minimum enclosing circle of the ring, radius from a SPHERICAL model — 7864 m, where WGS84
-    /// measures 7875.3 to the farthest vertex. Deliberately the pessimistic value: the proportional
-    /// coverage slack exists so a server using a different earth model doesn't get its region
-    /// dropped, and this fixture is what proves it.
-    private static let covering = (latitude: 43.219062, longitude: -79.099117, radius: 7864.0)
+    /// Minimum enclosing circle of the ring, radius measured on WGS84 — the farthest vertex sits
+    /// 7877.1 m out, which is what the server computes (PostGIS `geography`) and what
+    /// `CLLocation.distance` measures here. A spherical model puts the same circle at 7864 m, 13 m
+    /// short; `niagaraRing_expectSphericalRadiusRejected` pins that we depend on the WGS84 value.
+    private static let covering = (latitude: 43.219062, longitude: -79.099117, radius: 7878.0)
+
+    private static let sphericalCoveringRadius = 7864.0
 
     @Test
     func niagaraRing_expectAcceptedByKernel() {
@@ -25,27 +27,35 @@ struct NiagaraFixtureTests {
         #expect(region?.vertices.count == 7)
     }
 
-    @Test
-    func niagaraRing_expectAcceptedByApiValidation() {
-        let api = GeofenceApiRegion(
+    private static func apiRegion(coveringRadius: Double) -> GeofenceApiRegion {
+        GeofenceApiRegion(
             id: "niagara", name: "Niagara-on-the-Lake", shape: "polygon",
             latitude: nil, longitude: nil, radius: nil,
             geometry: GeofenceApiGeometry(
                 type: "Polygon",
                 // GeoJSON is longitude-first, and the ring stays closed on the wire.
-                coordinates: [Self.ring.map { [$0.longitude, $0.latitude] }]
+                coordinates: [ring.map { [$0.longitude, $0.latitude] }]
             ),
             enclosingCircle: GeofenceApiEnclosingCircle(
-                latitude: Self.covering.latitude,
-                longitude: Self.covering.longitude,
-                baseRadiusM: Self.covering.radius
+                latitude: covering.latitude, longitude: covering.longitude, baseRadiusM: coveringRadius
             ),
             externalId: nil, transitionTypes: nil, lastUpdated: nil, geosetIds: nil, metadata: nil
         )
-        let domain = api.toDomain()
+    }
+
+    @Test
+    func niagaraRing_expectAcceptedByApiValidation() {
+        let domain = Self.apiRegion(coveringRadius: Self.covering.radius).toDomain()
         #expect(domain != nil)
         #expect(domain?.vertices?.count == 7)
         #expect(domain?.polygonRegion != nil)
+    }
+
+    /// The coverage slack is a flat metre and does not scale, so a circle sized on the wrong earth
+    /// model no longer squeaks through: it fails coverage and the region is dropped outright.
+    @Test
+    func niagaraRing_expectSphericalRadiusRejected() {
+        #expect(Self.apiRegion(coveringRadius: Self.sphericalCoveringRadius).toDomain() == nil)
     }
 
     /// Well inside the town: the verdict must be decisive at any realistic accuracy.

--- a/Tests/LocationGeofence/Geometry/NiagaraFixtureTests.swift
+++ b/Tests/LocationGeofence/Geometry/NiagaraFixtureTests.swift
@@ -35,6 +35,7 @@ struct NiagaraFixtureTests {
             enclosingCircle: GeofenceApiEnclosingCircle(
                 latitude: covering.latitude, longitude: covering.longitude, baseRadiusM: coveringRadius
             ),
+            carriesPolygonFields: true,
             externalId: nil, transitionTypes: nil, lastUpdated: nil, geosetIds: nil, metadata: nil
         )
     }


### PR DESCRIPTION
Part of [MBL-2290](https://linear.app/customerio/issue/MBL-2290/ios-add-polygon-wire-contract-and-geometry-foundation)

Part 2 of the polygon geofence work. Teaches the API boundary the v2 wire shape agreed
with backend: a `shape` discriminator, GeoJSON `geometry`, and a nested `enclosing_circle` carrying
the unpadded canonical radius. A polygon still monitors as that circle, so nothing downstream
changes behaviour yet.

### What's here

- `latitude`/`longitude`/`radius` become optional and are resolved **per shape**, so a polygon
  region carrying only `enclosing_circle` decodes without throwing. That matters more than it
  looks: the region list is a plain array, so one region that throws takes the whole response with
  it — see the compatibility note below.
- An unrecognized `shape` **drops the region**. A shape we don't understand must never be monitored
  as whatever circle fields happen to be present.
- A region whose `shape` is **absent** while polygon fields are present also drops, but under a
  different reason, and the difference decides whether the cache survives. A shape the server
  *named* that this version cannot monitor means the workspace has moved on, so a refresh returning
  only those is allowed to clear stale monitors. A *missing* discriminator is a malformed response,
  so it counts as an unreadable region and the previous fence set is kept. A blank or
  whitespace-padded `shape` routes as absent for the same reason: left as a distinct string it
  reaches the unrecognized-shape branch, which is the exempt one, and clears the cache.
- Ring rules: `Polygon` only, exactly one ring, longitude-first positions, optional GeoJSON
  elevation ignored. Extra rings are holes we don't support, and honouring just the outer ring
  would report someone standing in a hole as inside the fence — so the fence drops instead.
- The vertex cap matches the server's cap on unique vertices, counted after unclosing the ring so
  the two agree.

The `shape` discriminator let this get *smaller*: intent is now explicit, so the previous
three-way absent/malformed/ring decode is gone and a polygon failing any rule simply drops.

### Three things worth a reviewer's attention

**Coverage slack is proportional, not flat.** The server computes the enclosing circle on a sphere;
`CLLocation.distance` measures WGS84. On a 7.9 km ring that is an 11 m gap. A failed coverage check
*drops* the region, so a flat 1 m slack would silently delete a fence whose circle legitimately
covers. Now that the contract calls the radius canonical — and therefore tight — this is
load-bearing rather than defensive. The Niagara-on-the-Lake fixture pins it, using the pessimistic
spherical radius deliberately.

**Why v2 is a separate endpoint rather than v1 growing a field.** Shipped 4.7.x decodes
`latitude`/`longitude`/`radius` as required, inside a non-lossy array. A polygon region under this
shape would throw and take the *entire* response with it — a user would lose every geofence,
circles included, until they moved out of range. v1 therefore never sends polygons, and must not
proxy v2's payload.

**A partially-unreadable response applies the survivors and deregisters the rest**, where before
this PR the whole sync failed and everything was kept. Deliberate — a region that cannot be read is
a region we cannot honour — but it is the one case the all-dropped guard does not cover, since that
guard fires only when *nothing* survived. Raised by @sydneycollins-cio in review.

### Testing

402/402 `LocationGeofenceTests` pass on iOS 26. Format and lint clean. No public API surface.

New coverage: decode and validation tests for every drop rule, an explicit longitude-first ordering
assertion, and the Niagara-on-the-Lake fixture — a real concave municipal boundary whose reflex
notch sits inside the covering circle but outside the town, which is the case a convex hull gets
wrong.

Payload cost was measured against this decoder before agreeing the 500-vertex cap: worst case
(100 fences × 500 vertices) is 1.2 MB raw, 292 KB deflated, 34 ms to decode and 26 ms to validate.
A typical 20 × 12 payload is 2 KB and under a millisecond.

### Stack

1. `mbl-2290-a-polygon-geometry-kernel` — geometry kernel (#1239, merged)
2. `mbl-2290-b-polygon-wire-contract` — v2 wire contract decode ← **this PR**
3. `mbl-2291-a-polygon-membership-layer` — membership belief + storage (#1244)
4. `mbl-2291-b-polygon-membership-resolver` — the resolver (#1245)
5. `mbl-2291-c-polygon-monitor-wiring` — monitor wiring (#1246)
6. `mbl-2290-c-polygon-antimeridian` — antimeridian projection fix (#1249)
7. `mbl-2291-f-polygon-shared-wake-circle` — shared dynamic movement circle (#1250, replaces the
   closed #1247 and #1248)

🤖 Generated with [Claude Code](https://claude.com/claude-code)





