### PR TITLE
chore(geofence): decide polygon membership from covering-circle events

### DIFF
--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -154,6 +154,22 @@ extension Logger {
         info("Synthesized \(transition.rawValue) for region \(identifier): fresh fix contradicts stored baseline (OS never delivered the crossing)", geofenceTag)
     }
 
+    /// Positive record of an OS-delivered business transition. Without it a native delivery is
+    /// only identifiable by the ABSENCE of a synthesized line, which makes the OS promotion rate
+    /// inferred rather than measured.
+    func geofenceOsTransitionReceived(identifier: String, transition: GeofenceTransition) {
+        debug("OS delivered \(transition.rawValue) for region \(identifier)", geofenceTag)
+    }
+
+    func geofencePolygonTransition(identifier: String, transition: GeofenceTransition, confirmedByFix: Bool) {
+        let basis = confirmedByFix ? "a gated fix" : "the covering-circle exit"
+        info("Polygon \(transition.rawValue) for region \(identifier), confirmed by \(basis)", geofenceTag)
+    }
+
+    func geofencePolygonUndecided(identifier: String, reason: String) {
+        debug("Polygon membership undecided for region \(identifier): \(reason)", geofenceTag)
+    }
+
     func geofenceEventRefusedByContradiction(identifier: String, transition: GeofenceTransition, distanceFromCenter: Double, radius: Double, accuracy: Double) {
         info("Refused OS \(transition.rawValue) for region \(identifier): a fresh fix contradicts it (distance \(Int(distanceFromCenter)) m, radius \(Int(radius)) m, accuracy \(Int(accuracy)) m)", geofenceTag)
     }

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -166,6 +166,12 @@ extension Logger {
         info("Polygon \(transition.rawValue) for region \(identifier), confirmed by \(basis)", geofenceTag)
     }
 
