### PR TITLE
chore(geofence): route monitored transitions through the polygon resolver

### DIFF
--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+InitialEnter.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+InitialEnter.swift
@@ -21,11 +21,22 @@ extension GeofenceSyncCoordinatorImpl {
         expectedUserId: String,
         anchor: LocationData
     ) {
-        let newInside = candidates.filter { region in
+        let newlyRegistered = candidates.filter { region in
             osRegistration.registeredIds.contains(region.id)
                 && !previouslyRegisteredIds.contains(region.id)
+        }
+        // A polygon must NOT be judged by this containment test: `radius` is its covering circle, so
+        // a device in the annulus would emit an enter it never earned. Newly-registered polygons go
+        // to the resolver's gated evaluation instead, which is also the only thing that reports the
+        // device already standing inside one — there is no crossing for the OS to deliver.
+        let newPolygons = newlyRegistered.filter { $0.vertices != nil }
+        let newInside = newlyRegistered.filter { region in
+            region.vertices == nil
                 && region.transitionTypes.contains(.enter)
                 && region.distanceTo(anchor) <= min(region.radius, osRegistration.maxMonitoringRadius)
+        }
+        if !newPolygons.isEmpty {
+            evaluateNewPolygons(newPolygons, expectedUserId: expectedUserId)
         }
         guard !newInside.isEmpty else { return }
         // Deliver off the refresh gate (like the binder does for real crossings) so a slow send can't
@@ -37,6 +48,20 @@ extension GeofenceSyncCoordinatorImpl {
                 // current — so stop the batch the moment identity changes.
                 guard contextStore.currentUserId == expectedUserId else { return }
                 await transitionEmitter.trackTransition(geofenceId: region.id, transition: .enter)
+            }
+        }
+    }
+
+    /// Hands newly-registered polygons to the gated evaluation. Resolved from the graph at the call
+    /// site rather than stored: the resolver is a `@MainActor` singleton and this coordinator is
+    /// one of its own dependencies, so a stored reference back would make the two initialize each
+    /// other.
+    private func evaluateNewPolygons(_ polygons: [Geofence], expectedUserId: String) {
+        Task { @MainActor [contextStore] in
+            let resolver = DIGraphShared.shared.polygonMembershipResolver
+            for polygon in polygons {
+                guard contextStore.currentUserId == expectedUserId else { return }
+                await resolver.evaluateMembership(geofenceId: polygon.id, reason: "new polygon")
             }
         }
     }

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+InitialEnter.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+InitialEnter.swift
@@ -61,7 +61,13 @@ extension GeofenceSyncCoordinatorImpl {
             let resolver = DIGraphShared.shared.polygonMembershipResolver
             for polygon in polygons {
                 guard contextStore.currentUserId == expectedUserId else { return }
-                await resolver.evaluateMembership(geofenceId: polygon.id, reason: "new polygon")
+                // Also re-checked inside, after the fix resolves: that await is the window where a
+                // user switch would otherwise land an event on the wrong profile.
+                await resolver.evaluateMembership(
+                    geofenceId: polygon.id,
+                    reason: "new polygon",
+                    isStillCurrent: { contextStore.currentUserId == expectedUserId }
+                )
             }
         }
     }

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+InitialEnter.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+InitialEnter.swift
@@ -58,17 +58,14 @@ extension GeofenceSyncCoordinatorImpl {
     /// other.
     private func evaluateNewPolygons(_ polygons: [Geofence], expectedUserId: String) {
         Task { @MainActor [contextStore] in
-            let resolver = DIGraphShared.shared.polygonMembershipResolver
-            for polygon in polygons {
-                guard contextStore.currentUserId == expectedUserId else { return }
-                // Also re-checked inside, after the fix resolves: that await is the window where a
-                // user switch would otherwise land an event on the wrong profile.
-                await resolver.evaluateMembership(
-                    geofenceId: polygon.id,
-                    reason: "new polygon",
-                    isStillCurrent: { contextStore.currentUserId == expectedUserId }
-                )
-            }
+            guard contextStore.currentUserId == expectedUserId else { return }
+            // Also re-checked inside, per polygon, after the fix resolves: that await is the window
+            // where a user switch would otherwise land an event on the wrong profile.
+            await DIGraphShared.shared.polygonMembershipResolver.evaluateMembership(
+                geofenceIds: polygons.map(\.id),
+                reason: "new polygon",
+                isStillCurrent: { contextStore.currentUserId == expectedUserId }
+            )
         }
     }
 }

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+OsRegistration.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+OsRegistration.swift
@@ -48,7 +48,20 @@ extension GeofenceSyncCoordinatorImpl {
                 transitionTypes: [.exit]
             ))
         }
