### PR TITLE
chore: resolve the published SDK version from the release job and repair the pbxproj swap

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -561,6 +561,10 @@ jobs:
     uses: ./.github/workflows/reusable_build_sample_apps.yml
     with:
       use_latest_sdk_version: true
+      # Pass the version that was just published. The sample app job cannot work it out on its
+      # own: it checks out the commit that triggered this run, and semantic-release puts the new
+      # tag on a child of that commit, so `git describe` there resolves to the previous release.
+      sdk_version: ${{ needs.deploy-cocoapods.outputs.version }}
     secrets:
       GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64: ${{ secrets.GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64 }}
       FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64: ${{ secrets.FIREBASE_APP_DISTRIBUTION_SERVICE_ACCOUNT_CREDS_B64 }}

--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -8,6 +8,11 @@ on:
         type: boolean
         required: false
         default: false
+      sdk_version:
+        description: "Published SDK version to build against (example: 4.7.6). Required when the caller is the deploy workflow; manual runs may leave it empty to fall back to the newest git tag."
+        type: string
+        required: false
+        default: ""
     secrets:
       GOOGLE_CLOUD_MATCH_READONLY_SERVICE_ACCOUNT_B64:
         required: true
@@ -73,11 +78,31 @@ jobs:
       - name: Get latest SDK version if requested
         if: ${{ inputs.use_latest_sdk_version == true }}
         id: latest-sdk-version-step
+        env:
+          SDK_VERSION: ${{ inputs.sdk_version }}
+        # The `if` above scopes everything here to release-version builds. Ordinary PR and push
+        # builds skip this step entirely, and `build-sample-app` recomputes `LATEST_TAG` with its
+        # own `git describe` for `commitsAheadCount`, which is a real ancestry question and stays
+        # answered by `git describe` on every build.
         run: |
-          git fetch --tags  # Make sure we have all tags
-          latest_tag=$(git describe --tags --abbrev=0)
-          echo "LATEST_TAG=$latest_tag" >> "$GITHUB_ENV"
-          echo "Found latest tag: $latest_tag"
+          if [ -n "$SDK_VERSION" ]; then
+            # The release path passes the version the release job just published.
+            echo "LATEST_TAG=$SDK_VERSION" >> "$GITHUB_ENV"
+            echo "Using SDK version supplied by the caller: $SDK_VERSION"
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            # Manual runs have no release job to ask, and the newest tag is already an
+            # ancestor of the checked out commit, so `git describe` is correct here.
+            git fetch --tags  # Make sure we have all tags
+            latest_tag=$(git describe --tags --abbrev=0)
+            echo "LATEST_TAG=$latest_tag" >> "$GITHUB_ENV"
+            echo "Found latest tag: $latest_tag"
+          else
+            # Never guess on the release path: semantic-release creates the tag on a new
+            # child commit, and `git describe` only walks ancestors of the commit this job
+            # checked out, so it would silently resolve to the *previous* release.
+            echo "::error::use_latest_sdk_version is true but no sdk_version was passed. The caller must pass the version that was just published."
+            exit 1
+          fi
 
       - name: Replace local references with published SDK version
         if: ${{ inputs.use_latest_sdk_version == true }}
@@ -124,9 +149,23 @@ jobs:
           sd 'XCLocalSwiftPackageReference "\.\./\.\./"' 'XCRemoteSwiftPackageReference "customerio-ios"' "$PBXPROJ"
           # Swap the reference body itself. Matching `isa` together with the `../../` path leaves the
           # sibling `../Common` local reference alone, which has to stay local.
-          sd 'isa = XCLocalSwiftPackageReference;\n(\s*)relativePath = "\.\./\.\./";' \
-             "isa = XCRemoteSwiftPackageReference;\n\${1}repositoryURL = \"https://github.com/customerio/customerio-ios.git\";\n\${1}requirement = {\n\${1}\tkind = upToNextMajorVersion;\n\${1}\tminimumVersion = \"${TAG}\";\n\${1}};" \
-             "$PBXPROJ"
+          # This one has to match across a newline, so it uses `perl -0` (slurp mode) rather than `sd`:
+          # `brew install sd` now pours sd 1.1.0, which matches line by line and can never match `\n`.
+          # It exits 0 having changed nothing, which is how this substitution stayed silently inert.
+          # `perl` is preinstalled on the macOS runners, so there is nothing to install or version-pin.
+          TAG="$TAG" perl -0pi -e 's!isa = XCLocalSwiftPackageReference;\n(\s*)relativePath = "\.\./\.\./";!isa = XCRemoteSwiftPackageReference;\n${1}repositoryURL = "https://github.com/customerio/customerio-ios.git";\n${1}requirement = {\n${1}\tkind = upToNextMajorVersion;\n${1}\tminimumVersion = "$ENV{TAG}";\n${1}};!' "$PBXPROJ"
+
+          # Every substitution in this step is silent on no match, so a stale pattern reads exactly
+          # like a successful run. Assert the local references are actually gone instead of finding
+          # out later from an unrelated-looking `Conflicting identity` failure in xcodebuild.
+          if grep -q 'relativePath = "\.\./\.\./";' "$PBXPROJ"; then
+            echo "::error::$PBXPROJ still points at the local SDK checkout. SwiftPM will fail to resolve with a conflicting identity for customerio-ios."
+            exit 1
+          fi
+          if grep -q '\.package(path:' "Apps/Common/Package.swift"; then
+            echo "::error::Apps/Common/Package.swift still points at the local SDK checkout."
+            exit 1
+          fi
 
           echo "Finished updating references. Now we have pinned SDK version $TAG."
 