+    /// A whole-set pass declined because one is already running. Logged so a foreground that
+    /// produced no verdicts is distinguishable from one that never ran.
+    func geofencePolygonPassSkipped(reason: String) {
+        debug("Skipped polygon evaluation pass: \(reason)", geofenceTag)
+    }
+
     func geofencePolygonUndecided(identifier: String, reason: String) {
         debug("Polygon membership undecided for region \(identifier): \(reason)", geofenceTag)
     }

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -156,7 +156,8 @@ extension Logger {
 
     /// Positive record of an OS-delivered business transition. Without it a native delivery is
     /// only identifiable by the ABSENCE of a synthesized line, which makes the OS promotion rate
-    /// inferred rather than measured.
+    /// inferred rather than measured. Logged at the monitors' dispatch sites, where provenance is
+    /// known: the resolver's entry point also receives synthesized heals, which would inflate it.
     func geofenceOsTransitionReceived(identifier: String, transition: GeofenceTransition) {
         debug("OS delivered \(transition.rawValue) for region \(identifier)", geofenceTag)
     }

--- a/Sources/LocationGeofence/Model/Geofence.swift
+++ b/Sources/LocationGeofence/Model/Geofence.swift
@@ -56,6 +56,12 @@ struct Geofence: Codable, Equatable, Sendable {
     /// `nil` means EITHER a circle or a polygon whose stored ring no longer builds, so it must not
     /// be read as "this is a circle": check `vertices` for that. The two differ if `init?` ever
     /// tightens, since cached rings decode without re-validation.
+    /// The circle this fence is monitored by, for comparison against the circle an OS event was
+    /// raised for. Same pair the OS was handed at registration.
+    var monitoredCircle: MonitoredCircle {
+        MonitoredCircle(center: LocationData(latitude: latitude, longitude: longitude), radius: radius)
+    }
+
     var polygonRegion: PolygonRegion? {
         vertices.flatMap(PolygonRegion.init(vertices:))
     }

--- a/Sources/LocationGeofence/Model/Geofence.swift
+++ b/Sources/LocationGeofence/Model/Geofence.swift
@@ -56,12 +56,6 @@ struct Geofence: Codable, Equatable, Sendable {
     /// `nil` means EITHER a circle or a polygon whose stored ring no longer builds, so it must not
     /// be read as "this is a circle": check `vertices` for that. The two differ if `init?` ever
     /// tightens, since cached rings decode without re-validation.
-    /// The circle this fence is monitored by, for comparison against the circle an OS event was
-    /// raised for. Same pair the OS was handed at registration.
-    var monitoredCircle: MonitoredCircle {
-        MonitoredCircle(center: LocationData(latitude: latitude, longitude: longitude), radius: radius)
-    }
-
     var polygonRegion: PolygonRegion? {
         vertices.flatMap(PolygonRegion.init(vertices:))
     }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -306,10 +306,12 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
             // a frozen cached fix pins the whole pipeline to a stale point — freshen it first.
             // Fire-and-forget so a slow fix can't stall the pending-event drain behind it.
             movementFixResolver.resolve(cached: bestKnownFix()) { [weak self] location in
+                self?.logger.geofenceOsTransitionReceived(identifier: identifier, transition: transition)
                 self?.onTransition?(identifier, transition, location)
             }
             return
         }
+        logger.geofenceOsTransitionReceived(identifier: identifier, transition: transition)
         onTransition?(identifier, transition, currentLocationData())
     }
 

--- a/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
@@ -213,10 +213,12 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
     private func dispatchTransition(identifier: String, transition: GeofenceTransition, capturedLocation: LocationData?) {
         if identifier == GeofenceConstants.movementTriggerIdentifier, transition == .exit {
             movementFixResolver.resolve(cached: bestKnownFix()) { [weak self] location in
+                self?.logger.geofenceOsTransitionReceived(identifier: identifier, transition: transition)
                 self?.onTransition?(identifier, transition, location ?? capturedLocation)
             }
             return
         }
+        logger.geofenceOsTransitionReceived(identifier: identifier, transition: transition)
         onTransition?(identifier, transition, capturedLocation)
     }
 

--- a/Sources/LocationGeofence/Monitor/GeofenceRegionMonitoring.swift
+++ b/Sources/LocationGeofence/Monitor/GeofenceRegionMonitoring.swift
@@ -19,6 +19,14 @@ typealias GeofenceAuthorizationChangedHandler = @MainActor () -> Void
 /// Invoked on the main actor.
 typealias GeofenceReconciledHandler = @MainActor () -> Void
 
+/// The circle the OS was monitoring when it raised an event. Carried with the event because a
+/// refresh can replace a fence under the same id, and a consumer reasoning about what the crossing
+/// PROVES has to know which circle it crossed — the current fence's circle may be a different one.
+struct MonitoredCircle: Equatable, Sendable {
+    let center: LocationData
+    let radius: Double
+}
+
 /// A circular region the caller wants monitored, as handed to `setMonitoredRegions`.
 struct GeofenceRegionRequest: Equatable, Sendable {
     let identifier: String

--- a/Sources/LocationGeofence/Monitor/GeofenceRegionMonitoring.swift
+++ b/Sources/LocationGeofence/Monitor/GeofenceRegionMonitoring.swift
@@ -24,7 +24,27 @@ typealias GeofenceReconciledHandler = @MainActor () -> Void
 /// PROVES has to know which circle it crossed — the current fence's circle may be a different one.
 struct MonitoredCircle: Equatable, Sendable {
     let center: LocationData
+    /// As REGISTERED, so already clamped to `maximumRadius`. Comparing it to a fence's own radius
+    /// without clamping that too reads every over-cap fence as changed, forever.
     let radius: Double
+    /// The cap the producer clamped against, carried so a consumer can reconstruct what the OS
+    /// would hold for a given fence.
+    let maximumRadius: Double
+
+    /// Whether this is the circle `geofence` is currently monitored by. Same comparison
+    /// `GeofenceRegionRequest.matchesRegistered` makes, and for the same reasons: clamp the fence's
+    /// radius to what the OS would actually hold, and allow for the float round trip through
+    /// CoreLocation rather than assuming it is exact.
+    func matches(_ geofence: Geofence) -> Bool {
+        abs(center.latitude - geofence.latitude) < Self.coordinateTolerance
+            && abs(center.longitude - geofence.longitude) < Self.coordinateTolerance
+            && abs(radius - min(geofence.radius, maximumRadius)) < Self.radiusTolerance
+    }
+
+    /// Same slack as `GeofenceRegionRequest`; kept in step with it deliberately — the two answer the
+    /// same question about the same round trip.
+    private static let coordinateTolerance = 1e-7
+    private static let radiusTolerance = 0.5
 }
 
 /// A circular region the caller wants monitored, as handed to `setMonitoredRegions`.

--- a/Sources/LocationGeofence/Monitor/MovementFixResolver.swift
+++ b/Sources/LocationGeofence/Monitor/MovementFixResolver.swift
@@ -31,15 +31,21 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
     }()
 
     /// Test seam mirroring `requestFreshFix`: where the pre-request fix comes from when this
-    /// resolver has delivered none itself. Unset, it reads CoreLocation's own cached fix.
+    /// resolver has delivered none itself. Unset, it reads CoreLocation's own cached fix — so any
+    /// test that reads `cachedFix` must set this, or the read instantiates a real
+    /// `CLLocationManager`. A seam returning nil answers nil; it does not fall through.
     var systemCachedFix: (() -> CLLocation?)?
 
-    /// Freshest usable fix obtainable without issuing a request, whichever source holds it — the
-    /// same newest-of-the-two rule the monitors' `bestKnownFix` applies, invalid coordinates
-    /// included. On a cold process this resolver has delivered nothing, so CoreLocation's cached
+    /// Freshest usable fix obtainable without issuing a request: the newer of the two sources, not
+    /// whichever this resolver happens to have produced, which is how the monitors' `bestKnownFix`
+    /// reads too. On a cold process this resolver has delivered nothing, so CoreLocation's cached
     /// fix is the only evidence available, and the decision's age gate is what keeps it honest.
     /// That cache also moves on its own between passes, driven by other clients in the process, so
     /// preferring `latestFix` by source would hand a stale fallback to a request that then fails.
+    ///
+    /// Only the system fix is checked for a valid coordinate. `latestFix` reaches this class
+    /// through a delegate callback that already rejects invalid ones — which a test feeding
+    /// `handleResolvedFix` directly does not.
     var cachedFix: CLLocation? {
         let systemFix = (systemCachedFix.map { $0() } ?? manager.location)
             .flatMap { CLLocationCoordinate2DIsValid($0.coordinate) ? $0 : nil }

--- a/Sources/LocationGeofence/Monitor/MovementFixResolver.swift
+++ b/Sources/LocationGeofence/Monitor/MovementFixResolver.swift
@@ -34,13 +34,16 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
     /// resolver has delivered none itself. Unset, it reads CoreLocation's own cached fix.
     var systemCachedFix: (() -> CLLocation?)?
 
-    /// Freshest fix obtainable without issuing a request. On a cold process this resolver has
-    /// delivered nothing, so CoreLocation's cached fix is the only evidence available — the
-    /// decision's age gate is what keeps it honest.
+    /// Freshest fix obtainable without issuing a request, whichever source holds it. On a cold
+    /// process this resolver has delivered nothing, so CoreLocation's cached fix is the only
+    /// evidence available — the decision's age gate is what keeps it honest. CoreLocation's cache
+    /// also moves on its own between passes, driven by other clients in the process, so preferring
+    /// `latestFix` on age alone would hand a stale fallback to a request that then fails.
     var cachedFix: CLLocation? {
-        if let latestFix { return latestFix }
-        if let systemCachedFix { return systemCachedFix() }
-        return manager.location
+        let systemFix: CLLocation? = systemCachedFix.map { $0() } ?? manager.location
+        guard let latestFix else { return systemFix }
+        guard let systemFix, systemFix.timestamp > latestFix.timestamp else { return latestFix }
+        return systemFix
     }
 
     /// Freshest fix this resolver has received, retained even when it arrives after a timeout.

--- a/Sources/LocationGeofence/Monitor/MovementFixResolver.swift
+++ b/Sources/LocationGeofence/Monitor/MovementFixResolver.swift
@@ -20,14 +20,28 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
     private let maxAge: TimeInterval
     private let requestTimeout: TimeInterval
     private let backgroundTaskRunner: BackgroundTaskRunner
+    private let desiredAccuracy: CLLocationAccuracy
 
     /// Created lazily so tests using the `requestFreshFix` seam never touch CoreLocation.
     private lazy var manager: CLLocationManager = {
         let manager = CLLocationManager()
-        manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+        manager.desiredAccuracy = desiredAccuracy
         manager.delegate = self
         return manager
     }()
+
+    /// Test seam mirroring `requestFreshFix`: where the pre-request fix comes from when this
+    /// resolver has delivered none itself. Unset, it reads CoreLocation's own cached fix.
+    var systemCachedFix: (() -> CLLocation?)?
+
+    /// Freshest fix obtainable without issuing a request. On a cold process this resolver has
+    /// delivered nothing, so CoreLocation's cached fix is the only evidence available — the
+    /// decision's age gate is what keeps it honest.
+    var cachedFix: CLLocation? {
+        if let latestFix { return latestFix }
+        if let systemCachedFix { return systemCachedFix() }
+        return manager.location
+    }
 
     /// Freshest fix this resolver has received, retained even when it arrives after a timeout.
     private(set) var latestFix: CLLocation?
@@ -47,12 +61,14 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
         logger: Logger,
         maxAge: TimeInterval = GeofenceConstants.movementFixMaxAge,
         requestTimeout: TimeInterval = GeofenceConstants.movementFixRequestTimeout,
-        backgroundTaskRunner: BackgroundTaskRunner = NoBackgroundTaskRunner()
+        backgroundTaskRunner: BackgroundTaskRunner = NoBackgroundTaskRunner(),
+        desiredAccuracy: CLLocationAccuracy = kCLLocationAccuracyHundredMeters
     ) {
         self.logger = logger
         self.maxAge = maxAge
         self.requestTimeout = requestTimeout
         self.backgroundTaskRunner = backgroundTaskRunner
+        self.desiredAccuracy = desiredAccuracy
     }
 
     deinit {

--- a/Sources/LocationGeofence/Monitor/MovementFixResolver.swift
+++ b/Sources/LocationGeofence/Monitor/MovementFixResolver.swift
@@ -34,13 +34,15 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
     /// resolver has delivered none itself. Unset, it reads CoreLocation's own cached fix.
     var systemCachedFix: (() -> CLLocation?)?
 
-    /// Freshest fix obtainable without issuing a request, whichever source holds it. On a cold
-    /// process this resolver has delivered nothing, so CoreLocation's cached fix is the only
-    /// evidence available — the decision's age gate is what keeps it honest. CoreLocation's cache
-    /// also moves on its own between passes, driven by other clients in the process, so preferring
-    /// `latestFix` on age alone would hand a stale fallback to a request that then fails.
+    /// Freshest usable fix obtainable without issuing a request, whichever source holds it — the
+    /// same newest-of-the-two rule the monitors' `bestKnownFix` applies, invalid coordinates
+    /// included. On a cold process this resolver has delivered nothing, so CoreLocation's cached
+    /// fix is the only evidence available, and the decision's age gate is what keeps it honest.
+    /// That cache also moves on its own between passes, driven by other clients in the process, so
+    /// preferring `latestFix` by source would hand a stale fallback to a request that then fails.
     var cachedFix: CLLocation? {
-        let systemFix: CLLocation? = systemCachedFix.map { $0() } ?? manager.location
+        let systemFix = (systemCachedFix.map { $0() } ?? manager.location)
+            .flatMap { CLLocationCoordinate2DIsValid($0.coordinate) ? $0 : nil }
         guard let latestFix else { return systemFix }
         guard let systemFix, systemFix.timestamp > latestFix.timestamp else { return latestFix }
         return systemFix

--- a/Sources/LocationGeofence/Polygon/PolygonMembership.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembership.swift
@@ -45,4 +45,7 @@ enum PolygonMembershipOutcome: Equatable {
     /// The polygon is not in the registered set — an evaluation that raced a prune. Creating a
     /// belief here would deliver an enter for a fence the OS is no longer watching.
     case suppressedUnmonitored
+    /// The ring the verdict was computed from is no longer the workspace's — a refresh replaced the
+    /// fence under the same id between the evaluation reading geometry and this write.
+    case suppressedGeometryChanged
 }

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver+DI.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver+DI.swift
@@ -1,0 +1,27 @@
+import CioInternalCommon
+import Foundation
+
+// MARK: - DI
+
+extension DIGraphShared {
+    /// Hand-written + `@MainActor`-isolated for the same reason as `geofenceMonitor`: the resolver
+    /// owns a `MovementFixResolver`, which owns a `CLLocationManager`. Override-check mirrors the
+    /// generated accessors so tests can substitute via `di.override(value:forType:)`.
+    @MainActor
+    var polygonMembershipResolver: PolygonMembershipResolver {
+        let overridden: PolygonMembershipResolver? = getOverriddenInstance()
+        return overridden ?? PolygonMembershipResolver.shared
+    }
+}
+
+extension PolygonMembershipResolver {
+    /// Process-wide singleton so one `CLLocationManager` serves every evaluation; the resolver
+    /// itself is stateless, all belief lives in `GeofenceStorage`.
+    @MainActor
+    static let shared = PolygonMembershipResolver(
+        storage: DIGraphShared.shared.geofenceStorage,
+        transitionEmitter: DIGraphShared.shared.geofenceEventTracker,
+        logger: DIGraphShared.shared.logger,
+        contextStore: DIGraphShared.shared.backgroundDeliveryContextStore
+    )
+}

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -31,6 +31,7 @@ final class PolygonMembershipResolver {
     private let fixResolver: MovementFixResolver
     private let logger: Logger
     private var foregroundObserverToken: NSObjectProtocol?
+    private var isEvaluatingAllPolygons = false
 
     init(
         storage: GeofenceStorage,
@@ -65,7 +66,7 @@ final class PolygonMembershipResolver {
     /// condition the cache has dropped) is forwarded rather than dropped: treating it as a circle
     /// is the behaviour that predates polygons, and losing a real crossing is worse than a
     /// covering-circle-shaped one.
-    func handleTransition(identifier: String, transition: GeofenceTransition, occurredAt: Date? = nil) async {
+    func handleTransition(identifier: String, transition: GeofenceTransition, occurredAt: Date) async {
         logger.geofenceOsTransitionReceived(identifier: identifier, transition: transition)
         guard let geofence = await cachedGeofence(id: identifier), geofence.vertices != nil else {
             // Uncached, or a genuine circle: forward untouched, the behaviour that predates polygons.
@@ -84,7 +85,7 @@ final class PolygonMembershipResolver {
             // fix. It is still ORDERED against the stored belief: a synthesized or replayed exit
             // arriving after a newer enter would otherwise swallow it and leave the device believed
             // outside while it sits inside.
-            await apply(.outside, to: geofence, evidence: occurredAt)
+            await apply(.outside, to: geofence, evidence: occurredAt, confirmedByFix: false)
         case .enter:
             await evaluate(geofence: geofence, polygon: polygon)
         }
@@ -94,15 +95,34 @@ final class PolygonMembershipResolver {
     ///
     /// The one case no OS event covers: a device already inside a polygon when monitoring begins
     /// has crossed nothing, so the OS has nothing to report, and a device standing still produces
-    /// no movement pass either. Foregrounding is the remaining signal, and it is free — the first
-    /// evaluation resolves a fix and the rest read it from the cache.
+    /// no movement pass either. Foregrounding is the remaining signal, and it is free — one fix
+    /// serves the whole pass.
+    ///
+    /// Foregrounds arrive in bursts, so a pass already running wins: a second concurrent scan reads
+    /// the same storage and the same fix and can only duplicate the location work.
     func evaluateAllPolygons() async {
+        guard !isEvaluatingAllPolygons else {
+            logger.geofencePolygonPassSkipped(reason: "a pass is already running")
+            return
+        }
+        isEvaluatingAllPolygons = true
+        defer { isEvaluatingAllPolygons = false }
         let registered = await storage.getRegisteredBusinessIds()
         let polygons = await storage.getCachedGeofences()
             .filter { registered.contains($0.id) && $0.vertices != nil }
+        guard !polygons.isEmpty else { return }
+        // One request for the whole pass. Resolving per polygon would issue a fresh timed request
+        // for every one of them whenever the cache stays empty, holding the main actor for minutes
+        // and still deciding nothing.
+        guard let fix = await resolveFix() else {
+            for geofence in polygons {
+                logger.geofencePolygonUndecided(identifier: geofence.id, reason: "no usable fix")
+            }
+            return
+        }
         for geofence in polygons {
             guard let polygon = geofence.polygonRegion else { continue }
-            await evaluate(geofence: geofence, polygon: polygon)
+            await evaluate(geofence: geofence, polygon: polygon, fix: fix)
         }
     }
 
@@ -122,7 +142,15 @@ final class PolygonMembershipResolver {
     }
 
     private func evaluate(geofence: Geofence, polygon: PolygonRegion) async {
-        guard let fix = await resolveFix(), CLLocationCoordinate2DIsValid(fix.coordinate) else {
+        guard let fix = await resolveFix() else {
+            logger.geofencePolygonUndecided(identifier: geofence.id, reason: "no usable fix")
+            return
+        }
+        await evaluate(geofence: geofence, polygon: polygon, fix: fix)
+    }
+
+    private func evaluate(geofence: Geofence, polygon: PolygonRegion, fix: CLLocation) async {
+        guard CLLocationCoordinate2DIsValid(fix.coordinate) else {
             logger.geofencePolygonUndecided(identifier: geofence.id, reason: "no usable fix")
             return
         }
@@ -139,14 +167,21 @@ final class PolygonMembershipResolver {
             )
             return
         }
-        await apply(membership, to: geofence, evidence: fix.timestamp)
+        await apply(membership, to: geofence, evidence: fix.timestamp, confirmedByFix: true)
     }
 
     /// Applies a membership verdict and delivers the crossing when it changes the stored belief.
     /// `evidence` is when the crossing happened — a fix's timestamp, or the OS event's date for a
-    /// covering-circle exit. `nil` only when the caller has no date, which leaves the write
-    /// unordered against the stored belief.
-    private func apply(_ membership: PolygonMembership, to geofence: Geofence, evidence: Date?) async {
+    /// covering-circle exit. Required, not optional: it is what orders the write against the stored
+    /// belief, and a caller allowed to omit it could silently write an unordered one. `confirmedByFix`
+    /// says which of the two it was, since both carry a date and the date alone cannot tell the log
+    /// how membership was decided.
+    private func apply(
+        _ membership: PolygonMembership,
+        to geofence: Geofence,
+        evidence: Date,
+        confirmedByFix: Bool
+    ) async {
         let outcome = await storage.recordPolygonMembership(
             membership,
             forIdentifier: geofence.id,
@@ -158,7 +193,7 @@ final class PolygonMembershipResolver {
         logger.geofencePolygonTransition(
             identifier: geofence.id,
             transition: transition,
-            confirmedByFix: evidence != nil
+            confirmedByFix: confirmedByFix
         )
         await transitionEmitter.trackTransition(geofenceId: geofence.id, transition: transition)
     }

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -1,0 +1,192 @@
+import CioInternalCommon
+import CoreLocation
+import Foundation
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// Turns OS covering-circle events into customer-facing polygon transitions.
+///
+/// The OS monitors a polygon's server-guaranteed covering circle and knows nothing about the
+/// polygon itself, so membership is a second fact that has to be established on device. This sits
+/// between the monitor and the event tracker and is the only component that owns it. Circle
+/// geofences pass straight through: the contradiction gate, baseline heal and dedup baseline that
+/// serve them are deliberately left unaware polygons exist.
+///
+/// Two invariants define correctness here, and neither may be relaxed:
+/// - an ENTER requires a gated fix placing the device inside the polygon;
+/// - an EXIT requires either a covering-circle exit — polygon ⊆ circle, so leaving the circle
+///   provably leaves the polygon — or a gated fix placing the device outside.
+///
+/// Everything else is silent. That is what "no event without gated geometric confirmation" means
+/// in code, and why an undecidable fix leaves the stored belief untouched rather than guessing.
+///
+/// Owns its own `MovementFixResolver` rather than reading the monitor's: the transition handler
+/// carries only coordinates, while the gate needs accuracy and age, and on a wrapper cold wake
+/// `CustomerIO.initialize` has not run — the same reasoning that gives each monitor its own.
+@MainActor
+final class PolygonMembershipResolver {
+    private let storage: GeofenceStorage
+    private let transitionEmitter: GeofenceTransitionEmitting
+    private let fixResolver: MovementFixResolver
+    private let logger: Logger
+    private var foregroundObserverToken: NSObjectProtocol?
+
+    init(
+        storage: GeofenceStorage,
+        transitionEmitter: GeofenceTransitionEmitting,
+        logger: Logger,
+        fixResolver: MovementFixResolver? = nil
+    ) {
+        self.storage = storage
+        self.transitionEmitter = transitionEmitter
+        self.logger = logger
+        self.fixResolver = fixResolver ?? MovementFixResolver(
+            logger: logger,
+            backgroundTaskRunner: GeofenceBackgroundTime.runner(name: "io.customer.geofence.polygon-fix")
+        )
+        registerForegroundEvaluation()
+    }
+
+    deinit {
+        if let foregroundObserverToken {
+            NotificationCenter.default.removeObserver(foregroundObserverToken)
+        }
+    }
+
+    /// Routes a business-geofence transition the OS delivered. A circle fence is forwarded to the
+    /// tracker unchanged; a polygon's covering-circle event is interpreted against membership.
+    ///
+    /// A geofence missing from the cache (a sync raced this event, or the OS still holds a
+    /// condition the cache has dropped) is forwarded rather than dropped: treating it as a circle
+    /// is the behaviour that predates polygons, and losing a real crossing is worse than a
+    /// covering-circle-shaped one.
+    func handleTransition(identifier: String, transition: GeofenceTransition) async {
+        logger.geofenceOsTransitionReceived(identifier: identifier, transition: transition)
+        guard let geofence = await cachedGeofence(id: identifier),
+              let polygon = geofence.polygonRegion
+        else {
+            await transitionEmitter.trackTransition(geofenceId: identifier, transition: transition)
+            return
+        }
+        switch transition {
+        case .exit:
+            // polygon ⊆ covering circle, so leaving the circle is geometric certainty and needs
+            // no fix.
+            await apply(.outside, to: geofence, evidence: nil)
+        case .enter:
+            await evaluate(geofence: geofence, polygon: polygon)
+        }
+    }
+
+    /// Re-evaluates every registered polygon when the app comes to the foreground.
+    ///
+    /// The one case no OS event covers: a device already inside a polygon when monitoring begins
+    /// has crossed nothing, so the OS has nothing to report, and a device standing still produces
+    /// no movement pass either. Foregrounding is the remaining signal, and it is free — the first
+    /// evaluation resolves a fix and the rest read it from the cache.
+    func evaluateAllPolygons() async {
+        let registered = await storage.getRegisteredBusinessIds()
+        let polygons = await storage.getCachedGeofences()
+            .filter { registered.contains($0.id) && $0.vertices != nil }
+        for geofence in polygons {
+            guard let polygon = geofence.polygonRegion else { continue }
+            await evaluate(geofence: geofence, polygon: polygon)
+        }
+    }
+
+    private func registerForegroundEvaluation() {
+        #if canImport(UIKit)
+        foregroundObserverToken = NotificationCenter.default.addObserver(
+            forName: UIApplication.willEnterForegroundNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                Task { await self.evaluateAllPolygons() }
+            }
+        }
+        #endif
+    }
+
+    private func evaluate(geofence: Geofence, polygon: PolygonRegion) async {
+        guard let fix = await resolveFix(), CLLocationCoordinate2DIsValid(fix.coordinate) else {
+            logger.geofencePolygonUndecided(identifier: geofence.id, reason: "no usable fix")
+            return
+        }
+        let point = LocationData(latitude: fix.coordinate.latitude, longitude: fix.coordinate.longitude)
+        let signedEdgeDistance = polygon.signedEdgeDistance(to: point)
+        guard let membership = PolygonMembershipDecision.resolvedMembership(
+            signedEdgeDistance: signedEdgeDistance,
+            horizontalAccuracy: fix.horizontalAccuracy,
+            fixAge: -fix.timestamp.timeIntervalSinceNow
+        ) else {
+            logger.geofencePolygonUndecided(
+                identifier: geofence.id,
+                reason: "edge distance \(Int(signedEdgeDistance)) m within accuracy \(Int(fix.horizontalAccuracy)) m"
+            )
+            return
+        }
+        await apply(membership, to: geofence, evidence: fix.timestamp)
+    }
+
+    /// Applies a membership verdict and delivers the crossing when it changes the stored belief.
+    /// `evidence` is the fix's timestamp, or `nil` for the covering-circle exit, which is
+    /// geometric rather than fix-derived and so is never outranked by a newer belief.
+    private func apply(_ membership: PolygonMembership, to geofence: Geofence, evidence: Date?) async {
+        let outcome = await storage.recordPolygonMembership(
+            membership,
+            forIdentifier: geofence.id,
+            onlyIfBeliefPredates: evidence
+        )
+        guard case .deliver(let transition) = outcome,
+              geofence.transitionTypes.contains(transition)
+        else { return }
+        logger.geofencePolygonTransition(
+            identifier: geofence.id,
+            transition: transition,
+            confirmedByFix: evidence != nil
+        )
+        await transitionEmitter.trackTransition(geofenceId: geofence.id, transition: transition)
+    }
+
+    private func cachedGeofence(id: String) async -> Geofence? {
+        await storage.getCachedGeofences().first { $0.id == id }
+    }
+
+    /// Freshest fix obtainable, requesting one when the cache is stale. Mirrors the gate's
+    /// resolution: the completion's coordinates are discarded in favour of `latestFix`, which
+    /// carries the accuracy and timestamp the decision needs.
+    private func resolveFix() async -> CLLocation? {
+        await withCheckedContinuation { continuation in
+            fixResolver.resolve(cached: fixResolver.latestFix) { [weak self] _ in
+                continuation.resume(returning: self?.fixResolver.latestFix)
+            }
+        }
+    }
+}
+
+// MARK: - DI
+
+extension DIGraphShared {
+    /// Hand-written + `@MainActor`-isolated for the same reason as `geofenceMonitor`: the resolver
+    /// owns a `MovementFixResolver`, which owns a `CLLocationManager`. Override-check mirrors the
+    /// generated accessors so tests can substitute via `di.override(value:forType:)`.
+    @MainActor
+    var polygonMembershipResolver: PolygonMembershipResolver {
+        let overridden: PolygonMembershipResolver? = getOverriddenInstance()
+        return overridden ?? PolygonMembershipResolver.shared
+    }
+}
+
+extension PolygonMembershipResolver {
+    /// Process-wide singleton so one `CLLocationManager` serves every evaluation; the resolver
+    /// itself is stateless, all belief lives in `GeofenceStorage`.
+    @MainActor
+    static let shared = PolygonMembershipResolver(
+        storage: DIGraphShared.shared.geofenceStorage,
+        transitionEmitter: DIGraphShared.shared.geofenceEventTracker,
+        logger: DIGraphShared.shared.logger
+    )
+}

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -41,9 +41,13 @@ final class PolygonMembershipResolver {
         self.storage = storage
         self.transitionEmitter = transitionEmitter
         self.logger = logger
+        // Ten metres, not the hundred the circle path uses: a verdict needs the device farther from
+        // the boundary than the fix is accurate, so a hundred-metre fix cannot decide anything for a
+        // polygon near the minimum monitored size.
         self.fixResolver = fixResolver ?? MovementFixResolver(
             logger: logger,
-            backgroundTaskRunner: GeofenceBackgroundTime.runner(name: "io.customer.geofence.polygon-fix")
+            backgroundTaskRunner: GeofenceBackgroundTime.runner(name: "io.customer.geofence.polygon-fix"),
+            desiredAccuracy: kCLLocationAccuracyNearestTenMeters
         )
         registerForegroundEvaluation()
     }
@@ -61,19 +65,26 @@ final class PolygonMembershipResolver {
     /// condition the cache has dropped) is forwarded rather than dropped: treating it as a circle
     /// is the behaviour that predates polygons, and losing a real crossing is worse than a
     /// covering-circle-shaped one.
-    func handleTransition(identifier: String, transition: GeofenceTransition) async {
+    func handleTransition(identifier: String, transition: GeofenceTransition, occurredAt: Date? = nil) async {
         logger.geofenceOsTransitionReceived(identifier: identifier, transition: transition)
-        guard let geofence = await cachedGeofence(id: identifier),
-              let polygon = geofence.polygonRegion
-        else {
+        guard let geofence = await cachedGeofence(id: identifier), geofence.vertices != nil else {
+            // Uncached, or a genuine circle: forward untouched, the behaviour that predates polygons.
             await transitionEmitter.trackTransition(geofenceId: identifier, transition: transition)
+            return
+        }
+        guard let polygon = geofence.polygonRegion else {
+            // A stored ring that no longer builds is NOT a circle — forwarding it would fire a
+            // customer enter anywhere inside the covering circle.
+            logger.geofencePolygonUndecided(identifier: identifier, reason: "stored ring no longer builds")
             return
         }
         switch transition {
         case .exit:
-            // polygon ⊆ covering circle, so leaving the circle is geometric certainty and needs
-            // no fix.
-            await apply(.outside, to: geofence, evidence: nil)
+            // polygon ⊆ covering circle, so leaving the circle is geometric certainty and needs no
+            // fix. It is still ORDERED against the stored belief: a synthesized or replayed exit
+            // arriving after a newer enter would otherwise swallow it and leave the device believed
+            // outside while it sits inside.
+            await apply(.outside, to: geofence, evidence: occurredAt)
         case .enter:
             await evaluate(geofence: geofence, polygon: polygon)
         }
@@ -132,8 +143,9 @@ final class PolygonMembershipResolver {
     }
 
     /// Applies a membership verdict and delivers the crossing when it changes the stored belief.
-    /// `evidence` is the fix's timestamp, or `nil` for the covering-circle exit, which is
-    /// geometric rather than fix-derived and so is never outranked by a newer belief.
+    /// `evidence` is when the crossing happened — a fix's timestamp, or the OS event's date for a
+    /// covering-circle exit. `nil` only when the caller has no date, which leaves the write
+    /// unordered against the stored belief.
     private func apply(_ membership: PolygonMembership, to geofence: Geofence, evidence: Date?) async {
         let outcome = await storage.recordPolygonMembership(
             membership,
@@ -160,8 +172,11 @@ final class PolygonMembershipResolver {
     /// carries the accuracy and timestamp the decision needs.
     private func resolveFix() async -> CLLocation? {
         await withCheckedContinuation { continuation in
-            fixResolver.resolve(cached: fixResolver.latestFix) { [weak self] _ in
-                continuation.resume(returning: self?.fixResolver.latestFix)
+            fixResolver.resolve(cached: fixResolver.cachedFix) { [weak self] _ in
+                // `cachedFix` again on failure: on a cold process this resolver has delivered
+                // nothing, and the monitor has already advanced its dedup baseline, so declining
+                // here loses the crossing for good. The decision's age gate bounds how stale it can be.
+                continuation.resume(returning: self?.fixResolver.cachedFix)
             }
         }
     }

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -67,26 +67,26 @@ final class PolygonMembershipResolver {
     /// is the behaviour that predates polygons, and losing a real crossing is worse than a
     /// covering-circle-shaped one.
     func handleTransition(identifier: String, transition: GeofenceTransition, occurredAt: Date) async {
-        logger.geofenceOsTransitionReceived(identifier: identifier, transition: transition)
         guard let geofence = await cachedGeofence(id: identifier), geofence.vertices != nil else {
             // Uncached, or a genuine circle: forward untouched, the behaviour that predates polygons.
             await transitionEmitter.trackTransition(geofenceId: identifier, transition: transition)
             return
         }
-        guard let polygon = geofence.polygonRegion else {
-            // A stored ring that no longer builds is NOT a circle — forwarding it would fire a
-            // customer enter anywhere inside the covering circle.
-            logger.geofencePolygonUndecided(identifier: identifier, reason: "stored ring no longer builds")
-            return
-        }
         switch transition {
         case .exit:
-            // polygon ⊆ covering circle, so leaving the circle is geometric certainty and needs no
-            // fix. It is still ORDERED against the stored belief: a synthesized or replayed exit
-            // arriving after a newer enter would otherwise swallow it and leave the device believed
-            // outside while it sits inside.
+            // polygon ⊆ covering circle, so leaving the circle is geometric certainty: it needs no
+            // fix, and no ring either — which is why this runs before the geometry is built. It is
+            // still ORDERED against the stored belief: a synthesized or replayed exit arriving
+            // after a newer enter would otherwise swallow it and leave the device believed outside
+            // while it sits inside.
             await apply(.outside, to: geofence, evidence: occurredAt, confirmedByFix: false)
         case .enter:
+            guard let polygon = geofence.polygonRegion else {
+                // A stored ring that no longer builds is NOT a circle — forwarding it would fire a
+                // customer enter anywhere inside the covering circle.
+                logger.geofencePolygonUndecided(identifier: identifier, reason: "stored ring no longer builds")
+                return
+            }
             await evaluate(geofence: geofence, polygon: polygon)
         }
     }

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -211,7 +211,7 @@ final class PolygonMembershipResolver {
         }
         await apply(
             membership, to: geofence, evidence: fix.timestamp,
-            confirmedByFix: true, isStillCurrent: isStillCurrent
+            confirmedByFix: true, evaluatedRing: geofence.vertices, isStillCurrent: isStillCurrent
         )
     }
 
@@ -226,17 +226,24 @@ final class PolygonMembershipResolver {
     /// the tracker stamps whoever is current when it is entered, and the write below is an await of
     /// its own. The write is left unguarded deliberately — a belief states geometry, true whoever
     /// is signed in; an emit is an ATTRIBUTION, and attribution is what a switch invalidates.
+    ///
+    /// `evaluatedRing` is the geometry the verdict was computed from, and the write is refused if
+    /// the workspace has moved off it since. Nil from the covering-circle exit, and that is not an
+    /// omission: polygon ⊆ circle holds for whatever ring is current, so leaving the circle is a
+    /// verdict no replacement can invalidate. Only a ring-derived verdict can go stale with the ring.
     private func apply(
         _ membership: PolygonMembership,
         to geofence: Geofence,
         evidence: Date,
         confirmedByFix: Bool,
+        evaluatedRing: [LocationData]? = nil,
         isStillCurrent: (@Sendable () -> Bool)? = nil
     ) async {
         let outcome = await storage.recordPolygonMembership(
             membership,
             forIdentifier: geofence.id,
-            onlyIfBeliefPredates: evidence
+            onlyIfBeliefPredates: evidence,
+            onlyIfRingMatches: evaluatedRing
         )
         guard case .deliver(let transition) = outcome,
               geofence.transitionTypes.contains(transition)

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -85,19 +85,16 @@ final class PolygonMembershipResolver {
         }
         switch transition {
         case .exit:
-            // The certainty is polygon ⊆ ITS OWN covering circle, so it only transfers when the
-            // circle crossed is the one this fence still has. A refresh replaces the ring and the
-            // circle together, and leaving the old circle says nothing about the new ring — the
-            // device can stand inside it. Refusing leaves the belief for a fix to decide; writing
-            // `outside` here would also stamp a date no older fix can then correct.
-            if let eventCircle, !eventCircle.matches(geofence) {
-                logger.geofencePolygonUndecided(identifier: identifier, reason: "exit was for a replaced circle")
-                return
-            }
-            // No ring needed — which is why this runs before the geometry is built. Still ORDERED
-            // against the stored belief: a synthesized or replayed exit arriving after a newer
-            // enter would otherwise swallow it and leave the device believed outside while inside.
-            await apply(.outside, to: geofence, evidence: occurredAt, confirmedByFix: false)
+            // No ring needed — leaving a circle says nothing about a ring — but the certainty is
+            // polygon ⊆ ITS OWN covering circle, so the crossed circle has to still be the fence's.
+            // That is checked inside the write, not here: a refresh landing between this hop and
+            // the store would otherwise leave `outside` recorded for a device inside the
+            // replacement polygon, stamped with a date no older fix can correct. A nil circle means
+            // the producer could not say which one was crossed, and is treated as current.
+            await apply(
+                .outside, to: geofence, evidence: occurredAt,
+                confirmedByFix: false, evaluatedCircle: eventCircle
+            )
         case .enter:
             guard geofence.polygonRegion != nil else {
                 // A stored ring that no longer builds is NOT a circle — forwarding it would fire a
@@ -249,13 +246,15 @@ final class PolygonMembershipResolver {
         evidence: Date,
         confirmedByFix: Bool,
         evaluatedRing: [LocationData]? = nil,
+        evaluatedCircle: MonitoredCircle? = nil,
         isStillCurrent: (@Sendable () -> Bool)? = nil
     ) async {
         let outcome = await storage.recordPolygonMembership(
             membership,
             forIdentifier: geofence.id,
             onlyIfBeliefPredates: evidence,
-            onlyIfRingMatches: evaluatedRing
+            onlyIfRingMatches: evaluatedRing,
+            onlyIfCircleMatches: evaluatedCircle
         )
         guard case .deliver(let transition) = outcome,
               geofence.transitionTypes.contains(transition)

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -30,6 +30,8 @@ final class PolygonMembershipResolver {
     private let transitionEmitter: GeofenceTransitionEmitting
     private let fixResolver: MovementFixResolver
     private let logger: Logger
+    private let contextStore: BackgroundDeliveryContextStore
+    private let notificationCenter: NotificationCenter
     private var foregroundObserverToken: NSObjectProtocol?
     private var isEvaluatingAllPolygons = false
 
@@ -37,11 +39,15 @@ final class PolygonMembershipResolver {
         storage: GeofenceStorage,
         transitionEmitter: GeofenceTransitionEmitting,
         logger: Logger,
-        fixResolver: MovementFixResolver? = nil
+        contextStore: BackgroundDeliveryContextStore,
+        fixResolver: MovementFixResolver? = nil,
+        notificationCenter: NotificationCenter = .default
     ) {
         self.storage = storage
         self.transitionEmitter = transitionEmitter
         self.logger = logger
+        self.contextStore = contextStore
+        self.notificationCenter = notificationCenter
         // Ten metres, not the hundred the circle path uses: a verdict needs the device farther from
         // the boundary than the fix is accurate, so a hundred-metre fix cannot decide anything for a
         // polygon near the minimum monitored size.
@@ -55,7 +61,7 @@ final class PolygonMembershipResolver {
 
     deinit {
         if let foregroundObserverToken {
-            NotificationCenter.default.removeObserver(foregroundObserverToken)
+            notificationCenter.removeObserver(foregroundObserverToken)
         }
     }
 
@@ -81,13 +87,13 @@ final class PolygonMembershipResolver {
             // while it sits inside.
             await apply(.outside, to: geofence, evidence: occurredAt, confirmedByFix: false)
         case .enter:
-            guard let polygon = geofence.polygonRegion else {
+            guard geofence.polygonRegion != nil else {
                 // A stored ring that no longer builds is NOT a circle — forwarding it would fire a
                 // customer enter anywhere inside the covering circle.
                 logger.geofencePolygonUndecided(identifier: identifier, reason: "stored ring no longer builds")
                 return
             }
-            await evaluate(geofence: geofence, polygon: polygon)
+            await evaluate(geofenceId: identifier)
         }
     }
 
@@ -100,7 +106,7 @@ final class PolygonMembershipResolver {
     ///
     /// Foregrounds arrive in bursts, so a pass already running wins: a second concurrent scan reads
     /// the same storage and the same fix and can only duplicate the location work.
-    func evaluateAllPolygons() async {
+    func evaluateAllPolygons(isStillCurrent: (@Sendable () -> Bool)? = nil) async {
         guard !isEvaluatingAllPolygons else {
             logger.geofencePolygonPassSkipped(reason: "a pass is already running")
             return
@@ -121,37 +127,73 @@ final class PolygonMembershipResolver {
             return
         }
         for geofence in polygons {
-            guard let polygon = geofence.polygonRegion else { continue }
-            await evaluate(geofence: geofence, polygon: polygon, fix: fix)
+            await evaluate(geofenceId: geofence.id, fix: fix, isStillCurrent: isStillCurrent)
         }
     }
 
     private func registerForegroundEvaluation() {
         #if canImport(UIKit)
-        foregroundObserverToken = NotificationCenter.default.addObserver(
+        foregroundObserverToken = notificationCenter.addObserver(
             forName: UIApplication.willEnterForegroundNotification,
             object: nil,
             queue: .main
         ) { [weak self] _ in
             MainActor.assumeIsolated {
                 guard let self else { return }
-                Task { await self.evaluateAllPolygons() }
+                // Sampled here, not read at emit time: the pass resolves a fix first, and a
+                // foregrounding app's cached fix is normally stale — the app was suspended — so
+                // that request really does suspend. No caller supplies an expected user on this
+                // path, so the observer takes its own.
+                //
+                // Anonymous at both ends compares nil to nil and proceeds; that is safe only
+                // because a signed-out process has no `monitoredGeofenceIds`, so the pass returns
+                // empty before it resolves anything. Registration while anonymous would break it.
+                let expectedUserId = self.contextStore.currentUserId
+                Task { [contextStore = self.contextStore] in
+                    await self.evaluateAllPolygons(
+                        isStillCurrent: { contextStore.currentUserId == expectedUserId }
+                    )
+                }
             }
         }
         #endif
     }
 
-    private func evaluate(geofence: Geofence, polygon: PolygonRegion) async {
+    private func evaluate(geofenceId: String, isStillCurrent: (@Sendable () -> Bool)? = nil) async {
         guard let fix = await resolveFix() else {
-            logger.geofencePolygonUndecided(identifier: geofence.id, reason: "no usable fix")
+            logger.geofencePolygonUndecided(identifier: geofenceId, reason: "no usable fix")
             return
         }
-        await evaluate(geofence: geofence, polygon: polygon, fix: fix)
+        await evaluate(geofenceId: geofenceId, fix: fix, isStillCurrent: isStillCurrent)
     }
 
-    private func evaluate(geofence: Geofence, polygon: PolygonRegion, fix: CLLocation) async {
+    /// Takes an id, never a caller's `PolygonRegion`: resolving a fix suspends, and a refresh can
+    /// replace the fence under the same id while it does. A ring captured before the await would
+    /// decide against geometry the workspace has already moved off — no user switch required — so
+    /// the current one is read here and the stale copy is never in scope to be used by mistake.
+    ///
+    /// Registration is re-read with it, from the same load: a fence unregistered during the fix
+    /// must not be judged either, and sampling one before the await and the other after is how the
+    /// two come to disagree. Costs one state decode per polygon, which is the price of the pass's
+    /// verdicts being at most one hop stale rather than a whole location request stale — do not
+    /// trade it back for a single snapshot without knowing that is what is being traded.
+    private func evaluate(
+        geofenceId: String,
+        fix: CLLocation,
+        isStillCurrent: (@Sendable () -> Bool)? = nil
+    ) async {
         guard CLLocationCoordinate2DIsValid(fix.coordinate) else {
-            logger.geofencePolygonUndecided(identifier: geofence.id, reason: "no usable fix")
+            logger.geofencePolygonUndecided(identifier: geofenceId, reason: "no usable fix")
+            return
+        }
+        if let isStillCurrent, !isStillCurrent() {
+            logger.geofencePolygonUndecided(identifier: geofenceId, reason: "user changed while resolving the fix")
+            return
+        }
+        guard let geofence = await storage.getRegisteredGeofence(id: geofenceId),
+              let polygon = geofence.polygonRegion
+        else {
+            logger.geofencePolygonUndecided(identifier: geofenceId, reason: "no longer a registered polygon")
             return
         }
         let point = LocationData(latitude: fix.coordinate.latitude, longitude: fix.coordinate.longitude)
@@ -167,7 +209,10 @@ final class PolygonMembershipResolver {
             )
             return
         }
-        await apply(membership, to: geofence, evidence: fix.timestamp, confirmedByFix: true)
+        await apply(
+            membership, to: geofence, evidence: fix.timestamp,
+            confirmedByFix: true, isStillCurrent: isStillCurrent
+        )
     }
 
     /// Applies a membership verdict and delivers the crossing when it changes the stored belief.
@@ -176,11 +221,17 @@ final class PolygonMembershipResolver {
     /// belief, and a caller allowed to omit it could silently write an unordered one. `confirmedByFix`
     /// says which of the two it was, since both carry a date and the date alone cannot tell the log
     /// how membership was decided.
+    ///
+    /// `isStillCurrent` is re-checked here, immediately before the emit and with no await after it:
+    /// the tracker stamps whoever is current when it is entered, and the write below is an await of
+    /// its own. The write is left unguarded deliberately — a belief states geometry, true whoever
+    /// is signed in; an emit is an ATTRIBUTION, and attribution is what a switch invalidates.
     private func apply(
         _ membership: PolygonMembership,
         to geofence: Geofence,
         evidence: Date,
-        confirmedByFix: Bool
+        confirmedByFix: Bool,
+        isStillCurrent: (@Sendable () -> Bool)? = nil
     ) async {
         let outcome = await storage.recordPolygonMembership(
             membership,
@@ -190,6 +241,10 @@ final class PolygonMembershipResolver {
         guard case .deliver(let transition) = outcome,
               geofence.transitionTypes.contains(transition)
         else { return }
+        if let isStillCurrent, !isStillCurrent() {
+            logger.geofencePolygonUndecided(identifier: geofence.id, reason: "user changed before delivery")
+            return
+        }
         logger.geofencePolygonTransition(
             identifier: geofence.id,
             transition: transition,
@@ -215,28 +270,4 @@ final class PolygonMembershipResolver {
             }
         }
     }
-}
-
-// MARK: - DI
-
-extension DIGraphShared {
-    /// Hand-written + `@MainActor`-isolated for the same reason as `geofenceMonitor`: the resolver
-    /// owns a `MovementFixResolver`, which owns a `CLLocationManager`. Override-check mirrors the
-    /// generated accessors so tests can substitute via `di.override(value:forType:)`.
-    @MainActor
-    var polygonMembershipResolver: PolygonMembershipResolver {
-        let overridden: PolygonMembershipResolver? = getOverriddenInstance()
-        return overridden ?? PolygonMembershipResolver.shared
-    }
-}
-
-extension PolygonMembershipResolver {
-    /// Process-wide singleton so one `CLLocationManager` serves every evaluation; the resolver
-    /// itself is stateless, all belief lives in `GeofenceStorage`.
-    @MainActor
-    static let shared = PolygonMembershipResolver(
-        storage: DIGraphShared.shared.geofenceStorage,
-        transitionEmitter: DIGraphShared.shared.geofenceEventTracker,
-        logger: DIGraphShared.shared.logger
-    )
 }

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -72,7 +72,12 @@ final class PolygonMembershipResolver {
     /// condition the cache has dropped) is forwarded rather than dropped: treating it as a circle
     /// is the behaviour that predates polygons, and losing a real crossing is worse than a
     /// covering-circle-shaped one.
-    func handleTransition(identifier: String, transition: GeofenceTransition, occurredAt: Date) async {
+    func handleTransition(
+        identifier: String,
+        transition: GeofenceTransition,
+        occurredAt: Date,
+        eventCircle: MonitoredCircle? = nil
+    ) async {
         guard let geofence = await cachedGeofence(id: identifier), geofence.vertices != nil else {
             // Uncached, or a genuine circle: forward untouched, the behaviour that predates polygons.
             await transitionEmitter.trackTransition(geofenceId: identifier, transition: transition)
@@ -80,11 +85,18 @@ final class PolygonMembershipResolver {
         }
         switch transition {
         case .exit:
-            // polygon ⊆ covering circle, so leaving the circle is geometric certainty: it needs no
-            // fix, and no ring either — which is why this runs before the geometry is built. It is
-            // still ORDERED against the stored belief: a synthesized or replayed exit arriving
-            // after a newer enter would otherwise swallow it and leave the device believed outside
-            // while it sits inside.
+            // The certainty is polygon ⊆ ITS OWN covering circle, so it only transfers when the
+            // circle crossed is the one this fence still has. A refresh replaces the ring and the
+            // circle together, and leaving the old circle says nothing about the new ring — the
+            // device can stand inside it. Refusing leaves the belief for a fix to decide; writing
+            // `outside` here would also stamp a date no older fix can then correct.
+            if let eventCircle, eventCircle != geofence.monitoredCircle {
+                logger.geofencePolygonUndecided(identifier: identifier, reason: "exit was for a replaced circle")
+                return
+            }
+            // No ring needed — which is why this runs before the geometry is built. Still ORDERED
+            // against the stored belief: a synthesized or replayed exit arriving after a newer
+            // enter would otherwise swallow it and leave the device believed outside while inside.
             await apply(.outside, to: geofence, evidence: occurredAt, confirmedByFix: false)
         case .enter:
             guard geofence.polygonRegion != nil else {

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -90,7 +90,7 @@ final class PolygonMembershipResolver {
             // circle together, and leaving the old circle says nothing about the new ring — the
             // device can stand inside it. Refusing leaves the belief for a fix to decide; writing
             // `outside` here would also stamp a date no older fix can then correct.
-            if let eventCircle, eventCircle != geofence.monitoredCircle {
+            if let eventCircle, !eventCircle.matches(geofence) {
                 logger.geofencePolygonUndecided(identifier: identifier, reason: "exit was for a replaced circle")
                 return
             }

--- a/Sources/LocationGeofence/Storage/GeofenceStorage+PolygonMembership.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage+PolygonMembership.swift
@@ -40,6 +40,7 @@ extension GeofenceStorage {
         forIdentifier identifier: String,
         onlyIfBeliefPredates evidenceTimestamp: Date? = nil,
         onlyIfRingMatches evaluatedRing: [LocationData]? = nil,
+        onlyIfCircleMatches evaluatedCircle: MonitoredCircle? = nil,
         now: Date = Date()
     ) -> PolygonMembershipOutcome {
         var state = loadFromDisk() ?? GeofenceState()
@@ -51,6 +52,16 @@ extension GeofenceStorage {
         if let evaluatedRing {
             let currentRing = state.cachedGeofences?.first { $0.id == identifier }?.vertices
             guard currentRing == evaluatedRing else { return .suppressedGeometryChanged }
+        }
+        // The covering exit's equivalent. It carries no ring — leaving a circle says nothing about
+        // a ring — but the certainty it rests on is polygon ⊆ ITS OWN circle, so it holds only
+        // while the fence still has the circle that was crossed. Checked here rather than before
+        // the hop for the same reason as the ring: a refresh landing in between would otherwise
+        // store `outside` for a device inside the replacement polygon.
+        if let evaluatedCircle {
+            guard let current = state.cachedGeofences?.first(where: { $0.id == identifier }),
+                  evaluatedCircle.matches(current)
+            else { return .suppressedGeometryChanged }
         }
         var records = state.polygonMembership ?? [:]
         let existing = records[identifier]

--- a/Sources/LocationGeofence/Storage/GeofenceStorage+PolygonMembership.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage+PolygonMembership.swift
@@ -80,6 +80,15 @@ extension GeofenceStorage {
         return .deliver(membership == .inside ? .enter : .exit)
     }
 
+    /// The cached fence for `id`, but only while it is still registered — both read from one load,
+    /// so the geometry and the registration a verdict rests on cannot disagree with each other.
+    /// A pass that sampled either before awaiting a fix must re-read through here afterwards.
+    func getRegisteredGeofence(id: String) -> Geofence? {
+        guard let state = loadFromDisk(), state.monitoredGeofenceIds?.contains(id) == true
+        else { return nil }
+        return state.cachedGeofences?.first { $0.id == id }
+    }
+
     /// Snapshot of every polygon membership belief.
     func getPolygonMembership() -> [String: PolygonMembershipRecord] {
         loadFromDisk()?.polygonMembership ?? [:]

--- a/Sources/LocationGeofence/Storage/GeofenceStorage+PolygonMembership.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage+PolygonMembership.swift
@@ -39,9 +39,19 @@ extension GeofenceStorage {
         _ membership: PolygonMembership,
         forIdentifier identifier: String,
         onlyIfBeliefPredates evidenceTimestamp: Date? = nil,
+        onlyIfRingMatches evaluatedRing: [LocationData]? = nil,
         now: Date = Date()
     ) -> PolygonMembershipOutcome {
         var state = loadFromDisk() ?? GeofenceState()
+        // Read and compared inside the same actor call that writes, because that is the only place
+        // the two cannot be separated. The evaluation's own re-read closes the location request;
+        // this closes what is left — deciding on the main actor and then hopping here to write, a
+        // gap a refresh can land in. The ring itself, not `lastUpdated`: the server owns that field
+        // and a replacement that failed to bump it would pass a check written against it.
+        if let evaluatedRing {
+            let currentRing = state.cachedGeofences?.first { $0.id == identifier }?.vertices
+            guard currentRing == evaluatedRing else { return .suppressedGeometryChanged }
+        }
         var records = state.polygonMembership ?? [:]
         let existing = records[identifier]
         if let evidenceTimestamp, let existing, existing.lastChangedAt > evidenceTimestamp {

--- a/Tests/LocationGeofence/Geofence/Monitor/MovementFixResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Monitor/MovementFixResolverTests.swift
@@ -238,6 +238,40 @@ struct MovementFixResolverTests {
         #expect(runner.finished.wrappedValue == 1)
         #expect(received.map(\.?.latitude) == [32.7])
     }
+
+    /// CoreLocation's cache advances on its own between passes — other clients in the process keep
+    /// it moving — so it can hold a newer fix than anything this resolver has delivered. Preferring
+    /// `latestFix` by source rather than by age would request a fix that is already in hand and,
+    /// when that request fails, fall back to the older of the two.
+    @Test
+    func cachedFix_givenSystemCacheNewerThanDeliveredFix_expectSystemCache() {
+        let resolver = makeResolver()
+        let systemFix = makeFix(latitude: 31.7, ageSeconds: 5)
+        resolver.handleResolvedFix(makeFix(latitude: 31.1, ageSeconds: 120))
+        resolver.systemCachedFix = { systemFix }
+
+        #expect(resolver.cachedFix?.coordinate.latitude == 31.7)
+    }
+
+    @Test
+    func cachedFix_givenDeliveredFixNewerThanSystemCache_expectDeliveredFix() {
+        let resolver = makeResolver()
+        let systemFix = makeFix(latitude: 31.7, ageSeconds: 120)
+        resolver.handleResolvedFix(makeFix(latitude: 31.1, ageSeconds: 5))
+        resolver.systemCachedFix = { systemFix }
+
+        #expect(resolver.cachedFix?.coordinate.latitude == 31.1)
+    }
+
+    /// The seam stands in for CoreLocation entirely: a seam returning nil must not fall through to
+    /// the real manager, or a unit test would reach for the device's location.
+    @Test
+    func cachedFix_givenSeamReturnsNilAndNothingDelivered_expectNil() {
+        let resolver = makeResolver()
+        resolver.systemCachedFix = { nil }
+
+        #expect(resolver.cachedFix == nil)
+    }
 }
 
 /// Records entry/exit of the background-time window so tests can assert it brackets the request.

--- a/Tests/LocationGeofence/Geofence/Monitor/MovementFixResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Monitor/MovementFixResolverTests.swift
@@ -263,6 +263,19 @@ struct MovementFixResolverTests {
         #expect(resolver.cachedFix?.coordinate.latitude == 31.1)
     }
 
+    /// An invalid cached coordinate must not win on age alone. It never becomes a verdict — the
+    /// consumers re-check — but as the freshness baseline it makes a genuinely newer delivered fix
+    /// look not-newer, and the verdict that fix was requested for is then refused.
+    @Test
+    func cachedFix_givenSystemCacheNewerButInvalid_expectDeliveredFix() {
+        let resolver = makeResolver()
+        let invalidFix = makeFix(latitude: 91.0, longitude: 181.0, ageSeconds: 1)
+        resolver.handleResolvedFix(makeFix(latitude: 31.1, ageSeconds: 120))
+        resolver.systemCachedFix = { invalidFix }
+
+        #expect(resolver.cachedFix?.coordinate.latitude == 31.1)
+    }
+
     /// The seam stands in for CoreLocation entirely: a seam returning nil must not fall through to
     /// the real manager, or a unit test would reach for the device's location.
     @Test

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -1,0 +1,252 @@
+@testable import CioInternalCommon
+@testable import CioInternalCommonMocks
+@testable import CioLocationGeofence
+@testable import CioLocationGeofenceMocks
+import CoreLocation
+import Foundation
+import SharedTests
+import Testing
+
+@Suite("PolygonMembershipResolver")
+@MainActor
+struct PolygonMembershipResolverTests {
+    /// Records what reached the event tracker, standing in for the real one.
+    private actor EmitterSpy: GeofenceTransitionEmitting {
+        private(set) var delivered: [(id: String, transition: GeofenceTransition)] = []
+
+        func trackTransition(geofenceId: String, transition: GeofenceTransition) async {
+            delivered.append((geofenceId, transition))
+        }
+
+        func snapshot() -> [(id: String, transition: GeofenceTransition)] {
+            delivered
+        }
+    }
+
+    /// A ~360 m square centred on the origin: comfortably past the 20 m margin floor at the centre,
+    /// so a precise fix there is decisive.
+    private static let squareVertices = [
+        LocationData(latitude: -0.0016, longitude: -0.0016),
+        LocationData(latitude: -0.0016, longitude: 0.0016),
+        LocationData(latitude: 0.0016, longitude: 0.0016),
+        LocationData(latitude: 0.0016, longitude: -0.0016)
+    ]
+
+    private func polygonGeofence(id: String = "1", transitionTypes: Set<GeofenceTransition> = [.enter, .exit]) -> Geofence {
+        Geofence(
+            id: id, latitude: 0, longitude: 0, radius: 300, name: "poly",
+            transitionTypes: transitionTypes, lastUpdated: Date(), vertices: Self.squareVertices
+        )
+    }
+
+    private func circleGeofence(id: String = "2") -> Geofence {
+        Geofence(
+            id: id, latitude: 0, longitude: 0, radius: 300, name: "circle",
+            transitionTypes: [.enter, .exit], lastUpdated: Date()
+        )
+    }
+
+    private struct Setup {
+        let resolver: PolygonMembershipResolver
+        let storage: GeofenceStorage
+        let emitter: EmitterSpy
+        let fixResolver: MovementFixResolver
+    }
+
+    private func makeSetup(fix: CLLocation?) async -> Setup {
+        let storage = GeofenceStorage(
+            fileManager: .default,
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        let emitter = EmitterSpy()
+        let fixResolver = MovementFixResolver(logger: LoggerMock())
+        // Seam: resolve inline with the supplied fix instead of touching CoreLocation.
+        fixResolver.requestFreshFix = { [weak fixResolver] in
+            guard let fix else { return fixResolver?.handleRequestFailure() ?? () }
+            fixResolver?.handleResolvedFix(fix)
+        }
+        return Setup(
+            resolver: PolygonMembershipResolver(
+                storage: storage,
+                transitionEmitter: emitter,
+                logger: LoggerMock(),
+                fixResolver: fixResolver
+            ),
+            storage: storage,
+            emitter: emitter,
+            fixResolver: fixResolver
+        )
+    }
+
+    private func fix(latitude: Double, longitude: Double, accuracy: Double = 5) -> CLLocation {
+        CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: latitude, longitude: longitude),
+            altitude: 0,
+            horizontalAccuracy: accuracy,
+            verticalAccuracy: 5,
+            timestamp: Date()
+        )
+    }
+
+    // MARK: - Circle fences pass through untouched
+
+    @Test
+    func handleTransition_givenCircleGeofence_expectForwardedUnchanged() async {
+        let setup = await makeSetup(fix: nil)
+        await setup.storage.setCachedGeofences([circleGeofence()])
+
+        await setup.resolver.handleTransition(identifier: "2", transition: .enter)
+
+        let delivered = await setup.emitter.snapshot()
+        #expect(delivered.count == 1)
+        #expect(delivered.first?.transition == .enter)
+    }
+
+    /// A sync can drop a geofence the OS still holds a condition for. Forwarding beats dropping:
+    /// losing a real crossing is worse than one shaped like its covering circle.
+    @Test
+    func handleTransition_givenUncachedGeofence_expectForwarded() async {
+        let setup = await makeSetup(fix: nil)
+
+        await setup.resolver.handleTransition(identifier: "999", transition: .exit)
+
+        #expect(await setup.emitter.snapshot().count == 1)
+    }
+
+    // MARK: - Covering-circle enter
+
+    @Test
+    func handleTransition_givenPolygonEnterAndFixInside_expectEnterDelivered() async {
+        let setup = await makeSetup(fix: fix(latitude: 0, longitude: 0))
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter)
+
+        let delivered = await setup.emitter.snapshot()
+        #expect(delivered.count == 1)
+        #expect(delivered.first?.transition == .enter)
+        #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
+    }
+
+    /// The annulus: inside the covering circle, outside the polygon. The OS thinks we arrived;
+    /// geometry says otherwise, so nothing is delivered and the belief records `outside`.
+    @Test
+    func handleTransition_givenPolygonEnterAndFixInAnnulus_expectNoEvent() async {
+        let setup = await makeSetup(fix: fix(latitude: 0.0024, longitude: 0))
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter)
+
+        #expect(await setup.emitter.snapshot().isEmpty)
+        #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .outside)
+    }
+
+    /// A fix too coarse to place the device relative to the boundary must leave no belief behind:
+    /// guessing either way would deliver an event we cannot stand behind.
+    @Test
+    func handleTransition_givenUndecidableFix_expectNoBelief() async {
+        let setup = await makeSetup(fix: fix(latitude: 0, longitude: 0, accuracy: 400))
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter)
+
+        #expect(await setup.emitter.snapshot().isEmpty)
+        #expect(await setup.storage.getPolygonMembership()["1"] == nil)
+    }
+
+    @Test
+    func handleTransition_givenNoFixObtainable_expectNothingRecorded() async {
+        let setup = await makeSetup(fix: nil)
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter)
+
+        #expect(await setup.emitter.snapshot().isEmpty)
+        #expect(await setup.storage.getPolygonMembership()["1"] == nil)
+    }
+
+    // MARK: - Covering-circle exit
+
+    /// polygon ⊆ circle, so leaving the circle proves the polygon was left — no fix required.
+    @Test
+    func handleTransition_givenPolygonExitWhileInside_expectExitDeliveredWithoutFix() async {
+        let setup = await makeSetup(fix: nil)
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+        _ = await setup.storage.recordPolygonMembership(.inside, forIdentifier: "1")
+
+        await setup.resolver.handleTransition(identifier: "1", transition: .exit)
+
+        let delivered = await setup.emitter.snapshot()
+        #expect(delivered.count == 1)
+        #expect(delivered.first?.transition == .exit)
+    }
+
+    @Test
+    func handleTransition_givenPolygonExitWhileNotInside_expectSilent() async {
+        let setup = await makeSetup(fix: nil)
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+        _ = await setup.storage.recordPolygonMembership(.outside, forIdentifier: "1")
+
+        await setup.resolver.handleTransition(identifier: "1", transition: .exit)
+
+        #expect(await setup.emitter.snapshot().isEmpty)
+    }
+
+    // MARK: - Foreground evaluation
+
+    /// The case no OS event reaches: a device already standing inside a polygon when monitoring
+    /// begins has crossed nothing, and standing still produces no movement pass either.
+    /// Foregrounding is the remaining signal.
+    @Test
+    func evaluateAllPolygons_givenDeviceInsideOneRegisteredPolygon_expectEnterForThatOneOnly() async {
+        let setup = await makeSetup(fix: fix(latitude: 0, longitude: 0))
+        let distant = Geofence(
+            id: "2", latitude: 1, longitude: 1, radius: 300, name: "far",
+            transitionTypes: [.enter, .exit], lastUpdated: Date(),
+            vertices: Self.squareVertices.map {
+                LocationData(latitude: $0.latitude + 1, longitude: $0.longitude + 1)
+            }
+        )
+        await setup.storage.setCachedGeofences([polygonGeofence(), distant])
+        await setup.storage.recordRegistration(
+            center: LocationData(latitude: 0, longitude: 0), businessIds: ["1", "2"]
+        )
+
+        await setup.resolver.evaluateAllPolygons()
+
+        let delivered = await setup.emitter.snapshot()
+        #expect(delivered.count == 1)
+        #expect(delivered.first?.id == "1")
+        #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
+        #expect(await setup.storage.getPolygonMembership()["2"]?.membership == .outside)
+    }
+
+    /// A polygon that has dropped out of the registered set is no longer monitored, so foreground
+    /// evaluation must not resurrect it.
+    @Test
+    func evaluateAllPolygons_givenUnregisteredPolygon_expectSkipped() async {
+        let setup = await makeSetup(fix: fix(latitude: 0, longitude: 0))
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+        await setup.storage.recordRegistration(
+            center: LocationData(latitude: 0, longitude: 0), businessIds: ["other"]
+        )
+
+        await setup.resolver.evaluateAllPolygons()
+
+        #expect(await setup.emitter.snapshot().isEmpty)
+    }
+
+    // MARK: - Transition-type filter
+
+    @Test
+    func handleTransition_givenEnterOnlyPolygon_expectExitSuppressed() async {
+        let setup = await makeSetup(fix: nil)
+        await setup.storage.setCachedGeofences([polygonGeofence(transitionTypes: [.enter])])
+        _ = await setup.storage.recordPolygonMembership(.inside, forIdentifier: "1")
+
+        await setup.resolver.handleTransition(identifier: "1", transition: .exit)
+
+        #expect(await setup.emitter.snapshot().isEmpty)
+        #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .outside)
+    }
+}

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -92,6 +92,57 @@ struct PolygonMembershipResolverTests {
         )
     }
 
+    /// Counts location requests so a pass that says it shares one fix can be held to it.
+    private final class RequestCounter {
+        var count = 0
+    }
+
+    private func countingRequests(_ setup: Setup) -> RequestCounter {
+        let counter = RequestCounter()
+        setup.fixResolver.requestFreshFix = { [weak fixResolver = setup.fixResolver] in
+            counter.count += 1
+            fixResolver?.handleRequestFailure()
+        }
+        return counter
+    }
+
+    private func registerPolygons(_ setup: Setup, ids: [String]) async {
+        await setup.storage.recordRegistration(
+            center: LocationData(latitude: 0, longitude: 0), businessIds: Set(ids)
+        )
+        await setup.storage.setCachedGeofences(ids.map { polygonGeofence(id: $0) })
+    }
+
+    // MARK: - One fix per pass
+
+    /// A failed request leaves the cache empty, so resolving inside the loop would issue one timed
+    /// request per polygon and hold the main actor for as long as that takes.
+    @Test
+    func evaluateAllPolygons_givenNoFixAvailable_expectOneRequestForTheWholePass() async {
+        let setup = await makeSetup(fix: nil)
+        await registerPolygons(setup, ids: ["1", "2", "3"])
+        let counter = countingRequests(setup)
+
+        await setup.resolver.evaluateAllPolygons()
+
+        #expect(counter.count == 1)
+    }
+
+    /// Foregrounds arrive in bursts. A second concurrent pass reads the same storage and the same
+    /// fix, so it can only duplicate the location work.
+    @Test
+    func evaluateAllPolygons_givenConcurrentPasses_expectSecondSkipped() async {
+        let setup = await makeSetup(fix: nil)
+        await registerPolygons(setup, ids: ["1", "2"])
+        let counter = countingRequests(setup)
+
+        async let first: Void = setup.resolver.evaluateAllPolygons()
+        async let second: Void = setup.resolver.evaluateAllPolygons()
+        _ = await(first, second)
+
+        #expect(counter.count == 1)
+    }
+
     // MARK: - Circle fences pass through untouched
 
     @Test
@@ -99,7 +150,7 @@ struct PolygonMembershipResolverTests {
         let setup = await makeSetup(fix: nil)
         await setup.storage.setCachedGeofences([circleGeofence()])
 
-        await setup.resolver.handleTransition(identifier: "2", transition: .enter)
+        await setup.resolver.handleTransition(identifier: "2", transition: .enter, occurredAt: Date())
 
         let delivered = await setup.emitter.snapshot()
         #expect(delivered.count == 1)
@@ -112,7 +163,7 @@ struct PolygonMembershipResolverTests {
     func handleTransition_givenUncachedGeofence_expectForwarded() async {
         let setup = await makeSetup(fix: nil)
 
-        await setup.resolver.handleTransition(identifier: "999", transition: .exit)
+        await setup.resolver.handleTransition(identifier: "999", transition: .exit, occurredAt: Date())
 
         #expect(await setup.emitter.snapshot().count == 1)
     }
@@ -124,7 +175,7 @@ struct PolygonMembershipResolverTests {
         let setup = await makeSetup(fix: fix(latitude: 0, longitude: 0))
         await setup.storage.setCachedGeofences([polygonGeofence()])
 
-        await setup.resolver.handleTransition(identifier: "1", transition: .enter)
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter, occurredAt: Date())
 
         let delivered = await setup.emitter.snapshot()
         #expect(delivered.count == 1)
@@ -144,7 +195,7 @@ struct PolygonMembershipResolverTests {
         )
         await setup.storage.setCachedGeofences([degenerate])
 
-        await setup.resolver.handleTransition(identifier: "1", transition: .enter)
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter, occurredAt: Date())
 
         #expect(await setup.emitter.snapshot().isEmpty)
         #expect(await setup.storage.getPolygonMembership()["1"] == nil)
@@ -156,7 +207,7 @@ struct PolygonMembershipResolverTests {
     func handleTransition_givenExitOlderThanBelief_expectSuppressed() async {
         let setup = await makeSetup(fix: fix(latitude: 0, longitude: 0))
         await setup.storage.setCachedGeofences([polygonGeofence()])
-        await setup.resolver.handleTransition(identifier: "1", transition: .enter)
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter, occurredAt: Date())
         #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
 
         await setup.resolver.handleTransition(
@@ -174,7 +225,7 @@ struct PolygonMembershipResolverTests {
         let setup = await makeSetup(fix: fix(latitude: 0.0024, longitude: 0))
         await setup.storage.setCachedGeofences([polygonGeofence()])
 
-        await setup.resolver.handleTransition(identifier: "1", transition: .enter)
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter, occurredAt: Date())
 
         #expect(await setup.emitter.snapshot().isEmpty)
         #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .outside)
@@ -187,7 +238,7 @@ struct PolygonMembershipResolverTests {
         let setup = await makeSetup(fix: fix(latitude: 0, longitude: 0, accuracy: 400))
         await setup.storage.setCachedGeofences([polygonGeofence()])
 
-        await setup.resolver.handleTransition(identifier: "1", transition: .enter)
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter, occurredAt: Date())
 
         #expect(await setup.emitter.snapshot().isEmpty)
         #expect(await setup.storage.getPolygonMembership()["1"] == nil)
@@ -198,7 +249,7 @@ struct PolygonMembershipResolverTests {
         let setup = await makeSetup(fix: nil)
         await setup.storage.setCachedGeofences([polygonGeofence()])
 
-        await setup.resolver.handleTransition(identifier: "1", transition: .enter)
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter, occurredAt: Date())
 
         #expect(await setup.emitter.snapshot().isEmpty)
         #expect(await setup.storage.getPolygonMembership()["1"] == nil)
@@ -213,7 +264,7 @@ struct PolygonMembershipResolverTests {
         await setup.storage.setCachedGeofences([polygonGeofence()])
         _ = await setup.storage.recordPolygonMembership(.inside, forIdentifier: "1")
 
-        await setup.resolver.handleTransition(identifier: "1", transition: .exit)
+        await setup.resolver.handleTransition(identifier: "1", transition: .exit, occurredAt: Date())
 
         let delivered = await setup.emitter.snapshot()
         #expect(delivered.count == 1)
@@ -226,7 +277,7 @@ struct PolygonMembershipResolverTests {
         await setup.storage.setCachedGeofences([polygonGeofence()])
         _ = await setup.storage.recordPolygonMembership(.outside, forIdentifier: "1")
 
-        await setup.resolver.handleTransition(identifier: "1", transition: .exit)
+        await setup.resolver.handleTransition(identifier: "1", transition: .exit, occurredAt: Date())
 
         #expect(await setup.emitter.snapshot().isEmpty)
     }
@@ -283,7 +334,7 @@ struct PolygonMembershipResolverTests {
         await setup.storage.setCachedGeofences([polygonGeofence(transitionTypes: [.enter])])
         _ = await setup.storage.recordPolygonMembership(.inside, forIdentifier: "1")
 
-        await setup.resolver.handleTransition(identifier: "1", transition: .exit)
+        await setup.resolver.handleTransition(identifier: "1", transition: .exit, occurredAt: Date())
 
         #expect(await setup.emitter.snapshot().isEmpty)
         #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .outside)

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -63,6 +63,7 @@ struct PolygonMembershipResolverTests {
         await storage.recordRegistration(center: LocationData(latitude: 0, longitude: 0), businessIds: ["1"])
         let emitter = EmitterSpy()
         let fixResolver = MovementFixResolver(logger: LoggerMock())
+        fixResolver.systemCachedFix = { nil } // never touch CoreLocation from a unit test
         // Seam: resolve inline with the supplied fix instead of touching CoreLocation.
         fixResolver.requestFreshFix = { [weak fixResolver] in
             guard let fix else { return fixResolver?.handleRequestFailure() ?? () }
@@ -129,6 +130,41 @@ struct PolygonMembershipResolverTests {
         #expect(delivered.count == 1)
         #expect(delivered.first?.transition == .enter)
         #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
+    }
+
+    /// A stored ring that no longer builds is not a circle. Forwarding it would fire a customer
+    /// enter anywhere inside the covering circle — the polygon's whole annulus included.
+    @Test
+    func handleTransition_givenStoredRingThatCannotBuild_expectNothingForwarded() async {
+        let setup = await makeSetup(fix: fix(latitude: 0, longitude: 0))
+        let degenerate = Geofence(
+            id: "1", latitude: 0, longitude: 0, radius: 300, name: "poly",
+            transitionTypes: [.enter, .exit], lastUpdated: Date(),
+            vertices: [LocationData(latitude: 0, longitude: 0), LocationData(latitude: 0, longitude: 0)]
+        )
+        await setup.storage.setCachedGeofences([degenerate])
+
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter)
+
+        #expect(await setup.emitter.snapshot().isEmpty)
+        #expect(await setup.storage.getPolygonMembership()["1"] == nil)
+    }
+
+    /// A replayed or synthesized exit arriving after a newer enter must not overwrite it: the device
+    /// would be believed outside while sitting inside, with the enter cooldown blocking recovery.
+    @Test
+    func handleTransition_givenExitOlderThanBelief_expectSuppressed() async {
+        let setup = await makeSetup(fix: fix(latitude: 0, longitude: 0))
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter)
+        #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
+
+        await setup.resolver.handleTransition(
+            identifier: "1", transition: .exit, occurredAt: Date(timeIntervalSince1970: 0)
+        )
+
+        #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
+        #expect(await setup.emitter.snapshot().map(\.transition) == [.enter])
     }
 
     /// The annulus: inside the covering circle, outside the polygon. The OS thinks we arrived;

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -58,6 +58,9 @@ struct PolygonMembershipResolverTests {
             fileManager: .default,
             directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         )
+        // A belief is only created for a registered polygon, so the fixture has to be registered or
+        // every write comes back `.suppressedUnmonitored`.
+        await storage.recordRegistration(center: LocationData(latitude: 0, longitude: 0), businessIds: ["1"])
         let emitter = EmitterSpy()
         let fixResolver = MovementFixResolver(logger: LoggerMock())
         // Seam: resolve inline with the supplied fix instead of touching CoreLocation.

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -201,6 +201,29 @@ struct PolygonMembershipResolverTests {
         #expect(await setup.storage.getPolygonMembership()["1"] == nil)
     }
 
+    /// An exit needs no ring: polygon ⊆ covering circle, so leaving the circle proves it whatever
+    /// the stored geometry does. Refusing one because the ring no longer builds would strand the
+    /// belief at inside, suppressing every later exit and re-enter.
+    @Test
+    func handleTransition_givenStoredRingThatCannotBuild_expectExitStillApplied() async {
+        let setup = await makeSetup(fix: fix(latitude: 0, longitude: 0))
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter, occurredAt: Date())
+        #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
+
+        let degenerate = Geofence(
+            id: "1", latitude: 0, longitude: 0, radius: 300, name: "poly",
+            transitionTypes: [.enter, .exit], lastUpdated: Date(),
+            vertices: [LocationData(latitude: 0, longitude: 0), LocationData(latitude: 0, longitude: 0)]
+        )
+        await setup.storage.setCachedGeofences([degenerate])
+
+        await setup.resolver.handleTransition(identifier: "1", transition: .exit, occurredAt: Date())
+
+        #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .outside)
+        #expect(await setup.emitter.snapshot().map(\.transition) == [.enter, .exit])
+    }
+
     /// A replayed or synthesized exit arriving after a newer enter must not overwrite it: the device
     /// would be believed outside while sitting inside, with the enter cooldown blocking recovery.
     @Test

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -42,6 +42,18 @@ struct PolygonMembershipResolverTests {
         )
     }
 
+    /// The same fence after a refresh replaced it: the server recomputes the enclosing circle from
+    /// the new ring, so the covering circle moves with the geometry.
+    private func replacedPolygonGeofence(id: String = "1") -> Geofence {
+        Geofence(
+            id: id, latitude: 0, longitude: 0.005, radius: 300, name: "poly",
+            transitionTypes: [.enter, .exit], lastUpdated: Date(),
+            vertices: Self.squareVertices.map {
+                LocationData(latitude: $0.latitude, longitude: $0.longitude + 0.005)
+            }
+        )
+    }
+
     private func circleGeofence(id: String = "2") -> Geofence {
         Geofence(
             id: id, latitude: 0, longitude: 0, radius: 300, name: "circle",
@@ -344,6 +356,44 @@ struct PolygonMembershipResolverTests {
         let delivered = await setup.emitter.snapshot()
         #expect(delivered.count == 1)
         #expect(delivered.first?.transition == .exit)
+    }
+
+    /// Leaving a circle only proves leaving the ring that circle encloses. A refresh moves both, so
+    /// an exit raised for the old circle says nothing about the new ring — the device can be
+    /// standing inside it. Writing `outside` here would also stamp a date that then refuses the
+    /// very fix that would correct it, so the belief sticks rather than self-heals.
+    @Test
+    func handleTransition_givenExitRaisedForAReplacedCircle_expectRefusedAndBeliefKept() async {
+        let setup = await makeSetup(fix: nil)
+        let original = polygonGeofence()
+        await setup.storage.setCachedGeofences([original])
+        _ = await setup.storage.recordPolygonMembership(.inside, forIdentifier: "1")
+        await setup.storage.setCachedGeofences([replacedPolygonGeofence()])
+
+        await setup.resolver.handleTransition(
+            identifier: "1", transition: .exit, occurredAt: Date(),
+            eventCircle: original.monitoredCircle
+        )
+
+        #expect(await setup.emitter.snapshot().isEmpty)
+        #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
+    }
+
+    /// Control: an exit for the circle the fence still has is the case the containment argument
+    /// covers, and must still deliver without a fix.
+    @Test
+    func handleTransition_givenExitRaisedForTheCurrentCircle_expectExitDelivered() async {
+        let setup = await makeSetup(fix: nil)
+        let geofence = polygonGeofence()
+        await setup.storage.setCachedGeofences([geofence])
+        _ = await setup.storage.recordPolygonMembership(.inside, forIdentifier: "1")
+
+        await setup.resolver.handleTransition(
+            identifier: "1", transition: .exit, occurredAt: Date(),
+            eventCircle: geofence.monitoredCircle
+        )
+
+        #expect(await setup.emitter.snapshot().first?.transition == .exit)
     }
 
     @Test

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -35,9 +35,13 @@ struct PolygonMembershipResolverTests {
         LocationData(latitude: 0.0016, longitude: -0.0016)
     ]
 
-    private func polygonGeofence(id: String = "1", transitionTypes: Set<GeofenceTransition> = [.enter, .exit]) -> Geofence {
+    private func polygonGeofence(
+        id: String = "1",
+        transitionTypes: Set<GeofenceTransition> = [.enter, .exit],
+        radius: Double = 300
+    ) -> Geofence {
         Geofence(
-            id: id, latitude: 0, longitude: 0, radius: 300, name: "poly",
+            id: id, latitude: 0, longitude: 0, radius: radius, name: "poly",
             transitionTypes: transitionTypes, lastUpdated: Date(), vertices: Self.squareVertices
         )
     }
@@ -372,7 +376,10 @@ struct PolygonMembershipResolverTests {
 
         await setup.resolver.handleTransition(
             identifier: "1", transition: .exit, occurredAt: Date(),
-            eventCircle: original.monitoredCircle
+            eventCircle: MonitoredCircle(
+                center: LocationData(latitude: original.latitude, longitude: original.longitude),
+                radius: original.radius, maximumRadius: 1000
+            )
         )
 
         #expect(await setup.emitter.snapshot().isEmpty)
@@ -390,7 +397,31 @@ struct PolygonMembershipResolverTests {
 
         await setup.resolver.handleTransition(
             identifier: "1", transition: .exit, occurredAt: Date(),
-            eventCircle: geofence.monitoredCircle
+            eventCircle: MonitoredCircle(
+                center: LocationData(latitude: geofence.latitude, longitude: geofence.longitude),
+                radius: geofence.radius, maximumRadius: 1000
+            )
+        )
+
+        #expect(await setup.emitter.snapshot().first?.transition == .exit)
+    }
+
+    /// The OS registers `min(radius, maximumRegionMonitoringDistance)`, so an over-cap fence is
+    /// monitored by a smaller circle than it declares. Comparing the event against the fence's own
+    /// radius would read every such fence as replaced and refuse its exits for good.
+    @Test
+    func handleTransition_givenExitForAnOverCapFence_expectExitDelivered() async {
+        let setup = await makeSetup(fix: nil)
+        let geofence = polygonGeofence(radius: 5000)
+        await setup.storage.setCachedGeofences([geofence])
+        _ = await setup.storage.recordPolygonMembership(.inside, forIdentifier: "1")
+
+        await setup.resolver.handleTransition(
+            identifier: "1", transition: .exit, occurredAt: Date(),
+            eventCircle: MonitoredCircle(
+                center: LocationData(latitude: 0, longitude: 0),
+                radius: min(5000, 1000), maximumRadius: 1000
+            )
         )
 
         #expect(await setup.emitter.snapshot().first?.transition == .exit)

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -6,6 +6,9 @@ import CoreLocation
 import Foundation
 import SharedTests
 import Testing
+#if canImport(UIKit)
+import UIKit
+#endif
 
 @Suite("PolygonMembershipResolver")
 @MainActor
@@ -51,9 +54,25 @@ struct PolygonMembershipResolverTests {
         let storage: GeofenceStorage
         let emitter: EmitterSpy
         let fixResolver: MovementFixResolver
+        let contextStore: BackgroundDeliveryContextStore
+        let notificationCenter: NotificationCenter
+        let logger: LoggerMock
     }
 
-    private func makeSetup(fix: CLLocation?) async -> Setup {
+    private func makeSetup(
+        fix: CLLocation?,
+        logger: LoggerMock = LoggerMock(),
+        contextStore: BackgroundDeliveryContextStore? = nil,
+        onFixDelivered: (@Sendable () -> Void)? = nil
+    ) async -> Setup {
+        // Its own centre: `willEnterForeground` posted on the default one reaches every other
+        // test's live resolver, whose pass then consumes their fix requests and writes their beliefs.
+        let notificationCenter = NotificationCenter()
+        let contextStore = contextStore ?? BackgroundDeliveryContextStore(
+            fileManager: .default,
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        if contextStore.currentUserId == nil { contextStore.setUserId("user-1") }
         let storage = GeofenceStorage(
             fileManager: .default,
             directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
@@ -68,17 +87,23 @@ struct PolygonMembershipResolverTests {
         fixResolver.requestFreshFix = { [weak fixResolver] in
             guard let fix else { return fixResolver?.handleRequestFailure() ?? () }
             fixResolver?.handleResolvedFix(fix)
+            onFixDelivered?()
         }
         return Setup(
             resolver: PolygonMembershipResolver(
                 storage: storage,
                 transitionEmitter: emitter,
-                logger: LoggerMock(),
-                fixResolver: fixResolver
+                logger: logger,
+                contextStore: contextStore,
+                fixResolver: fixResolver,
+                notificationCenter: notificationCenter
             ),
             storage: storage,
             emitter: emitter,
-            fixResolver: fixResolver
+            fixResolver: fixResolver,
+            contextStore: contextStore,
+            notificationCenter: notificationCenter,
+            logger: logger
         )
     }
 
@@ -93,8 +118,35 @@ struct PolygonMembershipResolverTests {
     }
 
     /// Counts location requests so a pass that says it shares one fix can be held to it.
-    private final class RequestCounter {
+    private final class RequestCounter: @unchecked Sendable {
         var count = 0
+    }
+
+    /// A latch the fix seam flips, so a test can place an event inside the resolve window.
+    private final class Flag: @unchecked Sendable {
+        var value = false
+    }
+
+    private func logged(_ logger: LoggerMock, _ needle: String) -> Bool {
+        logger.debugReceivedInvocations.contains { $0.message.contains(needle) }
+    }
+
+    private func yieldUntil(_ condition: () -> Bool) async {
+        for _ in 0 ..< 1000 where !condition() {
+            await Task.yield()
+        }
+    }
+
+    /// The same ring shifted a degree away, so a point decisive INSIDE the original is decisively
+    /// outside this one.
+    private func movedPolygonGeofence(id: String = "1") -> Geofence {
+        Geofence(
+            id: id, latitude: 1, longitude: 1, radius: 300, name: "poly",
+            transitionTypes: [.enter, .exit], lastUpdated: Date(),
+            vertices: Self.squareVertices.map {
+                LocationData(latitude: $0.latitude + 1, longitude: $0.longitude + 1)
+            }
+        )
     }
 
     private func countingRequests(_ setup: Setup) -> RequestCounter {
@@ -308,6 +360,207 @@ struct PolygonMembershipResolverTests {
     // MARK: - Foreground evaluation
 
     /// The case no OS event reaches: a device already standing inside a polygon when monitoring
+    /// A refresh can replace the fence under the same id while the fix is pending. The ring the
+    /// pass started with is then geometry the workspace has already moved off, and deciding from it
+    /// delivers a crossing for a shape we no longer monitor. No user switch is involved.
+    @Test
+    func evaluateAllPolygons_givenPolygonReplacedWhileFixPending_expectVerdictFromTheCurrentRing() async {
+        let setup = await makeSetup(fix: nil)
+        await registerPolygons(setup, ids: ["1"])
+        // Hold the pass inside its request so the swap lands strictly between the read and the verdict.
+        let requested = Flag()
+        setup.fixResolver.requestFreshFix = { requested.value = true }
+
+        async let pass: Void = setup.resolver.evaluateAllPolygons()
+        await yieldUntil { requested.value }
+        await setup.storage.setCachedGeofences([movedPolygonGeofence()])
+        setup.fixResolver.handleResolvedFix(fix(latitude: 0, longitude: 0))
+        await pass
+
+        // The device is inside the ring the pass started with and outside the one that replaced it.
+        #expect(await setup.emitter.snapshot().isEmpty)
+        #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .outside)
+    }
+
+    /// Control: the same interleaving with the catalog left alone must still deliver, so the guard
+    /// above is not passing by refusing anything that arrives late.
+    @Test
+    func evaluateAllPolygons_givenCatalogUnchangedWhileFixPending_expectEnterDelivered() async {
+        let setup = await makeSetup(fix: nil)
+        await registerPolygons(setup, ids: ["1"])
+        let requested = Flag()
+        setup.fixResolver.requestFreshFix = { requested.value = true }
+
+        async let pass: Void = setup.resolver.evaluateAllPolygons()
+        await yieldUntil { requested.value }
+        setup.fixResolver.handleResolvedFix(fix(latitude: 0, longitude: 0))
+        await pass
+
+        #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
+        #expect(await setup.emitter.snapshot().map(\.transition) == [.enter])
+    }
+
+    /// Registration is the other thing sampled before the fix. A polygon unregistered while the
+    /// request is out must not be judged either — the pass would otherwise decide for a fence the
+    /// device is no longer monitoring.
+    ///
+    /// Pins the OUTCOME, not the mechanism, and passes without the resolver's registration re-read:
+    /// `recordRegistration` prunes the belief with the set, so the write becomes a create and
+    /// storage refuses it as unmonitored. That is a second guard, not this one — the re-read is
+    /// what stops the resolver depending on a storage rule that only covers the create path.
+    @Test
+    func evaluateAllPolygons_givenPolygonUnregisteredWhileFixPending_expectNoVerdict() async {
+        let setup = await makeSetup(fix: nil)
+        await registerPolygons(setup, ids: ["1"])
+        let requested = Flag()
+        setup.fixResolver.requestFreshFix = { requested.value = true }
+
+        async let pass: Void = setup.resolver.evaluateAllPolygons()
+        await yieldUntil { requested.value }
+        await setup.storage.recordRegistration(center: LocationData(latitude: 0, longitude: 0), businessIds: [])
+        setup.fixResolver.handleResolvedFix(fix(latitude: 0, longitude: 0))
+        await pass
+
+        #expect(await setup.emitter.snapshot().isEmpty)
+        #expect(await setup.storage.getPolygonMembership()["1"] == nil)
+    }
+
+    /// A polygon dropped from the catalog entirely while the fix resolved has nothing left to
+    /// decide against, and must not be judged by the copy the pass is still holding.
+    @Test
+    func evaluateAllPolygons_givenPolygonDroppedWhileFixPending_expectNoVerdict() async {
+        let setup = await makeSetup(fix: nil)
+        await registerPolygons(setup, ids: ["1"])
+        let requested = Flag()
+        setup.fixResolver.requestFreshFix = { requested.value = true }
+
+        async let pass: Void = setup.resolver.evaluateAllPolygons()
+        await yieldUntil { requested.value }
+        await setup.storage.setCachedGeofences([])
+        setup.fixResolver.handleResolvedFix(fix(latitude: 0, longitude: 0))
+        await pass
+
+        #expect(await setup.emitter.snapshot().isEmpty)
+        #expect(await setup.storage.getPolygonMembership()["1"] == nil)
+    }
+
+    /// Foregrounding resolves a fix like any other pass, and a foregrounding app's cached fix is
+    /// normally stale — the app was suspended — so the request suspends for real. The observer has
+    /// no caller to take an expected user from, so it samples one itself.
+    ///
+    /// The switch lands at fix delivery, so this pins the check that runs after the fix; the one on
+    /// the emit's own stretch is pinned separately below. They are not duplicates.
+    @Test
+    func foreground_givenUserChangesWhileResolving_expectNoEvent() async {
+        let contextStore = BackgroundDeliveryContextStore(
+            fileManager: .default,
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        contextStore.setUserId("user-1")
+        let switched = Flag()
+        let setup = await makeSetup(
+            fix: fix(latitude: 0, longitude: 0),
+            contextStore: contextStore,
+            onFixDelivered: {
+                contextStore.setUserId("user-2")
+                switched.value = true
+            }
+        )
+        await registerPolygons(setup, ids: ["1"])
+
+        setup.notificationCenter.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+        await yieldUntil { switched.value }
+        // Waits for the refusal to be RECORDED, not for a fixed number of yields: an expect-nothing
+        // test with a fixed wait goes vacuous the moment this path gains another await.
+        await yieldUntil { logged(setup.logger, "user changed while resolving the fix") }
+
+        #expect(await setup.emitter.snapshot().isEmpty)
+        #expect(await setup.storage.getPolygonMembership()["1"] == nil)
+    }
+
+    /// The verdict is only half the path: the membership write and the emit are two more awaits,
+    /// and the tracker stamps whoever is current when it is entered. A switch landing after the
+    /// write must still not deliver — while the write itself may stand, since a belief states
+    /// geometry rather than attribution.
+    ///
+    /// A belief already exists, so the write takes the CHANGE path — the one
+    /// `monitoredGeofenceIds` does not guard.
+    @Test
+    func evaluateAllPolygons_givenUserChangesAfterTheWrite_expectNoEvent() async {
+        let setup = await makeSetup(fix: fix(latitude: 0, longitude: 0))
+        await registerPolygons(setup, ids: ["1"])
+        _ = await setup.storage.recordPolygonMembership(
+            .outside, forIdentifier: "1", onlyIfBeliefPredates: Date(timeIntervalSince1970: 0)
+        )
+        // True while the verdict is formed, false by the time the delivery boundary asks.
+        let asked = RequestCounter()
+
+        await setup.resolver.evaluateAllPolygons(isStillCurrent: {
+            asked.count += 1
+            return asked.count == 1
+        })
+
+        #expect(asked.count == 2)
+        #expect(await setup.emitter.snapshot().isEmpty)
+        #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
+    }
+
+    /// Control: the same foregrounding with nobody switching must still deliver, so the guard above
+    /// is not passing by refusing every foreground pass.
+    @Test
+    func foreground_givenUserUnchanged_expectVerdictRecorded() async {
+        let setup = await makeSetup(fix: fix(latitude: 0, longitude: 0))
+        await registerPolygons(setup, ids: ["1"])
+
+        setup.notificationCenter.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+        for _ in 0 ..< 1000 where await setup.emitter.snapshot().isEmpty {
+            await Task.yield()
+        }
+
+        #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
+        #expect(await setup.emitter.snapshot().map(\.transition) == [.enter])
+    }
+
+    /// The default centre is what production observes, and every other test here injects a private
+    /// one — so without this nothing would notice if that default broke and foreground evaluation
+    /// died in the field. Safe only while no other test posts to `.default` or builds the DI
+    /// singleton; if that changes, this is the test that will start cross-talking.
+    @Test
+    func foreground_givenTheDefaultNotificationCentre_expectPassRuns() async {
+        let storage = GeofenceStorage(
+            fileManager: .default,
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        await storage.recordRegistration(center: LocationData(latitude: 0, longitude: 0), businessIds: ["1"])
+        await storage.setCachedGeofences([polygonGeofence()])
+        let contextStore = BackgroundDeliveryContextStore(
+            fileManager: .default,
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        contextStore.setUserId("user-1")
+        let emitter = EmitterSpy()
+        let fixResolver = MovementFixResolver(logger: LoggerMock())
+        fixResolver.systemCachedFix = { nil }
+        fixResolver.requestFreshFix = { [weak fixResolver] in
+            fixResolver?.handleResolvedFix(CLLocation(
+                coordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0),
+                altitude: 0, horizontalAccuracy: 5, verticalAccuracy: 5, timestamp: Date()
+            ))
+        }
+        let resolver = PolygonMembershipResolver(
+            storage: storage, transitionEmitter: emitter,
+            logger: LoggerMock(), contextStore: contextStore, fixResolver: fixResolver
+        )
+
+        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+        for _ in 0 ..< 1000 where await emitter.snapshot().isEmpty {
+            await Task.yield()
+        }
+
+        #expect(await emitter.snapshot().map(\.transition) == [.enter])
+        _ = resolver
+    }
+
     /// begins has crossed nothing, and standing still produces no movement pass either.
     /// Foregrounding is the remaining signal.
     @Test

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipStorageTests.swift
@@ -239,10 +239,20 @@ struct PolygonMembershipStorageTests {
         LocationData(latitude: 6, longitude: 6)
     ]
 
-    private func polygon(id: String = "1", ring: [LocationData]) -> Geofence {
+    private func polygon(
+        id: String = "1", ring: [LocationData], latitude: Double = 0, longitude: Double = 0,
+        radius: Double = 300
+    ) -> Geofence {
         Geofence(
-            id: id, latitude: 0, longitude: 0, radius: 300, name: nil,
+            id: id, latitude: latitude, longitude: longitude, radius: radius, name: nil,
             transitionTypes: [.enter, .exit], lastUpdated: Date(), vertices: ring
+        )
+    }
+
+    private func circle(latitude: Double = 0, longitude: Double = 0, radius: Double = 300) -> MonitoredCircle {
+        MonitoredCircle(
+            center: LocationData(latitude: latitude, longitude: longitude),
+            radius: radius, maximumRadius: 1000
         )
     }
 
@@ -289,11 +299,8 @@ struct PolygonMembershipStorageTests {
         #expect(outcome == .suppressedGeometryChanged)
     }
 
-    /// Storage gates a ring-derived verdict and nothing else: a caller that supplies no ring is
-    /// stating the verdict does not rest on one, and gets no geometry check. Whether a
-    /// covering-circle exit still applies after a replacement is decided a layer up, by comparing
-    /// the circle the event was raised for — see
-    /// `handleTransition_givenExitRaisedForAReplacedCircle_expectRefusedAndBeliefKept`.
+    /// Supplying no ring states the verdict does not rest on one, so it gets no ring check. The
+    /// covering exit is the caller that does this, and is gated on its circle instead.
     @Test
     func recordPolygonMembership_givenNoRingSuppliedAndTheRingReplaced_expectTheGeometryCheckSkipped() async {
         let storage = await makeStorage()
@@ -302,6 +309,72 @@ struct PolygonMembershipStorageTests {
         await storage.setCachedGeofences([polygon(ring: Self.ringB)])
 
         let outcome = await storage.recordPolygonMembership(.outside, forIdentifier: "1")
+
+        #expect(outcome == .deliver(.exit))
+    }
+
+    /// The covering exit's window, and why the circle is compared inside the write rather than
+    /// before the hop: the resolver matched the event's circle against the fence it loaded, then a
+    /// refresh replaced ring and circle together before the store landed. Recording `outside` here
+    /// would assert the device left a polygon it may be standing inside, stamped with a date no
+    /// older fix can then correct.
+    @Test
+    func recordPolygonMembership_givenTheCircleReplacedSinceTheEventWasRaised_expectSuppressed() async {
+        let storage = await makeStorage()
+        await storage.setCachedGeofences([polygon(ring: Self.ringA)])
+        _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
+        await storage.setCachedGeofences([polygon(ring: Self.ringB, longitude: 0.005)])
+
+        let outcome = await storage.recordPolygonMembership(
+            .outside, forIdentifier: "1", onlyIfCircleMatches: circle()
+        )
+
+        #expect(outcome == .suppressedGeometryChanged)
+        #expect(await storage.getPolygonMembership()["1"]?.membership == .inside)
+    }
+
+    /// Control: the circle the fence still has is the case the containment argument covers and must
+    /// deliver, or the guard above is indistinguishable from one that refuses every exit.
+    @Test
+    func recordPolygonMembership_givenTheCircleUnchanged_expectExitDelivered() async {
+        let storage = await makeStorage()
+        await storage.setCachedGeofences([polygon(ring: Self.ringA)])
+        _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
+
+        let outcome = await storage.recordPolygonMembership(
+            .outside, forIdentifier: "1", onlyIfCircleMatches: circle()
+        )
+
+        #expect(outcome == .deliver(.exit))
+    }
+
+    /// A fence gone from the cache has no circle for the event to still match, so the exit is
+    /// refused on the same rule rather than falling through the guard.
+    @Test
+    func recordPolygonMembership_givenTheFenceLeftTheCacheAndACircleSupplied_expectSuppressed() async {
+        let storage = await makeStorage()
+        await storage.setCachedGeofences([polygon(ring: Self.ringA)])
+        _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
+        await storage.setCachedGeofences([])
+
+        let outcome = await storage.recordPolygonMembership(
+            .outside, forIdentifier: "1", onlyIfCircleMatches: circle()
+        )
+
+        #expect(outcome == .suppressedGeometryChanged)
+    }
+
+    /// An over-cap fence is monitored by `min(radius, cap)`, so comparing the event against the
+    /// fence's declared radius would read it as replaced and refuse its exits for good.
+    @Test
+    func recordPolygonMembership_givenAnOverCapFenceAndItsClampedCircle_expectExitDelivered() async {
+        let storage = await makeStorage()
+        await storage.setCachedGeofences([polygon(ring: Self.ringA, radius: 5000)])
+        _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
+
+        let outcome = await storage.recordPolygonMembership(
+            .outside, forIdentifier: "1", onlyIfCircleMatches: circle(radius: 1000)
+        )
 
         #expect(outcome == .deliver(.exit))
     }

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipStorageTests.swift
@@ -225,4 +225,82 @@ struct PolygonMembershipStorageTests {
         #expect(outcome == .suppressedUnmonitored)
         #expect(await storage.getPolygonMembership()["1"] == nil)
     }
+
+    // MARK: - Geometry boundary on the write
+
+    private static let ringA = [
+        LocationData(latitude: 0, longitude: 0),
+        LocationData(latitude: 0, longitude: 1),
+        LocationData(latitude: 1, longitude: 1)
+    ]
+    private static let ringB = [
+        LocationData(latitude: 5, longitude: 5),
+        LocationData(latitude: 5, longitude: 6),
+        LocationData(latitude: 6, longitude: 6)
+    ]
+
+    private func polygon(id: String = "1", ring: [LocationData]) -> Geofence {
+        Geofence(
+            id: id, latitude: 0, longitude: 0, radius: 300, name: nil,
+            transitionTypes: [.enter, .exit], lastUpdated: Date(), vertices: ring
+        )
+    }
+
+    /// The evaluation re-reads the ring after its location request, but it then decides on the main
+    /// actor and hops back here to write — a refresh can replace the fence under the same id in
+    /// that gap. The verdict belongs to the ring it was computed from, so the write is refused.
+    @Test
+    func recordPolygonMembership_givenTheRingReplacedSinceEvaluation_expectSuppressedAndNoBelief() async {
+        let storage = await makeStorage()
+        await storage.setCachedGeofences([polygon(ring: Self.ringB)])
+
+        let outcome = await storage.recordPolygonMembership(
+            .inside, forIdentifier: "1", onlyIfRingMatches: Self.ringA
+        )
+
+        #expect(outcome == .suppressedGeometryChanged)
+        #expect(await storage.getPolygonMembership()["1"] == nil)
+    }
+
+    /// Control: the same call against an unchanged catalog must still deliver, or the guard above
+    /// would be indistinguishable from one that refuses everything.
+    @Test
+    func recordPolygonMembership_givenTheRingUnchanged_expectEnterDelivered() async {
+        let storage = await makeStorage()
+        await storage.setCachedGeofences([polygon(ring: Self.ringA)])
+
+        let outcome = await storage.recordPolygonMembership(
+            .inside, forIdentifier: "1", onlyIfRingMatches: Self.ringA
+        )
+
+        #expect(outcome == .deliver(.enter))
+    }
+
+    /// A fence dropped from the cache entirely is the same failure as a replaced one: there is no
+    /// current ring for the verdict to belong to.
+    @Test
+    func recordPolygonMembership_givenTheFenceLeftTheCacheSinceEvaluation_expectSuppressed() async {
+        let storage = await makeStorage()
+
+        let outcome = await storage.recordPolygonMembership(
+            .inside, forIdentifier: "1", onlyIfRingMatches: Self.ringA
+        )
+
+        #expect(outcome == .suppressedGeometryChanged)
+    }
+
+    /// The covering-circle exit passes no ring, deliberately: polygon ⊆ circle holds for whatever
+    /// ring is current, so leaving the circle is a verdict a replacement cannot invalidate. It must
+    /// still be delivered after the exact replacement that refuses a fix-derived verdict.
+    @Test
+    func recordPolygonMembership_givenNoRingSuppliedAndTheRingReplaced_expectExitStillDelivered() async {
+        let storage = await makeStorage()
+        await storage.setCachedGeofences([polygon(ring: Self.ringA)])
+        _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1", onlyIfRingMatches: Self.ringA)
+        await storage.setCachedGeofences([polygon(ring: Self.ringB)])
+
+        let outcome = await storage.recordPolygonMembership(.outside, forIdentifier: "1")
+
+        #expect(outcome == .deliver(.exit))
+    }
 }

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipStorageTests.swift
@@ -289,11 +289,13 @@ struct PolygonMembershipStorageTests {
         #expect(outcome == .suppressedGeometryChanged)
     }
 
-    /// The covering-circle exit passes no ring, deliberately: polygon ⊆ circle holds for whatever
-    /// ring is current, so leaving the circle is a verdict a replacement cannot invalidate. It must
-    /// still be delivered after the exact replacement that refuses a fix-derived verdict.
+    /// Storage gates a ring-derived verdict and nothing else: a caller that supplies no ring is
+    /// stating the verdict does not rest on one, and gets no geometry check. Whether a
+    /// covering-circle exit still applies after a replacement is decided a layer up, by comparing
+    /// the circle the event was raised for — see
+    /// `handleTransition_givenExitRaisedForAReplacedCircle_expectRefusedAndBeliefKept`.
     @Test
-    func recordPolygonMembership_givenNoRingSuppliedAndTheRingReplaced_expectExitStillDelivered() async {
+    func recordPolygonMembership_givenNoRingSuppliedAndTheRingReplaced_expectTheGeometryCheckSkipped() async {
         let storage = await makeStorage()
         await storage.setCachedGeofences([polygon(ring: Self.ringA)])
         _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1", onlyIfRingMatches: Self.ringA)


### PR DESCRIPTION
Part of [MBL-2291](https://linear.app/customerio/issue/MBL-2291/ios-implement-responsive-on-device-polygon-monitoring)

Part 4 of the polygon geofence work. The resolver that turns OS covering-circle events into
customer-facing polygon transitions. Not wired to the monitor yet — that is the next PR.

### What's here

The OS monitors a polygon's covering circle and knows nothing about the polygon, so membership is a
second fact established on device. Two invariants define correctness, and neither may be relaxed:

- an ENTER requires a gated fix placing the device inside the polygon;
- an EXIT requires either a covering-circle exit — polygon ⊆ circle, so leaving one leaves the
  other — or a gated fix placing the device outside.

Everything else is silent. Circle geofences pass straight through to the tracker, so the
contradiction gate, baseline heal and dedup baseline that serve them stay unaware polygons exist.

Foreground evaluation covers the one case no OS event reaches: a device already standing inside a
polygon when monitoring begins has crossed nothing, and standing still produces no movement pass
either.

### Worth a reviewer's attention

A geofence missing from the cache is **forwarded, not dropped** — a sync can race an event, or the
OS can still hold a condition the cache dropped. Treating it as a circle is the behaviour that
predates polygons, and losing a real crossing is worse than one shaped like its covering circle.

The resolver owns its own `MovementFixResolver` rather than reading the monitor's, for the same
reason each monitor has one: the transition handler carries only coordinates while the gate needs
accuracy and age, and on a wrapper cold wake `CustomerIO.initialize` has not run.

It requests **ten-metre** accuracy, not the hundred the circle path uses. A verdict needs the device
farther from the boundary than the fix is accurate, so a hundred-metre fix could never decide
anything for a polygon near the minimum monitored size — those fences would sit registered and never
fire in either direction.

The cached fix is chosen by **age, not by source**. CoreLocation's own cache advances between
passes, driven by other clients in the process, so preferring this resolver's last delivered fix
outright requested a fix already in hand and, when that request failed, fell back to the older of
the two — the newest-of-the-two rule the monitors' `bestKnownFix` already applied, invalid
coordinates dropped the same way.

A cold process has delivered no fix of its own, so a failed request used to fall back to nothing and
lose the crossing permanently — the monitor has already advanced its dedup baseline. CoreLocation's
cached fix is the fallback now, still subject to the age gate.

A **stored ring that no longer builds is not a circle**: forwarding it would fire a customer enter
anywhere inside the covering circle, annulus included. Only `vertices == nil` takes the circle path.
That guard sits on the enter branch only — an exit needs no ring, so refusing one would strand the
belief at inside and suppress every later exit and re-enter.
And the covering exit carries the event date, so a replayed or synthesized exit cannot overwrite a
newer enter and leave the device believed outside while it sits inside. The date is required, not
optional: it is the only thing ordering that write, and a caller allowed to omit it writes unordered.

**A covering exit is refused when the circle crossed is not the one the fence still has.** The
certainty is polygon ⊆ *its own* covering circle. A refresh replaces ring and circle together, so
leaving the old circle says nothing about the new ring — the device can be standing inside it. This
does not self-heal: the spurious exit stamps the belief with the OS event's date, and the repairing
fix is then refused as an older decision, so the belief sticks outside. Refusing the exit instead
leaves the belief for a fix to decide against the current ring; refusing rather than clearing is
what stops a device that never left from being re-entered. A nil circle is accepted — a cold wake
cannot say which circle an event was for, and an event that cannot be shown stale is treated as
current.

**That comparison happens inside the write, not before the hop.** The resolver matched the event's
circle against the fence it had already loaded, then hopped to the storage actor — and a refresh
landing in that gap left `outside` recorded for a device inside the replacement polygon. The circle
now travels into `recordPolygonMembership` and is compared in the same `loadFromDisk` that writes,
exactly as the evaluated ring is. The pre-hop check was deleted rather than kept alongside it: two
comparisons against geometry read at different instants is the defect, not the cure. Raised by
@Shahroz16 in review.

The comparison uses the radius **as registered**. Both monitors register
`min(radius, maximumRegionMonitoringDistance)`, so comparing against the fence's raw radius would
never match an over-cap fence; `MonitoredCircle` therefore carries the cap it was clamped against
and reuses `matchesRegistered`'s clamp and tolerances rather than assuming the float round trip
through CoreLocation is exact. The clamp half is belt-and-braces at the shipped state — #1246 drops
over-cap polygons before registration, so they never reach this comparison — but the comparison
should not depend on a guard living in a later PR. The tolerance half is live either way.

**A verdict is decided from the ring current when it is decided, never the pass's copy.** Resolving
a fix suspends, and a refresh can replace a fence under the same id while it does — the pass would
then deliver a crossing for a shape the workspace has moved off, with no user switch involved.
`evaluate` takes an id and reads the fence itself afterwards, so a stale ring is not in scope to be
used by mistake. Registration is read from the same load: sampling one before the await and the
other after is how the two come to disagree. It costs one state decode per polygon, which buys
verdicts at most one hop stale instead of a whole location request stale.

That closed the window across the location request but left a second one: the verdict is computed
on the main actor and written by a separate hop onto the storage actor, and a replacement can commit
in that gap. The evaluated ring now travels into `recordPolygonMembership` and is compared inside
the same `loadFromDisk` that writes — the one place read and write cannot be separated. A third
check in the resolver would only be a third thing that can go stale. It compares the ring itself
rather than `lastUpdated`, which the server owns and may not bump on a replacement. Registration
needs no equivalent: `recordRegistration` prunes the belief in the same actor call that narrows the
set.

**The user is re-checked after the fix resolves, and again immediately before the emit.** The
tracker stamps whoever is current when it is entered, and the membership write is an await of its
own, so a check placed only at the verdict leaves the emit unguarded. The write is deliberately left
unguarded: a belief states geometry, true whoever is signed in, while an emit is an attribution, and
attribution is what a switch invalidates. The foreground observer has no caller to take an expected
user from, so it samples one when it fires.

The foreground pass resolves **one** fix above the loop. Resolving per polygon meant an empty cache
issued a fresh timed request for every registered polygon, holding the main actor for as long as
that took and still deciding nothing. Foregrounds also arrive in bursts, so a pass already running
wins and the skip is logged.

### Testing

468/468 `LocationGeofenceTests` pass on iOS 26. Format and lint clean, no public API surface.

Unit tests over the enter/exit/undecidable/no-fix matrix, foreground evaluation, the transition-type
filter, the unbuildable-ring path, and an exit older than the stored belief.

For the two hazards above, each test holds the pass inside its fix request so the event lands
strictly between the read and the verdict, and each has a control that must still deliver:
a fence replaced under the same id, a fence dropped from the catalog, a fence unregistered, a user
switching at fix delivery, and a user switching after the write but before the emit. Every one was
negative-controlled — reverting the guard makes it fail, and the failure is the wrong event being
delivered, not just an assertion.

The unregistered-mid-fix case pins the outcome rather than the mechanism, and says so: storage also
refuses that write because `recordRegistration` prunes the belief with the set. The resolver's own
check is what stops it depending on a storage rule that covers only the create path.

Four storage tests cover the write-time geometry window: a verdict whose ring was replaced mid-write
is refused, the unchanged-ring control still writes, a covering exit still lands after the exact
replacement that refuses a fix-derived verdict, and a fence dropped from the catalog refuses.

The exit-circle tests build the event circle **from the OS side**, not from the fence. The two
earlier ones built it from `geofence.monitoredCircle` — comparing the expression against itself —
which is why neither the replaced-circle case nor the clamped-radius case was visible. A further
case pins an over-cap fence's exit still being delivered.

Four storage tests cover the write-time circle window: a circle replaced since the event was raised
is refused, the unchanged circle still delivers, a fence gone from the cache is refused, and an
over-cap fence's clamped circle still delivers. **Negative-controlled** — removing the guard fails
those *and* the resolver-level replaced-circle case, which is what proves the check is carried by
the atomic write rather than by a leftover.

### Stack

1. #1239 `mbl-2290-a` geometry kernel (merged)
2. #1240 `mbl-2290-b` wire contract (merged)
3. #1244 `mbl-2291-a` membership layer (merged)
4. #1245 `mbl-2291-b` membership resolver ← **this PR**
5. #1246 `mbl-2291-c` monitor wiring
6. #1249 `mbl-2290-c` antimeridian fix
7. #1250 `mbl-2291-f` shared dynamic movement circle
8. #1259 `mbl-2291-h` belief survives eviction
9. #1262 `mbl-2291-g` event circle generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)