-        desired.append(contentsOf: businessRegions.map { region in
+        // A polygon whose covering circle exceeds the OS cap must be DROPPED, not clamped. Both
+        // monitors clamp silently, and a clamped circle no longer contains the polygon — which
+        // turns the covering-circle exit from geometric certainty into a false exit, and lets the
+        // device enter through a part of the polygon no wake covers. Circles keep clamping: for
+        // them the monitored circle IS the fence, so a smaller one only reports later.
+        let maximumRadius = monitor.maximumMonitoringRadius
+        let registrable = businessRegions.filter { region in
+            guard region.vertices != nil, region.radius > maximumRadius else { return true }
+            logger.geofencePolygonExceedsMonitoringLimit(
+                identifier: region.id, radius: region.radius, limit: maximumRadius
+            )
+            return false
+        }
+        desired.append(contentsOf: registrable.map { region in
             GeofenceRegionRequest(
                 identifier: region.id,
                 center: LocationData(latitude: region.latitude, longitude: region.longitude),

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+OsRegistration.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+OsRegistration.swift
@@ -53,6 +53,8 @@ extension GeofenceSyncCoordinatorImpl {
         // turns the covering-circle exit from geometric certainty into a false exit, and lets the
         // device enter through a part of the polygon no wake covers. Circles keep clamping: for
         // them the monitored circle IS the fence, so a smaller one only reports later.
+        // Callers drop these before ranking so the slot is reused; this is the last-line guard for
+        // anything that reached here anyway, and it logs so the skip is never silent.
         let maximumRadius = monitor.maximumMonitoringRadius
         let registrable = businessRegions.filter { region in
             guard region.vertices != nil, region.radius > maximumRadius else { return true }
@@ -66,7 +68,12 @@ extension GeofenceSyncCoordinatorImpl {
                 identifier: region.id,
                 center: LocationData(latitude: region.latitude, longitude: region.longitude),
                 radius: region.radius,
-                transitionTypes: region.transitionTypes
+                // A polygon's covering circle is machinery, not the customer's fence: it must report
+                // BOTH edges so membership can advance. Registering it with the customer's types
+                // would starve the resolver of the filtered edge — an enter-only polygon would fire
+                // once and never again, an exit-only one never at all. The customer's filter is
+                // applied to the polygon verdict instead.
+                transitionTypes: region.vertices == nil ? region.transitionTypes : [.enter, .exit]
             )
         })
         let diff = monitor.setMonitoredRegions(desired)

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
@@ -40,7 +40,8 @@ extension GeofenceSyncCoordinatorImpl {
         }
         let effectiveConfig = parsedConfig ?? cachedConfig ?? .fallback
         let anchor = LocationData(latitude: latitude, longitude: longitude)
-        let nearest = distanceFilter.nearest(regions, to: anchor, limit: effectiveConfig.maxBusinessGeofences, maxDistance: effectiveConfig.maxMonitoringDistance)
+        let monitorable = await MainActor.run { monitorableRegions(regions) }
+        let nearest = distanceFilter.nearest(monitorable, to: anchor, limit: effectiveConfig.maxBusinessGeofences, maxDistance: effectiveConfig.maxMonitoringDistance)
         let registerMovementTrigger = effectiveConfig.maxBusinessGeofences > 0
         // Read before `recordRegistration` overwrites it — the diff decides which registrations are new.
         let previouslyRegisteredIds = await storage.getRegisteredBusinessIds()
@@ -88,7 +89,8 @@ extension GeofenceSyncCoordinatorImpl {
         cachedRegions: [Geofence]
     ) async -> Result<Void, GeofenceSyncError> {
         let anchor = LocationData(latitude: latitude, longitude: longitude)
-        let nearest = distanceFilter.nearest(cachedRegions, to: anchor, limit: config.maxBusinessGeofences, maxDistance: config.maxMonitoringDistance)
+        let monitorable = await MainActor.run { monitorableRegions(cachedRegions) }
+        let nearest = distanceFilter.nearest(monitorable, to: anchor, limit: config.maxBusinessGeofences, maxDistance: config.maxMonitoringDistance)
         let registerMovementTrigger = config.maxBusinessGeofences > 0
         // Read before `recordRegistration` overwrites it — the diff decides which registrations are new.
         let previouslyRegisteredIds = await storage.getRegisteredBusinessIds()

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
@@ -61,7 +61,10 @@ extension GeofenceSyncCoordinatorImpl {
             await storage.setCachedConfig(parsedConfig)
         }
         await storage.recordSync(timestamp: dateUtil.now, location: anchor)
-        await storage.recordRegistration(center: anchor, businessIds: nearestIds)
+        // Only what the OS accepted: an oversized polygon is deliberately not registered, and
+        // recording it anyway would have the membership resolver evaluate a fence with no wake
+        // behind it — delivering an enter that nothing can ever balance with an exit.
+        await storage.recordRegistration(center: anchor, businessIds: nearestIds.intersection(osRegistration.registeredIds))
         emitInitialEnters(
             candidates: nearest,
             osRegistration: osRegistration,
@@ -98,7 +101,10 @@ extension GeofenceSyncCoordinatorImpl {
                 registerMovementTrigger: registerMovementTrigger
             )
         }
-        await storage.recordRegistration(center: anchor, businessIds: nearestIds)
+        // Only what the OS accepted: an oversized polygon is deliberately not registered, and
+        // recording it anyway would have the membership resolver evaluate a fence with no wake
+        // behind it — delivering an enter that nothing can ever balance with an exit.
+        await storage.recordRegistration(center: anchor, businessIds: nearestIds.intersection(osRegistration.registeredIds))
         emitInitialEnters(
             candidates: nearest,
             osRegistration: osRegistration,

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+RefreshDecision.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+RefreshDecision.swift
@@ -54,4 +54,18 @@ extension GeofenceSyncCoordinatorImpl {
         CLLocation(latitude: from.latitude, longitude: from.longitude)
             .distance(from: CLLocation(latitude: to.latitude, longitude: to.longitude))
     }
+
+    /// Drops polygons the OS cannot monitor BEFORE ranking, so a fence that would be refused does
+    /// not consume one of `maxBusinessGeofences` and leave a usable candidate unregistered.
+    @MainActor
+    func monitorableRegions(_ regions: [Geofence]) -> [Geofence] {
+        let maximumRadius = monitor.maximumMonitoringRadius
+        return regions.filter { region in
+            guard region.vertices != nil, region.radius > maximumRadius else { return true }
+            logger.geofencePolygonExceedsMonitoringLimit(
+                identifier: region.id, radius: region.radius, limit: maximumRadius
+            )
+            return false
+        }
+    }
 }

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
@@ -242,7 +242,7 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         let effectiveConfig = config ?? .fallback
         let nearest = distanceFilter.nearest(cachedRegions, to: anchor, limit: effectiveConfig.maxBusinessGeofences, maxDistance: effectiveConfig.maxMonitoringDistance)
         let registerMovementTrigger = effectiveConfig.maxBusinessGeofences > 0
-        registerWithOsSync(
+        let osRegistration = registerWithOsSync(
             businessRegions: nearest,
             movementTriggerLocation: anchor,
             movementTriggerRadius: effectiveConfig.localRefreshTriggerRadius,
@@ -251,7 +251,13 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         logger.geofenceSyncCompleted(registeredCount: nearest.count, movementTriggerRegistered: registerMovementTrigger)
         // No initial-enter here: a cold-wake restore of the pre-kill set (not new registrations) off a
         // possibly-stale anchor. Genuinely-new fences come from a refresh fetch, which emits there.
-        return GeofenceRegistration(center: anchor, businessIds: Set(nearest.map(\.id)))
+        // Only what the OS took, for the same reason as the refresh paths: an oversized polygon is
+        // deliberately unregistered, and recording it would have the resolver decide membership for
+        // a fence with no wake behind it.
+        return GeofenceRegistration(
+            center: anchor,
+            businessIds: Set(nearest.map(\.id)).intersection(osRegistration.registeredIds)
+        )
     }
 
     /// The identified user a gated operation runs for (`nil` when signed out); the exit cleanup compares against it.

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
@@ -240,7 +240,7 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         defer { releaseGate() }
 
         let effectiveConfig = config ?? .fallback
-        let nearest = distanceFilter.nearest(cachedRegions, to: anchor, limit: effectiveConfig.maxBusinessGeofences, maxDistance: effectiveConfig.maxMonitoringDistance)
+        let nearest = distanceFilter.nearest(monitorableRegions(cachedRegions), to: anchor, limit: effectiveConfig.maxBusinessGeofences, maxDistance: effectiveConfig.maxMonitoringDistance)
         let registerMovementTrigger = effectiveConfig.maxBusinessGeofences > 0
         let osRegistration = registerWithOsSync(
             businessRegions: nearest,

--- a/Sources/LocationGeofence/GeofenceBootstrap.swift
+++ b/Sources/LocationGeofence/GeofenceBootstrap.swift
@@ -61,9 +61,8 @@ enum GeofenceBootstrap {
         // `adoptExistingRegions` / `startMonitoring`, so `ownedRegionIdentifiers` is populated
         // before any new delegate call can land.
         let monitor = di.geofenceMonitor
-        let tracker = di.geofenceEventTracker
         let coordinator = di.geofenceSyncCoordinator
-        GeofenceMonitorBinder.bind(monitor: monitor, tracker: tracker, coordinator: coordinator)
+        GeofenceMonitorBinder.bind(monitor: monitor, resolver: di.polygonMembershipResolver, coordinator: coordinator)
 
         // Install both re-run handlers BEFORE the adopt/re-register decision so the CLMonitor path's
         // first reconciliation — which can fire right after this synchronous phase yields — finds a

--- a/Sources/LocationGeofence/GeofenceMonitorBinder.swift
+++ b/Sources/LocationGeofence/GeofenceMonitorBinder.swift
@@ -18,7 +18,7 @@ enum GeofenceMonitorBinder {
         coordinator: GeofenceSyncCoordinator,
         backgroundTaskRunner: BackgroundTaskRunner = GeofenceBackgroundTime.runner(name: "io.customer.geofence.movement-pass")
     ) {
-        monitor.setOnTransition { [weak resolver, weak coordinator] identifier, transition, location in
+        monitor.setOnTransition { [weak resolver, weak coordinator] identifier, transition, location, occurredAt in
             // CLLocationManager delivers on main; both handlers below are async with their
             // own serialization (tracker active-delivery dedup, coordinator refresh gate),
             // so fire-and-forget Tasks are safe.
@@ -36,7 +36,7 @@ enum GeofenceMonitorBinder {
                 }
                 return
             }
-            Task { await resolver?.handleTransition(identifier: identifier, transition: transition, occurredAt: Date()) }
+            Task { await resolver?.handleTransition(identifier: identifier, transition: transition, occurredAt: occurredAt) }
         }
     }
 }

--- a/Sources/LocationGeofence/GeofenceMonitorBinder.swift
+++ b/Sources/LocationGeofence/GeofenceMonitorBinder.swift
@@ -8,16 +8,17 @@ import Foundation
 /// Two dispatch paths:
 /// - `GeofenceConstants.movementTriggerIdentifier` (EXIT) → `coordinator.handleMovement`
 ///   (internal; never tracked as a customer event).
-/// - Any other identifier → `tracker.trackTransition` (the business geofences).
+/// - Any other identifier → `resolver.handleTransition`, which forwards circle geofences to the
+///   tracker unchanged and interprets a polygon's covering-circle event against membership.
 @MainActor
 enum GeofenceMonitorBinder {
     static func bind(
         monitor: GeofenceRegionMonitoring,
-        tracker: GeofenceEventTracker,
+        resolver: PolygonMembershipResolver,
         coordinator: GeofenceSyncCoordinator,
         backgroundTaskRunner: BackgroundTaskRunner = GeofenceBackgroundTime.runner(name: "io.customer.geofence.movement-pass")
     ) {
-        monitor.setOnTransition { [weak tracker, weak coordinator] identifier, transition, location in
+        monitor.setOnTransition { [weak resolver, weak coordinator] identifier, transition, location in
             // CLLocationManager delivers on main; both handlers below are async with their
             // own serialization (tracker active-delivery dedup, coordinator refresh gate),
             // so fire-and-forget Tasks are safe.
@@ -35,7 +36,7 @@ enum GeofenceMonitorBinder {
                 }
                 return
             }
-            Task { await tracker?.trackTransition(geofenceId: identifier, transition: transition) }
+            Task { await resolver?.handleTransition(identifier: identifier, transition: transition, occurredAt: Date()) }
         }
     }
 }

--- a/Sources/LocationGeofence/GeofenceMonitorBinder.swift
+++ b/Sources/LocationGeofence/GeofenceMonitorBinder.swift
@@ -18,7 +18,7 @@ enum GeofenceMonitorBinder {
         coordinator: GeofenceSyncCoordinator,
         backgroundTaskRunner: BackgroundTaskRunner = GeofenceBackgroundTime.runner(name: "io.customer.geofence.movement-pass")
     ) {
-        monitor.setOnTransition { [weak resolver, weak coordinator] identifier, transition, location, occurredAt in
+        monitor.setOnTransition { [weak resolver, weak coordinator] identifier, transition, location, occurredAt, eventCircle in
             // CLLocationManager delivers on main; both handlers below are async with their
             // own serialization (tracker active-delivery dedup, coordinator refresh gate),
             // so fire-and-forget Tasks are safe.
@@ -36,7 +36,12 @@ enum GeofenceMonitorBinder {
                 }
                 return
             }
-            Task { await resolver?.handleTransition(identifier: identifier, transition: transition, occurredAt: occurredAt) }
+            Task {
+                await resolver?.handleTransition(
+                    identifier: identifier, transition: transition,
+                    occurredAt: occurredAt, eventCircle: eventCircle
+                )
+            }
         }
     }
 }

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -173,6 +173,14 @@ extension Logger {
         debug("Skipped polygon evaluation pass: \(reason)", geofenceTag)
     }
 
+    func geofencePolygonEvaluationRequested(identifier: String, reason: String) {
+        debug("Re-evaluating polygon membership for region \(identifier) (\(reason))", geofenceTag)
+    }
+
+    func geofencePolygonExceedsMonitoringLimit(identifier: String, radius: Double, limit: Double) {
+        error("Polygon \(identifier) dropped: covering circle \(Int(radius)) m exceeds the OS monitoring limit \(Int(limit)) m, and a clamped circle would no longer contain the polygon", geofenceTag, nil)
+    }
+
     func geofencePolygonUndecided(identifier: String, reason: String) {
         debug("Polygon membership undecided for region \(identifier): \(reason)", geofenceTag)
     }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+BaselineHeal.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+BaselineHeal.swift
@@ -66,7 +66,8 @@ extension CLMonitorGeofenceMonitor {
                 self.onTransition?(
                     identifier,
                     transition,
-                    LocationData(latitude: fix.coordinate.latitude, longitude: fix.coordinate.longitude)
+                    LocationData(latitude: fix.coordinate.latitude, longitude: fix.coordinate.longitude),
+                    fix.timestamp
                 )
             }
         }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+BaselineHeal.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+BaselineHeal.swift
@@ -67,7 +67,8 @@ extension CLMonitorGeofenceMonitor {
                     identifier,
                     transition,
                     LocationData(latitude: fix.coordinate.latitude, longitude: fix.coordinate.longitude),
-                    fix.timestamp
+                    fix.timestamp,
+                    MonitoredCircle(center: condition.center, radius: condition.radius)
                 )
             }
         }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+BaselineHeal.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+BaselineHeal.swift
@@ -68,7 +68,10 @@ extension CLMonitorGeofenceMonitor {
                     transition,
                     LocationData(latitude: fix.coordinate.latitude, longitude: fix.coordinate.longitude),
                     fix.timestamp,
-                    MonitoredCircle(center: condition.center, radius: condition.radius)
+                    MonitoredCircle(
+                        center: condition.center, radius: condition.radius,
+                        maximumRadius: self.authManager.maximumRegionMonitoringDistance
+                    )
                 )
             }
         }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
@@ -227,4 +227,16 @@ extension CLMonitorGeofenceMonitor {
             transitionTypes: transitionTypes
         )
     }
+
+    /// The circle this monitor registered for `identifier`, which is the one the OS raised the
+    /// event against. Nil before adoption repopulates the map on a cold wake — the consumer then
+    /// cannot tell a replaced circle from the current one, and treats the event as current.
+    func eventCircle(for identifier: String) -> MonitoredCircle? {
+        registeredConditions[identifier].map {
+            MonitoredCircle(
+                center: $0.center, radius: $0.radius,
+                maximumRadius: authManager.maximumRegionMonitoringDistance
+            )
+        }
+    }
 }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -307,12 +307,12 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
             // Fire-and-forget so a slow fix can't stall the pending-event drain behind it.
             movementFixResolver.resolve(cached: bestKnownFix()) { [weak self] location in
                 self?.logger.geofenceOsTransitionReceived(identifier: identifier, transition: transition)
-                self?.onTransition?(identifier, transition, location)
+                self?.onTransition?(identifier, transition, location, event.date)
             }
             return
         }
         logger.geofenceOsTransitionReceived(identifier: identifier, transition: transition)
