### PR TITLE
chore(geofence): evaluate polygons crossing the antimeridian correctly

### DIFF
--- a/Sources/LocationGeofence/Geometry/PolygonRegion.swift
+++ b/Sources/LocationGeofence/Geometry/PolygonRegion.swift
@@ -187,7 +187,12 @@ struct PolygonRegion {
         }
     }
 
+    /// The walk is bounded by its inputs: `init?(vertices:)` refuses out-of-range ring positions and
+    /// `evaluate` refuses an invalid fix, so both sides arrive inside ±180°. The guard keeps that a
+    /// property of this function rather than of its callers — a value far enough out of range stops
+    /// changing when 360 is subtracted from it, and the loop would never end.
     private static func unwrapLongitude(_ longitude: Double, near reference: Double) -> Double {
+        guard longitude.isFinite, abs(longitude) <= 360, reference.isFinite else { return longitude }
         var value = longitude
         while value - reference > 180 {
             value -= 360

--- a/Sources/LocationGeofence/Geometry/PolygonRegion.swift
+++ b/Sources/LocationGeofence/Geometry/PolygonRegion.swift
@@ -62,12 +62,15 @@ struct PolygonRegion {
         }
         guard open.count >= 3 else { return nil }
 
-        let lat0 = open.map(\.latitude).reduce(0, +) / Double(open.count)
-        let lon0 = open.map(\.longitude).reduce(0, +) / Double(open.count)
+        // Unwrap before averaging: a ring spanning the antimeridian holds values near both +180
+        // and -180, whose mean is Greenwich, and the fence then projects a hemisphere wide.
+        let unwrapped = Self.unwrapLongitudes(open)
+        let lat0 = unwrapped.map(\.latitude).reduce(0, +) / Double(unwrapped.count)
+        let lon0 = unwrapped.map(\.longitude).reduce(0, +) / Double(unwrapped.count)
         let latitudeRadians = lat0 * Self.degreesToRadians
         let longitudeRadians = lon0 * Self.degreesToRadians
         let cosLatitude = cos(latitudeRadians)
-        let planar = open.map {
+        let planar = unwrapped.map {
             Self.project(
                 $0,
                 referenceLatitudeRadians: latitudeRadians,
@@ -175,9 +178,34 @@ struct PolygonRegion {
         return isInside(p) ? minDistance : -minDistance
     }
 
+    /// Shifts longitudes into the ±180° window around the first vertex so a ring crossing the
+    /// antimeridian is continuous. Part of the projection contract shared with Android.
+    private static func unwrapLongitudes(_ ring: [LocationData]) -> [LocationData] {
+        guard let reference = ring.first?.longitude else { return ring }
+        return ring.map {
+            LocationData(latitude: $0.latitude, longitude: unwrapLongitude($0.longitude, near: reference))
+        }
+    }
+
+    private static func unwrapLongitude(_ longitude: Double, near reference: Double) -> Double {
+        var value = longitude
+        while value - reference > 180 {
+            value -= 360
+        }
+        while value - reference < -180 {
+            value += 360
+        }
+        return value
+    }
+
     private func project(_ location: LocationData) -> Point {
-        Self.project(
-            location,
+        // Onto the ring's line: a fix at -179.99 belongs beside a ring unwrapped to +180.01.
+        let aligned = LocationData(
+            latitude: location.latitude,
+            longitude: Self.unwrapLongitude(location.longitude, near: referenceLongitudeRadians * 180 / .pi)
+        )
+        return Self.project(
+            aligned,
             referenceLatitudeRadians: referenceLatitudeRadians,
             referenceLongitudeRadians: referenceLongitudeRadians,
             cosReferenceLatitude: cosReferenceLatitude

--- a/Sources/LocationGeofence/Geometry/PolygonRegion.swift
+++ b/Sources/LocationGeofence/Geometry/PolygonRegion.swift
@@ -51,13 +51,17 @@ struct PolygonRegion {
     init?(vertices: [LocationData]) {
         var open: [LocationData] = []
         open.reserveCapacity(vertices.count)
-        for vertex in vertices where vertex != open.last {
+        for vertex in vertices {
+            // Validity first: `samePosition` unwraps, and an out-of-range longitude can unwrap onto
+            // a legitimate one — 360 lands on 0 — so testing it before this guard would let an
+            // invalid position be silently collapsed away instead of rejecting the ring.
             guard CLLocationCoordinate2DIsValid(
                 CLLocationCoordinate2D(latitude: vertex.latitude, longitude: vertex.longitude)
             ) else { return nil }
+            if let last = open.last, Self.samePosition(vertex, last) { continue }
             open.append(vertex)
         }
-        if let first = open.first, let last = open.last, open.count > 1, first == last {
+        if let first = open.first, let last = open.last, open.count > 1, Self.samePosition(first, last) {
             open.removeLast()
         }
         guard open.count >= 3 else { return nil }
@@ -85,6 +89,21 @@ struct PolygonRegion {
         self.projected = planar
     }
 
+    /// Same place, not same numbers: +180 and -180 name one meridian, and a ring may legally close
+    /// with the opposite sign to the one it opened with. Compared raw, that closing vertex survives
+    /// canonicalisation as a zero-length edge, which `selfIntersects` then reads as a crossing and
+    /// the whole fence drops. Android canonicalises the same way.
+    ///
+    /// Only sound for positions already known to be in range, which is why the caller validates
+    /// first: subtracting 360 is exact at ±180 but not in general, so this must not be reused as a
+    /// wrapping equality for arbitrary longitudes.
+    private static func samePosition(_ a: LocationData, _ b: LocationData) -> Bool {
+        a.latitude == b.latitude && unwrapLongitude(a.longitude, near: b.longitude) == b.longitude
+    }
+
+    /// This is the only writer of `Geofence.vertices`: a ring from any other source has not been
+    /// through the checks below and may not satisfy them.
+    ///
     /// Decode-time construction: additionally rejects rings that cannot be monitored sensibly —
     /// zero area, or self-intersecting. Separate from `init(vertices:)` because that one runs on
     /// hot paths (once per polygon per wake and per evaluation) while these checks are O(n²), so

--- a/Tests/LocationGeofence/Geometry/PolygonGeometryFixtures.swift
+++ b/Tests/LocationGeofence/Geometry/PolygonGeometryFixtures.swift
@@ -68,5 +68,18 @@ let polygonGeometryFixtures: [PolygonGeometryFixture] = [
             PolygonGeometryFixture.Sample(point: LocationData(latitude: 31.36950537, longitude: 74.17), inside: false, signedEdgeDistance: -5.0, note: "5m outside base"),
             PolygonGeometryFixture.Sample(point: LocationData(latitude: 31.37053959, longitude: 74.1707373), inside: false, signedEdgeDistance: -50.639, note: "outside near slanted edge")
         ]
+    ),
+    PolygonGeometryFixture(
+        name: "square400_dateline",
+        vertices: [LocationData(latitude: -16.85179864, longitude: 179.99812067), LocationData(latitude: -16.85179864, longitude: -179.99812067), LocationData(latitude: -16.84820136, longitude: -179.99812067), LocationData(latitude: -16.84820136, longitude: 179.99812067)],
+        samples: [
+            PolygonGeometryFixture.Sample(point: LocationData(latitude: -16.85, longitude: 180.0), inside: true, signedEdgeDistance: 200.0, note: "center (antimeridian twin of square400)"),
+            PolygonGeometryFixture.Sample(point: LocationData(latitude: -16.84865102, longitude: -179.9985905), inside: true, signedEdgeDistance: 50.0, note: "deep interior (antimeridian twin of square400)"),
+            PolygonGeometryFixture.Sample(point: LocationData(latitude: -16.85, longitude: -179.99816765), inside: true, signedEdgeDistance: 5.0, note: "5m inside edge (antimeridian twin of square400)"),
+            PolygonGeometryFixture.Sample(point: LocationData(latitude: -16.85, longitude: -179.99807369), inside: false, signedEdgeDistance: -5.0, note: "5m outside edge (antimeridian twin of square400)"),
+            PolygonGeometryFixture.Sample(point: LocationData(latitude: -16.84821035, longitude: -179.99813007), inside: true, signedEdgeDistance: 1.0, note: "near vertex inside (antimeridian twin of square400)"),
+            PolygonGeometryFixture.Sample(point: LocationData(latitude: -16.85, longitude: 179.99755687), inside: false, signedEdgeDistance: -60.0, note: "annulus (in covering circle, outside polygon) (antimeridian twin of square400)"),
+            PolygonGeometryFixture.Sample(point: LocationData(latitude: -16.85809389, longitude: 180.0), inside: false, signedEdgeDistance: -700.0, note: "far outside (antimeridian twin of square400)")
+        ]
     )
 ]

--- a/Tests/LocationGeofence/Geometry/PolygonRegionTests.swift
+++ b/Tests/LocationGeofence/Geometry/PolygonRegionTests.swift
@@ -197,6 +197,62 @@ struct PolygonRegionTests {
         #expect(!region.contains(LocationData(latitude: maxLat, longitude: maxLon))) // NE vertex
     }
 
+    /// Translation invariance: the same shape must behave identically wherever it sits. Before the
+    /// unwrap, a fix mid-island on an antimeridian ring read `contains=false` at -4256 m — decisive
+    /// enough to clear the ambiguity gate, so the fence silently never fired.
+    @Test
+    func contains_givenRingCrossingAntimeridian_expectSameVerdictsAsAwayFromIt() throws {
+        // Taveuni, Fiji — a real island on the antimeridian.
+        let onDateline = [
+            LocationData(latitude: -16.80, longitude: 179.95),
+            LocationData(latitude: -16.80, longitude: -179.95),
+            LocationData(latitude: -16.90, longitude: -179.95),
+            LocationData(latitude: -16.90, longitude: 179.95)
+        ]
+        // The identical 0.1-degree-wide shape, moved so nothing wraps.
+        let atGreenwich = onDateline.map {
+            LocationData(latitude: $0.latitude, longitude: $0.longitude > 0 ? $0.longitude - 180 : $0.longitude + 180)
+        }
+        let dateline = try #require(PolygonRegion(vertices: onDateline))
+        let control = try #require(PolygonRegion(vertices: atGreenwich))
+
+        for (offset, expectedInside) in [(0.0, true), (0.04, true), (0.08, false)] {
+            let datelinePoint = LocationData(latitude: -16.85, longitude: (180.0 - offset).normalizedLongitude)
+            let controlPoint = LocationData(latitude: -16.85, longitude: -offset)
+            #expect(dateline.contains(datelinePoint) == expectedInside, "offset \(offset)")
+            #expect(control.contains(controlPoint) == expectedInside, "control offset \(offset)")
+            let a = dateline.signedEdgeDistance(to: datelinePoint)
+            let b = control.signedEdgeDistance(to: controlPoint)
+            #expect(abs(a - b) < 0.001, "offset \(offset): dateline \(a) vs control \(b)")
+        }
+    }
+
+    /// The unwrap's reference is the first vertex, so rotating the ring must not change the fence.
+    @Test
+    func contains_givenAntimeridianRingRotated_expectIdenticalGeometry() throws {
+        let ring = [
+            LocationData(latitude: -16.80, longitude: 179.95),
+            LocationData(latitude: -16.80, longitude: -179.95),
+            LocationData(latitude: -16.90, longitude: -179.95),
+            LocationData(latitude: -16.90, longitude: 179.95)
+        ]
+        let base = try #require(PolygonRegion(vertices: ring))
+        for rotation in 1 ..< ring.count {
+            let rotated = try #require(PolygonRegion(vertices: Array(ring[rotation...] + ring[..<rotation])))
+            for point in [
+                LocationData(latitude: -16.85, longitude: 179.99),
+                LocationData(latitude: -16.85, longitude: -179.99),
+                LocationData(latitude: -16.85, longitude: 179.80)
+            ] {
+                #expect(rotated.contains(point) == base.contains(point), "rotation \(rotation)")
+                #expect(
+                    abs(rotated.signedEdgeDistance(to: point) - base.signedEdgeDistance(to: point)) < 0.001,
+                    "rotation \(rotation)"
+                )
+            }
+        }
+    }
+
     @Test
     func signedEdgeDistance_givenSignFlipAcrossEdge_expectContinuousMagnitude() throws {
         // Walk a straight line across the square's eastern edge; the signed distance must
@@ -219,5 +275,19 @@ struct PolygonRegionTests {
             previous = sd
         }
         #expect(signFlips == 1)
+    }
+}
+
+private extension Double {
+    /// Wraps a longitude built by arithmetic (e.g. `180 - offset`) back into [-180, 180].
+    var normalizedLongitude: Double {
+        var value = self
+        while value > 180 {
+            value -= 360
+        }
+        while value < -180 {
+            value += 360
+        }
+        return value
     }
 }

--- a/Tests/LocationGeofence/Geometry/PolygonRegionTests.swift
+++ b/Tests/LocationGeofence/Geometry/PolygonRegionTests.swift
@@ -276,6 +276,75 @@ struct PolygonRegionTests {
         }
         #expect(signFlips == 1)
     }
+
+    /// A ring on the antimeridian may legally close with the opposite sign to the one it opened
+    /// with — +180 and -180 are one meridian. Compared raw, the closing vertex survives as a
+    /// zero-length edge, `selfIntersects` reads that as a crossing, and the fence drops at decode.
+    /// Android canonicalises the same case away, so an unfixed iOS silently loses fences there.
+    @Test
+    func init_givenRingClosedWithTheOppositeSign_expectClosureCollapsed() throws {
+        let ring = [
+            LocationData(latitude: -16.80, longitude: 180.0),
+            LocationData(latitude: -16.80, longitude: -179.95),
+            LocationData(latitude: -16.90, longitude: -179.95),
+            LocationData(latitude: -16.90, longitude: 180.0),
+            LocationData(latitude: -16.80, longitude: -180.0)
+        ]
+
+        let region = try #require(PolygonRegion(validating: ring))
+
+        #expect(region.vertices.count == 4)
+        #expect(PolygonRegion(vertices: ring)?.vertices.count == 4)
+    }
+
+    /// Control: the same ring closed with the SAME sign must still collapse to four, so the fix is
+    /// recognising the meridian rather than dropping any trailing vertex.
+    @Test
+    func init_givenRingClosedWithTheSameSign_expectClosureCollapsed() throws {
+        let ring = [
+            LocationData(latitude: -16.80, longitude: 180.0),
+            LocationData(latitude: -16.80, longitude: -179.95),
+            LocationData(latitude: -16.90, longitude: -179.95),
+            LocationData(latitude: -16.90, longitude: 180.0),
+            LocationData(latitude: -16.80, longitude: 180.0)
+        ]
+
+        let region = try #require(PolygonRegion(validating: ring))
+
+        #expect(region.vertices.count == 4)
+    }
+
+    /// An out-of-range longitude must reject the ring, not be collapsed away. 360 unwraps onto 0,
+    /// so testing "same meridian" before validating would let exactly this vertex vanish and the
+    /// ring build as if the server had never sent it.
+    @Test
+    func init_givenOutOfRangeLongitudeAfterAMatchingVertex_expectRejected() {
+        let ring = [
+            LocationData(latitude: 0, longitude: 0),
+            LocationData(latitude: 0, longitude: 360),
+            LocationData(latitude: 0.001, longitude: 0.001),
+            LocationData(latitude: 0.001, longitude: 0)
+        ]
+
+        #expect(PolygonRegion(vertices: ring) == nil)
+        #expect(PolygonRegion(validating: ring) == nil)
+    }
+
+    /// Negative control: two positions a real distance apart on either side of the meridian are NOT
+    /// the same place, so an open ring keeps every vertex it was sent.
+    @Test
+    func init_givenDistinctPositionsNearTheMeridian_expectNoneCollapsed() throws {
+        let ring = [
+            LocationData(latitude: -16.80, longitude: 179.98),
+            LocationData(latitude: -16.80, longitude: -179.98),
+            LocationData(latitude: -16.90, longitude: -179.98),
+            LocationData(latitude: -16.90, longitude: 179.98)
+        ]
+
+        let region = try #require(PolygonRegion(validating: ring))
+
+        #expect(region.vertices.count == 4)
+    }
 }
 
 private extension Double {


### PR DESCRIPTION
Part of [MBL-2290](https://linear.app/customerio/issue/MBL-2290)

Found by @mahmoud in review of the polygon stack.

## The bug

`PolygonRegion` picked its projection reference by averaging vertex longitudes. A ring spanning the antimeridian holds values near both `+180` and `-180`, and their mean is `0` — Greenwich. An 800 m fence then projects a hemisphere wide and every verdict inverts.

Measured on a Taveuni (Fiji) ring, against the identical shape moved away from the wrap:

| | `contains` | `signedEdgeDistance` |
|---|---|---|
| on the antimeridian | `false` | `-4256.8 m` |
| same shape at Greenwich | `true` | `+4256.8 m` |

Exact sign flip. `-4256 m` is far past the ambiguity margin, so the gate records `.outside` with full confidence and logs no `geofencePolygonUndecided` — **the fence silently never fires and nothing in the logs says why**.

Nothing upstream catches it: the payload is valid, and the wrap only bites once the ring is projected.

## The fix

Unwrap longitudes into ±180° of the first vertex before anything averages them, and unwrap the query point onto **the ring's** line rather than its own — a fix at `-179.99` belongs beside a ring unwrapped to `+180.01`, not a full turn from it.

+33 / −5 production lines.

## Tests

Two properties rather than one fixture:

- **Translation invariance** — the antimeridian ring versus its twin at Greenwich; verdicts and distances must agree to 0.001 m across three sample points.
- **Rotation invariance** — the unwrap's reference is the first vertex, so rotating the ring must describe the same fence.

**Negative control:** with the unwrap disabled both tests fail, including a case reporting `contains=true` for a point that is outside — a false ENTER, which is worse than the miss above.

## A second antimeridian defect, found by parity audit

Same meridian, different mechanism, found while auditing Android's canonicalisation rather than in review.

A ring may legally close with the **opposite sign** to the one it opened with — `+180` and `-180` name one meridian and GeoJSON permits either. Positions were compared as raw values, so those two did not collapse. The closing vertex survived canonicalisation as a zero-length edge, `selfIntersects` read that as a crossing, and `init?(validating:)` returned nil — the region dropped at decode and **the fence never registered at all**. Android canonicalises this away, so the same payload worked there and silently did not here.

Confirmed by test before fixing, which exposed a second problem in the same output: the two initialisers **disagreed**. The cheap `init?(vertices:)` accepted the five-vertex ring with its zero-length edge; only the validating one rejected it. Anything rebuilt from cache through the hot path would have evaluated a degenerate ring.

Positions now compare equal when latitudes match and longitudes name the same meridian, reusing the `unwrapLongitude` the projection already depends on.

Four tests: the opposite-sign closure collapses to four vertices on **both** initialisers, a same-sign closure still collapses, two genuinely distinct positions either side of the meridian are not collapsed, and an **out-of-range longitude is rejected rather than collapsed away**. **Negative controls:** without the collapse the opposite-sign test fails while its controls pass; with the validity guard below the collapse instead of above it, the out-of-range test fails.

That last one is the order the guards run in. `360` unwraps onto `0`, so testing "same meridian" before validating would let an invalid position be silently dropped and the ring build as if the server had never sent it. The validity check therefore runs first, and `PolygonRegion.init?(validating:)` now states the invariant it rests on: it is the only writer of `Geofence.vertices`, so a ring from any other source has not been through these checks.

## Cross-SDK

The projection is a contract shared with Android, so the fixtures carry a new **`square400_dateline`**: the same meter-space square synthesized around an antimeridian anchor, with every expected value identical to `square400` by construction. An implementation with this bug fails the twin while the original still passes. Android needs the same fix to stay in parity.

## Termination

The walk itself now refuses a non-finite or out-of-range longitude. Both callers already reject
those (#1239 range-checks ring positions, the resolver gates the fix), so behaviour is unchanged —
it makes termination a property of the walk rather than of its callers. Past roughly 3.2e18,
subtracting 360 stops changing a `Double` and the loop would never end.

## Considered and not fixed

`GeofenceRegionMonitoring.swift:46` compares region centres with `abs(center.longitude - self.center.longitude)`, which at the wrap reads two points ~20 m apart as ~360 apart. Not reachable: both sides of that comparison derive from the same stored server value, which never flips sign. Left alone rather than widening scope.

## Stack

1. #1239 `mbl-2290-a` geometry kernel (merged)
2. #1240 `mbl-2290-b` wire contract (merged)
3. #1244 `mbl-2291-a` membership layer (merged)
4. #1245 `mbl-2291-b` membership resolver
5. #1246 `mbl-2291-c` monitor wiring
6. #1249 `mbl-2290-c` antimeridian fix ← **this PR**
7. #1250 `mbl-2291-f` shared dynamic movement circle
8. #1259 `mbl-2291-h` belief survives eviction
9. #1262 `mbl-2291-g` event circle generation

Based on `mbl-2291-c` rather than the geometry kernel.

482/482 `LocationGeofenceTests` pass on iOS 26. Format and lint clean.