--- a/.github/workflows/reusable_build_sample_apps.yml
+++ b/.github/workflows/reusable_build_sample_apps.yml
@@ -116,17 +116,19 @@ jobs:
           # Example lines to replace:
           #   pod 'CustomerIODataPipelines', :path => ...
           #   =>  pod 'CustomerIODataPipelines', '1.2.3'
-          sd "pod 'CustomerIODataPipelines', :path =>.*" "pod 'CustomerIODataPipelines', '$TAG'" "Apps/CocoaPods-FCM/Podfile"
-          sd "pod 'CustomerIOMessagingPushAPN', :path =>.*" "pod 'CustomerIOMessagingPushAPN', '$TAG'" "Apps/CocoaPods-FCM/Podfile"
-          sd "pod 'CustomerIOMessagingInApp', :path =>.*" "pod 'CustomerIOMessagingInApp', '$TAG'" "Apps/CocoaPods-FCM/Podfile"
-          sd "pod 'CustomerIOLocation', :path =>.*" "pod 'CustomerIOLocation', '$TAG'" "Apps/CocoaPods-FCM/Podfile"
-          sd "pod 'CustomerIOMessagingInbox', :path =>.*" "pod 'CustomerIOMessagingInbox', '$TAG'" "Apps/CocoaPods-FCM/Podfile"
-          sd "pod 'CustomerIOLocationGeofence', :path =>.*" "pod 'CustomerIOLocationGeofence', '$TAG'" "Apps/CocoaPods-FCM/Podfile"
-          sd "pod 'CustomerIOLiveActivities', :path =>.*" "pod 'CustomerIOLiveActivities', '$TAG'" "Apps/CocoaPods-FCM/Podfile"
-          sd "pod 'CustomerIOLiveActivitiesAttributes', :path =>.*" "pod 'CustomerIOLiveActivitiesAttributes', '$TAG'" "Apps/CocoaPods-FCM/Podfile"
-          # Declared in both the app and the widget extension targets; sd rewrites every occurrence.
-          sd "pod 'CustomerIOLiveActivitiesTemplates', :path =>.*" "pod 'CustomerIOLiveActivitiesTemplates', '$TAG'" "Apps/CocoaPods-FCM/Podfile"
-          # If you have other modules: repeat
+          #
+          # One rule for every local `CustomerIO*` pod rather than a hand-listed set.
+          # The list had drifted: `CustomerIOCommon`, `CustomerIOMessagingPush`,
+          # `CustomerIOMessagingPushFCM` and `CustomerIOTrackingMigration` were declared
+          # local but never rewritten, so they resolved from the triggering checkout at
+          # the previous release while the rewritten pods required the new one, and
+          # `pod install` failed on the exact-version conflict.
+          #
+          # `SampleAppsCommon` is not a `CustomerIO*` pod and stays local, which is correct.
+          # Pods declared in both the app and the widget extension targets are rewritten
+          # in every occurrence.
+          PODFILE="Apps/CocoaPods-FCM/Podfile"
+          TAG="$TAG" perl -pi -e "s/pod '(CustomerIO[A-Za-z]*)', :path =>.*/pod '\$1', '\$ENV{TAG}'/" "$PODFILE"
 
           # 2) SwiftPM package in `Apps/Common/Package.swift`
           # Original: .package(path: "../../")
@@ -164,6 +166,18 @@ jobs:
           fi
           if grep -q '\.package(path:' "Apps/Common/Package.swift"; then
             echo "::error::Apps/Common/Package.swift still points at the local SDK checkout."
+            exit 1
+          fi
+          # Catches a newly added CustomerIO pod that the rule above did not match,
+          # instead of letting it surface as a version conflict during `pod install`.
+          if grep -qE "pod 'CustomerIO[A-Za-z]*', :path =>" "$PODFILE"; then
+            echo "::error::$PODFILE still declares local CustomerIO pods:"
+            grep -nE "pod 'CustomerIO[A-Za-z]*', :path =>" "$PODFILE"
+            exit 1
+          fi
+          # SampleAppsCommon is the sample apps' own shared code and must stay local.
+          if ! grep -q "pod 'SampleAppsCommon', :path =>" "$PODFILE"; then
+            echo "::error::$PODFILE no longer declares SampleAppsCommon locally; the pod rewrite was too broad."
             exit 1
           fi
 


### PR DESCRIPTION
## Problem

The `Build sample apps with latest SDK version` job at the end of `deploy-sdk.yml` has two independent defects. It has failed on every release where it actually executed.