-        onTransition?(identifier, transition, currentLocationData())
+        onTransition?(identifier, transition, currentLocationData(), event.date)
     }
 
     // MARK: - GeofenceRegionMonitoring

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -315,13 +315,6 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
         onTransition?(identifier, transition, currentLocationData(), event.date, eventCircle(for: identifier))
     }
 
-    /// The circle this monitor registered for `identifier`, which is the one the OS raised the
-    /// event against. Nil before adoption repopulates the map on a cold wake — the consumer then
-    /// cannot tell a replaced circle from the current one, and treats the event as current.
-    private func eventCircle(for identifier: String) -> MonitoredCircle? {
-        registeredConditions[identifier].map { MonitoredCircle(center: $0.center, radius: $0.radius) }
-    }
-
     // MARK: - GeofenceRegionMonitoring
 
     var monitoredRegionIdentifiers: Set<String> {

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -307,12 +307,19 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
             // Fire-and-forget so a slow fix can't stall the pending-event drain behind it.
             movementFixResolver.resolve(cached: bestKnownFix()) { [weak self] location in
                 self?.logger.geofenceOsTransitionReceived(identifier: identifier, transition: transition)
-                self?.onTransition?(identifier, transition, location, event.date)
+                self?.onTransition?(identifier, transition, location, event.date, self?.eventCircle(for: identifier))
             }
             return
         }
         logger.geofenceOsTransitionReceived(identifier: identifier, transition: transition)
-        onTransition?(identifier, transition, currentLocationData(), event.date)
+        onTransition?(identifier, transition, currentLocationData(), event.date, eventCircle(for: identifier))
+    }
+
+    /// The circle this monitor registered for `identifier`, which is the one the OS raised the
+    /// event against. Nil before adoption repopulates the map on a cold wake — the consumer then
+    /// cannot tell a replaced circle from the current one, and treats the event as current.
+    private func eventCircle(for identifier: String) -> MonitoredCircle? {
+        registeredConditions[identifier].map { MonitoredCircle(center: $0.center, radius: $0.radius) }
     }
 
     // MARK: - GeofenceRegionMonitoring

--- a/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
@@ -36,6 +36,9 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
         let identifier: String
         let transition: GeofenceTransition
         let location: LocationData?
+        /// CoreLocation's region callbacks carry no date, so this is when we received it — which is
+        /// what a queued event needs so a drain minutes later is not read as happening now.
+        let receivedAt: Date
     }
 
     /// Region events received before the bootstrap bound `onTransition` (see `handleRegionEvent`).
@@ -183,13 +186,13 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
     private func handleRegionEvent(_ region: CLRegion, transition: GeofenceTransition) {
         guard region is CLCircularRegion else { return }
         if onTransition == nil || !pendingEvents.isEmpty || isDrainingPendingEvents {
-            pendingEvents.append(PendingRegionEvent(identifier: region.identifier, transition: transition, location: currentLocationData()))
+            pendingEvents.append(PendingRegionEvent(identifier: region.identifier, transition: transition, location: currentLocationData(), receivedAt: Date()))
             if pendingEvents.count > Self.maxPendingEvents { pendingEvents.removeFirst() }
             drainPendingEventsIfReady()
             return
         }
         guard ownedRegionIdentifiers.contains(region.identifier) else { return }
-        dispatchTransition(identifier: region.identifier, transition: transition, capturedLocation: currentLocationData())
+        dispatchTransition(identifier: region.identifier, transition: transition, capturedLocation: currentLocationData(), occurredAt: Date())
     }
 
     private func drainPendingEventsIfReady() {
@@ -200,7 +203,7 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
             while self.onTransition != nil, !self.pendingEvents.isEmpty {
                 let next = self.pendingEvents.removeFirst()
                 guard self.ownedRegionIdentifiers.contains(next.identifier) else { continue }
-                self.dispatchTransition(identifier: next.identifier, transition: next.transition, capturedLocation: next.location)
+                self.dispatchTransition(identifier: next.identifier, transition: next.transition, capturedLocation: next.location, occurredAt: next.receivedAt)
             }
             self.isDrainingPendingEvents = false
         }
@@ -210,16 +213,16 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
     /// coords, so a frozen cached fix pins the whole pipeline to a stale point — freshen it first,
     /// keeping the captured location only as the fallback. Fire-and-forget so a slow fix can't
     /// stall the pending-event drain behind it. Business events keep the captured location.
