### PR TITLE
chore(geofence): add the polygon membership layer

### DIFF
--- a/Sources/LocationGeofence/Model/GeofenceState.swift
+++ b/Sources/LocationGeofence/Model/GeofenceState.swift
@@ -20,6 +20,9 @@ struct GeofenceState: Codable, Equatable, Sendable {
     /// landed a `config` block yet — consumers fall back to `GeofenceConfig.fallback` or
     /// their component defaults.
     var cachedConfig: GeofenceConfig?
+    /// Believed device membership for each polygon geofence, keyed by geofence id. Absent for
+    /// circle fences, and absent for a polygon no fix has yet decided (see `PolygonMembership`).
+    var polygonMembership: [String: PolygonMembershipRecord]?
     /// Per-condition bookkeeping for the CLMonitor (iOS 17+) monitor, keyed by region identifier.
     /// `nil` on the classic CLLocationManager path, which needs neither: its delegate fires only on
     /// real crossings (no dedup needed) and filters transition types at the OS level.

--- a/Sources/LocationGeofence/Polygon/PolygonMembership.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembership.swift
@@ -23,6 +23,12 @@ struct PolygonMembershipRecord: Codable, Equatable, Sendable {
     /// establish it OR confirm it, not only the one that last changed it. Lets a late evaluation
     /// defer to a newer decision, the same way `MonitorRegionRecord.lastStateChangedAt` guards the
     /// baseline heal.
+    ///
+    /// Do not rename without a `CodingKeys` case mapping back to the literal `"lastChangedAt"`. The
+    /// synthesized keys make the property name the stored key, and a record written by an earlier
+    /// build then fails the whole `GeofenceState` decode — which `loadFromDisk` swallows with
+    /// `try?`, taking the cached geofences, monitor baselines, registration set and cooldowns with
+    /// it on the next write.
     var lastChangedAt: Date
 }
 

--- a/Sources/LocationGeofence/Polygon/PolygonMembership.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembership.swift
@@ -1,0 +1,37 @@
+import CioInternalCommon
+import Foundation
+
+/// What the SDK believes about the device's position relative to a polygon geofence.
+///
+/// Tracked separately from the OS-facing dedup baseline in `MonitorRegionRecord`: the OS monitors
+/// the polygon's covering circle and knows nothing about the polygon itself, so circle state and
+/// polygon membership are different facts about the same geofence.
+///
+/// There is deliberately no `unknown` case — the absence of a record is what "not yet decided"
+/// means. An undecidable fix therefore leaves an existing belief untouched instead of overwriting
+/// it, which is what stops a coarse fix from erasing a known-inside state.
+enum PolygonMembership: String, Codable, Sendable {
+    case inside
+    case outside
+}
+
+/// Per-polygon membership bookkeeping, persisted alongside the rest of the geofence state so a
+/// cold wake compares against the pre-kill belief rather than starting over.
+struct PolygonMembershipRecord: Codable, Equatable, Sendable {
+    var membership: PolygonMembership
+    /// When `membership` was last written. Lets a late evaluation defer to a newer decision, the
+    /// same way `MonitorRegionRecord.lastStateChangedAt` guards the baseline heal.
+    var lastChangedAt: Date
+}
+
+/// What `GeofenceStorage.recordPolygonMembership` decided about an evaluation.
+enum PolygonMembershipOutcome: Equatable {
+    /// Membership changed; the caller delivers this transition, subject to the geofence's own
+    /// transition-type filter.
+    case deliver(GeofenceTransition)
+    case suppressedNoChange
+    /// A newer decision was already recorded — the evaluation's fix predates it.
+    case suppressedNewerDecision
+    /// First decision for this polygon placed the device outside; there is no crossing to report.
+    case suppressedInitialOutside
+}

--- a/Sources/LocationGeofence/Polygon/PolygonMembership.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembership.swift
@@ -19,8 +19,10 @@ enum PolygonMembership: String, Codable, Sendable {
 /// cold wake compares against the pre-kill belief rather than starting over.
 struct PolygonMembershipRecord: Codable, Equatable, Sendable {
     var membership: PolygonMembership
-    /// When `membership` was last written. Lets a late evaluation defer to a newer decision, the
-    /// same way `MonitorRegionRecord.lastStateChangedAt` guards the baseline heal.
+    /// Evidence time of the belief currently held: the timestamp of the newest fix or OS event to
+    /// establish it OR confirm it, not only the one that last changed it. Lets a late evaluation
+    /// defer to a newer decision, the same way `MonitorRegionRecord.lastStateChangedAt` guards the
+    /// baseline heal.
     var lastChangedAt: Date
 }
 

--- a/Sources/LocationGeofence/Polygon/PolygonMembership.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembership.swift
@@ -34,4 +34,7 @@ enum PolygonMembershipOutcome: Equatable {
     case suppressedNewerDecision
     /// First decision for this polygon placed the device outside; there is no crossing to report.
     case suppressedInitialOutside
+    /// The polygon is not in the registered set — an evaluation that raced a prune. Creating a
+    /// belief here would deliver an enter for a fence the OS is no longer watching.
+    case suppressedUnmonitored
 }

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipDecision.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipDecision.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Decides what a fix establishes about a device's membership in a polygon.
+///
+/// The polygon counterpart of `BaselineHealDecision`, and deliberately the same guards applied to a
+/// polygon's signed edge distance instead of a circle's: the fix must be recent, its accuracy
+/// usable, and its distance from the boundary must exceed the ambiguity margin. This is the single
+/// place a polygon verdict is formed, so "no event without gated geometric confirmation" is
+/// enforced in one function rather than at each call site.
+enum PolygonMembershipDecision {
+    /// The membership the fix establishes, or `nil` when it cannot decide — a stale fix, an
+    /// unusable accuracy, or a boundary inside the ambiguity band. Never returns `.unknown`:
+    /// that is what the caller records in response to `nil`.
+    ///
+    /// - Parameter signedEdgeDistance: metres to the polygon boundary in `PolygonRegion`'s
+    ///   convention — **positive inside**, which is the opposite of the circle path's edge
+    ///   distance. Converting here rather than at call sites keeps the mismatch in one place.
+    static func resolvedMembership(
+        signedEdgeDistance: Double,
+        horizontalAccuracy: Double,
+        fixAge: TimeInterval
+    ) -> PolygonMembership? {
+        guard fixAge >= 0, fixAge <= GeofenceConstants.movementFixMaxAge else { return nil }
+        guard horizontalAccuracy > 0 else { return nil }
+        let margin = max(horizontalAccuracy, GeofenceConstants.baselineHealMinEdgeMargin)
+        guard abs(signedEdgeDistance) > margin else { return nil }
+        return signedEdgeDistance > 0 ? .inside : .outside
+    }
+}

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipDecision.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipDecision.swift
@@ -9,12 +9,11 @@ import Foundation
 /// enforced in one function rather than at each call site.
 enum PolygonMembershipDecision {
     /// The membership the fix establishes, or `nil` when it cannot decide — a stale fix, an
-    /// unusable accuracy, or a boundary inside the ambiguity band. Never returns `.unknown`:
-    /// that is what the caller records in response to `nil`.
+    /// unusable accuracy, or a boundary inside the ambiguity band.
     ///
     /// - Parameter signedEdgeDistance: metres to the polygon boundary in `PolygonRegion`'s
     ///   convention — **positive inside**, which is the opposite of the circle path's edge
-    ///   distance. Converting here rather than at call sites keeps the mismatch in one place.
+    ///   distance. The sign test below is written for this convention; nothing is converted.
     static func resolvedMembership(
         signedEdgeDistance: Double,
         horizontalAccuracy: Double,

--- a/Sources/LocationGeofence/Storage/GeofenceStorage+PolygonMembership.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage+PolygonMembership.swift
@@ -56,6 +56,13 @@ extension GeofenceStorage {
 }
 
 extension GeofenceState {
+    /// Drops one identifier's belief, for a reseed that has already decided the stored circle
+    /// baseline can no longer be trusted: kept, a belief of "inside" formed before an unmonitored
+    /// gap swallows the next real enter as no-change.
+    mutating func dropPolygonBelief(for identifier: String) {
+        polygonMembership?.removeValue(forKey: identifier)
+    }
+
     /// Drops polygon belief for geofences a registration no longer covers, on the same rule the
     /// monitor records use: a polygon outside the registered set is no longer being evaluated, so a
     /// retained belief would go stale and suppress the enter owed when the device comes back to it.

--- a/Sources/LocationGeofence/Storage/GeofenceStorage+PolygonMembership.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage+PolygonMembership.swift
@@ -20,6 +20,10 @@ extension GeofenceStorage {
     /// not the moment of the write — the comparison is evidence against evidence, and a write time
     /// always postdates the fix that justified it, so storing it would reject verdicts whose
     /// evidence is genuinely newer than the previous verdict's.
+    ///
+    /// An evaluation that CONFIRMS the belief refreshes that stamp too. Re-proving a belief is
+    /// newer evidence for it, and holding the stamp at the last change would let a later evaluation
+    /// carrying older opposite evidence pass the guard and flip what a newer fix just confirmed.
     func recordPolygonMembership(
         _ membership: PolygonMembership,
         forIdentifier identifier: String,
@@ -47,7 +51,16 @@ extension GeofenceStorage {
             saveToDisk(state)
             return membership == .inside ? .deliver(.enter) : .suppressedInitialOutside
         }
-        guard existing.membership != membership else { return .suppressedNoChange }
+        guard existing.membership != membership else {
+            if let evidenceTimestamp, evidenceTimestamp > existing.lastChangedAt {
+                records[identifier] = PolygonMembershipRecord(
+                    membership: membership, lastChangedAt: evidenceTimestamp
+                )
+                state.polygonMembership = records
+                saveToDisk(state)
+            }
+            return .suppressedNoChange
+        }
         records[identifier] = PolygonMembershipRecord(
             membership: membership, lastChangedAt: evidenceTimestamp ?? now
         )

--- a/Sources/LocationGeofence/Storage/GeofenceStorage+PolygonMembership.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage+PolygonMembership.swift
@@ -30,6 +30,13 @@ extension GeofenceStorage {
             return .suppressedNewerDecision
         }
         guard let existing else {
+            // An evaluation in flight when the polygon was pruned would otherwise create a belief —
+            // and an enter — for a fence no longer registered. Only the create path needs this: an
+            // existing record means it was registered when the belief was formed, and pruning
+            // removes it.
+            guard state.monitoredGeofenceIds?.contains(identifier) == true else {
+                return .suppressedUnmonitored
+            }
             records[identifier] = PolygonMembershipRecord(membership: membership, lastChangedAt: now)
             state.polygonMembership = records
             saveToDisk(state)

--- a/Sources/LocationGeofence/Storage/GeofenceStorage+PolygonMembership.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage+PolygonMembership.swift
@@ -24,6 +24,10 @@ extension GeofenceStorage {
     /// An evaluation that CONFIRMS the belief refreshes that stamp too. Re-proving a belief is
     /// newer evidence for it, and holding the stamp at the last change would let a later evaluation
     /// carrying older opposite evidence pass the guard and flip what a newer fix just confirmed.
+    /// Refreshing cannot suppress a queued covering-circle exit that is still owed: confirmation
+    /// requires the belief to be true, so a stamp advanced past that exit's date means the device
+    /// was inside the polygon — and polygon ⊆ circle, so inside the circle too, which makes the
+    /// older exit genuinely superseded rather than lost.
     func recordPolygonMembership(
         _ membership: PolygonMembership,
         forIdentifier identifier: String,

--- a/Sources/LocationGeofence/Storage/GeofenceStorage+PolygonMembership.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage+PolygonMembership.swift
@@ -16,7 +16,10 @@ extension GeofenceStorage {
     ///
     /// `onlyIfBeliefPredates` makes the write conditional on the belief's age, atomically with the
     /// compare-and-store: an evaluation whose fix predates a belief written since must not
-    /// overwrite it with an older reading.
+    /// overwrite it with an older reading. The stored `lastChangedAt` is that same evidence time,
+    /// not the moment of the write — the comparison is evidence against evidence, and a write time
+    /// always postdates the fix that justified it, so storing it would reject verdicts whose
+    /// evidence is genuinely newer than the previous verdict's.
     func recordPolygonMembership(
         _ membership: PolygonMembership,
         forIdentifier identifier: String,
@@ -37,13 +40,17 @@ extension GeofenceStorage {
             guard state.monitoredGeofenceIds?.contains(identifier) == true else {
                 return .suppressedUnmonitored
             }
-            records[identifier] = PolygonMembershipRecord(membership: membership, lastChangedAt: now)
+            records[identifier] = PolygonMembershipRecord(
+                membership: membership, lastChangedAt: evidenceTimestamp ?? now
+            )
             state.polygonMembership = records
             saveToDisk(state)
             return membership == .inside ? .deliver(.enter) : .suppressedInitialOutside
         }
         guard existing.membership != membership else { return .suppressedNoChange }
-        records[identifier] = PolygonMembershipRecord(membership: membership, lastChangedAt: now)
+        records[identifier] = PolygonMembershipRecord(
+            membership: membership, lastChangedAt: evidenceTimestamp ?? now
+        )
         state.polygonMembership = records
         saveToDisk(state)
         return .deliver(membership == .inside ? .enter : .exit)

--- a/Sources/LocationGeofence/Storage/GeofenceStorage+PolygonMembership.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage+PolygonMembership.swift
@@ -1,0 +1,60 @@
+import CioInternalCommon
+import Foundation
+
+/// Polygon membership persistence, split out to keep `GeofenceStorage` readable. Methods are
+/// `internal` (not `private`) only because they live in a separate file from their state; they
+/// remain storage implementation detail.
+extension GeofenceStorage {
+    /// Records what an evaluation established about a polygon and returns whether it is a crossing.
+    /// The whole compare-and-store runs inside the actor with no `await` between steps, so two
+    /// concurrent evaluations cannot both observe a stale belief and both deliver.
+    ///
+    /// A polygon with no record yet is undecided, not outside: the first decisive fix placing the
+    /// device inside is therefore a genuine enter (the polygon counterpart of enter-when-inside),
+    /// while a first fix placing it outside simply establishes the belief. Because the record
+    /// survives re-registration, a wholesale re-register stays silent without needing a diff.
+    ///
+    /// `onlyIfBeliefPredates` makes the write conditional on the belief's age, atomically with the
+    /// compare-and-store: an evaluation whose fix predates a belief written since must not
+    /// overwrite it with an older reading.
+    func recordPolygonMembership(
+        _ membership: PolygonMembership,
+        forIdentifier identifier: String,
+        onlyIfBeliefPredates evidenceTimestamp: Date? = nil,
+        now: Date = Date()
+    ) -> PolygonMembershipOutcome {
+        var state = loadFromDisk() ?? GeofenceState()
+        var records = state.polygonMembership ?? [:]
+        let existing = records[identifier]
+        if let evidenceTimestamp, let existing, existing.lastChangedAt > evidenceTimestamp {
+            return .suppressedNewerDecision
+        }
+        guard let existing else {
+            records[identifier] = PolygonMembershipRecord(membership: membership, lastChangedAt: now)
+            state.polygonMembership = records
+            saveToDisk(state)
+            return membership == .inside ? .deliver(.enter) : .suppressedInitialOutside
+        }
+        guard existing.membership != membership else { return .suppressedNoChange }
+        records[identifier] = PolygonMembershipRecord(membership: membership, lastChangedAt: now)
+        state.polygonMembership = records
+        saveToDisk(state)
+        return .deliver(membership == .inside ? .enter : .exit)
+    }
+
+    /// Snapshot of every polygon membership belief.
+    func getPolygonMembership() -> [String: PolygonMembershipRecord] {
+        loadFromDisk()?.polygonMembership ?? [:]
+    }
+}
+
+extension GeofenceState {
+    /// Drops polygon belief for geofences a registration no longer covers, on the same rule the
+    /// monitor records use: a polygon outside the registered set is no longer being evaluated, so a
+    /// retained belief would go stale and suppress the enter owed when the device comes back to it.
+    mutating func prunePolygonState(retaining businessIds: Set<String>) {
+        if let membership = polygonMembership {
+            polygonMembership = membership.filter { businessIds.contains($0.key) }
+        }
+    }
+}

--- a/Sources/LocationGeofence/Storage/GeofenceStorage+PolygonMembership.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage+PolygonMembership.swift
@@ -28,6 +28,13 @@ extension GeofenceStorage {
     /// requires the belief to be true, so a stamp advanced past that exit's date means the device
     /// was inside the polygon — and polygon ⊆ circle, so inside the circle too, which makes the
     /// older exit genuinely superseded rather than lost.
+    ///
+    /// A confirming OUTSIDE is the case that needs the refresh most. It drops a later evaluation
+    /// carrying an older INSIDE reading — correctly: the device was proven outside at the newer
+    /// instant, so that reading describes a visit already over, and delivering its enter would park
+    /// the belief at inside with no exit owed to bring it back. Without the refresh that stale
+    /// enter clears the guard against the last CHANGE, and the polygon stays believed-inside until
+    /// something else contradicts it.
     func recordPolygonMembership(
         _ membership: PolygonMembership,
         forIdentifier identifier: String,

--- a/Sources/LocationGeofence/Storage/GeofenceStorage.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage.swift
@@ -204,6 +204,7 @@ actor GeofenceStorage {
         state.movementTriggerCenter = nil
         state.monitoredGeofenceIds = nil
         state.monitorRegionRecords = nil
+        state.polygonMembership = nil
         saveToDisk(state)
     }
 
@@ -291,12 +292,14 @@ actor GeofenceStorage {
             let retained = businessIds.union([GeofenceConstants.movementTriggerIdentifier])
             state.monitorRegionRecords = records.filter { retained.contains($0.key) }
         }
+        state.prunePolygonState(retaining: businessIds)
         saveToDisk(state)
     }
 
     // MARK: - Private (file persistence)
 
-    private func loadFromDisk() -> GeofenceState? {
+    // Internal (not private): reached by the `+PolygonMembership` extension in its own file.
+    func loadFromDisk() -> GeofenceState? {
         guard let url = stateFileURL() else { return nil }
         guard fileManager.fileExists(atPath: url.path),
               let data = try? Data(contentsOf: url)
@@ -306,7 +309,7 @@ actor GeofenceStorage {
         return try? Self.makeDecoder().decode(GeofenceState.self, from: data)
     }
 
-    private func saveToDisk(_ state: GeofenceState) {
+    func saveToDisk(_ state: GeofenceState) {
         guard let data = try? Self.makeEncoder().encode(state),
               let url = stateFileURL()
         else {

--- a/Sources/LocationGeofence/Storage/GeofenceStorage.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage.swift
@@ -195,8 +195,8 @@ actor GeofenceStorage {
         saveToDisk(state)
     }
 
-    /// Clears the cooldown map, last-sync record, registration set, and monitor baselines but
-    /// preserves the cached geofences and config. Called on sign-out: the workspace cache is shared
+    /// Clears the cooldown map, last-sync record, registration set, monitor baselines and polygon
+    /// beliefs but preserves the cached geofences and config. Called on sign-out: the workspace cache is shared
     /// across users, while cooldowns belong to the signed-out user and the last-sync anchor would
     /// otherwise let the freshness gate skip the first sync for the next signed-in user against stale
     /// state. `monitorRegionRecords` is dropped so the next session can't inherit a stale per-region

--- a/Sources/LocationGeofence/Storage/GeofenceStorage.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage.swift
@@ -110,7 +110,7 @@ actor GeofenceStorage {
     /// `forceReseed` overrides that preservation. The caller sets it when the OS stopped monitoring
     /// the condition since the last registration: the device can cross while unmonitored, so the
     /// persisted state is no longer known to match reality and keeping it would suppress the next
-    /// genuine crossing.
+    /// genuine crossing. Polygon belief reseeds with it, for the same reason.
     func recordMonitorRegistration(
         identifier: String,
         transitionTypes: Set<GeofenceTransition>,
@@ -133,6 +133,7 @@ actor GeofenceStorage {
             lastStateChangedAt: preserved ? existing?.lastStateChangedAt : now
         )
         state.monitorRegionRecords = records
+        if forceReseed { state.dropPolygonBelief(for: identifier) }
         saveToDisk(state)
     }
 

--- a/Sources/LocationGeofence/Storage/GeofenceStorage.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage.swift
@@ -183,10 +183,14 @@ actor GeofenceStorage {
     /// Drops the baseline for a condition the OS stopped monitoring, so the next registration
     /// reseeds from the device's real position rather than carrying a state it may have left while
     /// unmonitored — an unchanged-geometry re-register would preserve that stale value.
+    /// Drops both the OS-facing baseline and the polygon belief: the region is no longer monitored,
+    /// so a belief kept across the gap would suppress the next real enter as no-change if the device
+    /// left the polygon while nothing was watching.
     func clearMonitorRegionRecord(identifier: String) {
         var state = loadFromDisk() ?? GeofenceState()
-        guard var records = state.monitorRegionRecords, records.removeValue(forKey: identifier) != nil else { return }
-        state.monitorRegionRecords = records
+        let hadRecord = state.monitorRegionRecords?.removeValue(forKey: identifier) != nil
+        let hadBelief = state.polygonMembership?.removeValue(forKey: identifier) != nil
+        guard hadRecord || hadBelief else { return }
         saveToDisk(state)
     }
 

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipDecisionTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipDecisionTests.swift
@@ -1,0 +1,96 @@
+@testable import CioInternalCommon
+@testable import CioLocationGeofence
+import Foundation
+import Testing
+
+@Suite("PolygonMembershipDecision")
+struct PolygonMembershipDecisionTests {
+    private let freshAge: TimeInterval = 1
+
+    // MARK: - Verdicts
+
+    @Test
+    func resolvedMembership_givenFixWellInside_expectInside() {
+        #expect(PolygonMembershipDecision.resolvedMembership(
+            signedEdgeDistance: 100, horizontalAccuracy: 10, fixAge: freshAge
+        ) == .inside)
+    }
+
+    @Test
+    func resolvedMembership_givenFixWellOutside_expectOutside() {
+        #expect(PolygonMembershipDecision.resolvedMembership(
+            signedEdgeDistance: -100, horizontalAccuracy: 10, fixAge: freshAge
+        ) == .outside)
+    }
+
+    // MARK: - Ambiguity band
+
+    /// The margin floor is 20 m even when the fix claims better accuracy, so a fix hugging the
+    /// boundary never produces a verdict.
+    @Test(arguments: [0.0, 5.0, -5.0, 19.9, -19.9])
+    func resolvedMembership_givenDistanceInsideMarginFloor_expectNoVerdict(distance: Double) {
+        #expect(PolygonMembershipDecision.resolvedMembership(
+            signedEdgeDistance: distance, horizontalAccuracy: 1, fixAge: freshAge
+        ) == nil)
+    }
+
+    /// With accuracy worse than the floor, the accuracy is the margin.
+    @Test
+    func resolvedMembership_givenDistanceInsideAccuracyMargin_expectNoVerdict() {
+        #expect(PolygonMembershipDecision.resolvedMembership(
+            signedEdgeDistance: 50, horizontalAccuracy: 65, fixAge: freshAge
+        ) == nil)
+    }
+
+    @Test
+    func resolvedMembership_givenDistanceJustBeyondAccuracyMargin_expectVerdict() {
+        #expect(PolygonMembershipDecision.resolvedMembership(
+            signedEdgeDistance: 66, horizontalAccuracy: 65, fixAge: freshAge
+        ) == .inside)
+    }
+
+    /// Boundary is exclusive: exactly at the margin is still ambiguous.
+    @Test
+    func resolvedMembership_givenDistanceExactlyAtMargin_expectNoVerdict() {
+        #expect(PolygonMembershipDecision.resolvedMembership(
+            signedEdgeDistance: 20, horizontalAccuracy: 10, fixAge: freshAge
+        ) == nil)
+    }
+
+    // MARK: - Fix quality guards
+
+    @Test
+    func resolvedMembership_givenStaleFix_expectNoVerdict() {
+        #expect(PolygonMembershipDecision.resolvedMembership(
+            signedEdgeDistance: 100,
+            horizontalAccuracy: 10,
+            fixAge: GeofenceConstants.movementFixMaxAge + 1
+        ) == nil)
+    }
+
+    /// A negative age means a fix timestamped in the future — unusable, not "extra fresh".
+    @Test
+    func resolvedMembership_givenFutureDatedFix_expectNoVerdict() {
+        #expect(PolygonMembershipDecision.resolvedMembership(
+            signedEdgeDistance: 100, horizontalAccuracy: 10, fixAge: -1
+        ) == nil)
+    }
+
+    /// CoreLocation reports a non-positive accuracy when the fix is invalid.
+    @Test(arguments: [0.0, -1.0])
+    func resolvedMembership_givenNonPositiveAccuracy_expectNoVerdict(accuracy: Double) {
+        #expect(PolygonMembershipDecision.resolvedMembership(
+            signedEdgeDistance: 100, horizontalAccuracy: accuracy, fixAge: freshAge
+        ) == nil)
+    }
+
+    /// The guard is on age, not on the fix being at the very edge of the window.
+    @Test
+    func resolvedMembership_givenFixAtMaxAge_expectVerdict() {
+        #expect(PolygonMembershipDecision.resolvedMembership(
+            signedEdgeDistance: 100,
+            horizontalAccuracy: 10,
+            fixAge: GeofenceConstants.movementFixMaxAge
+        ) == .inside)
+    }
+}

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipStorageTests.swift
@@ -127,6 +127,41 @@ struct PolygonMembershipStorageTests {
         #expect(await storage.recordPolygonMembership(.inside, forIdentifier: "1") == .deliver(.enter))
     }
 
