### PR TITLE
chore(geofence): persist polygon tripwires

### DIFF
--- a/Sources/LocationGeofence/GeofenceInternalIdentifier.swift
+++ b/Sources/LocationGeofence/GeofenceInternalIdentifier.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Region identifiers the SDK registers for its own control flow rather than for a customer
+/// geofence. Internal regions are never tracked as transitions and never emit an initial enter.
+///
+/// Two kinds exist: the single movement trigger, whose EXIT drives re-ranking, and the per-polygon
+/// tripwires planted inside a covering circle to wake the SDK for a membership re-evaluation.
+/// Tripwires are recognized by prefix rather than a registry, so a cold-wake event can be
+/// classified before any state has loaded. Customer geofence ids are server-assigned int64s, so
+/// they cannot collide with the prefix.
+enum GeofenceInternalIdentifier {
+    private static let tripwirePrefix = "cio_tripwire_"
+
+    /// The tripwire identifier for a polygon geofence.
+    static func tripwire(for geofenceId: String) -> String {
+        tripwirePrefix + geofenceId
+    }
+
+    /// The polygon geofence a tripwire belongs to, or `nil` when the identifier isn't a tripwire.
+    static func geofenceId(forTripwire identifier: String) -> String? {
+        guard identifier.hasPrefix(tripwirePrefix) else { return nil }
+        return String(identifier.dropFirst(tripwirePrefix.count))
+    }
+
+    /// Whether the identifier names an SDK control region rather than a customer geofence.
+    static func isInternal(_ identifier: String) -> Bool {
+        identifier == GeofenceConstants.movementTriggerIdentifier || identifier.hasPrefix(tripwirePrefix)
+    }
+}