-    private func dispatchTransition(identifier: String, transition: GeofenceTransition, capturedLocation: LocationData?) {
+    private func dispatchTransition(identifier: String, transition: GeofenceTransition, capturedLocation: LocationData?, occurredAt: Date) {
         if identifier == GeofenceConstants.movementTriggerIdentifier, transition == .exit {
             movementFixResolver.resolve(cached: bestKnownFix()) { [weak self] location in
                 self?.logger.geofenceOsTransitionReceived(identifier: identifier, transition: transition)
-                self?.onTransition?(identifier, transition, location ?? capturedLocation)
+                self?.onTransition?(identifier, transition, location ?? capturedLocation, occurredAt)
             }
             return
         }
         logger.geofenceOsTransitionReceived(identifier: identifier, transition: transition)
-        onTransition?(identifier, transition, capturedLocation)
+        onTransition?(identifier, transition, capturedLocation, occurredAt)
     }
 
     func locationManager(_ manager: CLLocationManager, monitoringDidFailFor region: CLRegion?, withError error: Error) {

--- a/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
@@ -39,6 +39,9 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
         /// CoreLocation's region callbacks carry no date, so this is when we received it — which is
         /// what a queued event needs so a drain minutes later is not read as happening now.
         let receivedAt: Date
+        /// The circle the OS raised this against, captured at intake — by drain time the region may
+        /// have been replaced under the same identifier.
+        let circle: MonitoredCircle?
     }
 
     /// Region events received before the bootstrap bound `onTransition` (see `handleRegionEvent`).
@@ -184,15 +187,25 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
     /// process that never binds; unlike CLMonitor there is no re-emission, but overflowing the cap
     /// requires bind to never run, and then every buffered event is undeliverable anyway.
     private func handleRegionEvent(_ region: CLRegion, transition: GeofenceTransition) {
-        guard region is CLCircularRegion else { return }
+        guard let circular = region as? CLCircularRegion else { return }
+        let circle = MonitoredCircle(
+            center: LocationData(latitude: circular.center.latitude, longitude: circular.center.longitude),
+            radius: circular.radius
+        )
         if onTransition == nil || !pendingEvents.isEmpty || isDrainingPendingEvents {
-            pendingEvents.append(PendingRegionEvent(identifier: region.identifier, transition: transition, location: currentLocationData(), receivedAt: Date()))
+            pendingEvents.append(PendingRegionEvent(
+                identifier: region.identifier, transition: transition,
+                location: currentLocationData(), receivedAt: Date(), circle: circle
+            ))
             if pendingEvents.count > Self.maxPendingEvents { pendingEvents.removeFirst() }
             drainPendingEventsIfReady()
             return
         }
         guard ownedRegionIdentifiers.contains(region.identifier) else { return }
-        dispatchTransition(identifier: region.identifier, transition: transition, capturedLocation: currentLocationData(), occurredAt: Date())
+        dispatchTransition(
+            identifier: region.identifier, transition: transition,
+            capturedLocation: currentLocationData(), occurredAt: Date(), circle: circle
+        )
     }
 
     private func drainPendingEventsIfReady() {
@@ -203,7 +216,10 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
             while self.onTransition != nil, !self.pendingEvents.isEmpty {
                 let next = self.pendingEvents.removeFirst()
                 guard self.ownedRegionIdentifiers.contains(next.identifier) else { continue }
-                self.dispatchTransition(identifier: next.identifier, transition: next.transition, capturedLocation: next.location, occurredAt: next.receivedAt)
+                self.dispatchTransition(
+                    identifier: next.identifier, transition: next.transition,
+                    capturedLocation: next.location, occurredAt: next.receivedAt, circle: next.circle
+                )
             }
             self.isDrainingPendingEvents = false
         }
@@ -213,16 +229,22 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
     /// coords, so a frozen cached fix pins the whole pipeline to a stale point — freshen it first,
     /// keeping the captured location only as the fallback. Fire-and-forget so a slow fix can't
     /// stall the pending-event drain behind it. Business events keep the captured location.
-    private func dispatchTransition(identifier: String, transition: GeofenceTransition, capturedLocation: LocationData?, occurredAt: Date) {
+    private func dispatchTransition(
+        identifier: String,
+        transition: GeofenceTransition,
+        capturedLocation: LocationData?,
+        occurredAt: Date,
+        circle: MonitoredCircle?
+    ) {
         if identifier == GeofenceConstants.movementTriggerIdentifier, transition == .exit {
             movementFixResolver.resolve(cached: bestKnownFix()) { [weak self] location in
                 self?.logger.geofenceOsTransitionReceived(identifier: identifier, transition: transition)
-                self?.onTransition?(identifier, transition, location ?? capturedLocation, occurredAt)
+                self?.onTransition?(identifier, transition, location ?? capturedLocation, occurredAt, circle)
             }
             return
         }
         logger.geofenceOsTransitionReceived(identifier: identifier, transition: transition)
-        onTransition?(identifier, transition, capturedLocation, occurredAt)
+        onTransition?(identifier, transition, capturedLocation, occurredAt, circle)
     }
 
     func locationManager(_ manager: CLLocationManager, monitoringDidFailFor region: CLRegion?, withError error: Error) {

--- a/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
@@ -190,7 +190,8 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
         guard let circular = region as? CLCircularRegion else { return }
         let circle = MonitoredCircle(
             center: LocationData(latitude: circular.center.latitude, longitude: circular.center.longitude),
-            radius: circular.radius
+            radius: circular.radius,
+            maximumRadius: manager.maximumRegionMonitoringDistance
         )
         if onTransition == nil || !pendingEvents.isEmpty || isDrainingPendingEvents {
             pendingEvents.append(PendingRegionEvent(

--- a/Sources/LocationGeofence/Monitor/GeofenceRegionMonitoring.swift
+++ b/Sources/LocationGeofence/Monitor/GeofenceRegionMonitoring.swift
@@ -9,7 +9,10 @@ import Foundation
 /// The closure body is not statically isolated — callers are free to hop to whatever actor they
 /// need: `Task.detached { ... }` for off-main work, `MainActor.assumeIsolated { ... }` for direct
 /// main-actor reads, or an `await someActor.method()` to hand off to another isolation domain.
-typealias GeofenceTransitionHandler = @Sendable (String, GeofenceTransition, LocationData?) -> Void
+/// `occurredAt` is when the crossing happened — the OS event's date, or the fix's timestamp for a
+/// synthesized heal. Lets a consumer order a late or replayed transition against what it believes,
+/// which is why every dispatch site owes one: a consumer handed no date writes unordered.
+typealias GeofenceTransitionHandler = @Sendable (String, GeofenceTransition, LocationData?, Date) -> Void
 
 /// Callback when iOS reports a change to the location authorization status.
 /// Invoked on the main actor — same isolation domain as `CLLocationManagerDelegate`.

--- a/Sources/LocationGeofence/Monitor/GeofenceRegionMonitoring.swift
+++ b/Sources/LocationGeofence/Monitor/GeofenceRegionMonitoring.swift
@@ -12,7 +12,11 @@ import Foundation
 /// `occurredAt` is when the crossing happened — the OS event's date, or the fix's timestamp for a
 /// synthesized heal. Lets a consumer order a late or replayed transition against what it believes,
 /// which is why every dispatch site owes one: a consumer handed no date writes unordered.
-typealias GeofenceTransitionHandler = @Sendable (String, GeofenceTransition, LocationData?, Date) -> Void
+/// The last parameter is the circle the OS was monitoring when it raised this event, `nil` when the
+/// monitor cannot say which one it was (a cold wake whose adoption has not populated its record
+/// yet). A consumer reasoning about what the crossing PROVES needs it: a refresh can replace a
+/// fence under the same id, and the guarantee a covering circle gives only holds for its own ring.
+typealias GeofenceTransitionHandler = @Sendable (String, GeofenceTransition, LocationData?, Date, MonitoredCircle?) -> Void
 
 /// Callback when iOS reports a change to the location authorization status.
 /// Invoked on the main actor — same isolation domain as `CLLocationManagerDelegate`.

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -112,26 +112,47 @@ final class PolygonMembershipResolver {
         }
     }
 
-    /// Re-evaluates membership for one polygon: the entry point for a polygon that has just been
-    /// registered, where the device may already be standing inside and no crossing will ever be
-    /// delivered. A geofence that is no longer cached or no longer a polygon has nothing to decide.
+    /// Re-evaluates membership for polygons that have just been registered, where the device may
+    /// already be standing inside and no crossing will ever be delivered. A geofence that is no
+    /// longer cached or no longer a polygon has nothing to decide.
+    ///
+    /// One fix serves the whole batch, for the same reason the foreground pass shares one: resolving
+    /// per geofence issues a fresh timed request each time the cache stays empty, and a registration
+    /// carrying several new polygons would spend that timeout once per polygon on the main actor.
     ///
     /// Logged because this path bypasses `handleTransition`, so nothing else records that we were
     /// asked to re-check. Reading the absence of a log line as an absence of evaluations led to
     /// exactly the wrong conclusion once already.
+    ///
     /// `isStillCurrent` is re-checked after the fix resolves. Resolving suspends, and a user switch
     /// in that window clears user-scoped state — without the re-check this task would resume and
     /// rewrite the old user's belief, stamping any resulting event to whoever signed in.
     func evaluateMembership(
-        geofenceId: String,
+        geofenceIds: [String],
         reason: String,
         isStillCurrent: (@Sendable () -> Bool)? = nil
     ) async {
-        logger.geofencePolygonEvaluationRequested(identifier: geofenceId, reason: reason)
-        // Early-out only. The ring that decides is read after the fix, inside `evaluate`.
-        guard let geofence = await cachedGeofence(id: geofenceId), geofence.polygonRegion != nil
-        else { return }
-        await evaluate(geofenceId: geofenceId, isStillCurrent: isStillCurrent)
+        for geofenceId in geofenceIds {
+            logger.geofencePolygonEvaluationRequested(identifier: geofenceId, reason: reason)
+        }
+        // Ids, never rings: one fix serves the batch, and the ring each verdict uses is read after
+        // that fix inside `evaluate`, so a refresh landing mid-request cannot be decided against.
+        var pending: [String] = []
+        for geofenceId in geofenceIds {
+            guard let geofence = await cachedGeofence(id: geofenceId), geofence.polygonRegion != nil
+            else { continue }
+            pending.append(geofenceId)
+        }
+        guard !pending.isEmpty else { return }
+        guard let fix = await resolveFix() else {
+            for geofenceId in pending {
+                logger.geofencePolygonUndecided(identifier: geofenceId, reason: "no usable fix")
+            }
+            return
+        }
+        for geofenceId in pending {
+            await evaluate(geofenceId: geofenceId, fix: fix, isStillCurrent: isStillCurrent)
+        }
     }
 
     /// Re-evaluates every registered polygon when the app comes to the foreground.

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -106,6 +106,21 @@ final class PolygonMembershipResolver {
         }
     }
 
+    /// Re-evaluates membership for one polygon: the entry point for a polygon that has just been
+    /// registered, where the device may already be standing inside and no crossing will ever be
+    /// delivered. A geofence that is no longer cached or no longer a polygon has nothing to decide.
+    ///
+    /// Logged because this path bypasses `handleTransition`, so nothing else records that we were
+    /// asked to re-check. Reading the absence of a log line as an absence of evaluations led to
+    /// exactly the wrong conclusion once already.
+    func evaluateMembership(geofenceId: String, reason: String) async {
+        logger.geofencePolygonEvaluationRequested(identifier: geofenceId, reason: reason)
+        guard let geofence = await cachedGeofence(id: geofenceId),
+              let polygon = geofence.polygonRegion
+        else { return }
+        await evaluate(geofence: geofence, polygon: polygon)
+    }
+
     /// Re-evaluates every registered polygon when the app comes to the foreground.
     ///
     /// The one case no OS event covers: a device already inside a polygon when monitoring begins

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -113,12 +113,19 @@ final class PolygonMembershipResolver {
     /// Logged because this path bypasses `handleTransition`, so nothing else records that we were
     /// asked to re-check. Reading the absence of a log line as an absence of evaluations led to
     /// exactly the wrong conclusion once already.
-    func evaluateMembership(geofenceId: String, reason: String) async {
+    /// `isStillCurrent` is re-checked after the fix resolves. Resolving suspends, and a user switch
+    /// in that window clears user-scoped state — without the re-check this task would resume and
+    /// rewrite the old user's belief, stamping any resulting event to whoever signed in.
+    func evaluateMembership(
+        geofenceId: String,
+        reason: String,
+        isStillCurrent: (@Sendable () -> Bool)? = nil
+    ) async {
         logger.geofencePolygonEvaluationRequested(identifier: geofenceId, reason: reason)
-        guard let geofence = await cachedGeofence(id: geofenceId),
-              let polygon = geofence.polygonRegion
+        // Early-out only. The ring that decides is read after the fix, inside `evaluate`.
+        guard let geofence = await cachedGeofence(id: geofenceId), geofence.polygonRegion != nil
         else { return }
-        await evaluate(geofence: geofence, polygon: polygon)
+        await evaluate(geofenceId: geofenceId, isStillCurrent: isStillCurrent)
     }
 
     /// Re-evaluates every registered polygon when the app comes to the foreground.
@@ -218,6 +225,10 @@ final class PolygonMembershipResolver {
               let polygon = geofence.polygonRegion
         else {
             logger.geofencePolygonUndecided(identifier: geofenceId, reason: "no longer a registered polygon")
+            return
+        }
+        if let isStillCurrent, !isStillCurrent() {
+            logger.geofencePolygonUndecided(identifier: geofence.id, reason: "user changed while resolving the fix")
             return
         }
         let point = LocationData(latitude: fix.coordinate.latitude, longitude: fix.coordinate.longitude)

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -102,6 +102,12 @@ final class PolygonMembershipResolver {
                 logger.geofencePolygonUndecided(identifier: identifier, reason: "stored ring no longer builds")
                 return
             }
+            // No user boundary across the fix, unlike `evaluateMembership`, and none exists to
+            // carry: the binder dispatches this with no expected user captured anywhere. Accepted
+            // on the trade this file makes elsewhere — the crossing is geometrically real, and
+            // declining it loses it for good because the dedup baseline has already advanced. The
+            // cost is real: a switch inside the fix window attributes it to a user who may not
+            // monitor this polygon at all.
             await evaluate(geofenceId: identifier)
         }
     }

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -139,6 +139,9 @@ final class PolygonMembershipResolver {
         // that fix inside `evaluate`, so a refresh landing mid-request cannot be decided against.
         var pending: [String] = []
         for geofenceId in geofenceIds {
+            // Builds the ring and discards it, unlike the foreground pass's cheaper `vertices`
+            // test: this one runs before the request, so an unbuildable ring is worth catching
+            // here rather than spending a whole fix request to reject it after.
             guard let geofence = await cachedGeofence(id: geofenceId), geofence.polygonRegion != nil
             else { continue }
             pending.append(geofenceId)
@@ -252,10 +255,6 @@ final class PolygonMembershipResolver {
               let polygon = geofence.polygonRegion
         else {
             logger.geofencePolygonUndecided(identifier: geofenceId, reason: "no longer a registered polygon")
-            return
-        }
-        if let isStillCurrent, !isStillCurrent() {
-            logger.geofencePolygonUndecided(identifier: geofence.id, reason: "user changed while resolving the fix")
             return
         }
         let point = LocationData(latitude: fix.coordinate.latitude, longitude: fix.coordinate.longitude)

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -788,6 +788,39 @@ struct GeofenceSyncCoordinatorTests {
         #expect(setup.monitor.startedRegions.isEmpty)
     }
 
+    /// Cold-wake sibling of the refresh rule: bootstrap persists whatever this returns, so an
+    /// oversized polygon reported here would be evaluated for membership with no OS wake behind it.
+    @Test
+    func applyCachedRegistration_givenOversizedPolygon_expectExcludedFromReportedRegistration() {
+        let monitor = MockGeofenceRegionMonitor()
+        monitor.maximumMonitoringRadius = 1000
+        let setup = makeCoordinator(storage: makeStorage(), monitor: monitor)
+        let oversizedPolygon = Geofence(
+            id: "poly", latitude: 0, longitude: 0, radius: 5000, name: nil,
+            transitionTypes: [.enter, .exit], lastUpdated: Date(timeIntervalSince1970: 0),
+            vertices: [
+                LocationData(latitude: -0.01, longitude: -0.01),
+                LocationData(latitude: -0.01, longitude: 0.01),
+                LocationData(latitude: 0.01, longitude: 0.01),
+                LocationData(latitude: 0.01, longitude: -0.01)
+            ]
+        )
+        let circle = Geofence(
+            id: "circle", latitude: 0, longitude: 0, radius: 100, name: nil,
+            transitionTypes: [.enter, .exit], lastUpdated: Date(timeIntervalSince1970: 0)
+        )
+
+        let registration = setup.coordinator.applyCachedRegistration(
+            cachedRegions: [oversizedPolygon, circle],
+            anchor: LocationData(latitude: 0, longitude: 0),
+            config: .fallback,
+            userId: "user-1"
+        )
+
+        #expect(registration?.businessIds.contains("poly") == false)
+        #expect(registration?.businessIds.contains("circle") == true)
+    }
+
     @Test
     func applyCachedRegistration_givenEmptyRegions_expectMovementTriggerRegistered() {
         // An empty nearby response clears the cache but leaves the trigger armed. If the OS then

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -1913,6 +1913,44 @@ struct GeofenceSyncCoordinatorTests {
         #expect(registered.contains("circle"))
     }
 
+    /// The dropped polygon must not be recorded as registered either: `evaluateAllPolygons` reads
+    /// that set, so recording it would have the resolver decide membership for a fence the OS never
+    /// took — an enter with no wake behind it and no exit to balance it.
+    @Test
+    func remoteRefresh_givenPolygonCoveringCircleOverOsLimit_expectNotRecordedAsRegistered() async {
+        let anchor = LocationData(latitude: 0, longitude: 0)
+        let storage = makeStorage()
+        let dateUtil = DateUtilStub()
+        await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-25 * 60 * 60), location: anchor)
+        let oversizedPolygon = Geofence(
+            id: "poly", latitude: 0, longitude: 0, radius: 5000, name: nil,
+            transitionTypes: [.enter, .exit], lastUpdated: dateUtil.givenNow,
+            vertices: [
+                LocationData(latitude: -0.01, longitude: -0.01),
+                LocationData(latitude: -0.01, longitude: 0.01),
+                LocationData(latitude: 0.01, longitude: 0.01),
+                LocationData(latitude: 0.01, longitude: -0.01)
+            ]
+        )
+        let smallCircle = Geofence(
+            id: "circle", latitude: 0, longitude: 0, radius: 100, name: nil,
+            transitionTypes: [.enter, .exit], lastUpdated: dateUtil.givenNow
+        )
+        let api = GeofenceApiServiceMock()
+        api.fetchNearbyGeofencesClosure = { _, _, completion in
+            completion(.success(makeApiResponse(regions: [oversizedPolygon, smallCircle])))
+        }
+        let monitor = MockGeofenceRegionMonitor()
+        monitor.maximumMonitoringRadius = 1000
+        let setup = makeCoordinator(api: api, storage: storage, monitor: monitor, dateUtil: dateUtil)
+
+        _ = await setup.coordinator.refresh(latitude: anchor.latitude, longitude: anchor.longitude)
+
+        let recorded = await storage.getRegisteredBusinessIds()
+        #expect(!recorded.contains("poly"))
+        #expect(recorded.contains("circle"))
+    }
+
     // MARK: - Initial enter-when-inside (diff-based, both monitor paths)
 
     /// A polygon's `radius` is its covering circle, so the containment test that serves circles

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -1946,6 +1946,84 @@ struct GeofenceSyncCoordinatorTests {
         #expect(registered.contains("circle"))
     }
 
+    /// A polygon the OS will refuse must not consume one of `maxBusinessGeofences`: dropping it
+    /// after ranking left the slot empty even with a usable candidate waiting behind it.
+    @Test
+    func remoteRefresh_givenOversizedPolygonAndSpareCandidate_expectSlotGoesToTheNextRegion() async {
+        let anchor = LocationData(latitude: 0, longitude: 0)
+        let storage = makeStorage()
+        let dateUtil = DateUtilStub()
+        await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-25 * 60 * 60), location: anchor)
+        let oversizedPolygon = Geofence(
+            id: "poly", latitude: 0, longitude: 0, radius: 5000, name: nil,
+            transitionTypes: [.enter, .exit], lastUpdated: dateUtil.givenNow,
+            vertices: [
+                LocationData(latitude: -0.01, longitude: -0.01),
+                LocationData(latitude: -0.01, longitude: 0.01),
+                LocationData(latitude: 0.01, longitude: 0.01),
+                LocationData(latitude: 0.01, longitude: -0.01)
+            ]
+        )
+        // Nearer than the spare, so ranking puts it in the single available slot.
+        let spare = Geofence(
+            id: "spare", latitude: 0.02, longitude: 0.02, radius: 100, name: nil,
+            transitionTypes: [.enter, .exit], lastUpdated: dateUtil.givenNow
+        )
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 750, remoteFetchRefreshTriggerRadius: 3000,
+            remoteFetchRefreshExpiry: 86400, duplicateEventsExpiry: 60,
+            maxBusinessGeofences: 1, maxMonitoringDistance: 100000
+        )
+        let api = GeofenceApiServiceMock()
+        api.fetchNearbyGeofencesClosure = { _, _, completion in
+            completion(.success(makeApiResponse(regions: [oversizedPolygon, spare], config: config)))
+        }
+        let monitor = MockGeofenceRegionMonitor()
+        monitor.maximumMonitoringRadius = 1000
+        let setup = makeCoordinator(api: api, storage: storage, monitor: monitor, dateUtil: dateUtil)
+
+        _ = await setup.coordinator.refresh(latitude: anchor.latitude, longitude: anchor.longitude)
+
+        #expect(setup.monitor.startedRegions.map(\.identifier).contains("spare"))
+    }
+
+    /// A polygon's covering circle is machinery: it must report both edges regardless of the
+    /// customer's transition types, or the resolver never sees the edge it needs to advance belief.
+    @Test
+    func remoteRefresh_givenEnterOnlyPolygon_expectCoveringCircleRegisteredWithBothEdges() async {
+        let anchor = LocationData(latitude: 0, longitude: 0)
+        let storage = makeStorage()
+        let dateUtil = DateUtilStub()
+        await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-25 * 60 * 60), location: anchor)
+        let enterOnly = Geofence(
+            id: "poly", latitude: 0, longitude: 0, radius: 300, name: nil,
+            transitionTypes: [.enter], lastUpdated: dateUtil.givenNow,
+            vertices: [
+                LocationData(latitude: -0.001, longitude: -0.001),
+                LocationData(latitude: -0.001, longitude: 0.001),
+                LocationData(latitude: 0.001, longitude: 0.001),
+                LocationData(latitude: 0.001, longitude: -0.001)
+            ]
+        )
+        let enterOnlyCircle = Geofence(
+            id: "circle", latitude: 0, longitude: 0, radius: 120, name: nil,
+            transitionTypes: [.enter], lastUpdated: dateUtil.givenNow
+        )
+        let api = GeofenceApiServiceMock()
+        api.fetchNearbyGeofencesClosure = { _, _, completion in
+            completion(.success(makeApiResponse(regions: [enterOnly, enterOnlyCircle])))
+        }
+        let setup = makeCoordinator(api: api, storage: storage, dateUtil: dateUtil)
+
+        _ = await setup.coordinator.refresh(latitude: anchor.latitude, longitude: anchor.longitude)
+
+        let polygonRequest = setup.monitor.startedRegions.first { $0.identifier == "poly" }
+        #expect(polygonRequest?.transitionTypes == [.enter, .exit])
+        // A real circle keeps the customer's types — the change is polygon-only.
+        let circleRequest = setup.monitor.startedRegions.first { $0.identifier == "circle" }
+        #expect(circleRequest?.transitionTypes == [.enter])
+    }
+
     /// The dropped polygon must not be recorded as registered either: `evaluateAllPolygons` reads
     /// that set, so recording it would have the resolver decide membership for a fence the OS never
     /// took — an enter with no wake behind it and no exit to balance it.

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -1871,7 +1871,83 @@ struct GeofenceSyncCoordinatorTests {
         #expect(refreshResult.errorOrNil == .alreadyInProgress)
     }
 
+    // MARK: - Oversized covering circles
+
+    /// Both monitors clamp a radius to the OS limit. For a circle that is graceful — the monitored
+    /// circle IS the fence, so a smaller one just reports later. For a polygon it is not: a clamped
+    /// circle no longer contains the polygon, so the covering-circle exit stops being geometric
+    /// certainty and becomes a false exit. Such a polygon is dropped instead, while the circle
+    /// alongside it still registers — the control that proves the drop is selective.
+    @Test
+    func remoteRefresh_givenPolygonCoveringCircleOverOsLimit_expectDroppedButCircleRegistered() async {
+        let anchor = LocationData(latitude: 0, longitude: 0)
+        let storage = makeStorage()
+        let dateUtil = DateUtilStub()
+        await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-25 * 60 * 60), location: LocationData(latitude: 0, longitude: 0))
+        let oversizedPolygon = Geofence(
+            id: "poly", latitude: 0, longitude: 0, radius: 5000, name: nil,
+            transitionTypes: [.enter, .exit], lastUpdated: dateUtil.givenNow,
+            vertices: [
+                LocationData(latitude: -0.01, longitude: -0.01),
+                LocationData(latitude: -0.01, longitude: 0.01),
+                LocationData(latitude: 0.01, longitude: 0.01),
+                LocationData(latitude: 0.01, longitude: -0.01)
+            ]
+        )
+        let oversizedCircle = Geofence(
+            id: "circle", latitude: 0, longitude: 0, radius: 5000, name: nil,
+            transitionTypes: [.enter, .exit], lastUpdated: dateUtil.givenNow
+        )
+        let api = GeofenceApiServiceMock()
+        api.fetchNearbyGeofencesClosure = { _, _, completion in
+            completion(.success(makeApiResponse(regions: [oversizedPolygon, oversizedCircle])))
+        }
+        let monitor = MockGeofenceRegionMonitor()
+        monitor.maximumMonitoringRadius = 1000
+        let setup = makeCoordinator(api: api, storage: storage, monitor: monitor, dateUtil: dateUtil)
+
+        _ = await setup.coordinator.refresh(latitude: anchor.latitude, longitude: anchor.longitude)
+
+        let registered = Set(setup.monitor.startedRegions.map(\.identifier))
+        #expect(!registered.contains("poly"))
+        #expect(registered.contains("circle"))
+    }
+
     // MARK: - Initial enter-when-inside (diff-based, both monitor paths)