+    /// The deferred clear can be skipped when a re-registration overtakes it, and then `forceReseed`
+    /// is the only thing standing between an unmonitored gap and a swallowed enter. It reseeds the
+    /// circle baseline, so it has to reseed the belief too.
+    @Test
+    func recordMonitorRegistration_givenForceReseed_expectPolygonBeliefCleared() async {
+        let storage = await makeStorage()
+        let center = LocationData(latitude: 0, longitude: 0)
+        _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
+
+        await storage.recordMonitorRegistration(
+            identifier: "1", transitionTypes: [.enter, .exit], initialState: .exit,
+            center: center, radius: 100, forceReseed: true
+        )
+
+        #expect(await storage.getPolygonMembership()["1"] == nil)
+        #expect(await storage.recordPolygonMembership(.inside, forIdentifier: "1") == .deliver(.enter))
+    }
+
+    /// The ordinary sync path re-registers every identifier. Dropping belief there would re-fire an
+    /// enter on every sync for a device that never moved.
+    @Test
+    func recordMonitorRegistration_givenRoutineReregistration_expectPolygonBeliefKept() async {
+        let storage = await makeStorage()
+        let center = LocationData(latitude: 0, longitude: 0)
+        _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
+
+        await storage.recordMonitorRegistration(
+            identifier: "1", transitionTypes: [.enter, .exit], initialState: .exit,
+            center: center, radius: 100
+        )
+
+        #expect(await storage.getPolygonMembership()["1"]?.membership == .inside)
+        #expect(await storage.recordPolygonMembership(.inside, forIdentifier: "1") == .suppressedNoChange)
+    }
+
     @Test
     func clearUserScopedState_expectMembershipCleared() async {
         let storage = await makeStorage()

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipStorageTests.swift
@@ -5,18 +5,22 @@ import Testing
 
 @Suite("GeofenceStorage polygon membership")
 struct PolygonMembershipStorageTests {
-    private func makeStorage() -> GeofenceStorage {
-        GeofenceStorage(
+    /// Registers the ids first: a belief is only created for a polygon in the registered set, so a
+    /// bare storage would suppress every write as `.suppressedUnmonitored`.
+    private func makeStorage(registering ids: Set<String> = ["1"]) async -> GeofenceStorage {
+        let storage = GeofenceStorage(
             fileManager: .default,
             directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         )
+        await storage.recordRegistration(center: LocationData(latitude: 0, longitude: 0), businessIds: ids)
+        return storage
     }
 
     /// A polygon with no record is undecided, not outside — so the first decisive fix placing the
     /// device inside is a genuine enter. This is the polygon counterpart of enter-when-inside.
     @Test
     func recordPolygonMembership_givenNoRecordAndInside_expectEnterDelivered() async {
-        let storage = makeStorage()
+        let storage = await makeStorage()
         let outcome = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
         #expect(outcome == .deliver(.enter))
     }
@@ -24,7 +28,7 @@ struct PolygonMembershipStorageTests {
     /// Establishing "outside" for the first time is not a crossing — nothing was entered to leave.
     @Test
     func recordPolygonMembership_givenNoRecordAndOutside_expectSuppressed() async {
-        let storage = makeStorage()
+        let storage = await makeStorage()
         let outcome = await storage.recordPolygonMembership(.outside, forIdentifier: "1")
         #expect(outcome == .suppressedInitialOutside)
         #expect(await storage.getPolygonMembership()["1"]?.membership == .outside)
@@ -32,7 +36,7 @@ struct PolygonMembershipStorageTests {
 
     @Test
     func recordPolygonMembership_givenUnchangedBelief_expectSuppressed() async {
-        let storage = makeStorage()
+        let storage = await makeStorage()
         _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
         let outcome = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
         #expect(outcome == .suppressedNoChange)
@@ -40,7 +44,7 @@ struct PolygonMembershipStorageTests {
 
     @Test
     func recordPolygonMembership_givenBeliefFlips_expectExitDelivered() async {
-        let storage = makeStorage()
+        let storage = await makeStorage()
         _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
         let outcome = await storage.recordPolygonMembership(.outside, forIdentifier: "1")
         #expect(outcome == .deliver(.exit))
@@ -51,7 +55,7 @@ struct PolygonMembershipStorageTests {
     /// reading — the same protection `recordMonitorEvent` gives the baseline heal.
     @Test
     func recordPolygonMembership_givenEvidenceOlderThanBelief_expectSuppressed() async {
-        let storage = makeStorage()
+        let storage = await makeStorage()
         let beliefWrittenAt = Date()
         _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1", now: beliefWrittenAt)
 
@@ -67,7 +71,7 @@ struct PolygonMembershipStorageTests {
 
     @Test
     func recordPolygonMembership_givenEvidenceNewerThanBelief_expectDelivered() async {
-        let storage = makeStorage()
+        let storage = await makeStorage()
         let beliefWrittenAt = Date()
         _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1", now: beliefWrittenAt)
 
@@ -84,7 +88,7 @@ struct PolygonMembershipStorageTests {
     /// without needing the registered-ids diff the circle path uses.
     @Test
     func recordPolygonMembership_givenRegistrationRetainsGeofence_expectBeliefPreserved() async {
-        let storage = makeStorage()
+        let storage = await makeStorage()
         _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
 
         await storage.recordRegistration(center: LocationData(latitude: 1, longitude: 1), businessIds: ["1"])
@@ -97,10 +101,27 @@ struct PolygonMembershipStorageTests {
     /// go stale and suppress the enter owed when the device comes back to it.
     @Test
     func recordPolygonMembership_givenGeofenceLeavesRegisteredSet_expectBeliefPruned() async {
-        let storage = makeStorage()
+        let storage = await makeStorage()
         _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
 
         await storage.recordRegistration(center: LocationData(latitude: 1, longitude: 1), businessIds: ["2"])
+        #expect(await storage.getPolygonMembership()["1"] == nil)
+
+        // Coming back means being registered again; the pruned belief is what makes it an enter
+        // rather than a no-change.
+        await storage.recordRegistration(center: LocationData(latitude: 0, longitude: 0), businessIds: ["1"])
+        #expect(await storage.recordPolygonMembership(.inside, forIdentifier: "1") == .deliver(.enter))
+    }
+
+    /// The OS reporting the covering circle unmonitored reseeds the circle baseline; the polygon
+    /// belief has to go with it. Kept, it would suppress the next real enter as no-change if the
+    /// device left the polygon while nothing was watching.
+    @Test
+    func clearMonitorRegionRecord_expectPolygonBeliefClearedToo() async {
+        let storage = await makeStorage()
+        _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
+
+        await storage.clearMonitorRegionRecord(identifier: "1")
 
         #expect(await storage.getPolygonMembership()["1"] == nil)
         #expect(await storage.recordPolygonMembership(.inside, forIdentifier: "1") == .deliver(.enter))
@@ -108,11 +129,21 @@ struct PolygonMembershipStorageTests {
 
     @Test
     func clearUserScopedState_expectMembershipCleared() async {
-        let storage = makeStorage()
+        let storage = await makeStorage()
         _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
 
         await storage.clearUserScopedState()
 
         #expect(await storage.getPolygonMembership().isEmpty)
+    }
+
+    /// An evaluation still in flight when the polygon is pruned must not resurrect it: creating a
+    /// belief there would deliver an enter for a fence the OS is no longer watching.
+    @Test
+    func recordPolygonMembership_givenIdNotRegistered_expectSuppressedAndNoRecord() async {
+        let storage = await makeStorage(registering: ["other"])
+        let outcome = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
+        #expect(outcome == .suppressedUnmonitored)
+        #expect(await storage.getPolygonMembership()["1"] == nil)
     }
 }

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipStorageTests.swift
@@ -184,6 +184,28 @@ struct PolygonMembershipStorageTests {
         #expect(outcome == .deliver(.exit))
     }
 
+    /// A confirming evaluation is newer evidence for the belief it re-proves. Left unrecorded, an
+    /// evaluation carrying OLDER opposite evidence — a foreground pass holding a pre-crossing fix,
+    /// resuming after a wake already decided — clears the ordering guard and delivers a crossing
+    /// the newer fix had just disproved.
+    @Test
+    func recordPolygonMembership_givenBeliefConfirmedByNewerEvidence_expectOlderOppositeSuppressed() async {
+        let storage = await makeStorage()
+        let established = Date(timeIntervalSince1970: 1000)
+        let stalePassFix = Date(timeIntervalSince1970: 1003)
+        let confirmingFix = Date(timeIntervalSince1970: 1005)
+        _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1", onlyIfBeliefPredates: established)
+        _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1", onlyIfBeliefPredates: confirmingFix)
+
+        let outcome = await storage.recordPolygonMembership(
+            .outside, forIdentifier: "1", onlyIfBeliefPredates: stalePassFix
+        )
+
+        #expect(outcome == .suppressedNewerDecision)
+        #expect(await storage.getPolygonMembership()["1"]?.membership == .inside)
+        #expect(await storage.getPolygonMembership()["1"]?.lastChangedAt == confirmingFix)
+    }
+
     @Test
     func clearUserScopedState_expectMembershipCleared() async {
         let storage = await makeStorage()

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipStorageTests.swift
@@ -1,0 +1,118 @@
+@testable import CioInternalCommon
+@testable import CioLocationGeofence
+import Foundation
+import Testing
+
+@Suite("GeofenceStorage polygon membership")
+struct PolygonMembershipStorageTests {
+    private func makeStorage() -> GeofenceStorage {
+        GeofenceStorage(
+            fileManager: .default,
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+    }
+
+    /// A polygon with no record is undecided, not outside — so the first decisive fix placing the
+    /// device inside is a genuine enter. This is the polygon counterpart of enter-when-inside.
+    @Test
+    func recordPolygonMembership_givenNoRecordAndInside_expectEnterDelivered() async {
+        let storage = makeStorage()
+        let outcome = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
+        #expect(outcome == .deliver(.enter))
+    }
+
+    /// Establishing "outside" for the first time is not a crossing — nothing was entered to leave.
+    @Test
+    func recordPolygonMembership_givenNoRecordAndOutside_expectSuppressed() async {
+        let storage = makeStorage()
+        let outcome = await storage.recordPolygonMembership(.outside, forIdentifier: "1")
+        #expect(outcome == .suppressedInitialOutside)
+        #expect(await storage.getPolygonMembership()["1"]?.membership == .outside)
+    }
+
+    @Test
+    func recordPolygonMembership_givenUnchangedBelief_expectSuppressed() async {
+        let storage = makeStorage()
+        _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
+        let outcome = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
+        #expect(outcome == .suppressedNoChange)
+    }
+
+    @Test
+    func recordPolygonMembership_givenBeliefFlips_expectExitDelivered() async {
+        let storage = makeStorage()
+        _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
+        let outcome = await storage.recordPolygonMembership(.outside, forIdentifier: "1")
+        #expect(outcome == .deliver(.exit))
+        #expect(await storage.getPolygonMembership()["1"]?.membership == .outside)
+    }
+
+    /// An evaluation whose fix predates the stored belief must not overwrite it with an older
+    /// reading — the same protection `recordMonitorEvent` gives the baseline heal.
+    @Test
+    func recordPolygonMembership_givenEvidenceOlderThanBelief_expectSuppressed() async {
+        let storage = makeStorage()
+        let beliefWrittenAt = Date()
+        _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1", now: beliefWrittenAt)
+
+        let outcome = await storage.recordPolygonMembership(
+            .outside,
+            forIdentifier: "1",
+            onlyIfBeliefPredates: beliefWrittenAt.addingTimeInterval(-10)
+        )
+
+        #expect(outcome == .suppressedNewerDecision)
+        #expect(await storage.getPolygonMembership()["1"]?.membership == .inside)
+    }
+
+    @Test
+    func recordPolygonMembership_givenEvidenceNewerThanBelief_expectDelivered() async {
+        let storage = makeStorage()
+        let beliefWrittenAt = Date()
+        _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1", now: beliefWrittenAt)
+
+        let outcome = await storage.recordPolygonMembership(
+            .outside,
+            forIdentifier: "1",
+            onlyIfBeliefPredates: beliefWrittenAt.addingTimeInterval(10)
+        )
+
+        #expect(outcome == .deliver(.exit))
+    }
+
+    /// Membership survives re-registration, which is what keeps a wholesale re-register silent
+    /// without needing the registered-ids diff the circle path uses.
+    @Test
+    func recordPolygonMembership_givenRegistrationRetainsGeofence_expectBeliefPreserved() async {
+        let storage = makeStorage()
+        _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
+
+        await storage.recordRegistration(center: LocationData(latitude: 1, longitude: 1), businessIds: ["1"])
+
+        #expect(await storage.getPolygonMembership()["1"]?.membership == .inside)
+        #expect(await storage.recordPolygonMembership(.inside, forIdentifier: "1") == .suppressedNoChange)
+    }
+
+    /// A polygon dropped from the registered set stops being evaluated, so a retained belief would
+    /// go stale and suppress the enter owed when the device comes back to it.
+    @Test
+    func recordPolygonMembership_givenGeofenceLeavesRegisteredSet_expectBeliefPruned() async {
+        let storage = makeStorage()
+        _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
+
+        await storage.recordRegistration(center: LocationData(latitude: 1, longitude: 1), businessIds: ["2"])
+
+        #expect(await storage.getPolygonMembership()["1"] == nil)
+        #expect(await storage.recordPolygonMembership(.inside, forIdentifier: "1") == .deliver(.enter))
+    }
+
+    @Test
+    func clearUserScopedState_expectMembershipCleared() async {
+        let storage = makeStorage()
+        _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
+
+        await storage.clearUserScopedState()
+
+        #expect(await storage.getPolygonMembership().isEmpty)
+    }
+}

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipStorageTests.swift
@@ -162,6 +162,28 @@ struct PolygonMembershipStorageTests {
         #expect(await storage.recordPolygonMembership(.inside, forIdentifier: "1") == .suppressedNoChange)
     }
 
+    /// The ordering guard compares the stored time against the incoming evidence, so the stored one
+    /// has to BE evidence. Storing the write time instead made every record instantly "newer" than
+    /// the fix that justified it, rejecting a later verdict whose own fix was genuinely newer.
+    @Test
+    func recordPolygonMembership_givenEvidenceNewerThanPriorEvidence_expectAccepted() async {
+        let storage = await makeStorage()
+        let firstFix = Date(timeIntervalSince1970: 1000)
+        let secondFix = Date(timeIntervalSince1970: 1005)
+        // A write lands well after the fix that justified it — the gap the old code stored.
+        _ = await storage.recordPolygonMembership(
+            .inside, forIdentifier: "1", onlyIfBeliefPredates: firstFix,
+            now: Date(timeIntervalSince1970: 1060)
+        )
+
+        let outcome = await storage.recordPolygonMembership(
+            .outside, forIdentifier: "1", onlyIfBeliefPredates: secondFix,
+            now: Date(timeIntervalSince1970: 1065)
+        )
+
+        #expect(outcome == .deliver(.exit))
+    }
+
     @Test
     func clearUserScopedState_expectMembershipCleared() async {
         let storage = await makeStorage()

--- a/Tests/LocationGeofence/Geofence/Polygon/SignConventionTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/SignConventionTests.swift
@@ -1,0 +1,79 @@
+@testable import CioInternalCommon
+@testable import CioLocationGeofence
+import Foundation
+import Testing
+
+/// Pins the RELATIONSHIP between the two edge-distance conventions in the SDK, which are opposite.
+///
+/// `PolygonRegion.signedEdgeDistance` is positive inside; the circle path's edge distance
+/// (`distanceFromCenter - radius`, what `BaselineHealDecision` consumes) is negative inside. The
+/// kernel's doc comment once claimed they were interchangeable, and the polygon decision function
+/// was written against that claim — producing inverted verdicts that neither side's unit tests
+/// could see, because each was self-consistent.
+///
+/// These tests are deliberately phrased in terms of PHYSICAL POSITION rather than sign, so flipping
+/// either convention breaks them. They are the cross-check that survives both implementations
+/// being ours.
+@Suite("Edge-distance sign conventions")
+struct SignConventionTests {
+    private static let square = [
+        LocationData(latitude: -0.0016, longitude: -0.0016),
+        LocationData(latitude: -0.0016, longitude: 0.0016),
+        LocationData(latitude: 0.0016, longitude: 0.0016),
+        LocationData(latitude: 0.0016, longitude: -0.0016)
+    ]
+
+    private func circleGeofence() -> Geofence {
+        Geofence(
+            id: "c", latitude: 0, longitude: 0, radius: 200, name: nil,
+            transitionTypes: [.enter, .exit], lastUpdated: Date()
+        )
+    }
+
+    /// One physical fact — the device is inside — must be reported as inside by BOTH layers, even
+    /// though they express it with opposite signs.
+    @Test
+    func deviceInside_expectBothLayersAgreeDespiteOppositeSigns() {
+        let at = LocationData(latitude: 0, longitude: 0)
+        let polygon = PolygonRegion(vertices: Self.square)
+        let circle = circleGeofence()
+
+        let polygonSigned = polygon?.signedEdgeDistance(to: at) ?? 0
+        let circleEdge = circle.distanceTo(at) - circle.radius
+
+        #expect(polygonSigned > 0, "polygon convention: positive inside")
+        #expect(circleEdge < 0, "circle convention: negative inside")
+
+        #expect(PolygonMembershipDecision.resolvedMembership(
+            signedEdgeDistance: polygonSigned, horizontalAccuracy: 5, fixAge: 1
+        ) == .inside)
+        // The heal reads the circle convention: a stored `.exit` baseline contradicted by a device
+        // that is actually inside must synthesize `.enter`.
+        #expect(BaselineHealDecision.synthesizedTransition(
+            distanceFromCenter: circle.distanceTo(at), radius: circle.radius,
+            horizontalAccuracy: 5, fixAge: 1, lastState: .exit
+        ) == .enter)
+    }
+
+    /// And the mirror image, so a test that passes by flipping both conventions at once fails here.
+    @Test
+    func deviceOutside_expectBothLayersAgreeDespiteOppositeSigns() {
+        let at = LocationData(latitude: 0.01, longitude: 0)
+        let polygon = PolygonRegion(vertices: Self.square)
+        let circle = circleGeofence()
+
+        let polygonSigned = polygon?.signedEdgeDistance(to: at) ?? 0
+        let circleEdge = circle.distanceTo(at) - circle.radius
+
+        #expect(polygonSigned < 0, "polygon convention: negative outside")
+        #expect(circleEdge > 0, "circle convention: positive outside")
+
+        #expect(PolygonMembershipDecision.resolvedMembership(
+            signedEdgeDistance: polygonSigned, horizontalAccuracy: 5, fixAge: 1
+        ) == .outside)
+        #expect(BaselineHealDecision.synthesizedTransition(
+            distanceFromCenter: circle.distanceTo(at), radius: circle.radius,
+            horizontalAccuracy: 5, fixAge: 1, lastState: .enter
+        ) == .exit)
+    }
+}


### PR DESCRIPTION
Part of [MBL-2291](https://linear.app/customerio/issue/MBL-2291/ios-implement-responsive-on-device-polygon-monitoring)

Part 3 of the polygon geofence work. The belief layer only — what the SDK thinks the device's
membership is for each polygon, and how that belief turns into a crossing. Nothing writes to it
yet; the resolver arrives in the next PR.

### What's here

**`PolygonMembership` / `PolygonMembershipDecision`** — the verdict and the accuracy gate that
produces it. A fix decides membership only when the device is farther from the boundary than its
own accuracy, floored at 20 m. Undecidable leaves the stored belief untouched rather than guessing,
which is what "no event without gated geometric confirmation" means in code.

**`GeofenceStorage+PolygonMembership`** — the persisted belief, with the first-decision rule that
matters: a polygon with no record is *undecided*, not outside, so the first decisive fix placing
the device inside is a genuine enter. Establishing "outside" for the first time is not a crossing.

Belief is pruned when a polygon leaves the registered set, on the same rule the monitor records
follow: it is no longer being evaluated, so a retained belief would go stale and suppress the enter
owed when the device returns. Clearing a monitor region record drops the belief with it, for the
same reason — kept across an unmonitored gap, an inside belief swallows the next real enter as
no-change if the device left while nothing was watching. A forced reseed does the same: the
deferred clear is skipped when a re-registration overtakes it, so the two halves of what an
identifier believes reseed together.

An evaluation that *confirms* the stored belief refreshes its evidence stamp, not only one that
changes it. Re-proving a belief is newer evidence for it, and holding the stamp at the last change
let a later evaluation carrying older opposite evidence clear the ordering guard and deliver a
crossing the newer fix had just disproved.

A belief is only ever *created* for a polygon in the registered set, so an evaluation that raced a
prune cannot resurrect a fence the OS is no longer watching and deliver an enter for it.

### Worth a reviewer's attention

The sign convention. `PolygonRegion.signedEdgeDistance` is positive inside, the circle path's edge
distance is negative inside. `SignConventionTests` pins the relationship in terms of physical
position rather than sign, because during the spike a consumer was written against the wrong
assumption and produced inverted verdicts that neither side's unit tests could see.

### Testing

429/429 `LocationGeofenceTests` pass on iOS 26. Format and lint clean, no public API surface.

Unit tests for the gate, the storage transitions, the sign convention, the unmonitored-clearing
rule, and the refusal to create a belief for an unregistered id.

### Stack

1. `mbl-2290-a-polygon-geometry-kernel` — geometry kernel (#1239, merged)
2. `mbl-2290-b-polygon-wire-contract` — v2 wire contract decode (#1240, merged)
3. `mbl-2291-a-polygon-membership-layer` — membership belief + storage ← **this PR**
4. `mbl-2291-b-polygon-membership-resolver` — the resolver (#1245)
5. `mbl-2291-c-polygon-monitor-wiring` — monitor wiring (#1246)
6. `mbl-2290-c-polygon-antimeridian` — antimeridian projection fix (#1249)
7. `mbl-2291-f-polygon-shared-wake-circle` — shared dynamic movement circle (#1250)

🤖 Generated with [Claude Code](https://claude.com/claude-code)