--- a/Sources/LocationGeofence/Model/GeofenceState.swift
+++ b/Sources/LocationGeofence/Model/GeofenceState.swift
@@ -23,6 +23,9 @@ struct GeofenceState: Codable, Equatable, Sendable {
     /// Believed device membership for each polygon geofence, keyed by geofence id. Absent for
     /// circle fences, and absent for a polygon no fix has yet decided (see `PolygonMembership`).
     var polygonMembership: [String: PolygonMembershipRecord]?
+    /// Tripwires currently planted for polygon geofences, keyed by geofence id. Present only while
+    /// the device is inside that polygon's covering circle.
+    var polygonTripwires: [String: PolygonTripwire]?
     /// Per-condition bookkeeping for the CLMonitor (iOS 17+) monitor, keyed by region identifier.
     /// `nil` on the classic CLLocationManager path, which needs neither: its delegate fires only on
     /// real crossings (no dedup needed) and filters transition types at the OS level.

--- a/Sources/LocationGeofence/Polygon/PolygonMembership.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembership.swift
@@ -35,3 +35,15 @@ enum PolygonMembershipOutcome: Equatable {
     /// First decision for this polygon placed the device outside; there is no crossing to report.
     case suppressedInitialOutside
 }
+
+/// The device-centered circle planted inside a polygon's covering circle so the OS wakes the SDK
+/// once the device has moved far enough for the membership verdict to change.
+///
+/// The covering circle alone is not enough: between the polygon boundary and the circle the OS is
+/// silent, and a crossing there would go unnoticed until some unrelated wake. Radius is the
+/// distance to the polygon boundary (floored), so leaving the tripwire is exactly the point at
+/// which the previous verdict stops being safe to trust.
+struct PolygonTripwire: Codable, Equatable, Sendable {
+    let center: LocationData
+    let radius: Double
+}

--- a/Sources/LocationGeofence/Storage/GeofenceStorage+PolygonMembership.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage+PolygonMembership.swift
@@ -46,15 +46,47 @@ extension GeofenceStorage {
     func getPolygonMembership() -> [String: PolygonMembershipRecord] {
         loadFromDisk()?.polygonMembership ?? [:]
     }
+
+    /// Snapshot of every planted tripwire. Read when composing the OS-monitored set, so a tripwire
+    /// survives the reconciliation that would otherwise sweep away a region nobody asked for.
+    func getPolygonTripwires() -> [String: PolygonTripwire] {
+        loadFromDisk()?.polygonTripwires ?? [:]
+    }
+
+    /// Plants or moves the tripwire for a polygon. Persisted before the OS registration so a sync
+    /// racing the plant still finds it in the desired set.
+    func setPolygonTripwire(_ tripwire: PolygonTripwire, forIdentifier identifier: String) {
+        var state = loadFromDisk() ?? GeofenceState()
+        var tripwires = state.polygonTripwires ?? [:]
+        tripwires[identifier] = tripwire
+        state.polygonTripwires = tripwires
+        saveToDisk(state)
+    }
+
+    /// Removes the tripwire for a polygon, once the device has left its covering circle and the
+    /// wake it provided is no longer needed. Returns whether anything was removed, so the caller
+    /// can skip a re-registration that would change nothing.
+    @discardableResult
+    func clearPolygonTripwire(forIdentifier identifier: String) -> Bool {
+        var state = loadFromDisk() ?? GeofenceState()
+        guard var tripwires = state.polygonTripwires, tripwires.removeValue(forKey: identifier) != nil else { return false }
+        state.polygonTripwires = tripwires
+        saveToDisk(state)
+        return true
+    }
 }
 
 extension GeofenceState {
-    /// Drops polygon belief for geofences a registration no longer covers, on the same rule the
-    /// monitor records use: a polygon outside the registered set is no longer being evaluated, so a
-    /// retained belief would go stale and suppress the enter owed when the device comes back to it.
+    /// Drops polygon belief and tripwires for geofences a registration no longer covers, on the
+    /// same rule the monitor records use: a polygon outside the registered set is no longer being
+    /// evaluated, so a retained belief would go stale and suppress the enter owed when the device
+    /// comes back to it, and a retained tripwire would name a condition nothing plants.
     mutating func prunePolygonState(retaining businessIds: Set<String>) {
         if let membership = polygonMembership {
             polygonMembership = membership.filter { businessIds.contains($0.key) }
+        }
+        if let tripwires = polygonTripwires {
+            polygonTripwires = tripwires.filter { businessIds.contains($0.key) }
         }
     }
 }

--- a/Sources/LocationGeofence/Storage/GeofenceStorage.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage.swift
@@ -205,6 +205,7 @@ actor GeofenceStorage {
         state.monitoredGeofenceIds = nil
         state.monitorRegionRecords = nil
         state.polygonMembership = nil
+        state.polygonTripwires = nil
         saveToDisk(state)
     }
 
@@ -289,7 +290,11 @@ actor GeofenceStorage {
         // dropped. Retaining exactly the registered set bounds the records the same way
         // `monitoredGeofenceIds` is bounded, and clears anything a previous version stranded.
         if let records = state.monitorRegionRecords {
-            let retained = businessIds.union([GeofenceConstants.movementTriggerIdentifier])
+            // Tripwire conditions are keyed by their own identifier, not the geofence id, so they
+            // have to be named explicitly or every sync would drop the record for a live tripwire.
+            let retained = businessIds
+                .union(businessIds.map(GeofenceInternalIdentifier.tripwire(for:)))
+                .union([GeofenceConstants.movementTriggerIdentifier])
             state.monitorRegionRecords = records.filter { retained.contains($0.key) }
         }
         state.prunePolygonState(retaining: businessIds)

--- a/Sources/LocationGeofence/Storage/GeofenceSyncStorage.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceSyncStorage.swift
@@ -10,6 +10,7 @@ protocol GeofenceSyncStorage: Sendable {
     func getLastSync() async -> LastSyncRecord?
     func getLastRegistrationCenter() async -> LocationData?
     func getRegisteredBusinessIds() async -> Set<String>
+    func getPolygonTripwires() async -> [String: PolygonTripwire]
     func setCachedGeofences(_ regions: [Geofence]) async
     func setCachedConfig(_ config: GeofenceConfig) async
     func recordSync(timestamp: Date, location: LocationData) async

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -2267,6 +2267,10 @@ private actor SpyGeofenceSyncStorage: GeofenceSyncStorage {
         return await underlying.getRegisteredBusinessIds()
     }
 
+    func getPolygonTripwires() async -> [String: PolygonTripwire] {
+        await underlying.getPolygonTripwires()
+    }
+
     func setCachedGeofences(_ regions: [Geofence]) async {
         onSetCachedGeofences?()
         operations.append(.setCachedGeofences)

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonTripwireStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonTripwireStorageTests.swift
@@ -1,0 +1,92 @@
+@testable import CioInternalCommon
+@testable import CioLocationGeofence
+import Foundation
+import Testing
+
+@Suite("GeofenceStorage polygon tripwires")
+struct PolygonTripwireStorageTests {
+    private func makeStorage() -> GeofenceStorage {
+        GeofenceStorage(
+            fileManager: .default,
+            directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        )
+    }
+
+    private func tripwire(radius: Double = 100) -> PolygonTripwire {
+        PolygonTripwire(center: LocationData(latitude: 1, longitude: 2), radius: radius)
+    }
+
+    @Test
+    func setPolygonTripwire_expectReadBackAndReplacedInPlace() async {
+        let storage = makeStorage()
+        await storage.setPolygonTripwire(tripwire(), forIdentifier: "1")
+        #expect(await storage.getPolygonTripwires()["1"]?.radius == 100)
+
+        await storage.setPolygonTripwire(tripwire(radius: 250), forIdentifier: "1")
+        let tripwires = await storage.getPolygonTripwires()
+        #expect(tripwires.count == 1)
+        #expect(tripwires["1"]?.radius == 250)
+    }
+
+    /// The caller re-registers with the OS only when something actually changed, so a clear that
+    /// removed nothing has to report it.
+    @Test
+    func clearPolygonTripwire_givenNonePlanted_expectFalse() async {
+        let storage = makeStorage()
+        #expect(await storage.clearPolygonTripwire(forIdentifier: "1") == false)
+    }
+
+    @Test
+    func clearPolygonTripwire_givenPlanted_expectRemovedAndTrue() async {
+        let storage = makeStorage()
+        await storage.setPolygonTripwire(tripwire(), forIdentifier: "1")
+
+        #expect(await storage.clearPolygonTripwire(forIdentifier: "1") == true)
+        #expect(await storage.getPolygonTripwires().isEmpty)
+    }
+
+    /// A polygon that drops out of the registered set is no longer evaluated, so its tripwire names
+    /// a condition nothing will plant again. The retained one is the control.
+    @Test
+    func recordRegistration_givenPolygonEvicted_expectItsTripwirePruned() async {
+        let storage = makeStorage()
+        await storage.setPolygonTripwire(tripwire(), forIdentifier: "evicted")
+        await storage.setPolygonTripwire(tripwire(), forIdentifier: "kept")
+
+        await storage.recordRegistration(center: LocationData(latitude: 1, longitude: 1), businessIds: ["kept"])
+
+        let tripwires = await storage.getPolygonTripwires()
+        #expect(tripwires["evicted"] == nil)
+        #expect(tripwires["kept"] != nil)
+    }
+
+    /// A tripwire's monitor record is keyed by the tripwire identifier, not the geofence id, so the
+    /// prune has to name it explicitly or every sync would strip the baseline of a live condition
+    /// and the OS's next EXIT would be deduped away.
+    @Test
+    func recordRegistration_givenLiveTripwire_expectItsMonitorRecordRetained() async {
+        let storage = makeStorage()
+        let tripwireId = GeofenceInternalIdentifier.tripwire(for: "1")
+        await storage.recordMonitorRegistration(
+            identifier: tripwireId,
+            transitionTypes: [.exit],
+            initialState: .enter,
+            center: LocationData(latitude: 1, longitude: 2),
+            radius: 100
+        )
+
+        await storage.recordRegistration(center: LocationData(latitude: 1, longitude: 1), businessIds: ["1"])
+
+        #expect(await storage.getMonitorRegionRecords()[tripwireId] != nil)
+    }
+
+    @Test
+    func clearUserScopedState_expectTripwiresCleared() async {
+        let storage = makeStorage()
+        await storage.setPolygonTripwire(tripwire(), forIdentifier: "1")
+
+        await storage.clearUserScopedState()
+
+        #expect(await storage.getPolygonTripwires().isEmpty)
+    }
+}


### PR DESCRIPTION
Part of [MBL-2291](https://linear.app/customerio/issue/MBL-2291/ios-implement-responsive-on-device-polygon-monitoring)

Part 6 of the polygon geofence work. Tripwire state only — the model, its storage, and the
identifier namespace. **Nothing plants one yet**; that is the next PR.

### What's here

A tripwire is the device-centred circle planted inside a covering circle so the OS wakes the SDK
once the device has moved far enough for the membership verdict to change. Between the polygon
boundary and the covering circle the OS is silent, and a crossing there would go unnoticed until
some unrelated wake.

Tripwires are recognized by identifier prefix rather than a registry, so a cold-wake event can be
classified before any state has loaded. Customer geofence ids are server-assigned int64s, so they
cannot collide with the prefix.

### Worth a reviewer's attention

Two prune rules, and the second is the subtle one. A tripwire is dropped when its polygon leaves
the registered set, on the same rule the membership belief follows. But its **monitor record** is
keyed by the tripwire identifier rather than the geofence id, so the record prune has to name it
explicitly — otherwise every sync would strip the baseline of a live condition and dedup away the
EXIT the tripwire exists to deliver. The state-space model catches exactly this as a negative
control: with the record prune keyed off business ids alone it reports 1.7 M suppressed crossings.

### Testing

Storage round-trip, both prune rules, and user-scoped clear.

### Stack

1. `mbl-2290-a-polygon-geometry-kernel` — geometry kernel (#1239)
2. `mbl-2290-b-polygon-wire-contract` — v2 wire contract decode (#1240)
3. `mbl-2291-a-polygon-membership-layer` — membership belief + storage (#1244)
4. `mbl-2291-b-polygon-membership-resolver` — the resolver (#1245)
5. `mbl-2291-c-polygon-monitor-wiring` — monitor wiring (#1246)
6. `mbl-2291-d-polygon-tripwire-state` — tripwire state ← **this PR**
7. `mbl-2291-e-polygon-tripwire-planting` — tripwire planting + budget (#1248)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