+
+    /// A polygon's `radius` is its covering circle, so the containment test that serves circles
+    /// would emit an enter for a device sitting in the annulus — a crossing that never happened.
+    /// Polygons are excluded here and decided by the resolver's gated evaluation instead.
+    ///
+    /// The circle in the same pass is the negative control: it proves the harness would have caught
+    /// an emit, so the polygon's silence is the exclusion working and not a dead assertion.
+    @Test
+    func remoteRefresh_givenNewPolygonCoveringAnchorButNotContainingIt_expectNoInitialEnter() async {
+        let anchor = LocationData(latitude: 0, longitude: 0)
+        // Square sitting ~111 m north of the anchor: every vertex is inside the 400 m covering
+        // circle, while the anchor itself is outside the polygon.
+        let polygon = Geofence(
+            id: "poly", latitude: 0, longitude: 0, radius: 400, name: nil,
+            transitionTypes: [.enter, .exit], lastUpdated: Date(),
+            vertices: [
+                LocationData(latitude: 0.001, longitude: -0.0016),
+                LocationData(latitude: 0.001, longitude: 0.0016),
+                LocationData(latitude: 0.0026, longitude: 0.0016),
+                LocationData(latitude: 0.0026, longitude: -0.0016)
+            ]
+        )
+        let circle = Geofence(
+            id: "circle", latitude: 0, longitude: 0, radius: 400, name: nil,
+            transitionTypes: [.enter, .exit], lastUpdated: Date()
+        )
+
+        let emitter = await runRemoteRefresh(regions: [polygon, circle], anchor: anchor, previousIds: [])
+        await awaitEmits(emitter, count: 1)
+
+        let emitted = emitter.calls.wrappedValue
+        #expect(emitted.count == 1)
+        #expect(emitted.first?.geofenceId == "circle")
+    }
 
     /// Drives a remote refresh that fetches `regions`, anchored at `anchor`, with `previousIds`
     /// already recorded as registered. The emit is fire-and-forget, so callers poll via `awaitEmits`.

