### PR TITLE
chore(geofence): plant polygon tripwires and register them

### DIFF
--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+InitialEnter.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+InitialEnter.swift
@@ -56,6 +56,11 @@ extension GeofenceSyncCoordinatorImpl {
     /// site rather than stored: the resolver is a `@MainActor` singleton and this coordinator is
     /// one of its own dependencies, so a stored reference back would make the two initialize each
     /// other.
+    ///
+    /// The tripwire this plants may not reach the OS on this pass — its re-registration needs the
+    /// refresh gate, which the sync calling us still holds. It is persisted either way, so the next
+    /// sync carries it. A device standing still has no next sync, which is what foreground
+    /// evaluation is for.
     private func evaluateNewPolygons(_ polygons: [Geofence], expectedUserId: String) {
         Task { @MainActor [contextStore] in
             let resolver = DIGraphShared.shared.polygonMembershipResolver

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+OsRegistration.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+OsRegistration.swift
@@ -32,7 +32,8 @@ extension GeofenceSyncCoordinatorImpl {
         businessRegions: [Geofence],
         movementTriggerLocation: LocationData,
         movementTriggerRadius: Double,
-        registerMovementTrigger: Bool
+        registerMovementTrigger: Bool,
+        tripwires: [String: PolygonTripwire] = [:]
     ) -> GeofenceOsRegistration {
         var desired: [GeofenceRegionRequest] = []
         // Order the movement trigger FIRST so it isn't starved when business regions fill the
@@ -61,6 +62,25 @@ extension GeofenceSyncCoordinatorImpl {
             )
             return false
         }
+        // Tripwires next, ahead of the business regions and for the same reason the movement
+        // trigger is: a tripwire only exists while the device is inside that polygon's covering
+        // circle, and losing it to a full budget would leave the annulus with no wake source at
+        // all. Only for polygons still in this pass's set — one evicted from the set is no longer
+        // evaluated, and its tripwire is pruned alongside its membership.
+        let registeredIdsForTripwires = Set(registrable.map(\.id))
+        desired.append(
+            contentsOf: tripwires
+                .filter { registeredIdsForTripwires.contains($0.key) }
+                .sorted { $0.key < $1.key }
+                .map { geofenceId, tripwire in
+                    GeofenceRegionRequest(
+                        identifier: GeofenceInternalIdentifier.tripwire(for: geofenceId),
+                        center: tripwire.center,
+                        radius: tripwire.radius,
+                        transitionTypes: [.exit]
+                    )
+                }
+        )
         desired.append(contentsOf: registrable.map { region in
             GeofenceRegionRequest(
                 identifier: region.id,

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
@@ -36,7 +36,8 @@ extension GeofenceSyncCoordinatorImpl {
         let regions = response.toDomainRegions(onInvalidRegion: { logger.geofenceInvalidRegionDropped($0) })
         let effectiveConfig = parsedConfig ?? cachedConfig ?? .fallback
         let anchor = LocationData(latitude: latitude, longitude: longitude)
-        let nearest = distanceFilter.nearest(regions, to: anchor, limit: effectiveConfig.maxBusinessGeofences, maxDistance: effectiveConfig.maxMonitoringDistance)
+        let tripwires = await storage.getPolygonTripwires()
+        let nearest = distanceFilter.nearest(regions, to: anchor, limit: businessLimit(for: effectiveConfig, tripwires: tripwires), maxDistance: effectiveConfig.maxMonitoringDistance)
         let registerMovementTrigger = effectiveConfig.maxBusinessGeofences > 0
         // Read before `recordRegistration` overwrites it — the diff decides which registrations are new.
         let previouslyRegisteredIds = await storage.getRegisteredBusinessIds()
@@ -46,7 +47,8 @@ extension GeofenceSyncCoordinatorImpl {
                 businessRegions: nearest,
                 movementTriggerLocation: anchor,
                 movementTriggerRadius: effectiveConfig.localRefreshTriggerRadius,
-                registerMovementTrigger: registerMovementTrigger
+                registerMovementTrigger: registerMovementTrigger,
+                tripwires: tripwires
             )
         }
 
@@ -81,7 +83,8 @@ extension GeofenceSyncCoordinatorImpl {
         cachedRegions: [Geofence]
     ) async -> Result<Void, GeofenceSyncError> {
         let anchor = LocationData(latitude: latitude, longitude: longitude)
-        let nearest = distanceFilter.nearest(cachedRegions, to: anchor, limit: config.maxBusinessGeofences, maxDistance: config.maxMonitoringDistance)
+        let tripwires = await storage.getPolygonTripwires()
+        let nearest = distanceFilter.nearest(cachedRegions, to: anchor, limit: businessLimit(for: config, tripwires: tripwires), maxDistance: config.maxMonitoringDistance)
         let registerMovementTrigger = config.maxBusinessGeofences > 0
         // Read before `recordRegistration` overwrites it — the diff decides which registrations are new.
         let previouslyRegisteredIds = await storage.getRegisteredBusinessIds()
@@ -91,7 +94,8 @@ extension GeofenceSyncCoordinatorImpl {
                 businessRegions: nearest,
                 movementTriggerLocation: anchor,
                 movementTriggerRadius: config.localRefreshTriggerRadius,
-                registerMovementTrigger: registerMovementTrigger
+                registerMovementTrigger: registerMovementTrigger,
+                tripwires: tripwires
             )
         }
         await storage.recordRegistration(center: anchor, businessIds: nearestIds)

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
@@ -37,7 +37,7 @@ extension GeofenceSyncCoordinatorImpl {
         let effectiveConfig = parsedConfig ?? cachedConfig ?? .fallback
         let anchor = LocationData(latitude: latitude, longitude: longitude)
         let tripwires = await storage.getPolygonTripwires()
-        let nearest = distanceFilter.nearest(regions, to: anchor, limit: businessLimit(for: effectiveConfig, tripwires: tripwires), maxDistance: effectiveConfig.maxMonitoringDistance)
+        let nearest = nearestBusinessRegions(regions, to: anchor, config: effectiveConfig, tripwires: tripwires)
         let registerMovementTrigger = effectiveConfig.maxBusinessGeofences > 0
         // Read before `recordRegistration` overwrites it — the diff decides which registrations are new.
         let previouslyRegisteredIds = await storage.getRegisteredBusinessIds()
@@ -84,7 +84,7 @@ extension GeofenceSyncCoordinatorImpl {
     ) async -> Result<Void, GeofenceSyncError> {
         let anchor = LocationData(latitude: latitude, longitude: longitude)
         let tripwires = await storage.getPolygonTripwires()
-        let nearest = distanceFilter.nearest(cachedRegions, to: anchor, limit: businessLimit(for: config, tripwires: tripwires), maxDistance: config.maxMonitoringDistance)
+        let nearest = nearestBusinessRegions(cachedRegions, to: anchor, config: config, tripwires: tripwires)
         let registerMovementTrigger = config.maxBusinessGeofences > 0
         // Read before `recordRegistration` overwrites it — the diff decides which registrations are new.
         let previouslyRegisteredIds = await storage.getRegisteredBusinessIds()

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
@@ -275,7 +275,7 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         defer { releaseGate() }
 
         let effectiveConfig = config ?? .fallback
-        let nearest = distanceFilter.nearest(cachedRegions, to: anchor, limit: businessLimit(for: effectiveConfig, tripwires: tripwires), maxDistance: effectiveConfig.maxMonitoringDistance)
+        let nearest = nearestBusinessRegions(cachedRegions, to: anchor, config: effectiveConfig, tripwires: tripwires)
         let registerMovementTrigger = effectiveConfig.maxBusinessGeofences > 0
         registerWithOsSync(
             businessRegions: nearest,
@@ -290,15 +290,31 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         return GeofenceRegistration(center: anchor, businessIds: Set(nearest.map(\.id)))
     }
 
-    /// Business-region cap for one pass, with a slot held back for every planted tripwire.
+    /// Nearest business regions for one pass, with a slot held back for each tripwire the pass will
+    /// actually register.
     ///
-    /// `maxBusinessGeofences` keeps meaning *business fences*, but a tripwire draws from the same
-    /// 20-region OS budget, so the cap has to shrink or the total overflows and the OS starts
-    /// refusing registrations. Steady-state tripwire count is zero, so this normally changes
-    /// nothing. A polygon whose tripwire costs it its own slot cannot happen: the device is inside
-    /// that polygon's covering circle, so its edge distance is 0 and it sorts first.
-    func businessLimit(for config: GeofenceConfig, tripwires: [String: PolygonTripwire]) -> Int {
-        max(0, config.maxBusinessGeofences - tripwires.count)
+    /// A tripwire draws from the same 20-region OS budget as a business fence, so the cap has to
+    /// shrink or the total overflows and the OS starts refusing registrations. Steady-state
+    /// tripwire count is zero, so this normally changes nothing.
+    ///
+    /// Only tripwires for polygons in the ranked set are reserved for, because only those are
+    /// composed into the desired set — one for a polygon that fell out of the ranking is pruned at
+    /// the end of this same pass, and reserving for it would register fewer fences than the budget
+    /// allows. Ranking first and trimming after avoids the circularity of letting the cap depend on
+    /// a set that depends on the cap: trimming can only drop tripwires from the reserved set, never
+    /// add them, so the total stays within budget without a second ranking pass.
+    func nearestBusinessRegions(
+        _ regions: [Geofence],
+        to anchor: LocationData,
+        config: GeofenceConfig,
+        tripwires: [String: PolygonTripwire]
+    ) -> [Geofence] {
+        let ranked = distanceFilter.nearest(
+            regions, to: anchor, limit: config.maxBusinessGeofences, maxDistance: config.maxMonitoringDistance
+        )
+        let rankedIds = Set(ranked.map(\.id))
+        let reserved = tripwires.keys.filter { rankedIds.contains($0) }.count
+        return Array(ranked.prefix(max(0, config.maxBusinessGeofences - reserved)))
     }
 
     /// The identified user a gated operation runs for (`nil` when signed out); the exit cleanup compares against it.

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
@@ -31,17 +31,23 @@ enum HandleMovementTier: String, Sendable {
 ///   `ownedRegionIdentifiers` is populated before the next yield — otherwise the OS may
 ///   deliver a queued cold-wake transition into an empty filter set. Returns what it
 ///   registered so the caller can persist it once the no-await window has closed.
+/// - `reapplyRegistration(latitude:longitude:)` — re-composes the OS-monitored set for the current
+///   location without consulting the server. Used when the desired set changed for a reason other
+///   than device movement: a polygon tripwire was planted or cleared and must reach the OS before
+///   the next sync would otherwise run.
 /// - `reset()` — sign-out cleanup. Stops OS-side monitoring and clears user-scoped store
 ///   state (cooldowns, last-sync). Preserves the workspace cache.
 protocol GeofenceSyncCoordinator: AutoMockable, AnyObject, Sendable {
     func refresh(latitude: Double, longitude: Double) async -> Result<Void, GeofenceSyncError>
     func handleMovement(latitude: Double, longitude: Double) async -> Result<Void, GeofenceSyncError>
     func reset() async -> Result<Void, GeofenceSyncError>
+    func reapplyRegistration(latitude: Double, longitude: Double) async -> Result<Void, GeofenceSyncError>
     @MainActor
     func applyCachedRegistration(
         cachedRegions: [Geofence],
         anchor: LocationData?,
         config: GeofenceConfig?,
+        tripwires: [String: PolygonTripwire],
         userId: String?
     ) -> GeofenceRegistration?
 }
@@ -193,6 +199,34 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         }
     }
 
+    func reapplyRegistration(latitude: Double, longitude: Double) async -> Result<Void, GeofenceSyncError> {
+        // Losing the gate here is benign: the tripwire that prompted this call is already persisted,
+        // so the sync currently holding the gate composes its desired set from storage and carries
+        // the tripwire to the OS itself.
+        guard acquireGate() else {
+            logger.geofenceSyncSkipped(reason: "refresh already in progress")
+            return .failure(.alreadyInProgress)
+        }
+        let expectedUserId = identifiedUserId
+        let result: Result<Void, GeofenceSyncError>
+        if let userId = expectedUserId {
+            result = await performLocalRefresh(
+                expectedUserId: userId,
+                latitude: latitude,
+                longitude: longitude,
+                config: await storage.getCachedConfig() ?? .fallback,
+                cachedRegions: await storage.getCachedGeofences()
+            )
+        } else {
+            logger.geofenceSyncSkipped(reason: "no identified user")
+            result = .failure(.noIdentifiedUser)
+        }
+        let cleaned = await cleanupIfUserChanged(expectedUserId: expectedUserId)
+        releaseGate()
+        if cleaned { retryForCurrentUser(latitude: latitude, longitude: longitude) }
+        return result
+    }
+
     func reset() async -> Result<Void, GeofenceSyncError> {
         guard acquireGate() else {
             logger.geofenceSyncSkipped(reason: "refresh already in progress")
@@ -219,6 +253,7 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         cachedRegions: [Geofence],
         anchor: LocationData?,
         config: GeofenceConfig?,
+        tripwires: [String: PolygonTripwire],
         userId: String?
     ) -> GeofenceRegistration? {
         guard let userId, !userId.isEmpty else {
@@ -240,18 +275,30 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         defer { releaseGate() }
 
         let effectiveConfig = config ?? .fallback
-        let nearest = distanceFilter.nearest(cachedRegions, to: anchor, limit: effectiveConfig.maxBusinessGeofences, maxDistance: effectiveConfig.maxMonitoringDistance)
+        let nearest = distanceFilter.nearest(cachedRegions, to: anchor, limit: businessLimit(for: effectiveConfig, tripwires: tripwires), maxDistance: effectiveConfig.maxMonitoringDistance)
         let registerMovementTrigger = effectiveConfig.maxBusinessGeofences > 0
         registerWithOsSync(
             businessRegions: nearest,
             movementTriggerLocation: anchor,
             movementTriggerRadius: effectiveConfig.localRefreshTriggerRadius,
-            registerMovementTrigger: registerMovementTrigger
+            registerMovementTrigger: registerMovementTrigger,
+            tripwires: tripwires
         )
         logger.geofenceSyncCompleted(registeredCount: nearest.count, movementTriggerRegistered: registerMovementTrigger)
         // No initial-enter here: a cold-wake restore of the pre-kill set (not new registrations) off a
         // possibly-stale anchor. Genuinely-new fences come from a refresh fetch, which emits there.
         return GeofenceRegistration(center: anchor, businessIds: Set(nearest.map(\.id)))
+    }
+
+    /// Business-region cap for one pass, with a slot held back for every planted tripwire.
+    ///
+    /// `maxBusinessGeofences` keeps meaning *business fences*, but a tripwire draws from the same
+    /// 20-region OS budget, so the cap has to shrink or the total overflows and the OS starts
+    /// refusing registrations. Steady-state tripwire count is zero, so this normally changes
+    /// nothing. A polygon whose tripwire costs it its own slot cannot happen: the device is inside
+    /// that polygon's covering circle, so its edge distance is 0 and it sorts first.
+    func businessLimit(for config: GeofenceConfig, tripwires: [String: PolygonTripwire]) -> Int {
+        max(0, config.maxBusinessGeofences - tripwires.count)
     }
 
     /// The identified user a gated operation runs for (`nil` when signed out); the exit cleanup compares against it.

--- a/Sources/LocationGeofence/GeofenceBootstrap.swift
+++ b/Sources/LocationGeofence/GeofenceBootstrap.swift
@@ -44,6 +44,7 @@ enum GeofenceBootstrap {
         // registration center but leaves lastSync at the fetch point, so restoring from lastSync
         // would revert the OS to the older nearest-set. Falls back to lastSync before any re-rank.
         let restoreAnchor = await di.geofenceStorage.getLastRegistrationCenter() ?? lastSync?.location
+        let tripwires = await di.geofenceStorage.getPolygonTripwires()
         let userId = di.backgroundDeliveryContextStore.currentUserId
 
         // The set we expect to still own: the business geofences registered last session plus the
@@ -51,8 +52,12 @@ enum GeofenceBootstrap {
         // — expected-owned mirrors the register condition, so a kill-switched account reclaims
         // nothing. Compared against the OS-retained set below.
         let lastRegisteredBusinessIds = await di.geofenceStorage.getRegisteredBusinessIds()
+        // Planted tripwires are owned regions too: without them here a cold wake never re-claims
+        // the condition, and the ownership gate drops the very EXIT the tripwire exists to deliver.
         let expectedOwnedRegions = (cachedConfig ?? .fallback).maxBusinessGeofences > 0
-            ? lastRegisteredBusinessIds.union([GeofenceConstants.movementTriggerIdentifier])
+            ? lastRegisteredBusinessIds
+            .union(tripwires.keys.map(GeofenceInternalIdentifier.tripwire(for:)))
+            .union([GeofenceConstants.movementTriggerIdentifier])
             : []
         // Adopt-time seed for the CLMonitor path's geometry bookkeeping (empty on classic).
         let monitorRecords = await di.geofenceStorage.getMonitorRegionRecords()
@@ -97,6 +102,7 @@ enum GeofenceBootstrap {
                 cachedRegions: cachedRegions,
                 anchor: restoreAnchor,
                 config: cachedConfig,
+                tripwires: tripwires,
                 userId: userId
             )
             // Persist what was registered as the ranking-staleness reference. The await is safe

--- a/Sources/LocationGeofence/GeofenceConstants.swift
+++ b/Sources/LocationGeofence/GeofenceConstants.swift
@@ -48,6 +48,11 @@ enum GeofenceConstants {
     /// this covers processes that live for days without one.
     static let foregroundRearmInterval: TimeInterval = 6 * 60 * 60
 
+    /// Floor on the radius of a polygon tripwire — the device-centered circle planted inside a
+    /// covering circle to provoke a wake once the device has moved far enough to change the
+    /// membership verdict. Below this the OS promotes crossings too unreliably to be worth a slot.
+    static let polygonTripwireMinRadius: Double = 100
+
     // Floor on the baseline-heal ambiguity margin (meters): a fix closer than this to the fence
     // edge never synthesizes a crossing, even when it reports better accuracy.
     static let baselineHealMinEdgeMargin: Double = 20

--- a/Sources/LocationGeofence/GeofenceMonitorBinder.swift
+++ b/Sources/LocationGeofence/GeofenceMonitorBinder.swift
@@ -5,9 +5,11 @@ import Foundation
 /// `startMonitoring` call so cold-wake delegate callbacks arriving immediately after
 /// `CLLocationManager` becomes active have a handler to dispatch to.
 ///
-/// Two dispatch paths:
+/// Three dispatch paths:
 /// - `GeofenceConstants.movementTriggerIdentifier` (EXIT) → `coordinator.handleMovement`
 ///   (internal; never tracked as a customer event).
+/// - A polygon's tripwire (EXIT) → `resolver.evaluateMembership` (internal; the wake that lets the
+///   SDK re-check membership inside a covering circle, where the OS is silent).
 /// - Any other identifier → `resolver.handleTransition`, which forwards circle geofences to the
 ///   tracker unchanged and interprets a polygon's covering-circle event against membership.
 @MainActor
@@ -36,7 +38,20 @@ enum GeofenceMonitorBinder {
                 }
                 return
             }
-            Task { await resolver?.handleTransition(identifier: identifier, transition: transition) }
+            if let polygonId = GeofenceInternalIdentifier.geofenceId(forTripwire: identifier) {
+                // A tripwire is planted around the device to provoke a wake once it has moved far
+                // enough to change the verdict; only leaving it carries information. Held under a
+                // background-task assertion for the same reason the movement pass is — the wake
+                // window can expire mid-evaluation, and nothing re-delivers a consumed EXIT.
+                guard transition == .exit else { return }
+                Task {
+                    await backgroundTaskRunner.withBackgroundTime {
+                        await resolver?.evaluateMembership(geofenceId: polygonId, reason: "tripwire wake")
+                    }
+                }
+                return
+            }
+            Task { await resolver?.handleTransition(identifier: identifier, transition: transition, location: location) }
         }
     }
 }

--- a/Sources/LocationGeofence/GeofenceMonitorBinder.swift
+++ b/Sources/LocationGeofence/GeofenceMonitorBinder.swift
@@ -46,7 +46,9 @@ enum GeofenceMonitorBinder {
                 guard transition == .exit else { return }
                 Task {
                     await backgroundTaskRunner.withBackgroundTime {
-                        await resolver?.evaluateMembership(geofenceId: polygonId, reason: "tripwire wake")
+                        await resolver?.evaluateMembership(
+                            geofenceId: polygonId, reason: "tripwire wake", requiresFreshFix: true
+                        )
                     }
                 }
                 return

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -158,6 +158,14 @@ extension Logger {
         info("Polygon \(transition.rawValue) for region \(identifier), confirmed by \(basis)", geofenceTag)
     }
 
+    func geofencePolygonTripwirePlanted(identifier: String, radius: Double) {
+        debug("Planted polygon tripwire for region \(identifier), radius \(Int(radius)) m", geofenceTag)
+    }
+
+    func geofencePolygonTripwireCleared(identifier: String) {
+        debug("Cleared polygon tripwire for region \(identifier)", geofenceTag)
+    }
+
     func geofencePolygonEvaluationRequested(identifier: String, reason: String) {
         debug("Re-evaluating polygon membership for region \(identifier) (\(reason))", geofenceTag)
     }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Registration.swift
@@ -67,8 +67,10 @@ extension CLMonitorGeofenceMonitor {
             transitionTypes: transitionTypes
         )
 
-        let isMovementTrigger = identifier == GeofenceConstants.movementTriggerIdentifier
-        let isInside = isDeviceInside(center: coordinate, radius: clampedRadius) ?? isMovementTrigger
+        // Internal regions — the movement trigger and polygon tripwires — are planted ON the
+        // device, so with no fix to check against, inside is the correct assumption.
+        let isDeviceCentered = GeofenceInternalIdentifier.isInternal(identifier)
+        let isInside = isDeviceInside(center: coordinate, radius: clampedRadius) ?? isDeviceCentered
         let initialTransition: GeofenceTransition = isInside ? .enter : .exit
         let assumedState: CLMonitor.Event.State = isInside ? .satisfied : .unsatisfied
 

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -293,7 +293,7 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
         }
         // Runs BEFORE the baseline advance below: a refused event must leave the stored baseline
         // untouched so the daemon's own re-evaluation dedups against it (see `+ContradictionGate`).
-        if identifier != GeofenceConstants.movementTriggerIdentifier,
+        if !GeofenceInternalIdentifier.isInternal(identifier),
            await isEventContradictedByFreshFix(identifier: identifier, transition: transition, eventDate: event.date) {
             return
         }
@@ -301,7 +301,7 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
         // No ownership re-check after the await: the baseline already advanced, so dropping here
         // loses the transition permanently — a sync's stop-all + re-add swap would eat a genuine
         // crossing that raced it. A region truly removed in that window delivers one last gated event.
-        if identifier == GeofenceConstants.movementTriggerIdentifier, transition == .exit {
+        if GeofenceInternalIdentifier.isInternal(identifier), transition == .exit {
             // The movement pass re-centers the trigger and measures displacement at these coords, so
             // a frozen cached fix pins the whole pipeline to a stale point — freshen it first.
             // Fire-and-forget so a slow fix can't stall the pending-event drain behind it.

--- a/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
@@ -211,7 +211,7 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
     /// keeping the captured location only as the fallback. Fire-and-forget so a slow fix can't
     /// stall the pending-event drain behind it. Business events keep the captured location.
     private func dispatchTransition(identifier: String, transition: GeofenceTransition, capturedLocation: LocationData?) {
-        if identifier == GeofenceConstants.movementTriggerIdentifier, transition == .exit {
+        if GeofenceInternalIdentifier.isInternal(identifier), transition == .exit {
             movementFixResolver.resolve(cached: bestKnownFix()) { [weak self] location in
                 self?.onTransition?(identifier, transition, location ?? capturedLocation)
             }

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -91,12 +91,17 @@ final class PolygonMembershipResolver {
     /// Logged because this path bypasses `handleTransition`, so nothing else records that we were
     /// asked to re-check. Reading the absence of a log line as an absence of evaluations led to
     /// exactly the wrong conclusion once already.
-    func evaluateMembership(geofenceId: String, reason: String) async {
+    /// `requiresFreshFix` is set by the tripwire wake, which fires *because* the device moved far
+    /// enough to change the verdict. Answering it from the cached fix — the one that planted the
+    /// tripwire, still inside `movementFixMaxAge` — replays the same verdict, leaves the tripwire
+    /// unchanged so nothing is re-planted, and consumes the wake for nothing. Measured on a 30 m/s
+    /// simulated drive: a 15 s-old fix is 450 m stale, and the polygon's ENTER was never delivered.
+    func evaluateMembership(geofenceId: String, reason: String, requiresFreshFix: Bool = false) async {
         logger.geofencePolygonEvaluationRequested(identifier: geofenceId, reason: reason)
         guard let geofence = await cachedGeofence(id: geofenceId),
               let polygon = geofence.polygonRegion
         else { return }
-        await evaluate(geofence: geofence, polygon: polygon)
+        await evaluate(geofence: geofence, polygon: polygon, requiresFreshFix: requiresFreshFix)
     }
 
     /// Re-evaluates every registered polygon when the app comes to the foreground.
@@ -142,9 +147,14 @@ final class PolygonMembershipResolver {
     }
 
     private func evaluate(
-        geofence: Geofence, polygon: PolygonRegion, containment: ContainmentEvidence = .fixOnly
+        geofence: Geofence,
+        polygon: PolygonRegion,
+        containment: ContainmentEvidence = .fixOnly,
+        requiresFreshFix: Bool = false
     ) async {
-        guard let fix = await resolveFix(), CLLocationCoordinate2DIsValid(fix.coordinate) else {
+        guard let fix = await resolveFix(requiringFresh: requiresFreshFix),
+              CLLocationCoordinate2DIsValid(fix.coordinate)
+        else {
             logger.geofencePolygonUndecided(identifier: geofence.id, reason: "no usable fix")
             return
         }
@@ -251,9 +261,9 @@ final class PolygonMembershipResolver {
     /// Freshest fix obtainable, requesting one when the cache is stale. Mirrors the gate's
     /// resolution: the completion's coordinates are discarded in favour of `latestFix`, which
     /// carries the accuracy and timestamp the decision needs.
-    private func resolveFix() async -> CLLocation? {
+    private func resolveFix(requiringFresh: Bool = false) async -> CLLocation? {
         await withCheckedContinuation { continuation in
-            fixResolver.resolve(cached: fixResolver.latestFix) { [weak self] _ in
+            fixResolver.resolve(cached: requiringFresh ? nil : fixResolver.latestFix) { [weak self] _ in
                 continuation.resume(returning: self?.fixResolver.latestFix)
             }
         }

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -79,7 +79,17 @@ final class PolygonMembershipResolver {
             await apply(.outside, to: geofence, evidence: nil)
             await clearTripwire(for: geofence.id, at: location)
         case .enter:
-            await evaluate(geofence: geofence, polygon: polygon, containment: .coveringCircleEnter)
+            // Fresh fix for the same reason the tripwire wake needs one: the OS is telling us the
+            // device is ON this circle's boundary right now, while a cached fix may be 30 s old —
+            // 900 m at driving speed. Measured on a simulated drive: a stale fix on this path put
+            // the device 918 m from the polygon and planted a tripwire wider than the covering
+            // circle, which can never fire before the circle's own exit.
+            await evaluate(
+                geofence: geofence,
+                polygon: polygon,
+                containment: .coveringCircleEnter,
+                requiresFreshFix: true
+            )
         }
     }
 

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -5,7 +5,7 @@ import Foundation
 import UIKit
 #endif
 
-/// Turns OS covering-circle events into customer-facing polygon transitions.
+/// Turns OS covering-circle events and tripwire wakes into customer-facing polygon transitions.
 ///
 /// The OS monitors a polygon's server-guaranteed covering circle and knows nothing about the
 /// polygon itself, so membership is a second fact that has to be established on device. This sits
@@ -28,6 +28,7 @@ import UIKit
 final class PolygonMembershipResolver {
     private let storage: GeofenceStorage
     private let transitionEmitter: GeofenceTransitionEmitting
+    private let coordinator: GeofenceSyncCoordinator
     private let fixResolver: MovementFixResolver
     private let logger: Logger
     private var foregroundObserverToken: NSObjectProtocol?
@@ -35,11 +36,13 @@ final class PolygonMembershipResolver {
     init(
         storage: GeofenceStorage,
         transitionEmitter: GeofenceTransitionEmitting,
+        coordinator: GeofenceSyncCoordinator,
         logger: Logger,
         fixResolver: MovementFixResolver? = nil
     ) {
         self.storage = storage
         self.transitionEmitter = transitionEmitter
+        self.coordinator = coordinator
         self.logger = logger
         self.fixResolver = fixResolver ?? MovementFixResolver(
             logger: logger,
@@ -61,7 +64,7 @@ final class PolygonMembershipResolver {
     /// condition the cache has dropped) is forwarded rather than dropped: treating it as a circle
     /// is the behaviour that predates polygons, and losing a real crossing is worse than a
     /// covering-circle-shaped one.
-    func handleTransition(identifier: String, transition: GeofenceTransition) async {
+    func handleTransition(identifier: String, transition: GeofenceTransition, location: LocationData?) async {
         logger.geofenceOsTransitionReceived(identifier: identifier, transition: transition)
         guard let geofence = await cachedGeofence(id: identifier),
               let polygon = geofence.polygonRegion
@@ -71,17 +74,19 @@ final class PolygonMembershipResolver {
         }
         switch transition {
         case .exit:
-            // polygon ⊆ covering circle, so leaving the circle is geometric certainty and needs
-            // no fix.
+            // polygon ⊆ covering circle, so leaving the circle is geometric certainty and needs no
+            // fix. The tripwire goes with it: outside the circle there is no annulus to watch.
             await apply(.outside, to: geofence, evidence: nil)
+            await clearTripwire(for: geofence.id, at: location)
         case .enter:
-            await evaluate(geofence: geofence, polygon: polygon)
+            await evaluate(geofence: geofence, polygon: polygon, containment: .coveringCircleEnter)
         }
     }
 
-    /// Re-evaluates membership for one polygon: the entry point for a polygon that has just been
-    /// registered, where the device may already be standing inside and no crossing will ever be
-    /// delivered. A geofence that is no longer cached or no longer a polygon has nothing to decide.
+    /// Re-evaluates membership for one polygon: the wake path used by tripwire exits, and the
+    /// entry point for a polygon that has just been registered, where the device may already be
+    /// standing inside and no crossing will ever be delivered. A geofence that is no longer cached
+    /// or no longer a polygon has nothing to decide.
     ///
     /// Logged because this path bypasses `handleTransition`, so nothing else records that we were
     /// asked to re-check. Reading the absence of a log line as an absence of evaluations led to
@@ -125,13 +130,52 @@ final class PolygonMembershipResolver {
         #endif
     }
 
-    private func evaluate(geofence: Geofence, polygon: PolygonRegion) async {
+    /// How we know whether the device is inside the covering circle, which decides whether a
+    /// tripwire is worth a slot. The distinction matters because our own fix can be staler than the
+    /// event we are reacting to.
+    private enum ContainmentEvidence {
+        /// The OS reported a crossing INTO the covering circle. That is stronger than any fix we
+        /// hold: it is the OS's own evaluation, at the moment it happened.
+        case coveringCircleEnter
+        /// No OS statement — containment has to be inferred from the fix.
+        case fixOnly
+    }
+
+    private func evaluate(
+        geofence: Geofence, polygon: PolygonRegion, containment: ContainmentEvidence = .fixOnly
+    ) async {
         guard let fix = await resolveFix(), CLLocationCoordinate2DIsValid(fix.coordinate) else {
             logger.geofencePolygonUndecided(identifier: geofence.id, reason: "no usable fix")
             return
         }
         let point = LocationData(latitude: fix.coordinate.latitude, longitude: fix.coordinate.longitude)
         let signedEdgeDistance = polygon.signedEdgeDistance(to: point)
+        // A tripwire is only worth a slot inside the covering circle. Outside it the OS's own
+        // covering-circle enter is the wake, and a tripwire would be a region that can never fire
+        // first — this path is reached for EVERY registered polygon on a foreground evaluation,
+        // including ones the device is kilometres from, so planting unconditionally burns the
+        // scarce 20-region budget on wakes that cannot happen.
+        //
+        // Planted before the verdict is consulted, and whatever the verdict is: an undecided
+        // evaluation still needs a wake to try again from, and that is exactly the annulus case the
+        // tripwire exists for.
+        let headroom = geofence.radius - geofence.distanceTo(point)
+        switch containment {
+        case .coveringCircleEnter:
+            // The OS just said we are inside, so never clear here, whatever our fix says. Measured
+            // in the field: a 15.5 s-old cached fix — well within `movementFixMaxAge` — placed the
+            // device ~400 m from where it was, outside a circle it had just entered, and retired
+            // the tripwire for the whole 12 minutes it then spent in the annulus.
+            await updateTripwire(for: geofence.id, center: point, signedEdgeDistance: signedEdgeDistance)
+        case .fixOnly:
+            if headroom > 0 {
+                await updateTripwire(for: geofence.id, center: point, signedEdgeDistance: signedEdgeDistance)
+            } else if -headroom > max(fix.horizontalAccuracy, GeofenceConstants.baselineHealMinEdgeMargin) {
+                // Retire it only when decisively outside. Inside the uncertainty band, leaving the
+                // tripwire alone costs a slot; dropping it can cost a crossing.
+                await clearTripwire(for: geofence.id, at: point)
+            }
+        }
         guard let membership = PolygonMembershipDecision.resolvedMembership(
             signedEdgeDistance: signedEdgeDistance,
             horizontalAccuracy: fix.horizontalAccuracy,
@@ -164,6 +208,40 @@ final class PolygonMembershipResolver {
             confirmedByFix: evidence != nil
         )
         await transitionEmitter.trackTransition(geofenceId: geofence.id, transition: transition)
+    }
+
+    /// Plants or moves the tripwire so it sits on the device with a radius reaching the polygon
+    /// boundary — leaving it is precisely the point at which this evaluation's verdict stops being
+    /// safe to trust. Floored, because below that the OS promotes crossings too unreliably.
+    ///
+    /// Deliberately NOT capped at the distance left inside the covering circle. Capping sounds
+    /// tidy — it keeps the tripwire a strictly earlier signal than the circle's own exit — but a
+    /// tripwire larger than the circle is merely redundant, while a small one is not promoted at
+    /// all, and the cap pinned the radius to the floor at exactly the moment a covering-circle
+    /// enter plants one. Promotability wins over tidiness.
+    ///
+    /// Persisted before the re-registration so a sync racing this call still composes it into the
+    /// desired set. An unchanged tripwire is left alone: re-registering the same circle would risk
+    /// absorbing a crossing the OS has detected but not yet delivered.
+    private func updateTripwire(for geofenceId: String, center: LocationData, signedEdgeDistance: Double) async {
+        let tripwire = PolygonTripwire(
+            center: center,
+            radius: max(abs(signedEdgeDistance), GeofenceConstants.polygonTripwireMinRadius)
+        )
+        guard await storage.getPolygonTripwires()[geofenceId] != tripwire else { return }
+        await storage.setPolygonTripwire(tripwire, forIdentifier: geofenceId)
+        logger.geofencePolygonTripwirePlanted(identifier: geofenceId, radius: tripwire.radius)
+        _ = await coordinator.reapplyRegistration(latitude: center.latitude, longitude: center.longitude)
+    }
+
+    /// Drops the tripwire once its polygon's covering circle has been left. Without a location the
+    /// re-registration is skipped rather than guessed at — the tripwire is already gone from
+    /// storage, so the next sync composes a desired set without it and the OS condition goes then.
+    private func clearTripwire(for geofenceId: String, at location: LocationData?) async {
+        guard await storage.clearPolygonTripwire(forIdentifier: geofenceId) else { return }
+        logger.geofencePolygonTripwireCleared(identifier: geofenceId)
+        guard let location else { return }
+        _ = await coordinator.reapplyRegistration(latitude: location.latitude, longitude: location.longitude)
     }
 
     private func cachedGeofence(id: String) async -> Geofence? {
@@ -202,6 +280,7 @@ extension PolygonMembershipResolver {
     static let shared = PolygonMembershipResolver(
         storage: DIGraphShared.shared.geofenceStorage,
         transitionEmitter: DIGraphShared.shared.geofenceEventTracker,
+        coordinator: DIGraphShared.shared.geofenceSyncCoordinator,
         logger: DIGraphShared.shared.logger
     )
 }

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -1781,6 +1781,71 @@ struct GeofenceSyncCoordinatorTests {
         #expect(refreshResult.errorOrNil == .alreadyInProgress)
     }
 
+    // MARK: - Tripwire slot budget
+
+    /// Drives a remote refresh whose config caps business fences at `maxBusiness`, with `tripwires`
+    /// already persisted from an earlier pass.
+    private func runBudgetRefresh(
+        regions: [Geofence], tripwires: [String: PolygonTripwire], maxBusiness: Int
+    ) async -> Set<String> {
+        let anchor = LocationData(latitude: 0, longitude: 0)
+        let storage = makeStorage()
+        let dateUtil = DateUtilStub()
+        await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-25 * 60 * 60), location: anchor)
+        for (id, tripwire) in tripwires {
+            await storage.setPolygonTripwire(tripwire, forIdentifier: id)
+        }
+        let config = GeofenceConfig(
+            localRefreshTriggerRadius: 1000,
+            remoteFetchRefreshTriggerRadius: 5000,
+            remoteFetchRefreshExpiry: 86400,
+            duplicateEventsExpiry: 3600,
+            maxBusinessGeofences: maxBusiness,
+            maxMonitoringDistance: 100000
+        )
+        let api = GeofenceApiServiceMock()
+        api.fetchNearbyGeofencesClosure = { _, _, completion in
+            completion(.success(makeApiResponse(regions: regions, config: config)))
+        }
+        let setup = makeCoordinator(api: api, storage: storage, dateUtil: dateUtil)
+        _ = await setup.coordinator.refresh(latitude: anchor.latitude, longitude: anchor.longitude)
+        return Set(setup.monitor.startedRegions.map(\.identifier))
+    }
+
+    /// A tripwire draws from the same 20-region budget as a business fence, so the business cap
+    /// shrinks by one for each tripwire this pass will register.
+    @Test
+    func remoteRefresh_givenTripwireForRankedPolygon_expectBusinessCapShrinksByOne() async {
+        let near = makeRegion(id: "first", latitude: 0, longitude: 0)
+        let second = makeRegion(id: "second", latitude: 0.5, longitude: 0)
+        let registered = await runBudgetRefresh(
+            regions: [near, second],
+            tripwires: ["first": PolygonTripwire(center: LocationData(latitude: 0, longitude: 0), radius: 100)],
+            maxBusiness: 2
+        )
+
+        #expect(registered.contains("first"))
+        #expect(registered.contains(GeofenceInternalIdentifier.tripwire(for: "first")))
+        #expect(!registered.contains("second"))
+    }
+
+    /// Reported by Bugbot on #1248: a tripwire whose polygon fell out of the ranking is pruned at
+    /// the end of this same pass, so reserving a slot for it registers fewer business fences than
+    /// the budget allows. Only tripwires the pass actually composes may cost a slot.
+    @Test
+    func remoteRefresh_givenTripwireForUnrankedPolygon_expectNoSlotReserved() async {
+        let first = makeRegion(id: "first", latitude: 0, longitude: 0)
+        let second = makeRegion(id: "second", latitude: 0.5, longitude: 0)
+        let registered = await runBudgetRefresh(
+            regions: [first, second],
+            tripwires: ["gone": PolygonTripwire(center: LocationData(latitude: 0, longitude: 0), radius: 100)],
+            maxBusiness: 2
+        )
+
+        #expect(registered.contains("first"))
+        #expect(registered.contains("second"))
+    }
+
     // MARK: - Oversized covering circles
 
     /// Both monitors clamp a radius to the OS limit. For a circle that is graceful — the monitored

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -681,6 +681,7 @@ struct GeofenceSyncCoordinatorTests {
             cachedRegions: [sampleRegion()],
             anchor: LocationData(latitude: 0, longitude: 0),
             config: .fallback,
+            tripwires: [:],
             userId: nil
         )
 
@@ -698,6 +699,7 @@ struct GeofenceSyncCoordinatorTests {
             cachedRegions: [],
             anchor: LocationData(latitude: 0, longitude: 0),
             config: .fallback,
+            tripwires: [:],
             userId: "user-1"
         )
 
@@ -722,6 +724,7 @@ struct GeofenceSyncCoordinatorTests {
             cachedRegions: [],
             anchor: LocationData(latitude: 0, longitude: 0),
             config: config,
+            tripwires: [:],
             userId: "user-1"
         )
 
@@ -738,6 +741,7 @@ struct GeofenceSyncCoordinatorTests {
             cachedRegions: [sampleRegion()],
             anchor: nil,
             config: .fallback,
+            tripwires: [:],
             userId: "user-1"
         )
 
@@ -765,6 +769,7 @@ struct GeofenceSyncCoordinatorTests {
             cachedRegions: regions,
             anchor: anchor,
             config: config,
+            tripwires: [:],
             userId: "user-1"
         )
 
@@ -806,6 +811,7 @@ struct GeofenceSyncCoordinatorTests {
             cachedRegions: regions,
             anchor: anchor,
             config: config,
+            tripwires: [:],
             userId: "user-1"
         )
 
@@ -821,6 +827,7 @@ struct GeofenceSyncCoordinatorTests {
             cachedRegions: [sampleRegion()],
             anchor: LocationData(latitude: 0, longitude: 0),
             config: .fallback,
+            tripwires: [:],
             userId: nil
         )
 
@@ -845,6 +852,7 @@ struct GeofenceSyncCoordinatorTests {
             cachedRegions: [makeRegion(id: "far", latitude: 1, longitude: 2)], // ~248 km from anchor
             anchor: LocationData(latitude: 0, longitude: 0),
             config: config,
+            tripwires: [:],
             userId: "user-1"
         )
 
@@ -869,6 +877,7 @@ struct GeofenceSyncCoordinatorTests {
             cachedRegions: [makeRegion(id: "g1", latitude: 0, longitude: 0)],
             anchor: LocationData(latitude: 0, longitude: 0),
             config: config,
+            tripwires: [:],
             userId: "user-1"
         )
 
@@ -884,6 +893,7 @@ struct GeofenceSyncCoordinatorTests {
             cachedRegions: [sampleRegion(offset: 0.1)],
             anchor: anchor,
             config: nil,
+            tripwires: [:],
             userId: "user-1"
         )
 
@@ -917,6 +927,7 @@ struct GeofenceSyncCoordinatorTests {
             cachedRegions: [sampleRegion()],
             anchor: LocationData(latitude: 0, longitude: 0),
             config: .fallback,
+            tripwires: [:],
             userId: "user-1"
         )
         #expect(setup.monitor.startedRegions.count == monitorCallsBefore)

--- a/Tests/LocationGeofence/Geofence/GeofenceInternalIdentifierTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceInternalIdentifierTests.swift
@@ -1,0 +1,32 @@
+@testable import CioLocationGeofence
+import Foundation
+import Testing
+
+@Suite("GeofenceInternalIdentifier")
+struct GeofenceInternalIdentifierTests {
+    @Test
+    func tripwire_expectRoundTripToItsGeofenceId() {
+        let identifier = GeofenceInternalIdentifier.tripwire(for: "1234")
+        #expect(GeofenceInternalIdentifier.geofenceId(forTripwire: identifier) == "1234")
+    }
+
+    /// Customer geofence ids are server-assigned int64s, so they can never carry the prefix — but
+    /// misreading one as a tripwire would route a real crossing to membership re-evaluation and
+    /// drop the customer's event, so it is pinned.
+    @Test
+    func geofenceIdForTripwire_givenCustomerGeofenceId_expectNil() {
+        #expect(GeofenceInternalIdentifier.geofenceId(forTripwire: "1234") == nil)
+        #expect(GeofenceInternalIdentifier.geofenceId(forTripwire: GeofenceConstants.movementTriggerIdentifier) == nil)
+    }
+
+    /// The monitors branch on this to decide three things for a region: that no fix means "assume
+    /// the device is inside" (internal regions are planted ON the device), that the contradiction
+    /// gate must not vet its events, and that its EXIT gets a freshened fix before dispatch.
+    @Test
+    func isInternal_expectMovementTriggerAndTripwiresOnly() {
+        #expect(GeofenceInternalIdentifier.isInternal(GeofenceConstants.movementTriggerIdentifier))
+        #expect(GeofenceInternalIdentifier.isInternal(GeofenceInternalIdentifier.tripwire(for: "1")))
+        #expect(!GeofenceInternalIdentifier.isInternal("1"))
+        #expect(!GeofenceInternalIdentifier.isInternal(""))
+    }
+}

--- a/Tests/LocationGeofence/Geofence/GeofenceMonitorBinderTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceMonitorBinderTests.swift
@@ -32,13 +32,14 @@ struct GeofenceMonitorBinderTests {
 
     /// The binder holds the resolver weakly (the production instance is a DI singleton), so every
     /// test must keep its own strong reference or the dispatch silently never fires.
-    private func makeResolver(tracker: GeofenceEventTracker) -> PolygonMembershipResolver {
+    private func makeResolver(tracker: GeofenceEventTracker, coordinator: GeofenceSyncCoordinator) -> PolygonMembershipResolver {
         PolygonMembershipResolver(
             storage: GeofenceStorage(
                 fileManager: .default,
                 directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
             ),
             transitionEmitter: tracker,
+            coordinator: coordinator,
             logger: LoggerMock()
         )
     }
@@ -47,6 +48,7 @@ struct GeofenceMonitorBinderTests {
         let mock = GeofenceSyncCoordinatorMock()
         mock.refreshReturnValue = .success(())
         mock.handleMovementReturnValue = .success(())
+        mock.reapplyRegistrationReturnValue = .success(())
         return mock
     }
 
@@ -71,7 +73,7 @@ struct GeofenceMonitorBinderTests {
         let coordinator = makeCoordinatorMock()
         let tracker = makeTracker(deliveryTracker: makeDeliveryMock())
 
-        let resolver = makeResolver(tracker: tracker)
+        let resolver = makeResolver(tracker: tracker, coordinator: coordinator)
         GeofenceMonitorBinder.bind(monitor: monitor, resolver: resolver, coordinator: coordinator)
         monitor.simulateTransition(
             identifier: GeofenceConstants.movementTriggerIdentifier,
@@ -94,7 +96,7 @@ struct GeofenceMonitorBinderTests {
         let delivery = makeDeliveryMock()
         let tracker = makeTracker(deliveryTracker: delivery)
 
-        let resolver = makeResolver(tracker: tracker)
+        let resolver = makeResolver(tracker: tracker, coordinator: coordinator)
         GeofenceMonitorBinder.bind(monitor: monitor, resolver: resolver, coordinator: coordinator)
         monitor.simulateTransition(
             identifier: GeofenceConstants.movementTriggerIdentifier,
@@ -117,7 +119,7 @@ struct GeofenceMonitorBinderTests {
         let coordinator = makeCoordinatorMock()
         let tracker = makeTracker(deliveryTracker: makeDeliveryMock())
 
-        let resolver = makeResolver(tracker: tracker)
+        let resolver = makeResolver(tracker: tracker, coordinator: coordinator)
         GeofenceMonitorBinder.bind(monitor: monitor, resolver: resolver, coordinator: coordinator)
         monitor.simulateTransition(
             identifier: GeofenceConstants.movementTriggerIdentifier,
@@ -138,7 +140,7 @@ struct GeofenceMonitorBinderTests {
         let delivery = makeDeliveryMock()
         let tracker = makeTracker(deliveryTracker: delivery)
 
-        let resolver = makeResolver(tracker: tracker)
+        let resolver = makeResolver(tracker: tracker, coordinator: coordinator)
         GeofenceMonitorBinder.bind(monitor: monitor, resolver: resolver, coordinator: coordinator)
         monitor.simulateTransition(
             identifier: "business-region-1",

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -349,6 +349,28 @@ struct PolygonMembershipResolverTests {
         #expect(setup.coordinator.reapplyRegistrationCallsCount == 1)
     }
 
+    /// The OS says the device is on this circle's boundary right now; a cached fix can be 30 s and
+    /// ~900 m out of date, which both mis-sizes the tripwire and can answer the membership question
+    /// for the wrong place.
+    @Test
+    func handleTransition_givenCoveringCircleEnter_expectFreshFixRequested() async {
+        let stale = fix(latitude: 0.02, longitude: 0)
+        let setup = await makeSetup(fix: stale)
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+        // Seed the cache with the stale fix, then move the device inside before the OS event lands.
+        _ = await setup.resolver.evaluateAllPolygons()
+        let inside = fix(latitude: 0, longitude: 0)
+        setup.fixResolver.requestFreshFix = { [weak fixResolver = setup.fixResolver] in
+            fixResolver?.handleResolvedFix(inside)
+        }
+
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter, location: nil)
+
+        let delivered = await setup.emitter.snapshot()
+        #expect(delivered.count == 1)
+        #expect(delivered.first?.transition == .enter)
+    }
+
     /// The tripwire fires BECAUSE the device moved far enough to change the verdict, so answering
     /// the wake from the fix that planted it just replays the old verdict — and because the
     /// tripwire it recomputes is identical, nothing is re-planted and the wake is spent for

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -50,6 +50,7 @@ struct PolygonMembershipResolverTests {
         let resolver: PolygonMembershipResolver
         let storage: GeofenceStorage
         let emitter: EmitterSpy
+        let coordinator: GeofenceSyncCoordinatorMock
         let fixResolver: MovementFixResolver
     }
 
@@ -59,6 +60,8 @@ struct PolygonMembershipResolverTests {
             directoryURL: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         )
         let emitter = EmitterSpy()
+        let coordinator = GeofenceSyncCoordinatorMock()
+        coordinator.reapplyRegistrationReturnValue = .success(())
         let fixResolver = MovementFixResolver(logger: LoggerMock())
         // Seam: resolve inline with the supplied fix instead of touching CoreLocation.
         fixResolver.requestFreshFix = { [weak fixResolver] in
@@ -69,11 +72,13 @@ struct PolygonMembershipResolverTests {
             resolver: PolygonMembershipResolver(
                 storage: storage,
                 transitionEmitter: emitter,
+                coordinator: coordinator,
                 logger: LoggerMock(),
                 fixResolver: fixResolver
             ),
             storage: storage,
             emitter: emitter,
+            coordinator: coordinator,
             fixResolver: fixResolver
         )
     }
@@ -95,7 +100,7 @@ struct PolygonMembershipResolverTests {
         let setup = await makeSetup(fix: nil)
         await setup.storage.setCachedGeofences([circleGeofence()])
 
-        await setup.resolver.handleTransition(identifier: "2", transition: .enter)
+        await setup.resolver.handleTransition(identifier: "2", transition: .enter, location: nil)
 
         let delivered = await setup.emitter.snapshot()
         #expect(delivered.count == 1)
@@ -108,7 +113,7 @@ struct PolygonMembershipResolverTests {
     func handleTransition_givenUncachedGeofence_expectForwarded() async {
         let setup = await makeSetup(fix: nil)
 
-        await setup.resolver.handleTransition(identifier: "999", transition: .exit)
+        await setup.resolver.handleTransition(identifier: "999", transition: .exit, location: nil)
 
         #expect(await setup.emitter.snapshot().count == 1)
     }
@@ -120,7 +125,7 @@ struct PolygonMembershipResolverTests {
         let setup = await makeSetup(fix: fix(latitude: 0, longitude: 0))
         await setup.storage.setCachedGeofences([polygonGeofence()])
 
-        await setup.resolver.handleTransition(identifier: "1", transition: .enter)
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter, location: nil)
 
         let delivered = await setup.emitter.snapshot()
         #expect(delivered.count == 1)
@@ -128,30 +133,33 @@ struct PolygonMembershipResolverTests {
         #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
     }
 
-    /// The annulus: inside the covering circle, outside the polygon. The OS thinks we arrived;
-    /// geometry says otherwise, so nothing is delivered and the belief records `outside`.
+    /// The annulus: inside the covering circle, outside the polygon. Nothing is delivered, and the
+    /// tripwire is what will wake us to try again.
     @Test
-    func handleTransition_givenPolygonEnterAndFixInAnnulus_expectNoEvent() async {
+    func handleTransition_givenPolygonEnterAndFixInAnnulus_expectNoEventButTripwirePlanted() async {
         let setup = await makeSetup(fix: fix(latitude: 0.0024, longitude: 0))
         await setup.storage.setCachedGeofences([polygonGeofence()])
 
-        await setup.resolver.handleTransition(identifier: "1", transition: .enter)
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter, location: nil)
 
         #expect(await setup.emitter.snapshot().isEmpty)
         #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .outside)
+        #expect(await setup.storage.getPolygonTripwires()["1"] != nil)
+        #expect(setup.coordinator.reapplyRegistrationCallsCount == 1)
     }
 
-    /// A fix too coarse to place the device relative to the boundary must leave no belief behind:
-    /// guessing either way would deliver an event we cannot stand behind.
+    /// A fix too coarse to place the device relative to the boundary must leave no belief behind,
+    /// but must still plant the tripwire that buys another attempt.
     @Test
-    func handleTransition_givenUndecidableFix_expectNoBelief() async {
+    func handleTransition_givenUndecidableFix_expectNoBeliefButTripwirePlanted() async {
         let setup = await makeSetup(fix: fix(latitude: 0, longitude: 0, accuracy: 400))
         await setup.storage.setCachedGeofences([polygonGeofence()])
 
-        await setup.resolver.handleTransition(identifier: "1", transition: .enter)
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter, location: nil)
 
         #expect(await setup.emitter.snapshot().isEmpty)
         #expect(await setup.storage.getPolygonMembership()["1"] == nil)
+        #expect(await setup.storage.getPolygonTripwires()["1"] != nil)
     }
 
     @Test
@@ -159,10 +167,11 @@ struct PolygonMembershipResolverTests {
         let setup = await makeSetup(fix: nil)
         await setup.storage.setCachedGeofences([polygonGeofence()])
 
-        await setup.resolver.handleTransition(identifier: "1", transition: .enter)
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter, location: nil)
 
         #expect(await setup.emitter.snapshot().isEmpty)
         #expect(await setup.storage.getPolygonMembership()["1"] == nil)
+        #expect(await setup.storage.getPolygonTripwires()["1"] == nil)
     }
 
     // MARK: - Covering-circle exit
@@ -173,12 +182,18 @@ struct PolygonMembershipResolverTests {
         let setup = await makeSetup(fix: nil)
         await setup.storage.setCachedGeofences([polygonGeofence()])
         _ = await setup.storage.recordPolygonMembership(.inside, forIdentifier: "1")
+        await setup.storage.setPolygonTripwire(
+            PolygonTripwire(center: LocationData(latitude: 0, longitude: 0), radius: 100), forIdentifier: "1"
+        )
 
-        await setup.resolver.handleTransition(identifier: "1", transition: .exit)
+        await setup.resolver.handleTransition(
+            identifier: "1", transition: .exit, location: LocationData(latitude: 1, longitude: 1)
+        )
 
         let delivered = await setup.emitter.snapshot()
         #expect(delivered.count == 1)
         #expect(delivered.first?.transition == .exit)
+        #expect(await setup.storage.getPolygonTripwires()["1"] == nil)
     }
 
     @Test
@@ -187,9 +202,151 @@ struct PolygonMembershipResolverTests {
         await setup.storage.setCachedGeofences([polygonGeofence()])
         _ = await setup.storage.recordPolygonMembership(.outside, forIdentifier: "1")
 
-        await setup.resolver.handleTransition(identifier: "1", transition: .exit)
+        await setup.resolver.handleTransition(identifier: "1", transition: .exit, location: nil)
 
         #expect(await setup.emitter.snapshot().isEmpty)
+    }
+
+    // MARK: - Tripwire wake
+
+    @Test
+    func evaluateMembership_givenDeviceNowInsidePolygon_expectEnterDelivered() async {
+        let setup = await makeSetup(fix: fix(latitude: 0, longitude: 0))
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+        // Seeded older than the fix: a belief written *after* the fix was taken correctly outranks
+        // it, which is the `onlyIfBeliefPredates` guard and not what this test is about.
+        _ = await setup.storage.recordPolygonMembership(
+            .outside, forIdentifier: "1", now: Date().addingTimeInterval(-60)
+        )
+
+        await setup.resolver.evaluateMembership(geofenceId: "1", reason: "test")
+
+        let delivered = await setup.emitter.snapshot()
+        #expect(delivered.count == 1)
+        #expect(delivered.first?.transition == .enter)
+    }
+
+    /// The tripwire reaches the polygon boundary, so leaving it is exactly when the verdict stops
+    /// being safe to trust. Here the fix sits ~89 m outside the square's edge.
+    @Test
+    func evaluateMembership_expectTripwireRadiusReachesPolygonEdge() async {
+        let setup = await makeSetup(fix: fix(latitude: 0.0024, longitude: 0))
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+
+        await setup.resolver.evaluateMembership(geofenceId: "1", reason: "test")
+
+        let tripwire = await setup.storage.getPolygonTripwires()["1"]
+        #expect(tripwire != nil)
+        #expect((tripwire?.radius ?? 0) >= GeofenceConstants.polygonTripwireMinRadius)
+    }
+
+    /// Below the floor the OS promotes crossings too unreliably for the slot to be worth spending.
+    @Test
+    func evaluateMembership_givenDeviceNearEdge_expectTripwireFloored() async {
+        let setup = await makeSetup(fix: fix(latitude: 0.00175, longitude: 0))
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+
+        await setup.resolver.evaluateMembership(geofenceId: "1", reason: "test")
+
+        #expect(await setup.storage.getPolygonTripwires()["1"]?.radius == GeofenceConstants.polygonTripwireMinRadius)
+    }
+
+    /// Field case, 2026-08-29: the OS delivered a covering-circle ENTER while our cached fix was
+    /// 15.5 s old — inside `movementFixMaxAge`, but ~400 m stale at driving speed, so it placed the
+    /// device outside the very circle the OS had just reported entering. The containment gate then
+    /// retired the tripwire and the device spent 12 minutes in the annulus with no wake source.
+    /// The OS's own statement outranks our fix on this path.
+    @Test
+    func handleTransition_givenCoveringCircleEnterAndStaleFixOutsideCircle_expectTripwirePlanted() async {
+        let setup = await makeSetup(fix: fix(latitude: 0.01, longitude: 0))
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter, location: nil)
+
+        #expect(await setup.storage.getPolygonTripwires()["1"] != nil)
+    }
+
+    /// Without an OS statement, a fix that lands just outside the circle is inside its own
+    /// uncertainty. Keeping the tripwire costs a slot; dropping it can cost a crossing.
+    @Test
+    func evaluateMembership_givenFixMarginallyOutsideCircle_expectTripwireKept() async {
+        let setup = await makeSetup(fix: fix(latitude: 0.0028, longitude: 0))
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+        await setup.storage.setPolygonTripwire(
+            PolygonTripwire(center: LocationData(latitude: 0.0024, longitude: 0), radius: 120),
+            forIdentifier: "1"
+        )
+
+        await setup.resolver.evaluateMembership(geofenceId: "1", reason: "test")
+
+        #expect(await setup.storage.getPolygonTripwires()["1"] != nil)
+    }
+
+    /// Found in the field: a foreground evaluation runs over EVERY registered polygon, including
+    /// ones the device is kilometres away from. Planting there spends one of the 20 OS regions on a
+    /// circle that can never fire before the covering circle's own exit does, and with a full fence
+    /// set those wasted slots evict real fences.
+    @Test
+    func evaluateMembership_givenDeviceOutsideCoveringCircle_expectNoTripwire() async {
+        let setup = await makeSetup(fix: fix(latitude: 0.02, longitude: 0))
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+
+        await setup.resolver.evaluateMembership(geofenceId: "1", reason: "test")
+
+        #expect(await setup.storage.getPolygonTripwires()["1"] == nil)
+        #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .outside)
+    }
+
+    /// Leaving the covering circle must retire an existing tripwire, not strand it: a stranded one
+    /// keeps costing a slot and gets re-registered by every later sync.
+    @Test
+    func evaluateMembership_givenTripwireAndDeviceOutsideCoveringCircle_expectTripwireCleared() async {
+        let setup = await makeSetup(fix: fix(latitude: 0.02, longitude: 0))
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+        await setup.storage.setPolygonTripwire(
+            PolygonTripwire(center: LocationData(latitude: 0.0024, longitude: 0), radius: 300),
+            forIdentifier: "1"
+        )
+
+        await setup.resolver.evaluateMembership(geofenceId: "1", reason: "test")
+
+        #expect(await setup.storage.getPolygonTripwires()["1"] == nil)
+    }
+
+    /// The radius reaches the polygon edge and is NOT clipped to the covering circle. A tripwire
+    /// wider than the circle is redundant, not harmful — the circle's own exit fires first — but a
+    /// small one is never promoted by the OS at all, which is the failure actually measured in the
+    /// field. Promotability wins over tidiness.
+    @Test
+    func evaluateMembership_givenPolygonFarInsideLargeCircle_expectRadiusReachesPolygonNotCircle() async throws {
+        let setup = await makeSetup(fix: fix(latitude: 0.0135, longitude: 0))
+        let wide = Geofence(
+            id: "1", latitude: 0, longitude: 0, radius: 2000, name: "poly",
+            transitionTypes: [.enter, .exit], lastUpdated: Date(), vertices: Self.squareVertices
+        )
+        await setup.storage.setCachedGeofences([wide])
+
+        await setup.resolver.evaluateMembership(geofenceId: "1", reason: "test")
+
+        let radius = try #require(await setup.storage.getPolygonTripwires()["1"]?.radius)
+        // ~1493 m from the centre, so ~1316 m to the polygon edge — well past the ~507 m of
+        // circle that remains.
+        #expect(radius > 1200)
+    }
+
+    /// Re-registering an unchanged circle risks absorbing a crossing the OS detected but has not
+    /// delivered, so an evaluation that does not move the tripwire must not touch the OS set.
+    @Test
+    func evaluateMembership_givenUnchangedTripwire_expectNoReregistration() async {
+        let setup = await makeSetup(fix: fix(latitude: 0, longitude: 0))
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+
+        await setup.resolver.evaluateMembership(geofenceId: "1", reason: "test")
+        let afterFirst = setup.coordinator.reapplyRegistrationCallsCount
+        await setup.resolver.evaluateMembership(geofenceId: "1", reason: "test")
+
+        #expect(afterFirst == 1)
+        #expect(setup.coordinator.reapplyRegistrationCallsCount == 1)
     }
 
     // MARK: - Foreground evaluation
@@ -244,7 +401,7 @@ struct PolygonMembershipResolverTests {
         await setup.storage.setCachedGeofences([polygonGeofence(transitionTypes: [.enter])])
         _ = await setup.storage.recordPolygonMembership(.inside, forIdentifier: "1")
 
-        await setup.resolver.handleTransition(identifier: "1", transition: .exit)
+        await setup.resolver.handleTransition(identifier: "1", transition: .exit, location: nil)
 
         #expect(await setup.emitter.snapshot().isEmpty)
         #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .outside)

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -349,6 +349,50 @@ struct PolygonMembershipResolverTests {
         #expect(setup.coordinator.reapplyRegistrationCallsCount == 1)
     }
 
+    /// The tripwire fires BECAUSE the device moved far enough to change the verdict, so answering
+    /// the wake from the fix that planted it just replays the old verdict — and because the
+    /// tripwire it recomputes is identical, nothing is re-planted and the wake is spent for
+    /// nothing. Caught on a simulated 30 m/s drive, where the polygon's ENTER was never delivered.
+    @Test
+    func evaluateMembership_givenTripwireWake_expectFreshFixRequestedNotCachedReplay() async {
+        let outside = fix(latitude: 0.0024, longitude: 0)
+        let setup = await makeSetup(fix: outside)
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter, location: nil)
+        #expect(await setup.emitter.snapshot().isEmpty)
+
+        // The device has since moved inside; only a fresh request can see it.
+        let inside = fix(latitude: 0, longitude: 0)
+        setup.fixResolver.requestFreshFix = { [weak fixResolver = setup.fixResolver] in
+            fixResolver?.handleResolvedFix(inside)
+        }
+
+        await setup.resolver.evaluateMembership(geofenceId: "1", reason: "tripwire wake", requiresFreshFix: true)
+
+        let delivered = await setup.emitter.snapshot()
+        #expect(delivered.count == 1)
+        #expect(delivered.first?.transition == .enter)
+    }
+
+    /// The negative control for the test above: without the flag the cached fix is still inside
+    /// `movementFixMaxAge`, so the stale verdict stands and no crossing is reported.
+    @Test
+    func evaluateMembership_givenCachedFixAllowed_expectStaleVerdictReplayed() async {
+        let outside = fix(latitude: 0.0024, longitude: 0)
+        let setup = await makeSetup(fix: outside)
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter, location: nil)
+
+        let inside = fix(latitude: 0, longitude: 0)
+        setup.fixResolver.requestFreshFix = { [weak fixResolver = setup.fixResolver] in
+            fixResolver?.handleResolvedFix(inside)
+        }
+
+        await setup.resolver.evaluateMembership(geofenceId: "1", reason: "sync pass")
+
+        #expect(await setup.emitter.snapshot().isEmpty)
+    }
+
     // MARK: - Foreground evaluation
 
     /// The case no OS event reaches: a device already standing inside a polygon when monitoring

--- a/Tests/Mocks/LocationGeofence/AutoMockable.generated.swift
+++ b/Tests/Mocks/LocationGeofence/AutoMockable.generated.swift
@@ -243,6 +243,11 @@ class GeofenceSyncCoordinatorMock: @unchecked Sendable, GeofenceSyncCoordinator,
         _resetCallsCount.wrappedValue = 0
 
         mockCalled = false // do last as resetting properties above can make this true
+        _reapplyRegistrationCallsCount.wrappedValue = 0
+        _reapplyRegistrationReceivedArguments.wrappedValue = nil
+        _reapplyRegistrationReceivedInvocations.wrappedValue = []
+
+        mockCalled = false // do last as resetting properties above can make this true
         _applyCachedRegistrationCallsCount.wrappedValue = 0
         _applyCachedRegistrationReceivedArguments.wrappedValue = nil
         _applyCachedRegistrationReceivedInvocations.wrappedValue = []
@@ -380,6 +385,54 @@ class GeofenceSyncCoordinatorMock: @unchecked Sendable, GeofenceSyncCoordinator,
         return resetClosure.map { $0() } ?? resetReturnValue
     }
 
+    // MARK: - reapplyRegistration
+
+    /// Number of times the function was called.
+    private let _reapplyRegistrationCallsCount: CioInternalCommon.Synchronized<Int> = .init(0)
+    var reapplyRegistrationCallsCount: Int {
+        _reapplyRegistrationCallsCount.wrappedValue
+    }
+
+    /// `true` if the function was ever called.
+    var reapplyRegistrationCalled: Bool {
+        reapplyRegistrationCallsCount > 0
+    }
+
+    /// The arguments from the *last* time the function was called.
+    private let _reapplyRegistrationReceivedArguments: CioInternalCommon.Synchronized<(latitude: Double, longitude: Double)?> = .init(nil)
+    var reapplyRegistrationReceivedArguments: (latitude: Double, longitude: Double)? {
+        _reapplyRegistrationReceivedArguments.wrappedValue
+    }
+
+    /// Arguments from *all* of the times that the function was called.
+    private let _reapplyRegistrationReceivedInvocations: CioInternalCommon.Synchronized<[(latitude: Double, longitude: Double)]> = .init([])
+    var reapplyRegistrationReceivedInvocations: [(latitude: Double, longitude: Double)] {
+        _reapplyRegistrationReceivedInvocations.wrappedValue
+    }
+
+    /// Value to return from the mocked function.
+    private let _reapplyRegistrationReturnValue: CioInternalCommon.Synchronized<Result<Void, GeofenceSyncError>?> = .init(nil)
+    var reapplyRegistrationReturnValue: Result<Void, GeofenceSyncError>! {
+        get { _reapplyRegistrationReturnValue.wrappedValue }
+        set { _reapplyRegistrationReturnValue.wrappedValue = newValue }
+    }
+
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     The closure has first priority to return a value for the mocked function. If the closure returns `nil`,
+     then the mock will attempt to return the value for `reapplyRegistrationReturnValue`
+     */
+    var reapplyRegistrationClosure: ((Double, Double) -> Result<Void, GeofenceSyncError>)?
+
+    /// Mocked function for `reapplyRegistration(latitude: Double, longitude: Double)`. Your opportunity to return a mocked value and check result of mock in test code.
+    func reapplyRegistration(latitude: Double, longitude: Double) -> Result<Void, GeofenceSyncError> {
+        mockCalled = true
+        _reapplyRegistrationCallsCount += 1
+        _reapplyRegistrationReceivedArguments.wrappedValue = (latitude: latitude, longitude: longitude)
+        _reapplyRegistrationReceivedInvocations.append((latitude: latitude, longitude: longitude))
+        return reapplyRegistrationClosure.map { $0(latitude, longitude) } ?? reapplyRegistrationReturnValue
+    }
+
     // MARK: - applyCachedRegistration
 
     /// Number of times the function was called.
@@ -394,14 +447,14 @@ class GeofenceSyncCoordinatorMock: @unchecked Sendable, GeofenceSyncCoordinator,
     }
 
     /// The arguments from the *last* time the function was called.
-    private let _applyCachedRegistrationReceivedArguments: CioInternalCommon.Synchronized<(cachedRegions: [Geofence], anchor: LocationData?, config: GeofenceConfig?, userId: String?)?> = .init(nil)
-    var applyCachedRegistrationReceivedArguments: (cachedRegions: [Geofence], anchor: LocationData?, config: GeofenceConfig?, userId: String?)? {
+    private let _applyCachedRegistrationReceivedArguments: CioInternalCommon.Synchronized<(cachedRegions: [Geofence], anchor: LocationData?, config: GeofenceConfig?, tripwires: [String: PolygonTripwire], userId: String?)?> = .init(nil)
+    var applyCachedRegistrationReceivedArguments: (cachedRegions: [Geofence], anchor: LocationData?, config: GeofenceConfig?, tripwires: [String: PolygonTripwire], userId: String?)? {
         _applyCachedRegistrationReceivedArguments.wrappedValue
     }
 
     /// Arguments from *all* of the times that the function was called.
-    private let _applyCachedRegistrationReceivedInvocations: CioInternalCommon.Synchronized<[(cachedRegions: [Geofence], anchor: LocationData?, config: GeofenceConfig?, userId: String?)]> = .init([])
-    var applyCachedRegistrationReceivedInvocations: [(cachedRegions: [Geofence], anchor: LocationData?, config: GeofenceConfig?, userId: String?)] {
+    private let _applyCachedRegistrationReceivedInvocations: CioInternalCommon.Synchronized<[(cachedRegions: [Geofence], anchor: LocationData?, config: GeofenceConfig?, tripwires: [String: PolygonTripwire], userId: String?)]> = .init([])
+    var applyCachedRegistrationReceivedInvocations: [(cachedRegions: [Geofence], anchor: LocationData?, config: GeofenceConfig?, tripwires: [String: PolygonTripwire], userId: String?)] {
         _applyCachedRegistrationReceivedInvocations.wrappedValue
     }
 
@@ -417,16 +470,16 @@ class GeofenceSyncCoordinatorMock: @unchecked Sendable, GeofenceSyncCoordinator,
      The closure has first priority to return a value for the mocked function. If the closure returns `nil`,
      then the mock will attempt to return the value for `applyCachedRegistrationReturnValue`
      */
-    var applyCachedRegistrationClosure: (([Geofence], LocationData?, GeofenceConfig?, String?) -> GeofenceRegistration?)?
+    var applyCachedRegistrationClosure: (([Geofence], LocationData?, GeofenceConfig?, [String: PolygonTripwire], String?) -> GeofenceRegistration?)?
 
-    /// Mocked function for `applyCachedRegistration(cachedRegions: [Geofence], anchor: LocationData?, config: GeofenceConfig?, userId: String?)`. Your opportunity to return a mocked value and check result of mock in test code.
+    /// Mocked function for `applyCachedRegistration(cachedRegions: [Geofence], anchor: LocationData?, config: GeofenceConfig?, tripwires: [String: PolygonTripwire], userId: String?)`. Your opportunity to return a mocked value and check result of mock in test code.
     @MainActor
-    func applyCachedRegistration(cachedRegions: [Geofence], anchor: LocationData?, config: GeofenceConfig?, userId: String?) -> GeofenceRegistration? {
+    func applyCachedRegistration(cachedRegions: [Geofence], anchor: LocationData?, config: GeofenceConfig?, tripwires: [String: PolygonTripwire], userId: String?) -> GeofenceRegistration? {
         mockCalled = true
         _applyCachedRegistrationCallsCount += 1
-        _applyCachedRegistrationReceivedArguments.wrappedValue = (cachedRegions: cachedRegions, anchor: anchor, config: config, userId: userId)
-        _applyCachedRegistrationReceivedInvocations.append((cachedRegions: cachedRegions, anchor: anchor, config: config, userId: userId))
-        return applyCachedRegistrationClosure.map { $0(cachedRegions, anchor, config, userId) } ?? applyCachedRegistrationReturnValue
+        _applyCachedRegistrationReceivedArguments.wrappedValue = (cachedRegions: cachedRegions, anchor: anchor, config: config, tripwires: tripwires, userId: userId)
+        _applyCachedRegistrationReceivedInvocations.append((cachedRegions: cachedRegions, anchor: anchor, config: config, tripwires: tripwires, userId: userId))
+        return applyCachedRegistrationClosure.map { $0(cachedRegions, anchor, config, tripwires, userId) } ?? applyCachedRegistrationReturnValue
     }
 }
 


### PR DESCRIPTION
Part of [MBL-2291](https://linear.app/customerio/issue/MBL-2291/ios-implement-responsive-on-device-polygon-monitoring)

Part 7 of the polygon geofence work, and the last of this ticket. Plants tripwires, composes them
into the OS-monitored set, and teaches both monitors what they are.

### What's here

A tripwire is planted whenever an evaluation places the device inside a covering circle, moved as
the device moves, and retired on leaving. Its radius reaches the polygon boundary, so leaving it is
exactly when the last verdict stops being safe to trust.

### Worth a reviewer's attention

**An OS covering-circle enter outranks our own fix.** Measured in the field: a 15.5 s-old cached
fix — well inside `movementFixMaxAge` — placed the device ~400 m from where it was, outside a
circle it had just entered, and retired the tripwire for the whole 12 minutes it then spent in the
annulus.

**A tripwire is never planted for a polygon the device is outside.** The foreground path evaluates
*every* registered polygon, including ones kilometres away, so planting unconditionally burns the
20-region budget on wakes that cannot happen. This was a real field bug: a 1205 m tripwire planted
for a polygon 1.7 km away.

**The business cap shrinks by the number of planted tripwires**, since both draw from the same
20-region OS budget.

**Both monitors now treat tripwires as internal regions.** Three places assumed otherwise:
registration assumed a region with no usable fix was outside (a tripwire is on the device, so it
must assume inside), the contradiction gate vetted tripwire events and could refuse the very EXIT
they exist to deliver, and that EXIT dispatched on a possibly-stale cached fix rather than a
freshened one.

### Testing

Unit tests over plant / move / retire, the stale-fix case above, the containment gate, and
registration composition. Neither monitor is unit-testable without a host, so the identifier is
what is pinned there.

The composition rules are also checked by an exhaustive model (18,398 compositions: polygon count ×
every inside/outside pattern × circle count × business cap). The shipping design violates nothing;
ungated planting violates in 7,974 cases, and dropping the business-cap adjustment overflows the
budget to 39 regions in the saturated case.

### Stack

1. `mbl-2290-a-polygon-geometry-kernel` — geometry kernel (#1239)
2. `mbl-2290-b-polygon-wire-contract` — v2 wire contract decode (#1240)
3. `mbl-2291-a-polygon-membership-layer` — membership belief + storage (#1244)
4. `mbl-2291-b-polygon-membership-resolver` — the resolver (#1245)
5. `mbl-2291-c-polygon-monitor-wiring` — monitor wiring (#1246)
6. `mbl-2291-d-polygon-tripwire-state` — tripwire state (#1247)
7. `mbl-2291-e-polygon-tripwire-planting` — tripwire planting + budget ← **this PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