**1. The pbxproj dependency swap silently no-ops.**

`reusable_build_sample_apps.yml` swaps the sample app's SDK dependency from the local checkout to the published release. It edits two places: `Apps/Common/Package.swift` (single-line `sd`, works) and the APN-UIKit `.pbxproj` (multi-line `sd`, does not). `brew install sd` now pours **sd 1.1.0**, which matches line by line and can never match across `\n`. It exits 0 having changed nothing, so `Package.swift` points at the remote package while the pbxproj still points at `../../`, and SwiftPM refuses to resolve:

```
xcodebuild: error: Could not resolve package dependencies:
  Conflicting identity for customerio-ios: dependency 'github.com/customerio/customerio-ios'
  and dependency '/users/runner/work/customerio-ios/customerio-ios'
  both point to the same package identity 'customerio-ios'
```

That pbxproj block was added in #1188 specifically to prevent this error. sd 1.1.0 was already Homebrew's default when it merged, so the fix has been inert since day one — the last release run (`32772415402`) logs `Pouring sd--1.1.0.arm64_tahoe.bottle.tar.gz`, prints `Finished updating references`, and then fails with the conflict above.

**2. The job builds the previous release, not the one just published.**

`LATEST_TAG=$(git describe --tags --abbrev=0)` runs against the commit that triggered the run. semantic-release puts the new tag on a *new child* commit (`chore: prepare for X.Y.Z [skip ci]`), and `git describe` only walks ancestors — so it deterministically resolves to the previous release. Same run: semantic-release published **4.7.6** while the sample app job logged `Found latest tag: 4.7.5`.

This one is silent on iOS. Once defect 1 is fixed, SPM resolves the one-behind version happily, so the job would go green while verifying the wrong release.

## What changed

`reusable_build_sample_apps.yml`
- Added an optional `sdk_version` input. When it is non-empty it wins; `git describe` remains only as the fallback for `workflow_dispatch` runs, where the newest tag *is* an ancestor of the checked-out commit. On the release path with no version passed, the job now fails loudly rather than guessing.
- Replaced the multi-line `sd` call with `perl -0pi` (slurp mode). `perl` is preinstalled on the macOS runners, so there is no install step and no version to pin. The single-line `sd` substitutions are unchanged.
- **Added an assertion after the swap block.** Every edit in that step is silent-on-no-match, which is exactly how a three-week-old fix stayed inert unnoticed. The step now fails if the pbxproj still contains `relativePath = "../../";` or `Apps/Common/Package.swift` still contains `.package(path:`, with an error naming the resolution failure it would otherwise cause.

`deploy-sdk.yml`
- Passes `sdk_version: ${{ needs.deploy-cocoapods.outputs.version }}` into the reusable workflow. That output already exists and already covers both paths (semantic-release's `new_release_version`, and `existing-git-tag` on a manual dispatch), and `deploy-cocoapods` is already in this job's `needs` — so no new outputs or dependency edges were needed.

### Scoping: who else reads `LATEST_TAG`

Worth stating explicitly, because it is the obvious way to get this wrong. The step that resolves the version is gated `if: inputs.use_latest_sdk_version == true`, so ordinary PR and push builds never enter it and the new hard-fail branch is unreachable for them.

`LATEST_TAG` does have a second consumer — `commitsAheadCount`, computed as `git rev-list $LAST_TAG..HEAD --count` in `.github/actions/build-sample-app/action.yml`. That is a genuine ancestry question and `git describe` is the right answer for it. It is unaffected here: the action recomputes `LATEST_TAG` with its own unconditional `git describe` (`Capture Git Context`) before using it, on every build.

That recompute does mean the action's env `LATEST_TAG` reverts to the previous release during a release run. It does not corrupt the pinned version: the release version reaches Fastlane through the `customerio-public-sdk-version` input and `fastlane-build-args`, both computed in this workflow *before* the action runs. The action's `${{ env.LATEST_TAG }}` is only a last-resort fallback for builds that pass no version at all.

## Verification

The swap step was extracted and run end-to-end against a copy of `Apps/`: the pbxproj reference becomes `XCRemoteSwiftPackageReference` pinned to the tag, byte-identical to what the old `sd` produced before 1.1.0; the sibling `../Common` local reference is left alone; Podfile and `Package.swift` pin correctly. The assertion was also verified in the negative — with a deliberately stale pattern the step exits 1 with the `::error::` annotation instead of passing. All three branches of the version-resolution step were exercised. All three workflow files parse.

**Not verified, and not verifiable without cutting a release:** the release path itself. `sdk_version` only flows on a real `deploy-sdk` run, so the wiring is verified by reading the job graph, not by execution.

The swap fix *is* verifiable on demand: dispatch **Build sample apps** with `use_latest_sdk_version: true`. That path takes the `git describe` fallback (correct for a manual run on `main`) and exercises the repaired pbxproj swap plus the new assertion. **Reviewer, please run that dispatch** — I deliberately did not, to avoid consuming contended macOS runners.

Fixes MBL-2324