--- a/Tests/LocationGeofence/Geofence/GeofenceMonitorBinderTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceMonitorBinderTests.swift
@@ -30,6 +30,19 @@ struct GeofenceMonitorBinderTests {
         )
     }
 
+    /// The binder holds the resolver weakly (the production instance is a DI singleton), so every
+    /// test must keep its own strong reference or the dispatch silently never fires.
+    private func makeResolver(tracker: GeofenceEventTracker) -> PolygonMembershipResolver {
+        PolygonMembershipResolver(
+            storage: GeofenceStorage(
+                fileManager: .default,
+                directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            ),
+            transitionEmitter: tracker,
+            logger: LoggerMock()
+        )
+    }
+
     private func makeCoordinatorMock() -> GeofenceSyncCoordinatorMock {
         let mock = GeofenceSyncCoordinatorMock()
         mock.refreshReturnValue = .success(())
@@ -58,7 +71,8 @@ struct GeofenceMonitorBinderTests {
         let coordinator = makeCoordinatorMock()
         let tracker = makeTracker(deliveryTracker: makeDeliveryMock())
 
-        GeofenceMonitorBinder.bind(monitor: monitor, tracker: tracker, coordinator: coordinator)
+        let resolver = makeResolver(tracker: tracker)
+        GeofenceMonitorBinder.bind(monitor: monitor, resolver: resolver, coordinator: coordinator)
         monitor.simulateTransition(
             identifier: GeofenceConstants.movementTriggerIdentifier,
             transition: .exit,
@@ -80,7 +94,8 @@ struct GeofenceMonitorBinderTests {
         let delivery = makeDeliveryMock()
         let tracker = makeTracker(deliveryTracker: delivery)
 
-        GeofenceMonitorBinder.bind(monitor: monitor, tracker: tracker, coordinator: coordinator)
+        let resolver = makeResolver(tracker: tracker)
+        GeofenceMonitorBinder.bind(monitor: monitor, resolver: resolver, coordinator: coordinator)
         monitor.simulateTransition(
             identifier: GeofenceConstants.movementTriggerIdentifier,
             transition: .enter,
@@ -102,7 +117,8 @@ struct GeofenceMonitorBinderTests {
         let coordinator = makeCoordinatorMock()
         let tracker = makeTracker(deliveryTracker: makeDeliveryMock())
 
-        GeofenceMonitorBinder.bind(monitor: monitor, tracker: tracker, coordinator: coordinator)
+        let resolver = makeResolver(tracker: tracker)
+        GeofenceMonitorBinder.bind(monitor: monitor, resolver: resolver, coordinator: coordinator)
         monitor.simulateTransition(
             identifier: GeofenceConstants.movementTriggerIdentifier,
             transition: .exit,
@@ -122,7 +138,8 @@ struct GeofenceMonitorBinderTests {
         let delivery = makeDeliveryMock()
         let tracker = makeTracker(deliveryTracker: delivery)
 
-        GeofenceMonitorBinder.bind(monitor: monitor, tracker: tracker, coordinator: coordinator)
+        let resolver = makeResolver(tracker: tracker)
+        GeofenceMonitorBinder.bind(monitor: monitor, resolver: resolver, coordinator: coordinator)
         monitor.simulateTransition(
             identifier: "business-region-1",
             transition: .enter,

--- a/Tests/LocationGeofence/Geofence/GeofenceMonitorBinderTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceMonitorBinderTests.swift
@@ -39,7 +39,11 @@ struct GeofenceMonitorBinderTests {
                 directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
             ),
             transitionEmitter: tracker,
-            logger: LoggerMock()
+            logger: LoggerMock(),
+            contextStore: BackgroundDeliveryContextStore(
+                fileManager: .default,
+                directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            )
         )
     }
 

--- a/Tests/LocationGeofence/Geofence/GeofenceMonitorBinderTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceMonitorBinderTests.swift
@@ -187,7 +187,7 @@ struct GeofenceMonitorBinderTests {
         GeofenceMonitorBinder.bind(monitor: monitor, resolver: resolver, coordinator: makeCoordinatorMock())
         monitor.simulateTransition(
             identifier: "poly-1", transition: .exit, location: nil,
-            eventCircle: MonitoredCircle(center: LocationData(latitude: 0, longitude: 0), radius: 300)
+            eventCircle: MonitoredCircle(center: LocationData(latitude: 0, longitude: 0), radius: 300, maximumRadius: 1000)
         )
         await awaitDispatch(delivery.trackMetricCallsCount > 0)
 

--- a/Tests/LocationGeofence/Geofence/GeofenceMonitorBinderTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceMonitorBinderTests.swift
@@ -32,12 +32,15 @@ struct GeofenceMonitorBinderTests {
 
     /// The binder holds the resolver weakly (the production instance is a DI singleton), so every
     /// test must keep its own strong reference or the dispatch silently never fires.
-    private func makeResolver(tracker: GeofenceEventTracker) -> PolygonMembershipResolver {
+    private func makeResolver(
+        tracker: GeofenceEventTracker,
+        storage: GeofenceStorage = GeofenceStorage(
+            fileManager: .default,
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+    ) -> PolygonMembershipResolver {
         PolygonMembershipResolver(
-            storage: GeofenceStorage(
-                fileManager: .default,
-                directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-            ),
+            storage: storage,
             transitionEmitter: tracker,
             logger: LoggerMock(),
             contextStore: BackgroundDeliveryContextStore(
@@ -154,5 +157,41 @@ struct GeofenceMonitorBinderTests {
 
         #expect(delivery.trackMetricCallsCount == 1)
         #expect(coordinator.handleMovementCallsCount == 0)
+    }
+
+    /// The circle an event was raised for has to survive the binder hop, or the resolver's
+    /// staleness check is fed nil on every real crossing and silently never fires.
+    @Test
+    func bind_givenExitForAReplacedCircle_expectResolverRefusesIt() async {
+        let monitor = MockGeofenceRegionMonitor()
+        let delivery = makeDeliveryMock()
+        let tracker = makeTracker(deliveryTracker: delivery)
+        let storage = GeofenceStorage(
+            fileManager: .default,
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+        let ring = [
+            LocationData(latitude: -0.0016, longitude: -0.0016),
+            LocationData(latitude: -0.0016, longitude: 0.0016),
+            LocationData(latitude: 0.0016, longitude: 0.0016)
+        ]
+        // Cached fence sits at the replacement's circle; the event names the one it replaced.
+        await storage.recordRegistration(center: LocationData(latitude: 0, longitude: 0), businessIds: ["poly-1"])
+        await storage.setCachedGeofences([Geofence(
+            id: "poly-1", latitude: 0, longitude: 0.005, radius: 300, name: nil,
+            transitionTypes: [.enter, .exit], lastUpdated: Date(), vertices: ring
+        )])
+        _ = await storage.recordPolygonMembership(.inside, forIdentifier: "poly-1")
+
+        let resolver = makeResolver(tracker: tracker, storage: storage)
+        GeofenceMonitorBinder.bind(monitor: monitor, resolver: resolver, coordinator: makeCoordinatorMock())
+        monitor.simulateTransition(
+            identifier: "poly-1", transition: .exit, location: nil,
+            eventCircle: MonitoredCircle(center: LocationData(latitude: 0, longitude: 0), radius: 300)
+        )
+        await awaitDispatch(delivery.trackMetricCallsCount > 0)
+
+        #expect(delivery.trackMetricCallsCount == 0)
+        #expect(await storage.getPolygonMembership()["poly-1"]?.membership == .inside)
     }
 }

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -339,6 +339,43 @@ struct PolygonMembershipResolverTests {
         #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
     }
 
+    /// The batch shares one fix, so every polygon in it spans the same request — and a refresh
+    /// landing inside that request replaces rings under the ids the batch is holding. Each verdict
+    /// must come from the ring current when it is decided, not the one the batch was built from.
+    @Test
+    func evaluateMembership_givenPolygonReplacedWhileFixPending_expectVerdictFromTheCurrentRing() async {
+        let setup = await makeSetup(fix: nil)
+        await registerPolygons(setup, ids: ["1"])
+        let requested = Flag()
+        setup.fixResolver.requestFreshFix = { requested.value = true }
+
+        async let pass: Void = setup.resolver.evaluateMembership(geofenceIds: ["1"], reason: "test")
+        await yieldUntil { requested.value }
+        await setup.storage.setCachedGeofences([movedPolygonGeofence()])
+        setup.fixResolver.handleResolvedFix(fix(latitude: 0, longitude: 0))
+        await pass
+
+        #expect(await setup.emitter.snapshot().isEmpty)
+        #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .outside)
+    }
+
+    /// Control: the same interleaving with the catalog left alone must still deliver.
+    @Test
+    func evaluateMembership_givenCatalogUnchangedWhileFixPending_expectEnterDelivered() async {
+        let setup = await makeSetup(fix: nil)
+        await registerPolygons(setup, ids: ["1"])
+        let requested = Flag()
+        setup.fixResolver.requestFreshFix = { requested.value = true }
+
+        async let pass: Void = setup.resolver.evaluateMembership(geofenceIds: ["1"], reason: "test")
+        await yieldUntil { requested.value }
+        setup.fixResolver.handleResolvedFix(fix(latitude: 0, longitude: 0))
+        await pass
+
+        #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
+        #expect(await setup.emitter.snapshot().map(\.transition) == [.enter])
+    }
+
     /// A registration carrying several new polygons must cost one location request, not one each:
     /// with no fix obtainable, per-polygon resolution spends the full request timeout N times over
     /// on the main actor and still decides nothing.

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -318,7 +318,7 @@ struct PolygonMembershipResolverTests {
         await setup.storage.setCachedGeofences([polygonGeofence()])
 
         await setup.resolver.evaluateMembership(
-            geofenceId: "1", reason: "test", isStillCurrent: { false }
+            geofenceIds: ["1"], reason: "test", isStillCurrent: { false }
         )
 
         #expect(await setup.emitter.snapshot().isEmpty)
@@ -333,10 +333,24 @@ struct PolygonMembershipResolverTests {
         await setup.storage.setCachedGeofences([polygonGeofence()])
 
         await setup.resolver.evaluateMembership(
-            geofenceId: "1", reason: "test", isStillCurrent: { true }
+            geofenceIds: ["1"], reason: "test", isStillCurrent: { true }
         )
 
         #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
+    }
+
+    /// A registration carrying several new polygons must cost one location request, not one each:
+    /// with no fix obtainable, per-polygon resolution spends the full request timeout N times over
+    /// on the main actor and still decides nothing.
+    @Test
+    func evaluateMembership_givenSeveralNewPolygons_expectOneRequestForTheBatch() async {
+        let setup = await makeSetup(fix: nil)
+        await registerPolygons(setup, ids: ["1", "2", "3"])
+        let counter = countingRequests(setup)
+
+        await setup.resolver.evaluateMembership(geofenceIds: ["1", "2", "3"], reason: "test")
+
+        #expect(counter.count == 1)
     }
 
     /// The annulus: inside the covering circle, outside the polygon. The OS thinks we arrived;

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -309,6 +309,36 @@ struct PolygonMembershipResolverTests {
         #expect(await setup.emitter.snapshot().map(\.transition) == [.enter])
     }
 
+    /// The fix resolves across a suspension point. If the user switches in that window, cleanup has
+    /// already cleared user-scoped state, so resuming would rewrite the old user's belief and stamp
+    /// any event to whoever signed in.
+    @Test
+    func evaluateMembership_givenUserChangesWhileResolving_expectNoBeliefAndNoEvent() async {
+        let setup = await makeSetup(fix: fix(latitude: 0, longitude: 0))
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+
+        await setup.resolver.evaluateMembership(
+            geofenceId: "1", reason: "test", isStillCurrent: { false }
+        )
+
+        #expect(await setup.emitter.snapshot().isEmpty)
+        #expect(await setup.storage.getPolygonMembership()["1"] == nil)
+    }
+
+    /// Control: the same call with the user unchanged must still decide, so the guard above is not
+    /// passing by refusing everything.
+    @Test
+    func evaluateMembership_givenUserUnchanged_expectVerdictRecorded() async {
+        let setup = await makeSetup(fix: fix(latitude: 0, longitude: 0))
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+
+        await setup.resolver.evaluateMembership(
+            geofenceId: "1", reason: "test", isStillCurrent: { true }
+        )
+
+        #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
+    }
+
     /// The annulus: inside the covering circle, outside the polygon. The OS thinks we arrived;
     /// geometry says otherwise, so nothing is delivered and the belief records `outside`.
     @Test

--- a/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
+++ b/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
@@ -230,7 +230,12 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
         )
     }
 
-    func simulateTransition(identifier: String, transition: GeofenceTransition, location: LocationData?) {
-        onTransition?(identifier, transition, location)
+    func simulateTransition(
+        identifier: String,
+        transition: GeofenceTransition,
+        location: LocationData?,
+        occurredAt: Date = Date()
+    ) {
+        onTransition?(identifier, transition, location, occurredAt)
     }
 }

--- a/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
+++ b/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
@@ -230,12 +230,18 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
         )
     }
 
+    /// `eventCircle` defaults to the circle this mock has registered for `identifier`, so a test
+    /// that does not care gets a self-consistent event rather than an accidentally stale one.
     func simulateTransition(
         identifier: String,
         transition: GeofenceTransition,
         location: LocationData?,
-        occurredAt: Date = Date()
+        occurredAt: Date = Date(),
+        eventCircle: MonitoredCircle? = nil
     ) {
-        onTransition?(identifier, transition, location, occurredAt)
+        let circle = eventCircle ?? registeredGeometry[identifier].map {
+            MonitoredCircle(center: $0.center, radius: $0.radius)
+        }
+        onTransition?(identifier, transition, location, occurredAt, circle)
     }
 }

--- a/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
+++ b/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
@@ -240,7 +240,7 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
         eventCircle: MonitoredCircle? = nil
     ) {
         let circle = eventCircle ?? registeredGeometry[identifier].map {
-            MonitoredCircle(center: $0.center, radius: $0.radius)
+            MonitoredCircle(center: $0.center, radius: $0.radius, maximumRadius: maximumMonitoringRadius)
         }
         onTransition?(identifier, transition, location, occurredAt, circle)
     }


### PR DESCRIPTION
Part of [MBL-2291](https://linear.app/customerio/issue/MBL-2291/ios-implement-responsive-on-device-polygon-monitoring)

Part 5 of the polygon geofence work. Wires the resolver into the monitor, and closes two
polygon-specific hazards in the paths around it.

### What's here

**Binder** — business transitions now dispatch to the resolver, which forwards circles to the
tracker unchanged and interprets a polygon's covering-circle event against membership.

**Initial enter-when-inside excludes polygons.** That test compares the anchor against `radius`,
which for a polygon is its *covering circle* — so a device sitting in the annulus would have been
handed an enter it never earned. Newly-registered polygons go to the gated evaluation instead,
which is also the only thing that reports a device already standing inside one.

**A polygon whose covering circle exceeds the OS limit is dropped, not clamped.** Both monitors
clamp silently, and a clamped circle no longer contains the polygon — which turns the
covering-circle exit from geometric certainty into a false exit, and lets the device enter through
a part of the polygon no wake covers. Circles keep clamping: for them the monitored circle *is* the
fence, so a smaller one only reports later. The drop happens **before ranking**, so a refused
polygon no longer occupies a business slot a usable candidate could take.

**A polygon's covering circle registers with both edges**, whatever the customer's transition types
are. The circle is machinery, not the fence: registering it enter-only starved the resolver of the
exit it needs to advance belief, so an enter-only polygon fired once per install and an exit-only
one never fired at all. The customer's filter applies to the polygon verdict instead. Real circles
keep the customer's types.

**Transitions carry the event date** — the OS event's, or the fix timestamp for a synthesized heal —
so a late or replayed one can be ordered against what the SDK believes. Not optional: every dispatch
site already had a date, and a consumer handed none writes unordered. The OS-received log moved to
the dispatch sites at the same time, where provenance is known; logged in the resolver it counted
the SDK's own synthesized heals as OS deliveries.

**Newly registered polygons are evaluated as a batch**, sharing one fix. Resolving per polygon
spends the whole location-request timeout once per polygon on the main actor whenever no fix is
obtainable, and decides nothing — the same defect the foreground pass had.

**The user is re-checked after the fix resolves**, not only before evaluation starts. Resolving
suspends, and a switch in that window clears user-scoped state — the resumed task would rewrite the
old user's belief and stamp any event to whoever signed in. The OS-delivered path deliberately does
not re-check: a sign-out clears the registration set, which already refuses the write, and a switch
that re-registers the same polygon leaves the new user genuinely inside it.

**The batch holds ids, not rings.** One fix serves every polygon in it, so a refresh has the whole
request in which to replace geometry under those ids — the same hazard the resolver closes in #1245,
reaching this path because the batch is built before the fix. It carries `[String]` and each verdict
reads its own fence afterwards. The pre-filter still builds the ring and discards it, deliberately:
it runs before the request, so rejecting an unbuildable ring there saves a whole fix request.

**Events carry the circle they were raised for.** #1245 refuses a covering-circle exit whose circle
the fence no longer has, but nothing supplied that circle, so on every real crossing the check saw
nil and never fired. CLMonitor now reports the condition it registered, the classic path the region
the delegate handed it — captured at intake, because a queued event can drain after the region was
replaced — and the baseline heal the condition it synthesized against. Each producer also reports
the cap it clamped that radius against, so the comparison can reconstruct what was actually
registered.

### Testing

476/476 `LocationGeofenceTests` pass on iOS 26. Format and lint clean.

Each behaviour is tested with a circle alongside the polygon as the negative control, so the
polygon's silence is the exclusion working rather than a dead assertion — including that a real
circle still registers with the customer's own transition types, and that a cap-sized candidate
takes the slot a refused polygon would have held.

### Stack

1. #1239 `mbl-2290-a` geometry kernel (merged)
2. #1240 `mbl-2290-b` wire contract (merged)
3. #1244 `mbl-2291-a` membership layer (merged)
4. #1245 `mbl-2291-b` membership resolver
5. #1246 `mbl-2291-c` monitor wiring ← **this PR**
6. #1249 `mbl-2290-c` antimeridian fix
7. #1250 `mbl-2291-f` shared dynamic movement circle
8. #1259 `mbl-2291-h` belief survives eviction
9. #1262 `mbl-2291-g` event circle generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)













