### PR TITLE
chore(geofence): wake polygon evaluation from the movement circle

### DIFF
--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+InitialEnter.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+InitialEnter.swift
@@ -56,6 +56,15 @@ extension GeofenceSyncCoordinatorImpl {
     /// site rather than stored: the resolver is a `@MainActor` singleton and this coordinator is
     /// one of its own dependencies, so a stored reference back would make the two initialize each
     /// other.
+    /// The trigger is sized to the nearest polygon boundary, so its EXIT is the signal that some
+    /// membership may have changed. Resolved from the graph for the same reason as `evaluateNewPolygons`.
+    func evaluatePolygonsAfterMovement(expectedUserId: String) {
+        Task { @MainActor [contextStore] in
+            guard contextStore.currentUserId == expectedUserId else { return }
+            await DIGraphShared.shared.polygonMembershipResolver.evaluateAllPolygons()
+        }
+    }
+
     private func evaluateNewPolygons(_ polygons: [Geofence], expectedUserId: String) {
         Task { @MainActor [contextStore] in
             guard contextStore.currentUserId == expectedUserId else { return }

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+InitialEnter.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+InitialEnter.swift
@@ -52,16 +52,14 @@ extension GeofenceSyncCoordinatorImpl {
         }
     }
 
-    /// Hands newly-registered polygons to the gated evaluation. Resolved from the graph at the call
-    /// site rather than stored: the resolver is a `@MainActor` singleton and this coordinator is
-    /// one of its own dependencies, so a stored reference back would make the two initialize each
-    /// other.
     /// The trigger is sized to the nearest polygon boundary, so its EXIT is the signal that some
-    /// membership may have changed. Resolved from the graph for the same reason as `evaluateNewPolygons`.
+    /// membership may have changed. A wake fires BECAUSE the device moved, so the cached fix
+    /// describes where it was — answering from it re-affirms the old verdict and swallows the
+    /// crossing outright (measured: a 26 s fix at 20 m/s is 520 m stale).
     func evaluatePolygonsAfterMovement(expectedUserId: String) {
         Task { @MainActor [contextStore] in
             guard contextStore.currentUserId == expectedUserId else { return }
-            await DIGraphShared.shared.polygonMembershipResolver.evaluateAllPolygons()
+            await DIGraphShared.shared.polygonMembershipResolver.evaluateAllPolygons(requiresFreshFix: true)
         }
     }
 

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+InitialEnter.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+InitialEnter.swift
@@ -73,9 +73,8 @@ extension GeofenceSyncCoordinatorImpl {
             guard contextStore.currentUserId == expectedUserId else { return }
             // Also re-checked inside, per polygon, after the fix resolves: that await is the window
             // where a user switch would otherwise land an event on the wrong profile.
-            await DIGraphShared.shared.polygonMembershipResolver.evaluateMembership(
+            await DIGraphShared.shared.polygonMembershipResolver.evaluateNewlyRegistered(
                 geofenceIds: polygons.map(\.id),
-                reason: "new polygon",
                 isStillCurrent: { contextStore.currentUserId == expectedUserId }
             )
         }

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+InitialEnter.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+InitialEnter.swift
@@ -59,7 +59,12 @@ extension GeofenceSyncCoordinatorImpl {
     func evaluatePolygonsAfterMovement(expectedUserId: String) {
         Task { @MainActor [contextStore] in
             guard contextStore.currentUserId == expectedUserId else { return }
-            await DIGraphShared.shared.polygonMembershipResolver.evaluateAllPolygons(requiresFreshFix: true)
+            // Re-checked inside, after the fix resolves and again before the emit: a forced-fresh
+            // request is the longest await in the feature, and the polygon set was read before it.
+            await DIGraphShared.shared.polygonMembershipResolver.evaluateAllPolygons(
+                requiresFreshFix: true,
+                isStillCurrent: { contextStore.currentUserId == expectedUserId }
+            )
         }
     }
 

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
@@ -75,6 +75,7 @@ extension GeofenceSyncCoordinatorImpl {
             anchor: anchor
         )
         logger.geofenceSyncCompleted(registeredCount: nearest.count, movementTriggerRegistered: registerMovementTrigger)
+        evaluatePolygonsAfterMovement(expectedUserId: expectedUserId)
         return .success(())
     }
 

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
@@ -46,13 +46,12 @@ extension GeofenceSyncCoordinatorImpl {
         // Read before `recordRegistration` overwrites it — the diff decides which registrations are new.
         let previouslyRegisteredIds = await storage.getRegisteredBusinessIds()
         let nearestIds = Set(nearest.map(\.id))
+        let wakeRadius = PolygonWakeRadius.radius(at: anchor, registeredPolygons: nearest, config: effectiveConfig)
         let osRegistration = await MainActor.run {
             registerWithOsSync(
                 businessRegions: nearest,
                 movementTriggerLocation: anchor,
-                movementTriggerRadius: PolygonWakeRadius.radius(
-                    at: anchor, registeredPolygons: nearest, config: effectiveConfig
-                ),
+                movementTriggerRadius: wakeRadius,
                 registerMovementTrigger: registerMovementTrigger
             )
         }

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
@@ -127,11 +127,12 @@ extension GeofenceSyncCoordinatorImpl {
     func performPolygonWakePass(
         expectedUserId: String,
         at location: LocationData,
-        config: GeofenceConfig
+        config: GeofenceConfig,
+        anchorIsLiveFix: Bool
     ) async -> Result<Void, GeofenceSyncError> {
         let registeredIds = await storage.getRegisteredBusinessIds()
         let registered = await storage.getCachedGeofences().filter { registeredIds.contains($0.id) }
-        let radius = PolygonWakeRadius.radius(at: location, registeredPolygons: registered, config: config)
+        let radius = wakeRadius(at: location, polygons: registered, config: config, anchorIsLiveFix: anchorIsLiveFix)
         logger.geofencePolygonWakePass(radius: radius, polygonCount: registered.count { $0.vertices != nil })
         _ = await MainActor.run {
             registerWithOsSync(
@@ -146,7 +147,15 @@ extension GeofenceSyncCoordinatorImpl {
     }
 
     /// The trigger radius for a registration, sized to the nearest polygon boundary only when the
-    /// anchor is where the device actually is. A stored anchor can be a long way from the device —
+    /// anchor is a fix the caller holds.
+    ///
+    /// `anchorIsLiveFix` means "a fix no older than `movementFixMaxAge`", NOT "the device is here":
+    /// a 30 s fix at speed is several hundred metres old, so a floor-sized trigger can still be
+    /// planted around a point the device has left. On iOS 17+ that costs one spurious re-arm cycle
+    /// and self-corrects; the classic path, where it would instead be a trigger that never fires,
+    /// has to size the radius against the fix's age. Logged with the chosen radius so a drive can
+    /// tell a spurious cycle from a real one — the fix's own age is on the line above it.
+    /// A stored anchor can be a long way from the device —
     /// unbounded once the process has been dead — and a boundary-sized circle around it would be
     /// one the device already stands outside: a spurious cycle on iOS 17+, and on the classic path
     /// a trigger that never fires at all. The full refresh radius is the safe default there; the
@@ -157,8 +166,13 @@ extension GeofenceSyncCoordinatorImpl {
         config: GeofenceConfig,
         anchorIsLiveFix: Bool
     ) -> Double {
-        guard anchorIsLiveFix else { return config.localRefreshTriggerRadius }
-        return PolygonWakeRadius.radius(at: anchor, registeredPolygons: polygons, config: config)
+        guard anchorIsLiveFix else {
+            logger.geofenceWakeRadiusChosen(radius: config.localRefreshTriggerRadius, anchorIsLiveFix: false)
+            return config.localRefreshTriggerRadius
+        }
+        let radius = PolygonWakeRadius.radius(at: anchor, registeredPolygons: polygons, config: config)
+        logger.geofenceWakeRadiusChosen(radius: radius, anchorIsLiveFix: true)
+        return radius
     }
 
     /// Decodes the response's regions, or fails when the payload turns out to be unreadable rather

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
@@ -149,17 +149,20 @@ extension GeofenceSyncCoordinatorImpl {
     /// The trigger radius for a registration, sized to the nearest polygon boundary only when the
     /// anchor is a fix the caller holds.
     ///
-    /// `anchorIsLiveFix` means "a fix no older than `movementFixMaxAge`", NOT "the device is here":
-    /// a 30 s fix at speed is several hundred metres old, so a floor-sized trigger can still be
-    /// planted around a point the device has left. On iOS 17+ that costs one spurious re-arm cycle
-    /// and self-corrects; the classic path, where it would instead be a trigger that never fires,
-    /// has to size the radius against the fix's age. Logged with the chosen radius so a drive can
-    /// tell a spurious cycle from a real one — the fix's own age is on the line above it.
-    /// A stored anchor can be a long way from the device —
-    /// unbounded once the process has been dead — and a boundary-sized circle around it would be
-    /// one the device already stands outside: a spurious cycle on iOS 17+, and on the classic path
-    /// a trigger that never fires at all. The full refresh radius is the safe default there; the
-    /// first movement pass re-arms against a live fix.
+    /// A stored anchor can be a long way from the device — unbounded once the process has been dead
+    /// — so a boundary-sized circle around one may already have the device outside it. The full
+    /// refresh radius is the safe default there, and the first movement pass re-arms against a fix.
+    ///
+    /// Residual, because `anchorIsLiveFix` means "a fix no older than `movementFixMaxAge`" and not
+    /// "the device is here": a 30 s fix at speed is several hundred metres old against a 100 m
+    /// floor, so a tight trigger can still be planted around a point the device has left. On iOS
+    /// 17+ that costs one spurious re-arm cycle and self-corrects. The classic path, where it is
+    /// instead a trigger that never fires, has to size the radius against the fix's own age — the
+    /// same strictly-newer question `PolygonMembershipResolver.resolveFix` already answers for a
+    /// forced-fresh evaluation, which is a deliberately stricter test than this one.
+    ///
+    /// The chosen radius is logged so a drive can tell a spurious re-arm from a real one; the fix's
+    /// age is on the resolver's line just above it.
     private func wakeRadius(
         at anchor: LocationData,
         polygons: [Geofence],

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
@@ -10,11 +10,11 @@ extension GeofenceSyncCoordinatorImpl {
     /// re-check that the identified user hasn't changed during the (potentially long) fetch.
     func performRemoteRefresh(
         expectedUserId: String,
-        latitude: Double,
-        longitude: Double,
-        cachedConfig: GeofenceConfig?
+        anchor: LocationData,
+        cachedConfig: GeofenceConfig?,
+        anchorIsLiveFix: Bool
     ) async -> Result<Void, GeofenceSyncError> {
-        let fetchResult = await awaitApiFetch(latitude: latitude, longitude: longitude)
+        let fetchResult = await awaitApiFetch(latitude: anchor.latitude, longitude: anchor.longitude)
         let response: GeofenceApiResponse
         switch fetchResult {
         case .success(let value):
@@ -39,14 +39,13 @@ extension GeofenceSyncCoordinatorImpl {
         case .failure(let error): return .failure(error)
         }
         let effectiveConfig = parsedConfig ?? cachedConfig ?? .fallback
-        let anchor = LocationData(latitude: latitude, longitude: longitude)
         let monitorable = await MainActor.run { monitorableRegions(regions) }
         let nearest = distanceFilter.nearest(monitorable, to: anchor, limit: effectiveConfig.maxBusinessGeofences, maxDistance: effectiveConfig.maxMonitoringDistance)
         let registerMovementTrigger = effectiveConfig.maxBusinessGeofences > 0
         // Read before `recordRegistration` overwrites it — the diff decides which registrations are new.
         let previouslyRegisteredIds = await storage.getRegisteredBusinessIds()
         let nearestIds = Set(nearest.map(\.id))
-        let wakeRadius = PolygonWakeRadius.radius(at: anchor, registeredPolygons: nearest, config: effectiveConfig)
+        let wakeRadius = wakeRadius(at: anchor, polygons: nearest, config: effectiveConfig, anchorIsLiveFix: anchorIsLiveFix)
         let osRegistration = await MainActor.run {
             registerWithOsSync(
                 businessRegions: nearest,
@@ -85,12 +84,11 @@ extension GeofenceSyncCoordinatorImpl {
     /// ranking-staleness reference follows the device after a local re-rank.
     func performLocalRefresh(
         expectedUserId: String,
-        latitude: Double,
-        longitude: Double,
+        anchor: LocationData,
         config: GeofenceConfig,
-        cachedRegions: [Geofence]
+        cachedRegions: [Geofence],
+        anchorIsLiveFix: Bool
     ) async -> Result<Void, GeofenceSyncError> {
-        let anchor = LocationData(latitude: latitude, longitude: longitude)
         let monitorable = await MainActor.run { monitorableRegions(cachedRegions) }
         let nearest = distanceFilter.nearest(monitorable, to: anchor, limit: config.maxBusinessGeofences, maxDistance: config.maxMonitoringDistance)
         let registerMovementTrigger = config.maxBusinessGeofences > 0
@@ -101,8 +99,8 @@ extension GeofenceSyncCoordinatorImpl {
             registerWithOsSync(
                 businessRegions: nearest,
                 movementTriggerLocation: anchor,
-                movementTriggerRadius: PolygonWakeRadius.radius(
-                    at: anchor, registeredPolygons: nearest, config: config
+                movementTriggerRadius: wakeRadius(
+                    at: anchor, polygons: nearest, config: config, anchorIsLiveFix: anchorIsLiveFix
                 ),
                 registerMovementTrigger: registerMovementTrigger
             )
@@ -145,6 +143,22 @@ extension GeofenceSyncCoordinatorImpl {
         }
         evaluatePolygonsAfterMovement(expectedUserId: expectedUserId)
         return .success(())
+    }
+
+    /// The trigger radius for a registration, sized to the nearest polygon boundary only when the
+    /// anchor is where the device actually is. A stored anchor can be a long way from the device —
+    /// unbounded once the process has been dead — and a boundary-sized circle around it would be
+    /// one the device already stands outside: a spurious cycle on iOS 17+, and on the classic path
+    /// a trigger that never fires at all. The full refresh radius is the safe default there; the
+    /// first movement pass re-arms against a live fix.
+    private func wakeRadius(
+        at anchor: LocationData,
+        polygons: [Geofence],
+        config: GeofenceConfig,
+        anchorIsLiveFix: Bool
+    ) -> Double {
+        guard anchorIsLiveFix else { return config.localRefreshTriggerRadius }
+        return PolygonWakeRadius.radius(at: anchor, registeredPolygons: polygons, config: config)
     }
 
     /// Decodes the response's regions, or fails when the payload turns out to be unreadable rather

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
@@ -50,7 +50,9 @@ extension GeofenceSyncCoordinatorImpl {
             registerWithOsSync(
                 businessRegions: nearest,
                 movementTriggerLocation: anchor,
-                movementTriggerRadius: effectiveConfig.localRefreshTriggerRadius,
+                movementTriggerRadius: PolygonWakeRadius.radius(
+                    at: anchor, registeredPolygons: nearest, config: effectiveConfig
+                ),
                 registerMovementTrigger: registerMovementTrigger
             )
         }
@@ -99,7 +101,9 @@ extension GeofenceSyncCoordinatorImpl {
             registerWithOsSync(
                 businessRegions: nearest,
                 movementTriggerLocation: anchor,
-                movementTriggerRadius: config.localRefreshTriggerRadius,
+                movementTriggerRadius: PolygonWakeRadius.radius(
+                    at: anchor, registeredPolygons: nearest, config: config
+                ),
                 registerMovementTrigger: registerMovementTrigger
             )
         }
@@ -115,6 +119,31 @@ extension GeofenceSyncCoordinatorImpl {
             anchor: anchor
         )
         logger.geofenceSyncCompleted(registeredCount: nearest.count, movementTriggerRegistered: registerMovementTrigger)
+        evaluatePolygonsAfterMovement(expectedUserId: expectedUserId)
+        return .success(())
+    }
+
+    /// Re-arms the wake and re-evaluates membership, nothing more: the nearby set is unchanged, so
+    /// ranking and cache writes would be waste. Must not `recordRegistration` — see
+    /// `movedBeyondRerankRadius`.
+    func performPolygonWakePass(
+        expectedUserId: String,
+        at location: LocationData,
+        config: GeofenceConfig
+    ) async -> Result<Void, GeofenceSyncError> {
+        let registeredIds = await storage.getRegisteredBusinessIds()
+        let registered = await storage.getCachedGeofences().filter { registeredIds.contains($0.id) }
+        let radius = PolygonWakeRadius.radius(at: location, registeredPolygons: registered, config: config)
+        logger.geofencePolygonWakePass(radius: radius, polygonCount: registered.count { $0.vertices != nil })
+        _ = await MainActor.run {
+            registerWithOsSync(
+                businessRegions: registered,
+                movementTriggerLocation: location,
+                movementTriggerRadius: radius,
+                registerMovementTrigger: config.maxBusinessGeofences > 0
+            )
+        }
+        evaluatePolygonsAfterMovement(expectedUserId: expectedUserId)
         return .success(())
     }
 

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+RefreshDecision.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+RefreshDecision.swift
@@ -24,6 +24,14 @@ extension GeofenceSyncCoordinatorImpl {
         return .skip
     }
 
+    /// True once the device has moved far enough from the last registration centre to re-rank.
+    /// Measured from that centre, never from the trigger: the trigger moves on every polygon wake,
+    /// so anchoring to it would reset the distance each time and re-ranking would never come due.
+    func movedBeyondRerankRadius(to location: LocationData, config: GeofenceConfig) async -> Bool {
+        guard let center = await storage.getLastRegistrationCenter() else { return true }
+        return distance(from: center, to: location) >= config.localRefreshTriggerRadius
+    }
+
     /// True once the device has moved beyond the refetch radius from the fetch anchor — the cached
     /// set was ranked around that anchor and no longer covers the area. False when there's no anchor
     /// to measure from.

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
@@ -20,9 +20,12 @@ enum HandleMovementTier: String, Sendable {
 
 /// Sync pipeline for the on-device geofence cache. Entry points:
 ///
-/// - `refresh(latitude:longitude:)` — identify / app-launch entry. Routes through `refreshAction`:
-///   re-fetch when stale, re-rank locally when the ranking is stale or the cache is unregistered,
-///   else skip. Gated on identified user and in-flight dedup.
+/// - `refresh(latitude:longitude:anchorIsLiveFix:)` — identify / app-launch entry. Routes through
+///   `refreshAction`: re-fetch when stale, re-rank locally when the ranking is stale or the cache is
+///   unregistered, else skip. Gated on identified user and in-flight dedup. `anchorIsLiveFix` says
+///   whether the coordinates describe where the device is NOW or are a stored value standing in for
+///   it; only the caller knows, and the movement trigger cannot be sized to a polygon boundary
+///   around a point the device may not be at.
 /// - `handleMovement(latitude:longitude:)` — movement-trigger EXIT entry. Re-ranks the cached set
 ///   for the new location; bootstraps from the server only when there's no anchor. Shares the same
 ///   dedup gate as `refresh`.
@@ -34,7 +37,7 @@ enum HandleMovementTier: String, Sendable {
 /// - `reset()` — sign-out cleanup. Stops OS-side monitoring and clears user-scoped store
 ///   state (cooldowns, last-sync). Preserves the workspace cache.
 protocol GeofenceSyncCoordinator: AutoMockable, AnyObject, Sendable {
-    func refresh(latitude: Double, longitude: Double) async -> Result<Void, GeofenceSyncError>
+    func refresh(latitude: Double, longitude: Double, anchorIsLiveFix: Bool) async -> Result<Void, GeofenceSyncError>
     func handleMovement(latitude: Double, longitude: Double) async -> Result<Void, GeofenceSyncError>
     func reset() async -> Result<Void, GeofenceSyncError>
     @MainActor
@@ -44,6 +47,14 @@ protocol GeofenceSyncCoordinator: AutoMockable, AnyObject, Sendable {
         config: GeofenceConfig?,
         userId: String?
     ) -> GeofenceRegistration?
+}
+
+extension GeofenceSyncCoordinator {
+    /// For callers holding a fix they just obtained. A caller passing a stored or fallback
+    /// coordinate must use the full form and say so — see `anchorIsLiveFix`.
+    func refresh(latitude: Double, longitude: Double) async -> Result<Void, GeofenceSyncError> {
+        await refresh(latitude: latitude, longitude: longitude, anchorIsLiveFix: true)
+    }
 }
 
 /// `@unchecked Sendable`: stored `Logger` and `DateUtil` are existentials of protocols
@@ -82,25 +93,33 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         self.logger = logger
     }
 
-    func refresh(latitude: Double, longitude: Double) async -> Result<Void, GeofenceSyncError> {
+    func refresh(latitude: Double, longitude: Double, anchorIsLiveFix: Bool) async -> Result<Void, GeofenceSyncError> {
         guard acquireGate() else {
             logger.geofenceSyncSkipped(reason: "refresh already in progress")
             return .failure(.alreadyInProgress)
         }
         let expectedUserId = identifiedUserId
-        let result = await performRefresh(expectedUserId: expectedUserId, latitude: latitude, longitude: longitude)
+        let result = await performRefresh(
+            expectedUserId: expectedUserId, latitude: latitude, longitude: longitude,
+            anchorIsLiveFix: anchorIsLiveFix
+        )
         let cleaned = await cleanupIfUserChanged(expectedUserId: expectedUserId)
         // Explicit release (not defer): the self-heal retry below must find the gate free, or it
         // would be dropped exactly like the refresh it compensates for.
         releaseGate()
-        if cleaned { retryForCurrentUser(latitude: latitude, longitude: longitude) }
+        if cleaned { retryForCurrentUser(latitude: latitude, longitude: longitude, anchorIsLiveFix: anchorIsLiveFix) }
         return result
     }
 
     /// The refresh body, extracted so `refresh` has a single exit at which `cleanupIfUserChanged`
     /// runs while the gate is still held — covering every path (freshness-skip, fetch failure,
     /// post-fetch supersede, success alike).
-    private func performRefresh(expectedUserId: String?, latitude: Double, longitude: Double) async -> Result<Void, GeofenceSyncError> {
+    private func performRefresh(
+        expectedUserId: String?,
+        latitude: Double,
+        longitude: Double,
+        anchorIsLiveFix: Bool
+    ) async -> Result<Void, GeofenceSyncError> {
         guard let userId = expectedUserId else {
             logger.geofenceSyncSkipped(reason: "no identified user")
             return .failure(.noIdentifiedUser)
@@ -113,18 +132,18 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         case .remote:
             return await performRemoteRefresh(
                 expectedUserId: userId,
-                latitude: latitude,
-                longitude: longitude,
-                cachedConfig: cachedConfig
+                anchor: location,
+                cachedConfig: cachedConfig,
+                anchorIsLiveFix: anchorIsLiveFix
             )
         case .local:
             let cachedRegions = await storage.getCachedGeofences()
             return await performLocalRefresh(
                 expectedUserId: userId,
-                latitude: latitude,
-                longitude: longitude,
+                anchor: location,
                 config: effectiveConfig,
-                cachedRegions: cachedRegions
+                cachedRegions: cachedRegions,
+                anchorIsLiveFix: anchorIsLiveFix
             )
         case .skip:
             logger.geofenceSyncSkippedFresh()
@@ -141,7 +160,8 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         let result = await performMovement(expectedUserId: expectedUserId, latitude: latitude, longitude: longitude)
         let cleaned = await cleanupIfUserChanged(expectedUserId: expectedUserId)
         releaseGate()
-        if cleaned { retryForCurrentUser(latitude: latitude, longitude: longitude) }
+        // A movement EXIT always carries a fresh fix, so the retry may size the trigger tightly.
+        if cleaned { retryForCurrentUser(latitude: latitude, longitude: longitude, anchorIsLiveFix: true) }
         return result
     }
 
@@ -163,9 +183,9 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
             logger.geofenceMovementTrigger(tier: .remoteRefresh)
             let remote = await performRemoteRefresh(
                 expectedUserId: userId,
-                latitude: latitude,
-                longitude: longitude,
-                cachedConfig: cachedConfig
+                anchor: movement,
+                cachedConfig: cachedConfig,
+                anchorIsLiveFix: true
             )
             if case .failure = remote {
                 // A failed pass never re-centers the trigger, leaving it on the circle the device
@@ -173,10 +193,10 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
                 logger.geofenceMovementRearmedAfterFailedRefresh()
                 _ = await performLocalRefresh(
                     expectedUserId: userId,
-                    latitude: latitude,
-                    longitude: longitude,
+                    anchor: movement,
                     config: effectiveConfig,
-                    cachedRegions: await storage.getCachedGeofences()
+                    cachedRegions: await storage.getCachedGeofences(),
+                    anchorIsLiveFix: true
                 )
             }
             return remote
@@ -189,10 +209,10 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
             let cachedRegions = await storage.getCachedGeofences()
             return await performLocalRefresh(
                 expectedUserId: userId,
-                latitude: latitude,
-                longitude: longitude,
+                anchor: movement,
                 config: effectiveConfig,
-                cachedRegions: cachedRegions
+                cachedRegions: cachedRegions,
+                anchorIsLiveFix: true
             )
         }
     }
@@ -249,12 +269,12 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         let osRegistration = registerWithOsSync(
             businessRegions: nearest,
             movementTriggerLocation: anchor,
-            // The full refresh radius, NOT a boundary-sized one: this path has no live fix, and
-            // `anchor` is the last recorded registration centre, which the wake pass deliberately
-            // does not walk. The device is therefore within `localRefreshTriggerRadius` of it and
-            // so inside a trigger of that size — an invariant a smaller circle would break, arming
-            // a region the device already stands outside. The first movement pass re-arms it
-            // against a live fix.
+            // The full refresh radius, NOT a boundary-sized one: this path has no live fix. While
+            // monitoring is live the recorded centre stays within `localRefreshTriggerRadius` of
+            // the device, but this path exists precisely because the OS dropped the regions and the
+            // process died — nothing re-recorded it, so the device can be arbitrarily far away. A
+            // boundary-sized circle there would be one the device already stands outside. The first
+            // movement pass re-arms against a live fix.
             movementTriggerRadius: effectiveConfig.localRefreshTriggerRadius,
             registerMovementTrigger: registerMovementTrigger
         )
@@ -281,10 +301,12 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
     /// signed in now, with this operation's seconds-old coordinates, so a user switch converges to a
     /// registered state instead of an outage lasting until the next launch. Loop-safe: a retry only
     /// re-fires if the identity changes yet again during the retry itself.
-    private func retryForCurrentUser(latitude: Double, longitude: Double) {
+    private func retryForCurrentUser(latitude: Double, longitude: Double, anchorIsLiveFix: Bool) {
         guard identifiedUserId != nil else { return }
         Task { [weak self] in
-            _ = await self?.refresh(latitude: latitude, longitude: longitude)
+            _ = await self?.refresh(
+                latitude: latitude, longitude: longitude, anchorIsLiveFix: anchorIsLiveFix
+            )
         }
     }
 

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
@@ -26,9 +26,10 @@ enum HandleMovementTier: String, Sendable {
 ///   whether the coordinates describe where the device is NOW or are a stored value standing in for
 ///   it; only the caller knows, and the movement trigger cannot be sized to a polygon boundary
 ///   around a point the device may not be at.
-/// - `handleMovement(latitude:longitude:)` — movement-trigger EXIT entry. Re-ranks the cached set
-///   for the new location; bootstraps from the server only when there's no anchor. Shares the same
-///   dedup gate as `refresh`.
+/// - `handleMovement(latitude:longitude:anchorIsLiveFix:)` — movement-trigger EXIT entry. Re-ranks
+///   the cached set for the new location; bootstraps from the server only when there's no anchor.
+///   Shares the same dedup gate as `refresh`. A movement pass whose fresh-fix request failed carries
+///   the cached fix that prompted it, so this entry is not automatically live either.
 /// - `applyCachedRegistration(...)` — synchronously register from caller-fetched state,
 ///   used by cold-wake / boot / auth-change paths. Synchronous on the main actor so
 ///   `ownedRegionIdentifiers` is populated before the next yield — otherwise the OS may
@@ -38,7 +39,7 @@ enum HandleMovementTier: String, Sendable {
 ///   state (cooldowns, last-sync). Preserves the workspace cache.
 protocol GeofenceSyncCoordinator: AutoMockable, AnyObject, Sendable {
     func refresh(latitude: Double, longitude: Double, anchorIsLiveFix: Bool) async -> Result<Void, GeofenceSyncError>
-    func handleMovement(latitude: Double, longitude: Double) async -> Result<Void, GeofenceSyncError>
+    func handleMovement(latitude: Double, longitude: Double, anchorIsLiveFix: Bool) async -> Result<Void, GeofenceSyncError>
     func reset() async -> Result<Void, GeofenceSyncError>
     @MainActor
     func applyCachedRegistration(
@@ -47,14 +48,6 @@ protocol GeofenceSyncCoordinator: AutoMockable, AnyObject, Sendable {
         config: GeofenceConfig?,
         userId: String?
     ) -> GeofenceRegistration?
-}
-
-extension GeofenceSyncCoordinator {
-    /// For callers holding a fix they just obtained. A caller passing a stored or fallback
-    /// coordinate must use the full form and say so — see `anchorIsLiveFix`.
-    func refresh(latitude: Double, longitude: Double) async -> Result<Void, GeofenceSyncError> {
-        await refresh(latitude: latitude, longitude: longitude, anchorIsLiveFix: true)
-    }
 }
 
 /// `@unchecked Sendable`: stored `Logger` and `DateUtil` are existentials of protocols
@@ -151,22 +144,29 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         }
     }
 
-    func handleMovement(latitude: Double, longitude: Double) async -> Result<Void, GeofenceSyncError> {
+    func handleMovement(latitude: Double, longitude: Double, anchorIsLiveFix: Bool) async -> Result<Void, GeofenceSyncError> {
         guard acquireGate() else {
             logger.geofenceSyncSkipped(reason: "refresh already in progress")
             return .failure(.alreadyInProgress)
         }
         let expectedUserId = identifiedUserId
-        let result = await performMovement(expectedUserId: expectedUserId, latitude: latitude, longitude: longitude)
+        let result = await performMovement(
+            expectedUserId: expectedUserId, latitude: latitude, longitude: longitude,
+            anchorIsLiveFix: anchorIsLiveFix
+        )
         let cleaned = await cleanupIfUserChanged(expectedUserId: expectedUserId)
         releaseGate()
-        // A movement EXIT always carries a fresh fix, so the retry may size the trigger tightly.
-        if cleaned { retryForCurrentUser(latitude: latitude, longitude: longitude, anchorIsLiveFix: true) }
+        if cleaned { retryForCurrentUser(latitude: latitude, longitude: longitude, anchorIsLiveFix: anchorIsLiveFix) }
         return result
     }
 
     /// The movement body, extracted for a single gated exit — same rationale as `performRefresh`.
-    private func performMovement(expectedUserId: String?, latitude: Double, longitude: Double) async -> Result<Void, GeofenceSyncError> {
+    private func performMovement(
+        expectedUserId: String?,
+        latitude: Double,
+        longitude: Double,
+        anchorIsLiveFix: Bool
+    ) async -> Result<Void, GeofenceSyncError> {
         guard let userId = expectedUserId else {
             logger.geofenceSyncSkipped(reason: "no identified user")
             return .failure(.noIdentifiedUser)
@@ -185,7 +185,7 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
                 expectedUserId: userId,
                 anchor: movement,
                 cachedConfig: cachedConfig,
-                anchorIsLiveFix: true
+                anchorIsLiveFix: anchorIsLiveFix
             )
             if case .failure = remote {
                 // A failed pass never re-centers the trigger, leaving it on the circle the device
@@ -196,13 +196,14 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
                     anchor: movement,
                     config: effectiveConfig,
                     cachedRegions: await storage.getCachedGeofences(),
-                    anchorIsLiveFix: true
+                    anchorIsLiveFix: anchorIsLiveFix
                 )
             }
             return remote
         } else if await !movedBeyondRerankRadius(to: movement, config: effectiveConfig) {
             return await performPolygonWakePass(
-                expectedUserId: userId, at: movement, config: effectiveConfig
+                expectedUserId: userId, at: movement, config: effectiveConfig,
+                anchorIsLiveFix: anchorIsLiveFix
             )
         } else {
             logger.geofenceMovementTrigger(tier: .localRerank)
@@ -212,7 +213,7 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
                 anchor: movement,
                 config: effectiveConfig,
                 cachedRegions: cachedRegions,
-                anchorIsLiveFix: true
+                anchorIsLiveFix: anchorIsLiveFix
             )
         }
     }

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
@@ -249,9 +249,13 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         let osRegistration = registerWithOsSync(
             businessRegions: nearest,
             movementTriggerLocation: anchor,
-            movementTriggerRadius: PolygonWakeRadius.radius(
-                at: anchor, registeredPolygons: nearest, config: effectiveConfig
-            ),
+            // The full refresh radius, NOT a boundary-sized one: this path has no live fix, and
+            // `anchor` is the last recorded registration centre, which the wake pass deliberately
+            // does not walk. The device is therefore within `localRefreshTriggerRadius` of it and
+            // so inside a trigger of that size — an invariant a smaller circle would break, arming
+            // a region the device already stands outside. The first movement pass re-arms it
+            // against a live fix.
+            movementTriggerRadius: effectiveConfig.localRefreshTriggerRadius,
             registerMovementTrigger: registerMovementTrigger
         )
         logger.geofenceSyncCompleted(registeredCount: nearest.count, movementTriggerRegistered: registerMovementTrigger)

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator.swift
@@ -180,6 +180,10 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
                 )
             }
             return remote
+        } else if await !movedBeyondRerankRadius(to: movement, config: effectiveConfig) {
+            return await performPolygonWakePass(
+                expectedUserId: userId, at: movement, config: effectiveConfig
+            )
         } else {
             logger.geofenceMovementTrigger(tier: .localRerank)
             let cachedRegions = await storage.getCachedGeofences()
@@ -245,7 +249,9 @@ final class GeofenceSyncCoordinatorImpl: GeofenceSyncCoordinator, @unchecked Sen
         let osRegistration = registerWithOsSync(
             businessRegions: nearest,
             movementTriggerLocation: anchor,
-            movementTriggerRadius: effectiveConfig.localRefreshTriggerRadius,
+            movementTriggerRadius: PolygonWakeRadius.radius(
+                at: anchor, registeredPolygons: nearest, config: effectiveConfig
+            ),
             registerMovementTrigger: registerMovementTrigger
         )
         logger.geofenceSyncCompleted(registeredCount: nearest.count, movementTriggerRegistered: registerMovementTrigger)

--- a/Sources/LocationGeofence/GeofenceConstants.swift
+++ b/Sources/LocationGeofence/GeofenceConstants.swift
@@ -76,4 +76,8 @@ enum GeofenceConstants {
     // drop valid data; per-value size is left to the server.
     static let maxMetadataCount = 100
     static let maxMetadataPayloadBytes = 100 * 1024 // ~20× the server's 5 KB total
+
+    /// Floor on the movement trigger's radius once polygons shrink it: below this the OS promotes
+    /// crossings too unreliably to be worth a wake, so a nearer boundary is reached late.
+    static let polygonWakeMinRadius: Double = 100
 }

--- a/Sources/LocationGeofence/GeofenceModuleState.swift
+++ b/Sources/LocationGeofence/GeofenceModuleState.swift
@@ -106,9 +106,13 @@ final class GeofenceModuleState {
                 return
             }
             self.lastSkippedForNoLocation.wrappedValue = false
+            // Not a live fix: `anchor` is the stored registration centre (or, before anything is
+            // registered, the last-known cache), so the movement trigger must not be sized to a
+            // polygon boundary around it.
             _ = await di.geofenceSyncCoordinator.refresh(
                 latitude: anchor.latitude,
-                longitude: anchor.longitude
+                longitude: anchor.longitude,
+                anchorIsLiveFix: false
             )
         }
     }
@@ -140,7 +144,8 @@ final class GeofenceModuleState {
         Task { @MainActor in
             _ = await di.geofenceSyncCoordinator.refresh(
                 latitude: location.latitude,
-                longitude: location.longitude
+                longitude: location.longitude,
+                anchorIsLiveFix: true
             )
         }
     }

--- a/Sources/LocationGeofence/GeofenceMonitorBinder.swift
+++ b/Sources/LocationGeofence/GeofenceMonitorBinder.swift
@@ -18,7 +18,7 @@ enum GeofenceMonitorBinder {
         coordinator: GeofenceSyncCoordinator,
         backgroundTaskRunner: BackgroundTaskRunner = GeofenceBackgroundTime.runner(name: "io.customer.geofence.movement-pass")
     ) {
-        monitor.setOnTransition { [weak resolver, weak coordinator] identifier, transition, location, occurredAt, eventCircle in
+        monitor.setOnTransition { [weak resolver, weak coordinator] identifier, transition, location, occurredAt, locationIsFresh, eventCircle in
             // CLLocationManager delivers on main; both handlers below are async with their
             // own serialization (tracker active-delivery dedup, coordinator refresh gate),
             // so fire-and-forget Tasks are safe.
@@ -31,7 +31,11 @@ enum GeofenceMonitorBinder {
                 // (The tracker path holds its own inside `trackTransition`.)
                 Task {
                     await backgroundTaskRunner.withBackgroundTime {
-                        _ = await coordinator?.handleMovement(latitude: location.latitude, longitude: location.longitude)
+                        _ = await coordinator?.handleMovement(
+                            latitude: location.latitude,
+                            longitude: location.longitude,
+                            anchorIsLiveFix: locationIsFresh
+                        )
                     }
                 }
                 return

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -181,6 +181,10 @@ extension Logger {
         error("Polygon \(identifier) dropped: covering circle \(Int(radius)) m exceeds the OS monitoring limit \(Int(limit)) m, and a clamped circle would no longer contain the polygon", geofenceTag, nil)
     }
 
+    func geofencePolygonWakePass(radius: Double, polygonCount: Int) {
+        debug("Polygon wake pass: re-armed at \(Int(radius)) m, re-evaluating \(polygonCount) polygon(s)", geofenceTag)
+    }
+
     func geofencePolygonUndecided(identifier: String, reason: String) {
         debug("Polygon membership undecided for region \(identifier): \(reason)", geofenceTag)
     }

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -185,6 +185,17 @@ extension Logger {
         debug("Polygon wake pass: re-armed at \(Int(radius)) m, re-evaluating \(polygonCount) polygon(s)", geofenceTag)
     }
 
+    /// Logged on every decisive evaluation, delivered or not: without it the commonest outcome —
+    /// decisively outside, belief unchanged — writes nothing, and a correct silence is
+    /// indistinguishable from an evaluator that never ran.
+    func geofencePolygonVerdict(identifier: String, membership: PolygonMembership, signedEdgeDistance: Double, horizontalAccuracy: Double, fixAge: TimeInterval) {
+        debug("Polygon membership \(membership) for region \(identifier): edge \(Int(signedEdgeDistance)) m, accuracy \(Int(horizontalAccuracy)) m, fix age \(String(format: "%.1f", fixAge))s", geofenceTag)
+    }
+
+    func geofencePolygonNotDelivered(identifier: String, outcome: String) {
+        debug("Polygon verdict for region \(identifier) delivered nothing: \(outcome)", geofenceTag)
+    }
+
     func geofencePolygonUndecided(identifier: String, reason: String) {
         debug("Polygon membership undecided for region \(identifier): \(reason)", geofenceTag)
     }

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -196,6 +196,13 @@ extension Logger {
         debug("Polygon verdict for region \(identifier) delivered nothing: \(outcome)", geofenceTag)
     }
 
+    /// Which radius the movement trigger was armed with and why. Pairs with the fix-age line the
+    /// resolver logs just before it: together they say whether a re-arm was warranted.
+    func geofenceWakeRadiusChosen(radius: Double, anchorIsLiveFix: Bool) {
+        let basis = anchorIsLiveFix ? "a held fix" : "a stored anchor"
+        debug("Movement trigger sized to \(Int(radius)) m from \(basis)", geofenceTag)
+    }
+
     func geofencePolygonUndecided(identifier: String, reason: String) {
         debug("Polygon membership undecided for region \(identifier): \(reason)", geofenceTag)
     }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+BaselineHeal.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+BaselineHeal.swift
@@ -68,6 +68,8 @@ extension CLMonitorGeofenceMonitor {
                     transition,
                     LocationData(latitude: fix.coordinate.latitude, longitude: fix.coordinate.longitude),
                     fix.timestamp,
+                    // A heal only synthesizes off a fix it just gated as fresh.
+                    true,
                     MonitoredCircle(
                         center: condition.center, radius: condition.radius,
                         maximumRadius: self.authManager.maximumRegionMonitoringDistance
@@ -88,7 +90,7 @@ extension CLMonitorGeofenceMonitor {
     /// wins; the decision's fix-age guard applies to the result.
     private func resolveHealFix() async -> CLLocation? {
         await withCheckedContinuation { continuation in
-            movementFixResolver.resolve(cached: bestKnownFix()) { [weak self] _ in
+            movementFixResolver.resolve(cached: bestKnownFix()) { [weak self] _, _ in
                 continuation.resume(returning: self?.bestKnownFix())
             }
         }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+ContradictionGate.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+ContradictionGate.swift
@@ -95,7 +95,7 @@ extension CLMonitorGeofenceMonitor {
             return bestKnownFix()
         }
         let fix: CLLocation? = await withCheckedContinuation { continuation in
-            movementFixResolver.resolve(cached: bestKnownFix()) { [weak self] _ in
+            movementFixResolver.resolve(cached: bestKnownFix()) { [weak self] _, _ in
                 continuation.resume(returning: self?.bestKnownFix())
             }
         }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -305,14 +305,18 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
             // The movement pass re-centers the trigger and measures displacement at these coords, so
             // a frozen cached fix pins the whole pipeline to a stale point — freshen it first.
             // Fire-and-forget so a slow fix can't stall the pending-event drain behind it.
-            movementFixResolver.resolve(cached: bestKnownFix()) { [weak self] location in
+            movementFixResolver.resolve(cached: bestKnownFix()) { [weak self] location, isFresh in
                 self?.logger.geofenceOsTransitionReceived(identifier: identifier, transition: transition)
-                self?.onTransition?(identifier, transition, location, event.date, self?.eventCircle(for: identifier))
+                self?.onTransition?(
+                    identifier, transition, location, event.date, isFresh,
+                    self?.eventCircle(for: identifier)
+                )
             }
             return
         }
         logger.geofenceOsTransitionReceived(identifier: identifier, transition: transition)
-        onTransition?(identifier, transition, currentLocationData(), event.date, eventCircle(for: identifier))
+        // Business events carry the captured location for context only; nothing sizes to it.
+        onTransition?(identifier, transition, currentLocationData(), event.date, false, eventCircle(for: identifier))
     }
 
     // MARK: - GeofenceRegionMonitoring

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -307,10 +307,7 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
             // Fire-and-forget so a slow fix can't stall the pending-event drain behind it.
             movementFixResolver.resolve(cached: bestKnownFix()) { [weak self] location, isFresh in
                 self?.logger.geofenceOsTransitionReceived(identifier: identifier, transition: transition)
-                self?.onTransition?(
-                    identifier, transition, location, event.date, isFresh,
-                    self?.eventCircle(for: identifier)
-                )
+                self?.onTransition?(identifier, transition, location, event.date, isFresh, self?.eventCircle(for: identifier))
             }
             return
         }

--- a/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor.swift
@@ -238,14 +238,19 @@ final class CoreLocationGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @pr
         circle: MonitoredCircle?
     ) {
         if identifier == GeofenceConstants.movementTriggerIdentifier, transition == .exit {
-            movementFixResolver.resolve(cached: bestKnownFix()) { [weak self] location in
+            movementFixResolver.resolve(cached: bestKnownFix()) { [weak self] location, isFresh in
                 self?.logger.geofenceOsTransitionReceived(identifier: identifier, transition: transition)
-                self?.onTransition?(identifier, transition, location ?? capturedLocation, occurredAt, circle)
+                // Falling back to the captured location is a second layer of staleness on top of a
+                // failed request, so it can never be reported as current.
+                self?.onTransition?(
+                    identifier, transition, location ?? capturedLocation, occurredAt,
+                    isFresh && location != nil, circle
+                )
             }
             return
         }
         logger.geofenceOsTransitionReceived(identifier: identifier, transition: transition)
-        onTransition?(identifier, transition, capturedLocation, occurredAt, circle)
+        onTransition?(identifier, transition, capturedLocation, occurredAt, false, circle)
     }
 
     func locationManager(_ manager: CLLocationManager, monitoringDidFailFor region: CLRegion?, withError error: Error) {

--- a/Sources/LocationGeofence/Monitor/GeofenceRegionMonitoring.swift
+++ b/Sources/LocationGeofence/Monitor/GeofenceRegionMonitoring.swift
@@ -12,11 +12,17 @@ import Foundation
 /// `occurredAt` is when the crossing happened — the OS event's date, or the fix's timestamp for a
 /// synthesized heal. Lets a consumer order a late or replayed transition against what it believes,
 /// which is why every dispatch site owes one: a consumer handed no date writes unordered.
+///
+/// `locationIsFresh` says whether the attached coordinates came from a fix delivered for THIS event
+/// rather than a cached one. A movement pass falls back to the cached fix when its request fails or
+/// times out, and that fix is by definition the stale one that prompted the request — a consumer
+/// sizing anything to those coordinates has to know the difference.
+///
 /// The last parameter is the circle the OS was monitoring when it raised this event, `nil` when the
 /// monitor cannot say which one it was (a cold wake whose adoption has not populated its record
 /// yet). A consumer reasoning about what the crossing PROVES needs it: a refresh can replace a
 /// fence under the same id, and the guarantee a covering circle gives only holds for its own ring.
-typealias GeofenceTransitionHandler = @Sendable (String, GeofenceTransition, LocationData?, Date, MonitoredCircle?) -> Void
+typealias GeofenceTransitionHandler = @Sendable (String, GeofenceTransition, LocationData?, Date, Bool, MonitoredCircle?) -> Void
 
 /// Callback when iOS reports a change to the location authorization status.
 /// Invoked on the main actor — same isolation domain as `CLLocationManagerDelegate`.

--- a/Sources/LocationGeofence/Monitor/MovementFixResolver.swift
+++ b/Sources/LocationGeofence/Monitor/MovementFixResolver.swift
@@ -56,7 +56,7 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
 
     /// Freshest fix this resolver has received, retained even when it arrives after a timeout.
     private(set) var latestFix: CLLocation?
-    private var pendingCompletions: [(LocationData?) -> Void] = []
+    private var pendingCompletions: [(LocationData?, Bool) -> Void] = []
     /// Newest cached fix seen while a request is in flight — the fallback on failure/timeout.
     private var fallbackFix: CLLocation?
     private var timeoutTask: Task<Void, Never>?
@@ -89,11 +89,17 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
 
     /// Completes with a fix no older than `maxAge` when one can be obtained, exactly once per call.
     /// `cached` should be the caller's best currently-known fix.
-    func resolve(cached: CLLocation?, completion: @escaping (LocationData?) -> Void) {
+    ///
+    /// The completion's `Bool` is whether those coordinates are current: true for a delivered fix or
+    /// a cached one still inside `maxAge`, false when the request failed or timed out and the answer
+    /// is `fallbackFix` — which is by definition the stale fix that prompted the request. A caller
+    /// that sizes anything to the coordinates needs that apart, and deriving it from the fix's age
+    /// at the call site would put this rule in two more places to get wrong.
+    func resolve(cached: CLLocation?, completion: @escaping (LocationData?, Bool) -> Void) {
         let age = cached.map { -$0.timestamp.timeIntervalSinceNow }
         if let cached, let age, age <= maxAge {
             logger.geofenceMovementFixResolved(ageSeconds: age, requested: false)
-            completion(locationData(from: cached))
+            completion(locationData(from: cached), true)
             return
         }
         logger.geofenceMovementFixStale(ageSeconds: age)
@@ -137,13 +143,13 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
         recordDeliveredFix(fix)
         guard !pendingCompletions.isEmpty else { return }
         logger.geofenceMovementFixResolved(ageSeconds: -fix.timestamp.timeIntervalSinceNow, requested: true)
-        completeAll(with: locationData(from: fix))
+        completeAll(with: locationData(from: fix), isFresh: true)
     }
 
     func handleRequestFailure() {
         guard !pendingCompletions.isEmpty else { return }
         logger.geofenceMovementFixRequestFailed(fallingBackToCached: fallbackFix != nil)
-        completeAll(with: fallbackFix.map(locationData(from:)))
+        completeAll(with: fallbackFix.map(locationData(from:)), isFresh: false)
     }
 
     // MARK: - Private
@@ -175,7 +181,7 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
         }
     }
 
-    private func completeAll(with location: LocationData?) {
+    private func completeAll(with location: LocationData?, isFresh: Bool) {
         timeoutTask?.cancel()
         timeoutTask = nil
         fallbackFix = nil
@@ -184,7 +190,7 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
         let completions = pendingCompletions
         pendingCompletions = []
         for completion in completions {
-            completion(location)
+            completion(location, isFresh)
         }
     }
 

--- a/Sources/LocationGeofence/Monitor/MovementFixResolver.swift
+++ b/Sources/LocationGeofence/Monitor/MovementFixResolver.swift
@@ -46,6 +46,11 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
     /// Only the system fix is checked for a valid coordinate. `latestFix` reaches this class
     /// through a delegate callback that already rejects invalid ones — which a test feeding
     /// `handleResolvedFix` directly does not.
+    ///
+    /// This is a FALLBACK VALUE — the best position to act on when no request is made — and newest
+    /// is what makes it best. It is not a freshness baseline: a caller asking "is the answer newer
+    /// than what I had" must compare against `latestFix`, because this property tracks a cache that
+    /// advances on its own and would leave nothing able to beat it.
     var cachedFix: CLLocation? {
         let systemFix = (systemCachedFix.map { $0() } ?? manager.location)
             .flatMap { CLLocationCoordinate2DIsValid($0.coordinate) ? $0 : nil }

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver+Foreground.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver+Foreground.swift
@@ -1,0 +1,39 @@
+import CioInternalCommon
+import Foundation
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// The foreground re-evaluation pass, split from the resolver's core so both stay under the file
+/// cap. The members it reads are `internal` rather than `private` only because of this split; they
+/// remain implementation detail of an internal type.
+@MainActor
+extension PolygonMembershipResolver {
+    func registerForegroundEvaluation() {
+        #if canImport(UIKit)
+        foregroundObserverToken = notificationCenter.addObserver(
+            forName: UIApplication.willEnterForegroundNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                // Sampled here, not read at emit time: the pass resolves a fix first, and a
+                // foregrounding app's cached fix is normally stale — the app was suspended — so
+                // that request really does suspend. No caller supplies an expected user on this
+                // path, so the observer takes its own.
+                //
+                // Anonymous at both ends compares nil to nil and proceeds; that is safe only
+                // because a signed-out process has no `monitoredGeofenceIds`, so the pass returns
+                // empty before it resolves anything. Registration while anonymous would break it.
+                let expectedUserId = self.contextStore.currentUserId
+                Task { [contextStore = self.contextStore] in
+                    await self.evaluateAllPolygons(
+                        isStillCurrent: { contextStore.currentUserId == expectedUserId }
+                    )
+                }
+            }
+        }
+        #endif
+    }
+}

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver+NewlyRegistered.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver+NewlyRegistered.swift
@@ -1,0 +1,34 @@
+import CioInternalCommon
+import Foundation
+
+/// The pass for polygons a refresh has just registered, split from the resolver's core so both stay
+/// under the file cap.
+@MainActor
+extension PolygonMembershipResolver {
+    /// The pass for polygons a refresh has just registered.
+    ///
+    /// Forces a fresh fix so this and the movement pass the same refresh starts decide from the
+    /// same one. Deciding here from a cached fix while the movement pass forces a fresh one let a
+    /// single refresh deliver an enter and then its own correcting exit: the cached fix is accepted
+    /// up to `movementFixMaxAge` old, which at speed is the several hundred metres the movement
+    /// pass forces a fresh fix precisely to avoid.
+    ///
+    /// The cached fix stays as the fallback for a failed request, because enter-when-inside is owed
+    /// for a polygon the device is standing in and the movement pass will have decided nothing
+    /// either. It cannot resurrect the contradiction: a verdict it writes is older evidence than
+    /// any later fresh one, so the ordering guard lets the fresh verdict correct it.
+    func evaluateNewlyRegistered(
+        geofenceIds: [String],
+        isStillCurrent: (@Sendable () -> Bool)? = nil
+    ) async {
+        let decided = await evaluateMembership(
+            geofenceIds: geofenceIds, reason: "new polygon",
+            requiresFreshFix: true, isStillCurrent: isStillCurrent
+        )
+        guard !decided else { return }
+        await evaluateMembership(
+            geofenceIds: geofenceIds, reason: "new polygon, forced request failed",
+            isStillCurrent: isStillCurrent
+        )
+    }
+}

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -370,8 +370,8 @@ final class PolygonMembershipResolver {
     ///
     /// On the FIRST pass of a process the two collapse into one. Nothing has been delivered to be
     /// newer than, and CoreLocation may echo its cached fix as a new manager's first delivery — an
-    /// echo inside `movementFixMaxAge` is accepted — so a cold wake can be answered by a fix that
-    /// much older than the wake, several hundred metres at speed. That is the same bound
+    /// echo inside `movementFixMaxAge` is accepted — so a cold wake can be answered by a fix up to
+    /// that much older than the wake, several hundred metres at speed. That is the same bound
     /// `PolygonMembershipDecision` already applies, so `requiringFresh` adds nothing on a cold
     /// process, and every cold-process wake is a first pass. Tightening it needs an assumed-speed
     /// constant — the same one the ≤17 wake radius wants — so it belongs with that work. The
@@ -413,7 +413,10 @@ final class PolygonMembershipResolver {
                 // Not `latestFix` first: `resolve` answers from the caller's cached fix without
                 // requesting when that fix is young enough, and takes that fast path WITHOUT
                 // recording it — so `latestFix` can still be a much older delivered fix while the
-                // fresh system fix is the very thing that let this pass proceed. It also covers the
+                // fresh system fix is the very thing that let this pass proceed. Fix it HERE and
+                // not by recording on that fast path: letting `latestFix` absorb the system cache
+                // would make the forced-fresh baseline above unbeatable again, which is the defect
+                // this whole path was repaired from. It also covers the
                 // cold process whose request failed, where CoreLocation's cache is the only
                 // evidence there is and the monitor has already advanced its dedup baseline, so
                 // declining would lose the crossing for good.

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -173,7 +173,14 @@ final class PolygonMembershipResolver {
     /// covers only a pass content with the fix already in hand. A wake runs BECAUSE the device
     /// moved, and any pass already in flight is working from a fix requested before that movement —
     /// so no wake yields, not even to another wake, and nothing else would retry it if it did.
-    /// Concurrent requests coalesce inside `MovementFixResolver`, which is what bounds the cost.
+    ///
+    /// What running actually buys the second wake is bounded, and worth stating so it is not
+    /// over-read: concurrent requests COALESCE inside `MovementFixResolver`, so a wake arriving
+    /// while a request is in flight is answered by that request rather than one of its own. It
+    /// gains a delivered fix it would otherwise never have seen, but not one that postdates its own
+    /// crossing, and if the shared request fails both wakes end undecided rather than one of them
+    /// skipped. Giving the second wake a fix of its own means a request per wake — a design change,
+    /// not a comment fix.
     func evaluateAllPolygons(
         requiresFreshFix: Bool = false,
         isStillCurrent: (@Sendable () -> Bool)? = nil
@@ -355,11 +362,20 @@ final class PolygonMembershipResolver {
     /// carries the accuracy and timestamp the decision needs.
     ///
     /// "Fresh" here is a fix this resolver received in answer to THIS request, and strictly newer
-    /// than the last one it delivered — a deliberately stricter test than the
-    /// within-`movementFixMaxAge` one the movement trigger is sized against
-    /// (`GeofenceSyncCoordinatorImpl.wakeRadius`). A verdict may not be re-affirmed by the very fix
+    /// than the last one it delivered. Once it has delivered anything that is stricter than the
+    /// within-`movementFixMaxAge` test the movement trigger is sized against
+    /// (`GeofenceSyncCoordinatorImpl.wakeRadius`): a verdict may not be re-affirmed by the very fix
     /// the wake exists to revisit, whereas a trigger only needs an anchor roughly where the device
-    /// is. The two are not interchangeable and neither should be relaxed to the other.
+    /// is.
+    ///
+    /// On the FIRST pass of a process the two collapse into one. Nothing has been delivered to be
+    /// newer than, and CoreLocation may echo its cached fix as a new manager's first delivery — an
+    /// echo inside `movementFixMaxAge` is accepted — so a cold wake can be answered by a fix that
+    /// much older than the wake, several hundred metres at speed. That is the same bound
+    /// `PolygonMembershipDecision` already applies, so `requiringFresh` adds nothing on a cold
+    /// process, and every cold-process wake is a first pass. Tightening it needs an assumed-speed
+    /// constant — the same one the ≤17 wake radius wants — so it belongs with that work. The
+    /// verdict line logs fix age, which is what makes a stale-echo verdict identifiable in a field log.
     ///
     /// When a fresh fix is REQUIRED, a request that fails or times out still resumes with the fix
     /// already held. That one predates the wake and can sit inside `movementFixMaxAge`, so it would
@@ -376,10 +392,11 @@ final class PolygonMembershipResolver {
                 let resolved = fixResolver.latestFix
                 if requiringFresh {
                     // `isFresh` is the resolver's own account of what it answered with: true only
-                    // for a fix it received in response to this request. It is what stops the first
-                    // wake of a process — which has delivered nothing, so has no baseline — from
-                    // being answered out of CoreLocation's pre-movement cache. The timestamp
-                    // comparison then keeps each later wake strictly ahead of the one before.
+                    // for a fix it received in response to this request, which is what keeps a
+                    // failed or timed-out request from resuming on the held fix. It does NOT prove
+                    // the fix postdates the wake — an echoed cache fix inside `movementFixMaxAge`
+                    // clears it — so on a cold process the age gate is the whole bound. The
+                    // timestamp comparison then keeps each later wake strictly ahead of the one before.
                     //
                     // No fallback to the held fix here, on any branch: a wake fires BECAUSE the
                     // device moved, so anything predating the request describes where it was.

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -358,6 +358,12 @@ final class PolygonMembershipResolver {
     /// resolution: the completion's coordinates are discarded in favour of `latestFix`, which
     /// carries the accuracy and timestamp the decision needs.
     ///
+    /// "Fresh" here is strictly newer than anything held before the request — a deliberately
+    /// stricter test than the within-`movementFixMaxAge` one the movement trigger is sized against
+    /// (`GeofenceSyncCoordinatorImpl.wakeRadius`). A verdict may not be re-affirmed by the very fix
+    /// the wake exists to revisit, whereas a trigger only needs an anchor roughly where the device
+    /// is. The two are not interchangeable and neither should be relaxed to the other.
+    ///
     /// When a fresh fix is REQUIRED, a request that fails or times out still resumes with the fix
     /// already held. That one predates the wake and can sit inside `movementFixMaxAge`, so it would
     /// re-affirm the very verdict the wake exists to revisit — report no fix instead.

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -409,10 +409,15 @@ final class PolygonMembershipResolver {
                     continuation.resume(returning: resolved)
                     return
                 }
-                // Cold process: nothing delivered and the request failed, so CoreLocation's own
-                // cached fix is the only evidence there is. The monitor has already advanced its
-                // dedup baseline, so declining here loses the crossing for good.
-                continuation.resume(returning: resolved ?? fixResolver.cachedFix)
+                // Newest of whatever exists, which is what a pass content with a held fix wants.
+                // Not `latestFix` first: `resolve` answers from the caller's cached fix without
+                // requesting when that fix is young enough, and takes that fast path WITHOUT
+                // recording it — so `latestFix` can still be a much older delivered fix while the
+                // fresh system fix is the very thing that let this pass proceed. It also covers the
+                // cold process whose request failed, where CoreLocation's cache is the only
+                // evidence there is and the monitor has already advanced its dedup baseline, so
+                // declining would lose the crossing for good.
+                continuation.resume(returning: fixResolver.cachedFix)
             }
         }
     }

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -174,13 +174,11 @@ final class PolygonMembershipResolver {
     /// moved, and any pass already in flight is working from a fix requested before that movement —
     /// so no wake yields, not even to another wake, and nothing else would retry it if it did.
     ///
-    /// What running actually buys the second wake is bounded, and worth stating so it is not
-    /// over-read: concurrent requests COALESCE inside `MovementFixResolver`, so a wake arriving
-    /// while a request is in flight is answered by that request rather than one of its own. It
-    /// gains a delivered fix it would otherwise never have seen, but not one that postdates its own
-    /// crossing, and if the shared request fails both wakes end undecided rather than one of them
-    /// skipped. Giving the second wake a fix of its own means a request per wake — a design change,
-    /// not a comment fix.
+    /// What running buys the second wake is bounded: concurrent requests COALESCE inside
+    /// `MovementFixResolver`, so a wake arriving while one is in flight is answered by that request
+    /// — a fix it would otherwise never have seen, but not one that postdates its own crossing. If
+    /// the shared request fails both wakes end undecided. Giving the second wake a fix of its own
+    /// means a request per wake: a design change, not a comment fix.
     func evaluateAllPolygons(
         requiresFreshFix: Bool = false,
         isStillCurrent: (@Sendable () -> Bool)? = nil
@@ -361,25 +359,21 @@ final class PolygonMembershipResolver {
     /// resolution: the completion's coordinates are discarded in favour of `latestFix`, which
     /// carries the accuracy and timestamp the decision needs.
     ///
-    /// "Fresh" here is a fix this resolver received in answer to THIS request, and strictly newer
-    /// than the last one it delivered. Once it has delivered anything that is stricter than the
-    /// within-`movementFixMaxAge` test the movement trigger is sized against
-    /// (`GeofenceSyncCoordinatorImpl.wakeRadius`): a verdict may not be re-affirmed by the very fix
-    /// the wake exists to revisit, whereas a trigger only needs an anchor roughly where the device
-    /// is.
+    /// "Fresh" here is a fix received in answer to THIS request and strictly newer than the last
+    /// one delivered — stricter than the `movementFixMaxAge` test the movement trigger is sized
+    /// against (`GeofenceSyncCoordinatorImpl.wakeRadius`), which only needs an anchor roughly where
+    /// the device is. The two are not interchangeable; neither may be relaxed to the other.
     ///
-    /// On the FIRST pass of a process the two collapse into one. Nothing has been delivered to be
-    /// newer than, and CoreLocation may echo its cached fix as a new manager's first delivery — an
-    /// echo inside `movementFixMaxAge` is accepted — so a cold wake can be answered by a fix up to
-    /// that much older than the wake, several hundred metres at speed. That is the same bound
-    /// `PolygonMembershipDecision` already applies, so `requiringFresh` adds nothing on a cold
-    /// process, and every cold-process wake is a first pass. Tightening it needs an assumed-speed
-    /// constant — the same one the ≤17 wake radius wants — so it belongs with that work. The
-    /// verdict line logs fix age, which is what makes a stale-echo verdict identifiable in a field log.
+    /// On the FIRST pass of a process the two collapse into one: nothing has been delivered to be
+    /// newer than, and CoreLocation may echo its cached fix as a new manager's first delivery, so a
+    /// cold wake can be answered by a fix up to `movementFixMaxAge` older than itself — several
+    /// hundred metres at speed. Every cold-process wake is a first pass, so `requiringFresh` adds
+    /// nothing there; tightening it needs the assumed-speed constant the ≤17 wake radius also
+    /// wants. The verdict line logs fix age, which is what makes such a verdict identifiable.
     ///
     /// When a fresh fix is REQUIRED, a request that fails or times out still resumes with the fix
-    /// already held. That one predates the wake and can sit inside `movementFixMaxAge`, so it would
-    /// re-affirm the very verdict the wake exists to revisit — report no fix instead.
+    /// already held — it predates the wake and would re-affirm the verdict the wake exists to
+    /// revisit, so report no fix instead.
     private func resolveFix(requiringFresh: Bool = false) async -> CLLocation? {
         // What this resolver has already DELIVERED, which is what a forced request must improve on.
         // Deliberately not `cachedFix`: that reports the newest fix obtainable from either source,
@@ -410,16 +404,13 @@ final class PolygonMembershipResolver {
                     return
                 }
                 // Newest of whatever exists, which is what a pass content with a held fix wants.
-                // Not `latestFix` first: `resolve` answers from the caller's cached fix without
-                // requesting when that fix is young enough, and takes that fast path WITHOUT
-                // recording it — so `latestFix` can still be a much older delivered fix while the
-                // fresh system fix is the very thing that let this pass proceed. Fix it HERE and
-                // not by recording on that fast path: letting `latestFix` absorb the system cache
-                // would make the forced-fresh baseline above unbeatable again, which is the defect
-                // this whole path was repaired from. It also covers the
-                // cold process whose request failed, where CoreLocation's cache is the only
-                // evidence there is and the monitor has already advanced its dedup baseline, so
-                // declining would lose the crossing for good.
+                // Not `latestFix` first: `resolve` answers from the caller's cached fix WITHOUT
+                // recording it when that fix is young enough, so `latestFix` can be much older than
+                // the system fix that let this pass proceed. Fixed here and not by recording on
+                // that fast path — letting `latestFix` absorb the system cache would make the
+                // forced-fresh baseline above unbeatable again, the defect this path was repaired
+                // from. It also covers a cold process whose request failed, where CoreLocation's
+                // cache is the only evidence and the monitor's dedup baseline has already advanced.
                 continuation.resume(returning: fixResolver.cachedFix)
             }
         }

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -367,7 +367,7 @@ final class PolygonMembershipResolver {
         // nothing to compare against, and CoreLocation's own cached fix would pass as fresh.
         let priorTimestamp = fixResolver.cachedFix?.timestamp
         return await withCheckedContinuation { continuation in
-            fixResolver.resolve(cached: requiringFresh ? nil : fixResolver.cachedFix) { [weak self] _ in
+            fixResolver.resolve(cached: requiringFresh ? nil : fixResolver.cachedFix) { [weak self] _, _ in
                 guard let self else { return continuation.resume(returning: nil) }
                 let resolved = fixResolver.latestFix
                 if requiringFresh {

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -33,7 +33,8 @@ final class PolygonMembershipResolver {
     private let contextStore: BackgroundDeliveryContextStore
     private let notificationCenter: NotificationCenter
     private var foregroundObserverToken: NSObjectProtocol?
-    private var isEvaluatingAllPolygons = false
+    private var passesInFlight = 0
+    private var freshPassInFlight = false
 
     init(
         storage: GeofenceStorage,
@@ -169,17 +170,24 @@ final class PolygonMembershipResolver {
     /// serves the whole pass.
     ///
     /// Foregrounds arrive in bursts, so a pass already running wins: a second concurrent scan reads
-    /// the same storage and the same fix and can only duplicate the location work.
+    /// the same storage and the same fix and can only duplicate the location work. Strength decides
+    /// that, not mere existence — a wake requires a fresh fix and an in-flight foreground pass does
+    /// not, so skipping behind one would drop exactly the pass that runs BECAUSE the device moved,
+    /// with nothing to retry it.
     func evaluateAllPolygons(
         requiresFreshFix: Bool = false,
         isStillCurrent: (@Sendable () -> Bool)? = nil
     ) async {
-        guard !isEvaluatingAllPolygons else {
-            logger.geofencePolygonPassSkipped(reason: "a pass is already running")
+        if passesInFlight > 0, freshPassInFlight || !requiresFreshFix {
+            logger.geofencePolygonPassSkipped(reason: "a pass of at least this strength is already running")
             return
         }
-        isEvaluatingAllPolygons = true
-        defer { isEvaluatingAllPolygons = false }
+        passesInFlight += 1
+        freshPassInFlight = freshPassInFlight || requiresFreshFix
+        defer {
+            passesInFlight -= 1
+            if passesInFlight == 0 { freshPassInFlight = false }
+        }
         let registered = await storage.getRegisteredBusinessIds()
         let polygons = await storage.getCachedGeofences()
             .filter { registered.contains($0.id) && $0.vertices != nil }

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -355,25 +355,18 @@ final class PolygonMembershipResolver {
         await storage.getCachedGeofences().first { $0.id == id }
     }
 
-    /// Freshest fix obtainable, requesting one when the cache is stale. Mirrors the gate's
-    /// resolution: the completion's coordinates are discarded in favour of `latestFix`, which
-    /// carries the accuracy and timestamp the decision needs.
+    /// Freshest fix obtainable, requesting one when the cache is stale. Mirrors the gate: the
+    /// completion's coordinates are discarded for `latestFix`, which carries accuracy and timestamp.
     ///
     /// "Fresh" here is a fix received in answer to THIS request and strictly newer than the last
-    /// one delivered — stricter than the `movementFixMaxAge` test the movement trigger is sized
-    /// against (`GeofenceSyncCoordinatorImpl.wakeRadius`), which only needs an anchor roughly where
-    /// the device is. The two are not interchangeable; neither may be relaxed to the other.
+    /// one delivered — stricter than the `movementFixMaxAge` test `wakeRadius` is sized against,
+    /// which only needs an anchor roughly where the device is. Neither may be relaxed to the other.
     ///
-    /// On the FIRST pass of a process the two collapse into one: nothing has been delivered to be
-    /// newer than, and CoreLocation may echo its cached fix as a new manager's first delivery, so a
-    /// cold wake can be answered by a fix up to `movementFixMaxAge` older than itself — several
-    /// hundred metres at speed. Every cold-process wake is a first pass, so `requiringFresh` adds
-    /// nothing there; tightening it needs the assumed-speed constant the ≤17 wake radius also
-    /// wants. The verdict line logs fix age, which is what makes such a verdict identifiable.
-    ///
-    /// When a fresh fix is REQUIRED, a request that fails or times out still resumes with the fix
-    /// already held — it predates the wake and would re-affirm the verdict the wake exists to
-    /// revisit, so report no fix instead.
+    /// On the FIRST pass of a process the two collapse: nothing has been delivered to be newer
+    /// than, and CoreLocation may echo its cached fix as a manager's first delivery, so a cold wake
+    /// can be answered by a fix up to `movementFixMaxAge` older than itself — hundreds of metres at
+    /// speed. Tightening it needs the ≤17 wake radius's assumed-speed constant; the verdict line
+    /// logs fix age, which is what makes such a verdict identifiable.
     private func resolveFix(requiringFresh: Bool = false) async -> CLLocation? {
         // What this resolver has already DELIVERED, which is what a forced request must improve on.
         // Deliberately not `cachedFix`: that reports the newest fix obtainable from either source,

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -102,13 +102,15 @@ final class PolygonMembershipResolver {
                 logger.geofencePolygonUndecided(identifier: identifier, reason: "stored ring no longer builds")
                 return
             }
+            // Also a movement event, so the same staleness rule applies as on a wake.
+            //
             // No user boundary across the fix, unlike `evaluateMembership`, and none exists to
             // carry: the binder dispatches this with no expected user captured anywhere. Accepted
             // on the trade this file makes elsewhere — the crossing is geometrically real, and
             // declining it loses it for good because the dedup baseline has already advanced. The
             // cost is real: a switch inside the fix window attributes it to a user who may not
             // monitor this polygon at all.
-            await evaluate(geofenceId: identifier)
+            await evaluate(geofenceId: identifier, requiresFreshFix: true)
         }
     }
 
@@ -130,6 +132,7 @@ final class PolygonMembershipResolver {
     func evaluateMembership(
         geofenceIds: [String],
         reason: String,
+        requiresFreshFix: Bool = false,
         isStillCurrent: (@Sendable () -> Bool)? = nil
     ) async {
         for geofenceId in geofenceIds {
@@ -147,7 +150,7 @@ final class PolygonMembershipResolver {
             pending.append(geofenceId)
         }
         guard !pending.isEmpty else { return }
-        guard let fix = await resolveFix() else {
+        guard let fix = await resolveFix(requiringFresh: requiresFreshFix) else {
             for geofenceId in pending {
                 logger.geofencePolygonUndecided(identifier: geofenceId, reason: "no usable fix")
             }
@@ -167,7 +170,10 @@ final class PolygonMembershipResolver {
     ///
     /// Foregrounds arrive in bursts, so a pass already running wins: a second concurrent scan reads
     /// the same storage and the same fix and can only duplicate the location work.
-    func evaluateAllPolygons(isStillCurrent: (@Sendable () -> Bool)? = nil) async {
+    func evaluateAllPolygons(
+        requiresFreshFix: Bool = false,
+        isStillCurrent: (@Sendable () -> Bool)? = nil
+    ) async {
         guard !isEvaluatingAllPolygons else {
             logger.geofencePolygonPassSkipped(reason: "a pass is already running")
             return
@@ -180,8 +186,9 @@ final class PolygonMembershipResolver {
         guard !polygons.isEmpty else { return }
         // One request for the whole pass. Resolving per polygon would issue a fresh timed request
         // for every one of them whenever the cache stays empty, holding the main actor for minutes
-        // and still deciding nothing.
-        guard let fix = await resolveFix() else {
+        // and still deciding nothing — and a failed fresh request would silently downgrade every
+        // polygon after the first to the pre-wake fix.
+        guard let fix = await resolveFix(requiringFresh: requiresFreshFix) else {
             for geofence in polygons {
                 logger.geofencePolygonUndecided(identifier: geofence.id, reason: "no usable fix")
             }
@@ -220,8 +227,12 @@ final class PolygonMembershipResolver {
         #endif
     }
 
-    private func evaluate(geofenceId: String, isStillCurrent: (@Sendable () -> Bool)? = nil) async {
-        guard let fix = await resolveFix() else {
+    private func evaluate(
+        geofenceId: String,
+        requiresFreshFix: Bool = false,
+        isStillCurrent: (@Sendable () -> Bool)? = nil
+    ) async {
+        guard let fix = await resolveFix(requiringFresh: requiresFreshFix) else {
             logger.geofencePolygonUndecided(identifier: geofenceId, reason: "no usable fix")
             return
         }
@@ -270,6 +281,11 @@ final class PolygonMembershipResolver {
             )
             return
         }
+        logger.geofencePolygonVerdict(
+            identifier: geofence.id, membership: membership,
+            signedEdgeDistance: signedEdgeDistance, horizontalAccuracy: fix.horizontalAccuracy,
+            fixAge: -fix.timestamp.timeIntervalSinceNow
+        )
         await apply(
             membership, to: geofence, evidence: fix.timestamp,
             confirmedByFix: true, evaluatedRing: geofence.vertices, isStillCurrent: isStillCurrent
@@ -310,9 +326,12 @@ final class PolygonMembershipResolver {
         )
         guard case .deliver(let transition) = outcome,
               geofence.transitionTypes.contains(transition)
-        else { return }
+        else {
+            logger.geofencePolygonNotDelivered(identifier: geofence.id, outcome: "\(outcome)")
+            return
+        }
         if let isStillCurrent, !isStillCurrent() {
-            logger.geofencePolygonUndecided(identifier: geofence.id, reason: "user changed before delivery")
+            logger.geofencePolygonNotDelivered(identifier: geofence.id, outcome: "user changed before delivery")
             return
         }
         logger.geofencePolygonTransition(
@@ -330,12 +349,12 @@ final class PolygonMembershipResolver {
     /// Freshest fix obtainable, requesting one when the cache is stale. Mirrors the gate's
     /// resolution: the completion's coordinates are discarded in favour of `latestFix`, which
     /// carries the accuracy and timestamp the decision needs.
-    private func resolveFix() async -> CLLocation? {
+    private func resolveFix(requiringFresh: Bool = false) async -> CLLocation? {
         await withCheckedContinuation { continuation in
-            fixResolver.resolve(cached: fixResolver.cachedFix) { [weak self] _ in
-                // `cachedFix` again on failure: on a cold process this resolver has delivered
-                // nothing, and the monitor has already advanced its dedup baseline, so declining
-                // here loses the crossing for good. The decision's age gate bounds how stale it can be.
+            fixResolver.resolve(cached: requiringFresh ? nil : fixResolver.cachedFix) { [weak self] _ in
+                // `cachedFix` on failure: on a cold process this resolver has delivered nothing, and
+                // the monitor has already advanced its dedup baseline, so declining loses the
+                // crossing for good. The decision's age gate bounds how stale it can be.
                 continuation.resume(returning: self?.fixResolver.cachedFix)
             }
         }

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -34,7 +34,6 @@ final class PolygonMembershipResolver {
     private let notificationCenter: NotificationCenter
     private var foregroundObserverToken: NSObjectProtocol?
     private var passesInFlight = 0
-    private var freshPassInFlight = false
 
     init(
         storage: GeofenceStorage,
@@ -170,24 +169,21 @@ final class PolygonMembershipResolver {
     /// serves the whole pass.
     ///
     /// Foregrounds arrive in bursts, so a pass already running wins: a second concurrent scan reads
-    /// the same storage and the same fix and can only duplicate the location work. Strength decides
-    /// that, not mere existence — a wake requires a fresh fix and an in-flight foreground pass does
-    /// not, so skipping behind one would drop exactly the pass that runs BECAUSE the device moved,
-    /// with nothing to retry it.
+    /// the same storage and the same fix and can only duplicate the location work. That reasoning
+    /// covers only a pass content with the fix already in hand. A wake runs BECAUSE the device
+    /// moved, and any pass already in flight is working from a fix requested before that movement —
+    /// so no wake yields, not even to another wake, and nothing else would retry it if it did.
+    /// Concurrent requests coalesce inside `MovementFixResolver`, which is what bounds the cost.
     func evaluateAllPolygons(
         requiresFreshFix: Bool = false,
         isStillCurrent: (@Sendable () -> Bool)? = nil
     ) async {
-        if passesInFlight > 0, freshPassInFlight || !requiresFreshFix {
-            logger.geofencePolygonPassSkipped(reason: "a pass of at least this strength is already running")
+        if passesInFlight > 0, !requiresFreshFix {
+            logger.geofencePolygonPassSkipped(reason: "a pass is already running")
             return
         }
         passesInFlight += 1
-        freshPassInFlight = freshPassInFlight || requiresFreshFix
-        defer {
-            passesInFlight -= 1
-            if passesInFlight == 0 { freshPassInFlight = false }
-        }
+        defer { passesInFlight -= 1 }
         let registered = await storage.getRegisteredBusinessIds()
         let polygons = await storage.getCachedGeofences()
             .filter { registered.contains($0.id) && $0.vertices != nil }

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -354,8 +354,9 @@ final class PolygonMembershipResolver {
     /// resolution: the completion's coordinates are discarded in favour of `latestFix`, which
     /// carries the accuracy and timestamp the decision needs.
     ///
-    /// "Fresh" here is strictly newer than anything held before the request — a deliberately
-    /// stricter test than the within-`movementFixMaxAge` one the movement trigger is sized against
+    /// "Fresh" here is a fix this resolver received in answer to THIS request, and strictly newer
+    /// than the last one it delivered — a deliberately stricter test than the
+    /// within-`movementFixMaxAge` one the movement trigger is sized against
     /// (`GeofenceSyncCoordinatorImpl.wakeRadius`). A verdict may not be re-affirmed by the very fix
     /// the wake exists to revisit, whereas a trigger only needs an anchor roughly where the device
     /// is. The two are not interchangeable and neither should be relaxed to the other.
@@ -364,18 +365,27 @@ final class PolygonMembershipResolver {
     /// already held. That one predates the wake and can sit inside `movementFixMaxAge`, so it would
     /// re-affirm the very verdict the wake exists to revisit — report no fix instead.
     private func resolveFix(requiringFresh: Bool = false) async -> CLLocation? {
-        // Everything obtainable without asking, which is exactly what a forced request must beat.
-        // Reading only `latestFix` would leave the first wake of a process — which has none — with
-        // nothing to compare against, and CoreLocation's own cached fix would pass as fresh.
-        let priorTimestamp = fixResolver.cachedFix?.timestamp
+        // What this resolver has already DELIVERED, which is what a forced request must improve on.
+        // Deliberately not `cachedFix`: that reports the newest fix obtainable from either source,
+        // and CoreLocation's own cache advances on its own, so using it here makes the baseline as
+        // current as any answer a request can return and the guard below can never pass.
+        let priorTimestamp = fixResolver.latestFix?.timestamp
         return await withCheckedContinuation { continuation in
-            fixResolver.resolve(cached: requiringFresh ? nil : fixResolver.cachedFix) { [weak self] _, _ in
+            fixResolver.resolve(cached: requiringFresh ? nil : fixResolver.cachedFix) { [weak self] _, isFresh in
                 guard let self else { return continuation.resume(returning: nil) }
                 let resolved = fixResolver.latestFix
                 if requiringFresh {
+                    // `isFresh` is the resolver's own account of what it answered with: true only
+                    // for a fix it received in response to this request. It is what stops the first
+                    // wake of a process — which has delivered nothing, so has no baseline — from
+                    // being answered out of CoreLocation's pre-movement cache. The timestamp
+                    // comparison then keeps each later wake strictly ahead of the one before.
+                    //
                     // No fallback to the held fix here, on any branch: a wake fires BECAUSE the
                     // device moved, so anything predating the request describes where it was.
-                    guard let resolved, priorTimestamp.map({ resolved.timestamp > $0 }) ?? true else {
+                    guard isFresh, let resolved,
+                          priorTimestamp.map({ resolved.timestamp > $0 }) ?? true
+                    else {
                         continuation.resume(returning: nil)
                         return
                     }

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -129,12 +129,15 @@ final class PolygonMembershipResolver {
     /// `isStillCurrent` is re-checked after the fix resolves. Resolving suspends, and a user switch
     /// in that window clears user-scoped state — without the re-check this task would resume and
     /// rewrite the old user's belief, stamping any resulting event to whoever signed in.
+    /// - Returns: whether a usable fix was obtained, so a caller that owes a verdict can retry on
+    /// other terms. True when there was nothing to evaluate — nothing is owed then.
+    @discardableResult
     func evaluateMembership(
         geofenceIds: [String],
         reason: String,
         requiresFreshFix: Bool = false,
         isStillCurrent: (@Sendable () -> Bool)? = nil
-    ) async {
+    ) async -> Bool {
         for geofenceId in geofenceIds {
             logger.geofencePolygonEvaluationRequested(identifier: geofenceId, reason: reason)
         }
@@ -149,16 +152,17 @@ final class PolygonMembershipResolver {
             else { continue }
             pending.append(geofenceId)
         }
-        guard !pending.isEmpty else { return }
+        guard !pending.isEmpty else { return true }
         guard let fix = await resolveFix(requiringFresh: requiresFreshFix) else {
             for geofenceId in pending {
                 logger.geofencePolygonUndecided(identifier: geofenceId, reason: "no usable fix")
             }
-            return
+            return false
         }
         for geofenceId in pending {
             await evaluate(geofenceId: geofenceId, fix: fix, isStillCurrent: isStillCurrent)
         }
+        return true
     }
 
     /// Re-evaluates every registered polygon when the app comes to the foreground.

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -349,13 +349,24 @@ final class PolygonMembershipResolver {
     /// Freshest fix obtainable, requesting one when the cache is stale. Mirrors the gate's
     /// resolution: the completion's coordinates are discarded in favour of `latestFix`, which
     /// carries the accuracy and timestamp the decision needs.
+    ///
+    /// When a fresh fix is REQUIRED, a request that fails or times out still resumes with the fix
+    /// already held. That one predates the wake and can sit inside `movementFixMaxAge`, so it would
+    /// re-affirm the very verdict the wake exists to revisit — report no fix instead.
     private func resolveFix(requiringFresh: Bool = false) async -> CLLocation? {
-        await withCheckedContinuation { continuation in
+        let priorTimestamp = fixResolver.latestFix?.timestamp
+        return await withCheckedContinuation { continuation in
             fixResolver.resolve(cached: requiringFresh ? nil : fixResolver.cachedFix) { [weak self] _ in
-                // `cachedFix` on failure: on a cold process this resolver has delivered nothing, and
-                // the monitor has already advanced its dedup baseline, so declining loses the
-                // crossing for good. The decision's age gate bounds how stale it can be.
-                continuation.resume(returning: self?.fixResolver.cachedFix)
+                guard let self else { return continuation.resume(returning: nil) }
+                let resolved = fixResolver.latestFix
+                if requiringFresh, let resolved, let priorTimestamp, resolved.timestamp <= priorTimestamp {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                // Cold process: nothing delivered and the request failed, so CoreLocation's own
+                // cached fix is the only evidence there is. The monitor has already advanced its
+                // dedup baseline, so declining here loses the crossing for good.
+                continuation.resume(returning: resolved ?? fixResolver.cachedFix)
             }
         }
     }

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -354,13 +354,22 @@ final class PolygonMembershipResolver {
     /// already held. That one predates the wake and can sit inside `movementFixMaxAge`, so it would
     /// re-affirm the very verdict the wake exists to revisit — report no fix instead.
     private func resolveFix(requiringFresh: Bool = false) async -> CLLocation? {
-        let priorTimestamp = fixResolver.latestFix?.timestamp
+        // Everything obtainable without asking, which is exactly what a forced request must beat.
+        // Reading only `latestFix` would leave the first wake of a process — which has none — with
+        // nothing to compare against, and CoreLocation's own cached fix would pass as fresh.
+        let priorTimestamp = fixResolver.cachedFix?.timestamp
         return await withCheckedContinuation { continuation in
             fixResolver.resolve(cached: requiringFresh ? nil : fixResolver.cachedFix) { [weak self] _ in
                 guard let self else { return continuation.resume(returning: nil) }
                 let resolved = fixResolver.latestFix
-                if requiringFresh, let resolved, let priorTimestamp, resolved.timestamp <= priorTimestamp {
-                    continuation.resume(returning: nil)
+                if requiringFresh {
+                    // No fallback to the held fix here, on any branch: a wake fires BECAUSE the
+                    // device moved, so anything predating the request describes where it was.
+                    guard let resolved, priorTimestamp.map({ resolved.timestamp > $0 }) ?? true else {
+                        continuation.resume(returning: nil)
+                        return
+                    }
+                    continuation.resume(returning: resolved)
                     return
                 }
                 // Cold process: nothing delivered and the request failed, so CoreLocation's own

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -30,9 +30,9 @@ final class PolygonMembershipResolver {
     private let transitionEmitter: GeofenceTransitionEmitting
     private let fixResolver: MovementFixResolver
     private let logger: Logger
-    private let contextStore: BackgroundDeliveryContextStore
-    private let notificationCenter: NotificationCenter
-    private var foregroundObserverToken: NSObjectProtocol?
+    let contextStore: BackgroundDeliveryContextStore
+    let notificationCenter: NotificationCenter
+    var foregroundObserverToken: NSObjectProtocol?
     private var passesInFlight = 0
 
     init(
@@ -206,34 +206,6 @@ final class PolygonMembershipResolver {
         for geofence in polygons {
             await evaluate(geofenceId: geofence.id, fix: fix, isStillCurrent: isStillCurrent)
         }
-    }
-
-    private func registerForegroundEvaluation() {
-        #if canImport(UIKit)
-        foregroundObserverToken = notificationCenter.addObserver(
-            forName: UIApplication.willEnterForegroundNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            MainActor.assumeIsolated {
-                guard let self else { return }
-                // Sampled here, not read at emit time: the pass resolves a fix first, and a
-                // foregrounding app's cached fix is normally stale — the app was suspended — so
-                // that request really does suspend. No caller supplies an expected user on this
-                // path, so the observer takes its own.
-                //
-                // Anonymous at both ends compares nil to nil and proceeds; that is safe only
-                // because a signed-out process has no `monitoredGeofenceIds`, so the pass returns
-                // empty before it resolves anything. Registration while anonymous would break it.
-                let expectedUserId = self.contextStore.currentUserId
-                Task { [contextStore = self.contextStore] in
-                    await self.evaluateAllPolygons(
-                        isStillCurrent: { contextStore.currentUserId == expectedUserId }
-                    )
-                }
-            }
-        }
-        #endif
     }
 
     private func evaluate(

--- a/Sources/LocationGeofence/Polygon/PolygonWakeRadius.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonWakeRadius.swift
@@ -1,14 +1,19 @@
 import CioInternalCommon
-import CoreLocation
 import Foundation
 
 /// Sizes the movement trigger so it doubles as the wake source for polygon membership: crossing a
 /// polygon boundary produces no OS event, so something has to wake us to re-evaluate.
 enum PolygonWakeRadius {
-    /// Sized to the nearest boundary among polygons whose covering circle contains the device —
-    /// leaving that circle is exactly where a verdict may change. Polygons elsewhere cannot be
-    /// crossed before their own covering-circle enter fires. Falls back to the configured refresh
-    /// radius, so a device with no polygons nearby behaves exactly as before.
+    /// Sized to the nearest polygon boundary, wherever the device stands relative to the covering
+    /// circles. Falls back to the configured refresh radius, so a device with no polygon boundary
+    /// closer than that behaves exactly as before.
+    ///
+    /// Deliberately NOT restricted to circles the device is already inside. A covering-circle enter
+    /// does not re-arm the trigger, so a device that entered a circle while still inside a wide
+    /// trigger would carry that wide trigger across the polygon boundary: no OS event, no wake, and
+    /// on the way out an exit over an unchanged `outside` belief — the whole visit silent rather
+    /// than late. Sizing to the boundary from outside makes the trigger tighten as the device
+    /// approaches, so the wake arrives before the crossing.
     static func radius(
         at location: LocationData,
         registeredPolygons: [Geofence],
@@ -24,12 +29,10 @@ enum PolygonWakeRadius {
         )
     }
 
-    /// `nil` when `geofence` is not a polygon, or the device is outside its covering circle.
+    /// `nil` when `geofence` is not a polygon. Unsigned: the distance to the boundary is what the
+    /// trigger is sized against whether the device is inside the ring or outside it.
     private static func boundaryDistance(from location: LocationData, to geofence: Geofence) -> Double? {
         guard let polygon = geofence.polygonRegion else { return nil }
-        let center = CLLocation(latitude: geofence.latitude, longitude: geofence.longitude)
-        let here = CLLocation(latitude: location.latitude, longitude: location.longitude)
-        guard here.distance(from: center) <= geofence.radius else { return nil }
         return abs(polygon.signedEdgeDistance(to: location))
     }
 }

--- a/Sources/LocationGeofence/Polygon/PolygonWakeRadius.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonWakeRadius.swift
@@ -1,0 +1,35 @@
+import CioInternalCommon
+import CoreLocation
+import Foundation
+
+/// Sizes the movement trigger so it doubles as the wake source for polygon membership: crossing a
+/// polygon boundary produces no OS event, so something has to wake us to re-evaluate.
+enum PolygonWakeRadius {
+    /// Sized to the nearest boundary among polygons whose covering circle contains the device —
+    /// leaving that circle is exactly where a verdict may change. Polygons elsewhere cannot be
+    /// crossed before their own covering-circle enter fires. Falls back to the configured refresh
+    /// radius, so a device with no polygons nearby behaves exactly as before.
+    static func radius(
+        at location: LocationData,
+        registeredPolygons: [Geofence],
+        config: GeofenceConfig
+    ) -> Double {
+        let nearestBoundary = registeredPolygons
+            .compactMap { boundaryDistance(from: location, to: $0) }
+            .min()
+        guard let nearestBoundary else { return config.localRefreshTriggerRadius }
+        return max(
+            GeofenceConstants.polygonWakeMinRadius,
+            min(config.localRefreshTriggerRadius, nearestBoundary)
+        )
+    }
+
+    /// `nil` when `geofence` is not a polygon, or the device is outside its covering circle.
+    private static func boundaryDistance(from location: LocationData, to geofence: Geofence) -> Double? {
+        guard let polygon = geofence.polygonRegion else { return nil }
+        let center = CLLocation(latitude: geofence.latitude, longitude: geofence.longitude)
+        let here = CLLocation(latitude: location.latitude, longitude: location.longitude)
+        guard here.distance(from: center) <= geofence.radius else { return nil }
+        return abs(polygon.signedEdgeDistance(to: location))
+    }
+}

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -126,7 +126,7 @@ struct GeofenceSyncCoordinatorTests {
         let storage = makeStorage()
         let setup = makeCoordinator(storage: storage, contextStore: makeContextStore(userId: nil))
 
-        let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
+        let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0, anchorIsLiveFix: true)
 
         #expect(result.errorOrNil == .noIdentifiedUser)
         #expect(setup.api.fetchNearbyGeofencesCallsCount == 0)
@@ -154,7 +154,7 @@ struct GeofenceSyncCoordinatorTests {
 
         let setup = makeCoordinator(storage: storage, dateUtil: dateUtil)
         // Same anchor → distance is 0; freshness gate skips API.
-        let result = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+        let result = await setup.coordinator.refresh(latitude: 0, longitude: 0, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(setup.api.fetchNearbyGeofencesCallsCount == 0)
@@ -183,7 +183,7 @@ struct GeofenceSyncCoordinatorTests {
 
         // ~2.2km from the anchor: beyond the 1km trigger radius (ranking stale) but within the 3km
         // refetch radius (no remote fetch).
-        let result = await setup.coordinator.refresh(latitude: 0.02, longitude: 0)
+        let result = await setup.coordinator.refresh(latitude: 0.02, longitude: 0, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(setup.api.fetchNearbyGeofencesCallsCount == 0)
@@ -212,7 +212,7 @@ struct GeofenceSyncCoordinatorTests {
         let setup = makeCoordinator(storage: storage, dateUtil: dateUtil)
 
         // Same location as anchor → time-fresh + ranking-fresh, but nothing is registered.
-        let result = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+        let result = await setup.coordinator.refresh(latitude: 0, longitude: 0, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(setup.api.fetchNearbyGeofencesCallsCount == 0)
@@ -241,7 +241,7 @@ struct GeofenceSyncCoordinatorTests {
         await storage.setCachedGeofences([makeRegion(id: "far", latitude: 1, longitude: 2)]) // ~248 km, beyond the 5 km cap
         let setup = makeCoordinator(storage: storage, dateUtil: dateUtil)
 
-        let result = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+        let result = await setup.coordinator.refresh(latitude: 0, longitude: 0, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(setup.api.fetchNearbyGeofencesCallsCount == 0)
@@ -274,7 +274,7 @@ struct GeofenceSyncCoordinatorTests {
         }
         let setup = makeCoordinator(api: api, storage: storage, dateUtil: dateUtil)
 
-        let result = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+        let result = await setup.coordinator.refresh(latitude: 0, longitude: 0, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(api.fetchNearbyGeofencesCallsCount == 1)
@@ -299,7 +299,7 @@ struct GeofenceSyncCoordinatorTests {
         }
 
         let setup = makeCoordinator(api: api, storage: storage, dateUtil: dateUtil)
-        let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
+        let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(api.fetchNearbyGeofencesCallsCount == 1)
@@ -323,7 +323,7 @@ struct GeofenceSyncCoordinatorTests {
         let setup = makeCoordinator(storage: storage, dateUtil: dateUtil)
 
         // Same anchor → distance is 0; freshness gate skips even without a cached config.
-        let result = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+        let result = await setup.coordinator.refresh(latitude: 0, longitude: 0, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(setup.api.fetchNearbyGeofencesCallsCount == 0)
@@ -340,7 +340,7 @@ struct GeofenceSyncCoordinatorTests {
         }
         let setup = makeCoordinator(api: api, storage: storage)
 
-        let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
+        let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(api.fetchNearbyGeofencesCallsCount == 1)
@@ -354,7 +354,7 @@ struct GeofenceSyncCoordinatorTests {
         contextStore.setUserId("") // covers the `!userId.isEmpty` branch
         let setup = makeCoordinator(storage: storage, contextStore: contextStore)
 
-        let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
+        let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0, anchorIsLiveFix: true)
 
         #expect(result.errorOrNil == .noIdentifiedUser)
         #expect(setup.api.fetchNearbyGeofencesCallsCount == 0)
@@ -371,7 +371,7 @@ struct GeofenceSyncCoordinatorTests {
         }
 
         let setup = makeCoordinator(api: api, storage: storage)
-        let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
+        let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0, anchorIsLiveFix: true)
 
         #expect(result.errorOrNil == .fetchFailed(.transport))
         let cached = await storage.getCachedGeofences()
@@ -399,7 +399,7 @@ struct GeofenceSyncCoordinatorTests {
         }
 
         let setup = makeCoordinator(api: api, storage: storage)
-        _ = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
+        _ = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0, anchorIsLiveFix: true)
 
         let cached = await storage.getCachedConfig()
         #expect(cached == priorConfig)
@@ -422,7 +422,7 @@ struct GeofenceSyncCoordinatorTests {
         }
 
         let setup = makeCoordinator(api: api, storage: storage)
-        _ = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
+        _ = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0, anchorIsLiveFix: true)
 
         #expect(await storage.getCachedConfig() == newConfig)
     }
@@ -452,7 +452,7 @@ struct GeofenceSyncCoordinatorTests {
         }
 
         let setup = makeCoordinator(api: api, storage: storage)
-        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0, anchorIsLiveFix: true)
 
         let registeredIds = setup.monitor.startedRegions.map(\.identifier)
         #expect(registeredIds.contains("g0"))
@@ -481,7 +481,7 @@ struct GeofenceSyncCoordinatorTests {
         }
 
         let setup = makeCoordinator(api: api, storage: storage)
-        _ = await setup.coordinator.refresh(latitude: 37.7749, longitude: -122.4194)
+        _ = await setup.coordinator.refresh(latitude: 37.7749, longitude: -122.4194, anchorIsLiveFix: true)
 
         let movementTrigger = setup.monitor.startedRegions.first {
             $0.identifier == GeofenceConstants.movementTriggerIdentifier
@@ -510,7 +510,7 @@ struct GeofenceSyncCoordinatorTests {
         }
 
         let setup = makeCoordinator(api: api, storage: storage)
-        let result = await setup.coordinator.refresh(latitude: 37.7749, longitude: -122.4194)
+        let result = await setup.coordinator.refresh(latitude: 37.7749, longitude: -122.4194, anchorIsLiveFix: true)
 
         #expect(result.errorOrNil == .fetchFailed(.decoding))
         let cached = await storage.getCachedGeofences()
@@ -538,7 +538,7 @@ struct GeofenceSyncCoordinatorTests {
         api.fetchNearbyGeofencesClosure = { _, _, completion in completion(.success(response)) }
 
         let setup = makeCoordinator(api: api, storage: storage)
-        let result = await setup.coordinator.refresh(latitude: 37.7749, longitude: -122.4194)
+        let result = await setup.coordinator.refresh(latitude: 37.7749, longitude: -122.4194, anchorIsLiveFix: true)
 
         #expect(result.errorOrNil == .fetchFailed(.decoding))
         #expect(await storage.getCachedGeofences().map(\.id) == ["kept"])
@@ -586,7 +586,7 @@ struct GeofenceSyncCoordinatorTests {
         }
 
         let setup = makeCoordinator(api: api, storage: storage)
-        let result = await setup.coordinator.refresh(latitude: 37.7749, longitude: -122.4194)
+        let result = await setup.coordinator.refresh(latitude: 37.7749, longitude: -122.4194, anchorIsLiveFix: true)
 
         #expect(result.errorOrNil == nil)
         #expect(await storage.getCachedGeofences().isEmpty)
@@ -601,7 +601,7 @@ struct GeofenceSyncCoordinatorTests {
         }
 
         let setup = makeCoordinator(api: api, storage: storage)
-        _ = await setup.coordinator.refresh(latitude: 37.7749, longitude: -122.4194)
+        _ = await setup.coordinator.refresh(latitude: 37.7749, longitude: -122.4194, anchorIsLiveFix: true)
 
         // Empty nearby response is a geofence-free area, not a stop signal: keep the movement trigger
         // armed so a later EXIT re-fetches as the device moves back toward geofences. The trigger is
@@ -629,7 +629,7 @@ struct GeofenceSyncCoordinatorTests {
         }
 
         let setup = makeCoordinator(api: api, storage: storage)
-        _ = await setup.coordinator.refresh(latitude: 37.7749, longitude: -122.4194)
+        _ = await setup.coordinator.refresh(latitude: 37.7749, longitude: -122.4194, anchorIsLiveFix: true)
 
         #expect(setup.monitor.startedRegions.isEmpty)
     }
@@ -644,7 +644,7 @@ struct GeofenceSyncCoordinatorTests {
         }
 
         let setup = makeCoordinator(api: api, storage: storage)
-        _ = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
+        _ = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0, anchorIsLiveFix: true)
 
         // The trigger goes first so it isn't starved when business regions fill the shared OS budget.
         // Nothing was registered before, so nothing is stopped.
@@ -671,11 +671,11 @@ struct GeofenceSyncCoordinatorTests {
         }
 
         let setup = makeCoordinator(api: api, storage: storage)
-        async let first = setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
+        async let first = setup.coordinator.refresh(latitude: 1.0, longitude: 2.0, anchorIsLiveFix: true)
         // Wait for the first call to enter the API mock before firing the second, so the
         // dedup-gate test is deterministic instead of timing-dependent.
         await firstReachedApi.wait()
-        let second = await setup.coordinator.refresh(latitude: 3.0, longitude: 4.0)
+        let second = await setup.coordinator.refresh(latitude: 3.0, longitude: 4.0, anchorIsLiveFix: true)
         await allowFinish.fire()
         let firstResult = await first
 
@@ -709,7 +709,7 @@ struct GeofenceSyncCoordinatorTests {
         }
         let setup = makeCoordinator(api: api, storage: spy)
 
-        _ = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
+        _ = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0, anchorIsLiveFix: true)
 
         let writes = await spy.operations.filter { op in
             op == .setCachedGeofences || op == .setCachedConfig || op == .recordSync || op == .recordRegistration
@@ -739,7 +739,7 @@ struct GeofenceSyncCoordinatorTests {
         }
         let setup = makeCoordinator(api: api, storage: storage)
 
-        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0, anchorIsLiveFix: true)
 
         #expect(await storage.getLastRegistrationCenter() == LocationData(latitude: 0, longitude: 0))
         #expect(await storage.getRegisteredBusinessIds() == ["g0", "g1"])
@@ -763,7 +763,7 @@ struct GeofenceSyncCoordinatorTests {
         }
         let setup = makeCoordinator(api: api, storage: storage)
 
-        _ = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
+        _ = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0, anchorIsLiveFix: true)
 
         #expect(await storage.getCachedConfig() == priorConfig)
     }
@@ -1041,7 +1041,7 @@ struct GeofenceSyncCoordinatorTests {
             }
         }
         let setup = makeCoordinator(api: api, storage: storage)
-        async let refreshResult = setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
+        async let refreshResult = setup.coordinator.refresh(latitude: 1.0, longitude: 2.0, anchorIsLiveFix: true)
         await firstReachedApi.wait()
 
         // Refresh holds the dedup gate. ApplyCachedRegistration must bail without touching
@@ -1073,12 +1073,12 @@ struct GeofenceSyncCoordinatorTests {
         }
         let setup = makeCoordinator(api: api, storage: storage, contextStore: contextStore)
 
-        let first = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
+        let first = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0, anchorIsLiveFix: true)
         #expect(first.errorOrNil == .noIdentifiedUser)
 
         // User signs in between calls.
         contextStore.setUserId("user-1")
-        let second = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0)
+        let second = await setup.coordinator.refresh(latitude: 1.0, longitude: 2.0, anchorIsLiveFix: true)
 
         #expect(second.isSuccess)
         #expect(api.fetchNearbyGeofencesCallsCount == 1)
@@ -1091,7 +1091,7 @@ struct GeofenceSyncCoordinatorTests {
         let storage = makeStorage()
         let setup = makeCoordinator(storage: storage, contextStore: makeContextStore(userId: nil))
 
-        let result = await setup.coordinator.handleMovement(latitude: 1.0, longitude: 2.0)
+        let result = await setup.coordinator.handleMovement(latitude: 1.0, longitude: 2.0, anchorIsLiveFix: true)
 
         #expect(result.errorOrNil == .noIdentifiedUser)
         #expect(setup.api.fetchNearbyGeofencesCallsCount == 0)
@@ -1109,7 +1109,7 @@ struct GeofenceSyncCoordinatorTests {
         }
         let setup = makeCoordinator(api: api, storage: storage)
 
-        let result = await setup.coordinator.handleMovement(latitude: 1.0, longitude: 2.0)
+        let result = await setup.coordinator.handleMovement(latitude: 1.0, longitude: 2.0, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(setup.api.fetchNearbyGeofencesCallsCount == 1)
@@ -1137,7 +1137,7 @@ struct GeofenceSyncCoordinatorTests {
         let setup = makeCoordinator(api: api, storage: storage)
 
         // New position ~111 m from anchor — re-ranks the cached set locally, no fetch.
-        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
+        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(setup.api.fetchNearbyGeofencesCallsCount == 0)
@@ -1166,7 +1166,7 @@ struct GeofenceSyncCoordinatorTests {
         let setup = makeCoordinator(api: api, storage: storage)
 
         // ~111 m from anchor — within the refetch radius, so it re-ranks locally, no fetch.
-        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
+        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(setup.api.fetchNearbyGeofencesCallsCount == 0)
@@ -1196,7 +1196,7 @@ struct GeofenceSyncCoordinatorTests {
         let setup = makeCoordinator(api: api, storage: storage)
 
         // ~157 km from anchor — beyond the 5 km refetch radius.
-        let result = await setup.coordinator.handleMovement(latitude: 1.0, longitude: 1.0)
+        let result = await setup.coordinator.handleMovement(latitude: 1.0, longitude: 1.0, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(setup.api.fetchNearbyGeofencesCallsCount == 1)
@@ -1227,7 +1227,7 @@ struct GeofenceSyncCoordinatorTests {
         let setup = makeCoordinator(api: api, storage: storage, dateUtil: dateUtil)
 
         // ~157 km from the fetch anchor — beyond the 5 km refetch radius.
-        let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 1.0)
+        let result = await setup.coordinator.refresh(latitude: 1.0, longitude: 1.0, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(setup.api.fetchNearbyGeofencesCallsCount == 1)
@@ -1253,7 +1253,7 @@ struct GeofenceSyncCoordinatorTests {
         await storage.setCachedGeofences([makeRegion(id: "g1", latitude: 0, longitude: 0)])
         let setup = makeCoordinator(storage: storage)
 
-        _ = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
+        _ = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001, anchorIsLiveFix: true)
 
         let lastSync = await storage.getLastSync()
         #expect(lastSync?.location == originalAnchor)
@@ -1279,7 +1279,7 @@ struct GeofenceSyncCoordinatorTests {
         let setup = makeCoordinator(storage: storage)
 
         let newLocation = LocationData(latitude: 0, longitude: 0.001)
-        _ = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude)
+        _ = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude, anchorIsLiveFix: true)
 
         #expect(await storage.getLastRegistrationCenter() == newLocation)
         #expect(await storage.getRegisteredBusinessIds() == ["near"])
@@ -1304,7 +1304,7 @@ struct GeofenceSyncCoordinatorTests {
         let setup = makeCoordinator(storage: storage)
 
         let newLocation = LocationData(latitude: 0, longitude: 0.001)
-        _ = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude)
+        _ = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude, anchorIsLiveFix: true)
 
         let movementTrigger = setup.monitor.startedRegions.first { $0.identifier == GeofenceConstants.movementTriggerIdentifier }
         #expect(movementTrigger?.center == newLocation)
@@ -1335,7 +1335,7 @@ struct GeofenceSyncCoordinatorTests {
 
         // ~157 km from the anchor — beyond the 5 km refetch radius, so this takes the remote tier.
         let newLocation = LocationData(latitude: 1.0, longitude: 1.0)
-        let result = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude)
+        let result = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude, anchorIsLiveFix: true)
 
         // The fetch failure is still what the caller sees.
         #expect(result.errorOrNil == .fetchFailed(.transport))
@@ -1369,7 +1369,7 @@ struct GeofenceSyncCoordinatorTests {
         }
         let setup = makeCoordinator(api: api, storage: storage)
 
-        let result = await setup.coordinator.handleMovement(latitude: 1.0, longitude: 1.0)
+        let result = await setup.coordinator.handleMovement(latitude: 1.0, longitude: 1.0, anchorIsLiveFix: true)
 
         #expect(result.errorOrNil == .fetchFailed(.transport))
         #expect(setup.monitor.monitoredRegionIdentifiers.isEmpty)
@@ -1391,7 +1391,7 @@ struct GeofenceSyncCoordinatorTests {
             completion(.success(makeApiResponse(regions: regions, config: config)))
         }
         let setup = makeCoordinator(api: api, storage: storage)
-        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0, anchorIsLiveFix: true)
         return setup
     }
 
@@ -1422,7 +1422,7 @@ struct GeofenceSyncCoordinatorTests {
 
         // ~111 m: within the refetch radius → local re-rank, same nearest set.
         let newLocation = LocationData(latitude: 0, longitude: 0.001)
-        let result = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude)
+        let result = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(setup.monitor.stopAllCallCount == 0)
@@ -1510,7 +1510,7 @@ struct GeofenceSyncCoordinatorTests {
         let setup = await makeRegisteredSetup(regions: [polygon], config: diffConfig, storage: storage)
 
         // ~111 m east of centre: still ~89 m from the eastern edge, so the floor should win.
-        _ = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
+        _ = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001, anchorIsLiveFix: true)
 
         let trigger = setup.monitor.startedRegions
             .last { $0.identifier == GeofenceConstants.movementTriggerIdentifier }
@@ -1520,7 +1520,7 @@ struct GeofenceSyncCoordinatorTests {
         let circleSetup = await makeRegisteredSetup(
             regions: [makeRegion(id: "c1", latitude: 0, longitude: 0)], config: diffConfig, storage: circleStorage
         )
-        _ = await circleSetup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
+        _ = await circleSetup.coordinator.handleMovement(latitude: 0, longitude: 0.001, anchorIsLiveFix: true)
         let circleTrigger = circleSetup.monitor.startedRegions
             .last { $0.identifier == GeofenceConstants.movementTriggerIdentifier }
         #expect(circleTrigger?.radius == diffConfig.localRefreshTriggerRadius)
@@ -1536,7 +1536,7 @@ struct GeofenceSyncCoordinatorTests {
 
         // ~1.7 km east: beyond localRefreshTriggerRadius (1000 m), inside the refetch radius.
         let newLocation = LocationData(latitude: 0, longitude: 0.015)
-        let result = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude)
+        let result = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(await storage.getLastRegistrationCenter() == newLocation)
@@ -1560,7 +1560,7 @@ struct GeofenceSyncCoordinatorTests {
             maxMonitoringDistance: GeofenceConstants.noMonitoringDistanceCap
         ))
 
-        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
+        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(setup.monitor.stoppedIdentifiers == [GeofenceConstants.movementTriggerIdentifier])
@@ -1584,7 +1584,7 @@ struct GeofenceSyncCoordinatorTests {
         let setup = await makeRegisteredSetup(regions: [nearStart, nearEnd], config: config, storage: makeStorage())
 
         // ~2.2 km: still a local re-rank, but the single budget slot now belongs to near-end.
-        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.02)
+        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.02, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(setup.monitor.stopAllCallCount == 0)
@@ -1613,7 +1613,7 @@ struct GeofenceSyncCoordinatorTests {
         #expect(setup.monitor.monitoredRegionIdentifiers == ["carry", "leaves", GeofenceConstants.movementTriggerIdentifier])
 
         // ~2.2 km east: local re-rank. `joins` takes the slot `leaves` gives up; `carry` stays.
-        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.02)
+        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.02, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(setup.monitor.monitoredRegionIdentifiers == ["carry", "joins", GeofenceConstants.movementTriggerIdentifier])
@@ -1637,9 +1637,9 @@ struct GeofenceSyncCoordinatorTests {
             completion(.success(makeApiResponse(regions: [region], config: diffConfig)))
         }
         let setup = makeCoordinator(api: api, storage: storage, monitor: monitor)
-        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0, anchorIsLiveFix: true)
 
-        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
+        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(!setup.monitor.stoppedIdentifiers.contains("wide"))
@@ -1654,7 +1654,7 @@ struct GeofenceSyncCoordinatorTests {
         let setup = await makeRegisteredSetup(regions: [region], config: diffConfig, storage: makeStorage())
         setup.monitor.osMonitoredRegions.remove("g1")
 
-        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
+        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(setup.monitor.stopAllCallCount == 0)
@@ -1679,7 +1679,7 @@ struct GeofenceSyncCoordinatorTests {
             transitionTypes: [.enter, .exit]
         )
 
-        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0, anchorIsLiveFix: true)
 
         #expect(!setup.monitor.osMonitoredRegions.contains("stranded"))
         #expect(setup.monitor.osMonitoredRegions.contains("g1"))
@@ -1711,7 +1711,7 @@ struct GeofenceSyncCoordinatorTests {
             ]
         )
 
-        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0, anchorIsLiveFix: true)
 
         #expect(!setup.monitor.stoppedIdentifiers.contains("g1"))
         #expect(setup.monitor.startedRegions.filter { $0.identifier == "g1" }.isEmpty)
@@ -1740,7 +1740,7 @@ struct GeofenceSyncCoordinatorTests {
             transitionTypes: [.enter, .exit]
         )
 
-        let result = await setup.coordinator.refresh(latitude: 0.02, longitude: 0)
+        let result = await setup.coordinator.refresh(latitude: 0.02, longitude: 0, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(setup.monitor.osGeometry(for: "g1")?.radius == 750)
@@ -1761,7 +1761,7 @@ struct GeofenceSyncCoordinatorTests {
         setup.monitor.osMonitoredRegions = ["g1", GeofenceConstants.movementTriggerIdentifier]
 
         // ~2.2 km from the registration center → ranking stale → local re-rank, same nearest set.
-        let result = await setup.coordinator.refresh(latitude: 0.02, longitude: 0)
+        let result = await setup.coordinator.refresh(latitude: 0.02, longitude: 0, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(setup.monitor.stopAllCallCount == 0)
@@ -1780,7 +1780,7 @@ struct GeofenceSyncCoordinatorTests {
 
         // ~5.5 km from the fetch anchor → remote tier.
         let newLocation = LocationData(latitude: 0, longitude: 0.05)
-        let result = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude)
+        let result = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(setup.api.fetchNearbyGeofencesCallsCount == 2)
@@ -1805,9 +1805,9 @@ struct GeofenceSyncCoordinatorTests {
             completion(.success(makeApiResponse(regions: responses.removeFirst(), config: config)))
         }
         let setup = makeCoordinator(api: api, storage: makeStorage())
-        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0, anchorIsLiveFix: true)
 
-        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.05)
+        let result = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.05, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(setup.monitor.stoppedIdentifiers.contains("g1"))
@@ -1821,7 +1821,7 @@ struct GeofenceSyncCoordinatorTests {
         let setup = await makeRegisteredSetup(regions: [], config: diffConfig, storage: makeStorage())
 
         let newLocation = LocationData(latitude: 0, longitude: 0.05)
-        let result = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude)
+        let result = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(setup.api.fetchNearbyGeofencesCallsCount == 2)
@@ -1849,9 +1849,9 @@ struct GeofenceSyncCoordinatorTests {
         }
         let setup = makeCoordinator(api: api, storage: storage)
 
-        async let firstRefresh = setup.coordinator.refresh(latitude: 0, longitude: 0)
+        async let firstRefresh = setup.coordinator.refresh(latitude: 0, longitude: 0, anchorIsLiveFix: true)
         await arrived.wait()
-        let movement = await setup.coordinator.handleMovement(latitude: 0, longitude: 0)
+        let movement = await setup.coordinator.handleMovement(latitude: 0, longitude: 0, anchorIsLiveFix: true)
         await suspendUntil.fire()
         _ = await firstRefresh
 
@@ -1918,7 +1918,7 @@ struct GeofenceSyncCoordinatorTests {
         }
         let setup = makeCoordinator(api: api, storage: storage)
 
-        async let firstRefresh = setup.coordinator.refresh(latitude: 0, longitude: 0)
+        async let firstRefresh = setup.coordinator.refresh(latitude: 0, longitude: 0, anchorIsLiveFix: true)
         await arrived.wait()
         let resetResult = await setup.coordinator.reset()
         await suspendUntil.fire()
@@ -1945,7 +1945,7 @@ struct GeofenceSyncCoordinatorTests {
         }
         let setup = makeCoordinator(api: api, storage: storage, contextStore: contextStore)
 
-        async let refreshResult = setup.coordinator.refresh(latitude: 0, longitude: 0)
+        async let refreshResult = setup.coordinator.refresh(latitude: 0, longitude: 0, anchorIsLiveFix: true)
         await arrived.wait()
         // User signs out while the API call is pending.
         contextStore.setUserId(nil)
@@ -1977,7 +1977,7 @@ struct GeofenceSyncCoordinatorTests {
         }
         let setup = makeCoordinator(api: api, storage: storage, contextStore: contextStore)
 
-        async let refreshResult = setup.coordinator.refresh(latitude: 0, longitude: 0)
+        async let refreshResult = setup.coordinator.refresh(latitude: 0, longitude: 0, anchorIsLiveFix: true)
         await arrived.wait()
         contextStore.setUserId("user-2")
         await suspendUntil.fire()
@@ -2008,9 +2008,9 @@ struct GeofenceSyncCoordinatorTests {
         }
         let setup = makeCoordinator(api: api, storage: storage)
 
-        async let firstMovement = setup.coordinator.handleMovement(latitude: 0, longitude: 0)
+        async let firstMovement = setup.coordinator.handleMovement(latitude: 0, longitude: 0, anchorIsLiveFix: true)
         await arrived.wait()
-        let refreshResult = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+        let refreshResult = await setup.coordinator.refresh(latitude: 0, longitude: 0, anchorIsLiveFix: true)
         await suspendUntil.fire()
         _ = await firstMovement
 
@@ -2052,7 +2052,7 @@ struct GeofenceSyncCoordinatorTests {
         monitor.maximumMonitoringRadius = 1000
         let setup = makeCoordinator(api: api, storage: storage, monitor: monitor, dateUtil: dateUtil)
 
-        _ = await setup.coordinator.refresh(latitude: anchor.latitude, longitude: anchor.longitude)
+        _ = await setup.coordinator.refresh(latitude: anchor.latitude, longitude: anchor.longitude, anchorIsLiveFix: true)
 
         let registered = Set(setup.monitor.startedRegions.map(\.identifier))
         #expect(!registered.contains("poly"))
@@ -2095,7 +2095,7 @@ struct GeofenceSyncCoordinatorTests {
         monitor.maximumMonitoringRadius = 1000
         let setup = makeCoordinator(api: api, storage: storage, monitor: monitor, dateUtil: dateUtil)
 
-        _ = await setup.coordinator.refresh(latitude: anchor.latitude, longitude: anchor.longitude)
+        _ = await setup.coordinator.refresh(latitude: anchor.latitude, longitude: anchor.longitude, anchorIsLiveFix: true)
 
         #expect(setup.monitor.startedRegions.map(\.identifier).contains("spare"))
     }
@@ -2128,7 +2128,7 @@ struct GeofenceSyncCoordinatorTests {
         }
         let setup = makeCoordinator(api: api, storage: storage, dateUtil: dateUtil)
 
-        _ = await setup.coordinator.refresh(latitude: anchor.latitude, longitude: anchor.longitude)
+        _ = await setup.coordinator.refresh(latitude: anchor.latitude, longitude: anchor.longitude, anchorIsLiveFix: true)
 
         let polygonRequest = setup.monitor.startedRegions.first { $0.identifier == "poly" }
         #expect(polygonRequest?.transitionTypes == [.enter, .exit])
@@ -2168,7 +2168,7 @@ struct GeofenceSyncCoordinatorTests {
         monitor.maximumMonitoringRadius = 1000
         let setup = makeCoordinator(api: api, storage: storage, monitor: monitor, dateUtil: dateUtil)
 
-        _ = await setup.coordinator.refresh(latitude: anchor.latitude, longitude: anchor.longitude)
+        _ = await setup.coordinator.refresh(latitude: anchor.latitude, longitude: anchor.longitude, anchorIsLiveFix: true)
 
         let recorded = await storage.getRegisteredBusinessIds()
         #expect(!recorded.contains("poly"))
@@ -2224,7 +2224,7 @@ struct GeofenceSyncCoordinatorTests {
         let api = GeofenceApiServiceMock()
         api.fetchNearbyGeofencesClosure = { _, _, completion in completion(.success(makeApiResponse(regions: regions))) }
         let setup = makeCoordinator(api: api, storage: storage, dateUtil: dateUtil)
-        _ = await setup.coordinator.refresh(latitude: anchor.latitude, longitude: anchor.longitude)
+        _ = await setup.coordinator.refresh(latitude: anchor.latitude, longitude: anchor.longitude, anchorIsLiveFix: true)
         return setup.emitter
     }
 
@@ -2284,7 +2284,7 @@ struct GeofenceSyncCoordinatorTests {
         await storage.recordSync(timestamp: dateUtil.givenNow.addingTimeInterval(-60), location: anchor)
         let setup = makeCoordinator(storage: storage, dateUtil: dateUtil)
 
-        _ = await setup.coordinator.refresh(latitude: anchor.latitude, longitude: anchor.longitude)
+        _ = await setup.coordinator.refresh(latitude: anchor.latitude, longitude: anchor.longitude, anchorIsLiveFix: true)
 
         await awaitEmits(setup.emitter, count: 1)
         #expect(setup.api.fetchNearbyGeofencesCallsCount == 0) // local path — no fetch
@@ -2307,7 +2307,7 @@ struct GeofenceSyncCoordinatorTests {
         monitor.rejectedIdentifiers = ["g1"]
         let setup = makeCoordinator(api: api, storage: storage, monitor: monitor, dateUtil: dateUtil)
 
-        _ = await setup.coordinator.refresh(latitude: anchor.latitude, longitude: anchor.longitude)
+        _ = await setup.coordinator.refresh(latitude: anchor.latitude, longitude: anchor.longitude, anchorIsLiveFix: true)
 
         // No count to await — assert nothing emitted after yielding the fire-and-forget window. The
         // sibling "device inside" test proves this same setup DOES emit without the rejection, so
@@ -2329,13 +2329,13 @@ struct GeofenceSyncCoordinatorTests {
         await storage.setCachedGeofences([makeRegion(id: "g1", latitude: 0.001, longitude: 0, radius: 500)])
         let setup = makeCoordinator(storage: storage, dateUtil: dateUtil)
 
-        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0, anchorIsLiveFix: true)
         #expect(setup.monitor.monitoredRegionIdentifiers.contains("g1"))
 
         // Same id, different circle, and the monitor now refuses it.
         await storage.setCachedGeofences([makeRegion(id: "g1", latitude: 0.001, longitude: 0, radius: 900)])
         setup.monitor.rejectedIdentifiers = ["g1"]
-        _ = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
+        _ = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001, anchorIsLiveFix: true)
 
         #expect(!setup.monitor.monitoredRegionIdentifiers.contains("g1"))
         // And the circle it held before the refused reshape is gone from the OS, not left occupying
@@ -2364,7 +2364,7 @@ struct GeofenceSyncCoordinatorTests {
         monitor.maximumMonitoringRadius = 200
         let setup = makeCoordinator(api: api, storage: storage, monitor: monitor, dateUtil: dateUtil)
 
-        _ = await setup.coordinator.refresh(latitude: anchor.latitude, longitude: anchor.longitude)
+        _ = await setup.coordinator.refresh(latitude: anchor.latitude, longitude: anchor.longitude, anchorIsLiveFix: true)
 
         await awaitEmits(setup.emitter, count: 0)
         #expect(setup.emitter.calls.wrappedValue.isEmpty)
@@ -2390,7 +2390,7 @@ struct GeofenceSyncCoordinatorTests {
         emitter.onEmit = { index in if index == 0 { contextStore.setUserId("user-2") } }
         let setup = makeCoordinator(api: api, storage: storage, contextStore: contextStore, emitter: emitter, dateUtil: dateUtil)
 
-        _ = await setup.coordinator.refresh(latitude: anchor.latitude, longitude: anchor.longitude)
+        _ = await setup.coordinator.refresh(latitude: anchor.latitude, longitude: anchor.longitude, anchorIsLiveFix: true)
 
         // Exactly one delivered: the guard stopped the batch after the first send changed identity.
         // Without the per-iteration recheck, both would fire (count == 2).
@@ -2414,7 +2414,7 @@ struct GeofenceSyncCoordinatorTests {
         }
         let setup = makeCoordinator(api: api, storage: spy, contextStore: contextStore, dateUtil: dateUtil)
 
-        let result = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+        let result = await setup.coordinator.refresh(latitude: 0, longitude: 0, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         // Cleanup ran: monitoring torn down wholesale, user-scoped state cleared, and no initial
@@ -2442,7 +2442,7 @@ struct GeofenceSyncCoordinatorTests {
         }
         let setup = makeCoordinator(api: api, storage: storage, contextStore: contextStore)
 
-        let result = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+        let result = await setup.coordinator.refresh(latitude: 0, longitude: 0, anchorIsLiveFix: true)
 
         #expect(result.errorOrNil == .fetchFailed(.transport))
         // The exit cleanup ran: monitoring stopped and the stale user-scoped state cleared.
@@ -2464,7 +2464,7 @@ struct GeofenceSyncCoordinatorTests {
         let spy = SpyGeofenceSyncStorage(underlying: backing, onGetLastSync: { contextStore.setUserId(nil) })
         let setup = makeCoordinator(storage: spy, contextStore: contextStore, dateUtil: dateUtil)
 
-        let result = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+        let result = await setup.coordinator.refresh(latitude: 0, longitude: 0, anchorIsLiveFix: true)
 
         #expect(result.isSuccess)
         #expect(setup.api.fetchNearbyGeofencesCallsCount == 0)
@@ -2490,7 +2490,7 @@ struct GeofenceSyncCoordinatorTests {
         }
         let setup = makeCoordinator(api: api, storage: storage, contextStore: contextStore)
 
-        let refreshTask = Task { await setup.coordinator.refresh(latitude: 0, longitude: 0) }
+        let refreshTask = Task { await setup.coordinator.refresh(latitude: 0, longitude: 0, anchorIsLiveFix: true) }
         for await _ in fetchStarted {
             break
         }
@@ -2533,7 +2533,7 @@ struct GeofenceSyncCoordinatorTests {
         }
         let setup = makeCoordinator(api: api, storage: storage, contextStore: contextStore)
 
-        let result = await setup.coordinator.refresh(latitude: 0, longitude: 0)
+        let result = await setup.coordinator.refresh(latitude: 0, longitude: 0, anchorIsLiveFix: true)
         #expect(result.isSuccess)
 
         // The retry is fire-and-forget; wait for its registration to land.

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -560,7 +560,7 @@ struct GeofenceSyncCoordinatorTests {
         api.fetchNearbyGeofencesClosure = { _, _, completion in completion(.success(response)) }
 
         let setup = makeCoordinator(api: api, storage: storage)
-        let result = await setup.coordinator.refresh(latitude: 37.7749, longitude: -122.4194)
+        let result = await setup.coordinator.refresh(latitude: 37.7749, longitude: -122.4194, anchorIsLiveFix: true)
 
         #expect(result.errorOrNil == .fetchFailed(.decoding))
         #expect(await storage.getCachedGeofences().map(\.id) == ["kept"])

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -1434,6 +1434,63 @@ struct GeofenceSyncCoordinatorTests {
         #expect(await storage.getLastRegistrationCenter() == LocationData(latitude: 0, longitude: 0))
     }
 
+    /// The launch/identify refresh anchors on the STORED registration centre, not a live fix, so a
+    /// boundary-sized trigger there would be a small circle around a point the device may be far
+    /// from — spurious on 17+, and never fired at all on the classic path. Only a caller holding a
+    /// real fix gets the tight radius.
+    @Test
+    func refresh_givenNearbyPolygonButStoredAnchor_expectFullRefreshRadius() async {
+        let ring = [
+            LocationData(latitude: -0.0018, longitude: -0.0018),
+            LocationData(latitude: -0.0018, longitude: 0.0018),
+            LocationData(latitude: 0.0018, longitude: 0.0018),
+            LocationData(latitude: 0.0018, longitude: -0.0018)
+        ]
+        let polygon = Geofence(
+            id: "poly", latitude: 0, longitude: 0, radius: 500, name: "poly",
+            transitionTypes: [.enter, .exit], lastUpdated: Date(timeIntervalSince1970: 1700000000),
+            vertices: ring
+        )
+        let storage = makeStorage()
+        let setup = await makeRegisteredSetup(regions: [polygon], config: diffConfig, storage: storage)
+        let before = setup.monitor.startedRegions.count
+        // Age the sync so the refresh actually re-registers rather than taking the freshness skip.
+        await storage.recordSync(timestamp: Date(timeIntervalSince1970: 0), location: LocationData(latitude: 0, longitude: 0))
+
+        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0.001, anchorIsLiveFix: false)
+
+        let trigger = setup.monitor.startedRegions.dropFirst(before)
+            .last { $0.identifier == GeofenceConstants.movementTriggerIdentifier }
+        #expect(trigger?.radius == diffConfig.localRefreshTriggerRadius, "got \(String(describing: trigger?.radius))")
+    }
+
+    /// Control for the above: the same refresh from a caller that does hold a fix still tightens.
+    @Test
+    func refresh_givenNearbyPolygonAndLiveAnchor_expectTriggerShrunkToItsBoundary() async {
+        let ring = [
+            LocationData(latitude: -0.0018, longitude: -0.0018),
+            LocationData(latitude: -0.0018, longitude: 0.0018),
+            LocationData(latitude: 0.0018, longitude: 0.0018),
+            LocationData(latitude: 0.0018, longitude: -0.0018)
+        ]
+        let polygon = Geofence(
+            id: "poly", latitude: 0, longitude: 0, radius: 500, name: "poly",
+            transitionTypes: [.enter, .exit], lastUpdated: Date(timeIntervalSince1970: 1700000000),
+            vertices: ring
+        )
+        let storage = makeStorage()
+        let setup = await makeRegisteredSetup(regions: [polygon], config: diffConfig, storage: storage)
+        let before = setup.monitor.startedRegions.count
+        // Age the sync so the refresh actually re-registers rather than taking the freshness skip.
+        await storage.recordSync(timestamp: Date(timeIntervalSince1970: 0), location: LocationData(latitude: 0, longitude: 0))
+
+        _ = await setup.coordinator.refresh(latitude: 0, longitude: 0.001, anchorIsLiveFix: true)
+
+        let trigger = setup.monitor.startedRegions.dropFirst(before)
+            .last { $0.identifier == GeofenceConstants.movementTriggerIdentifier }
+        #expect(trigger?.radius == GeofenceConstants.polygonWakeMinRadius, "got \(String(describing: trigger?.radius))")
+    }
+
     @Test
     func handleMovement_givenNearbyPolygon_expectTriggerShrunkToItsBoundary() async {
         // The end-to-end assertion behind `PolygonWakeRadius`: a polygon the device stands inside

--- a/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
+++ b/Tests/LocationGeofence/Geofence/Coordinator/GeofenceSyncCoordinatorTests.swift
@@ -1408,9 +1408,14 @@ struct GeofenceSyncCoordinatorTests {
 
     @Test
     func handleMovement_givenRerankLandsOnSameNearestSet_expectBusinessRegionsUntouched() async {
-        // Steady-state drive: adjacent trigger EXITs mostly re-rank onto the identical nearest set.
+        // Steady-state drive: adjacent trigger EXITs mostly land on the identical nearest set.
         // Re-registering re-seeds the OS's assumed state and absorbs an undelivered crossing, so the
-        // business regions must be left alone — only the trigger re-centers and the ranking anchor walks.
+        // business regions must be left alone — only the trigger re-centers.
+        //
+        // 111 m is inside the re-rank radius, so this takes the cheap polygon wake pass: the wake
+        // re-arms at the new position but the ranking anchor must NOT walk. Walking it on every
+        // wake would reset the distance re-ranking is measured against, and re-ranking would never
+        // come due — see `handleMovement_givenMoveBeyondRerankRadius_expectAnchorWalks`.
         let region = makeRegion(id: "g1", latitude: 0.5, longitude: 0.5)
         let storage = makeStorage()
         let setup = await makeRegisteredSetup(regions: [region], config: diffConfig, storage: storage)
@@ -1426,6 +1431,57 @@ struct GeofenceSyncCoordinatorTests {
         let triggerStarts = setup.monitor.startedRegions.filter { $0.identifier == GeofenceConstants.movementTriggerIdentifier }
         #expect(triggerStarts.count == 2)
         #expect(triggerStarts.last?.center == newLocation)
+        #expect(await storage.getLastRegistrationCenter() == LocationData(latitude: 0, longitude: 0))
+    }
+
+    @Test
+    func handleMovement_givenNearbyPolygon_expectTriggerShrunkToItsBoundary() async {
+        // The end-to-end assertion behind `PolygonWakeRadius`: a polygon the device stands inside
+        // must actually shrink the trigger the OS is given, not just the value the helper returns.
+        let ring = [
+            LocationData(latitude: -0.0018, longitude: -0.0018),
+            LocationData(latitude: -0.0018, longitude: 0.0018),
+            LocationData(latitude: 0.0018, longitude: 0.0018),
+            LocationData(latitude: 0.0018, longitude: -0.0018)
+        ]
+        let polygon = Geofence(
+            id: "poly", latitude: 0, longitude: 0, radius: 500, name: "poly",
+            transitionTypes: [.enter, .exit], lastUpdated: Date(timeIntervalSince1970: 1700000000),
+            vertices: ring
+        )
+        let storage = makeStorage()
+        let setup = await makeRegisteredSetup(regions: [polygon], config: diffConfig, storage: storage)
+
+        // ~111 m east of centre: still ~89 m from the eastern edge, so the floor should win.
+        _ = await setup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
+
+        let trigger = setup.monitor.startedRegions
+            .last { $0.identifier == GeofenceConstants.movementTriggerIdentifier }
+        #expect(trigger?.radius == GeofenceConstants.polygonWakeMinRadius, "got \(String(describing: trigger?.radius))")
+        // And the circle-only control: no polygon means the configured radius, untouched.
+        let circleStorage = makeStorage()
+        let circleSetup = await makeRegisteredSetup(
+            regions: [makeRegion(id: "c1", latitude: 0, longitude: 0)], config: diffConfig, storage: circleStorage
+        )
+        _ = await circleSetup.coordinator.handleMovement(latitude: 0, longitude: 0.001)
+        let circleTrigger = circleSetup.monitor.startedRegions
+            .last { $0.identifier == GeofenceConstants.movementTriggerIdentifier }
+        #expect(circleTrigger?.radius == diffConfig.localRefreshTriggerRadius)
+    }
+
+    @Test
+    func handleMovement_givenMoveBeyondRerankRadius_expectAnchorWalks() async {
+        // The other side of the gate: past the re-rank radius the full pass runs and the ranking
+        // anchor moves, so the cheap-pass short-circuit cannot starve re-ranking.
+        let region = makeRegion(id: "g1", latitude: 0.5, longitude: 0.5)
+        let storage = makeStorage()
+        let setup = await makeRegisteredSetup(regions: [region], config: diffConfig, storage: storage)
+
+        // ~1.7 km east: beyond localRefreshTriggerRadius (1000 m), inside the refetch radius.
+        let newLocation = LocationData(latitude: 0, longitude: 0.015)
+        let result = await setup.coordinator.handleMovement(latitude: newLocation.latitude, longitude: newLocation.longitude)
+
+        #expect(result.isSuccess)
         #expect(await storage.getLastRegistrationCenter() == newLocation)
     }
 

--- a/Tests/LocationGeofence/Geofence/GeofenceMonitorBinderTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceMonitorBinderTests.swift
@@ -90,6 +90,29 @@ struct GeofenceMonitorBinderTests {
         #expect(coordinator.handleMovementCallsCount == 1)
         #expect(coordinator.handleMovementReceivedArguments?.latitude == 37.0)
         #expect(coordinator.handleMovementReceivedArguments?.longitude == -122.0)
+        #expect(coordinator.handleMovementReceivedArguments?.anchorIsLiveFix == true)
+    }
+
+    /// A movement pass whose fresh-fix request failed carries the cached fix that prompted it. The
+    /// coordinator sizes the wake circle from these coordinates, so the staleness has to survive the
+    /// hop rather than being assumed away because it is the movement path.
+    @Test
+    func bind_givenMovementTriggerExitOnStaleFix_expectAnchorNotReportedLive() async {
+        let monitor = MockGeofenceRegionMonitor()
+        let coordinator = makeCoordinatorMock()
+        let tracker = makeTracker(deliveryTracker: makeDeliveryMock())
+
+        let resolver = makeResolver(tracker: tracker)
+        GeofenceMonitorBinder.bind(monitor: monitor, resolver: resolver, coordinator: coordinator)
+        monitor.simulateTransition(
+            identifier: GeofenceConstants.movementTriggerIdentifier,
+            transition: .exit,
+            location: LocationData(latitude: 37.0, longitude: -122.0),
+            locationIsFresh: false
+        )
+        await awaitDispatch(coordinator.handleMovementCallsCount > 0)
+
+        #expect(coordinator.handleMovementReceivedArguments?.anchorIsLiveFix == false)
     }
 
     /// We only register the movement trigger for `.exit`; an unexpected `.enter` on the

--- a/Tests/LocationGeofence/Geofence/Monitor/MovementFixResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Monitor/MovementFixResolverTests.swift
@@ -35,13 +35,45 @@ struct MovementFixResolverTests {
         )
     }
 
+    /// The flag the wake radius is sized from. A late fix arriving after the timeout still updates
+    /// `latestFix`, so the answer has to come from which completion path fired, not from inspecting
+    /// state afterwards.
+    @Test
+    func resolve_expectFreshnessReportedFromTheCompletionPath() {
+        var freshness: [Bool] = []
+
+        let warm = MovementFixResolver(logger: LoggerMock())
+        warm.systemCachedFix = { nil }
+        warm.requestFreshFix = {}
+        warm.resolve(cached: makeFix(ageSeconds: 5)) { _, isFresh in freshness.append(isFresh) }
+        #expect(freshness == [true]) // inside maxAge, answered without a request
+
+        let delivered = MovementFixResolver(logger: LoggerMock())
+        delivered.systemCachedFix = { nil }
+        delivered.requestFreshFix = { [weak delivered] in
+            delivered?.handleResolvedFix(makeFix(ageSeconds: 0))
+        }
+        delivered.resolve(cached: makeFix(ageSeconds: 120)) { _, isFresh in freshness.append(isFresh) }
+        #expect(freshness == [true, true])
+
+        let failed = MovementFixResolver(logger: LoggerMock())
+        failed.systemCachedFix = { nil }
+        failed.requestFreshFix = { [weak failed] in failed?.handleRequestFailure() }
+        failed.resolve(cached: makeFix(ageSeconds: 120)) { _, isFresh in freshness.append(isFresh) }
+        #expect(freshness == [true, true, false]) // fell back to the fix that prompted the request
+
+        // A fix landing after that failure must not retroactively make the answer fresh.
+        failed.handleResolvedFix(makeFix(ageSeconds: 0))
+        #expect(freshness == [true, true, false])
+    }
+
     @Test
     func resolve_givenFreshCachedFix_expectImmediateCompletionWithoutRequest() {
         var requestCount = 0
         let resolver = makeResolver(onRequest: { requestCount += 1 })
         var received: [LocationData?] = []
 
-        resolver.resolve(cached: makeFix(latitude: 31.5, ageSeconds: 5)) { received.append($0) }
+        resolver.resolve(cached: makeFix(latitude: 31.5, ageSeconds: 5)) { location, _ in received.append(location) }
 
         #expect(received.map(\.?.latitude) == [31.5])
         #expect(requestCount == 0)
@@ -53,7 +85,7 @@ struct MovementFixResolverTests {
         let resolver = makeResolver(onRequest: { requestCount += 1 })
         var received: [LocationData?] = []
 
-        resolver.resolve(cached: makeFix(latitude: 31.1, ageSeconds: 120)) { received.append($0) }
+        resolver.resolve(cached: makeFix(latitude: 31.1, ageSeconds: 120)) { location, _ in received.append(location) }
         #expect(received.isEmpty)
         #expect(requestCount == 1)
 
@@ -67,7 +99,7 @@ struct MovementFixResolverTests {
         let resolver = makeResolver(onRequest: { requestCount += 1 })
         var received: [LocationData?] = []
 
-        resolver.resolve(cached: nil) { received.append($0) }
+        resolver.resolve(cached: nil) { location, _ in received.append(location) }
         #expect(requestCount == 1)
 
         resolver.handleRequestFailure()
@@ -80,7 +112,7 @@ struct MovementFixResolverTests {
         let resolver = makeResolver()
         var received: [LocationData?] = []
 
-        resolver.resolve(cached: makeFix(latitude: 31.2, ageSeconds: 120)) { received.append($0) }
+        resolver.resolve(cached: makeFix(latitude: 31.2, ageSeconds: 120)) { location, _ in received.append(location) }
         resolver.handleRequestFailure()
 
         #expect(received.map(\.?.latitude) == [31.2])
@@ -93,8 +125,8 @@ struct MovementFixResolverTests {
         var first: [LocationData?] = []
         var second: [LocationData?] = []
 
-        resolver.resolve(cached: makeFix(ageSeconds: 120)) { first.append($0) }
-        resolver.resolve(cached: makeFix(ageSeconds: 90)) { second.append($0) }
+        resolver.resolve(cached: makeFix(ageSeconds: 120)) { location, _ in first.append(location) }
+        resolver.resolve(cached: makeFix(ageSeconds: 90)) { location, _ in second.append(location) }
         #expect(requestCount == 1)
 
         resolver.handleResolvedFix(makeFix(latitude: 32.0, ageSeconds: 0))
@@ -107,7 +139,7 @@ struct MovementFixResolverTests {
         let resolver = makeResolver(requestTimeout: 0.05)
         var received: [LocationData?] = []
 
-        resolver.resolve(cached: makeFix(latitude: 31.3, ageSeconds: 120)) { received.append($0) }
+        resolver.resolve(cached: makeFix(latitude: 31.3, ageSeconds: 120)) { location, _ in received.append(location) }
 
         for _ in 0 ..< 200 {
             if !received.isEmpty { break }
@@ -127,8 +159,8 @@ struct MovementFixResolverTests {
         var first: [LocationData?] = []
         var second: [LocationData?] = []
 
-        resolver.resolve(cached: makeFix(latitude: 31.6, ageSeconds: 120)) { first.append($0) }
-        resolver.resolve(cached: makeFix(latitude: 31.7, ageSeconds: 90)) { second.append($0) }
+        resolver.resolve(cached: makeFix(latitude: 31.6, ageSeconds: 120)) { location, _ in first.append(location) }
+        resolver.resolve(cached: makeFix(latitude: 31.7, ageSeconds: 90)) { location, _ in second.append(location) }
         resolver.handleRequestFailure()
 
         #expect(first.map(\.?.latitude) == [31.7])
@@ -140,7 +172,7 @@ struct MovementFixResolverTests {
         let resolver = makeResolver()
         var received: [LocationData?] = []
 
-        resolver.resolve(cached: nil) { received.append($0) }
+        resolver.resolve(cached: nil) { location, _ in received.append(location) }
         resolver.locationManager(CLLocationManager(), didUpdateLocations: [
             makeFix(latitude: 200.0, longitude: 200.0, ageSeconds: 0)
         ])
@@ -168,10 +200,10 @@ struct MovementFixResolverTests {
         let resolver = makeResolver(onRequest: { requestCount += 1 })
         var received: [LocationData?] = []
 
-        resolver.resolve(cached: makeFix(ageSeconds: 120)) { received.append($0) }
+        resolver.resolve(cached: makeFix(ageSeconds: 120)) { location, _ in received.append(location) }
         resolver.handleResolvedFix(makeFix(latitude: 32.1, ageSeconds: 0))
 
-        resolver.resolve(cached: makeFix(ageSeconds: 120)) { received.append($0) }
+        resolver.resolve(cached: makeFix(ageSeconds: 120)) { location, _ in received.append(location) }
         #expect(requestCount == 2)
 
         resolver.handleResolvedFix(makeFix(latitude: 32.2, ageSeconds: 0))
@@ -183,7 +215,7 @@ struct MovementFixResolverTests {
         let resolver = makeResolver()
         var received: [LocationData?] = []
 
-        resolver.resolve(cached: nil) { received.append($0) }
+        resolver.resolve(cached: nil) { location, _ in received.append(location) }
         // Core Location echoing a cached (stale) location must not complete the pass...
         resolver.locationManager(CLLocationManager(), didUpdateLocations: [
             makeFix(latitude: 31.9, ageSeconds: 120)
@@ -203,7 +235,7 @@ struct MovementFixResolverTests {
         let resolver = makeResolver()
         var received: [LocationData?] = []
 
-        resolver.resolve(cached: nil) { received.append($0) }
+        resolver.resolve(cached: nil) { location, _ in received.append(location) }
         resolver.locationManager(CLLocationManager(), didUpdateLocations: [
             makeFix(latitude: 31.9, ageSeconds: 0, accuracy: -1)
         ])
@@ -222,7 +254,7 @@ struct MovementFixResolverTests {
         let resolver = makeResolver(backgroundTaskRunner: runner)
         var received: [LocationData?] = []
 
-        resolver.resolve(cached: makeFix(ageSeconds: 120)) { received.append($0) }
+        resolver.resolve(cached: makeFix(ageSeconds: 120)) { location, _ in received.append(location) }
         for _ in 0 ..< 200 {
             if runner.started.wrappedValue == 1 { break }
             try? await Task.sleep(nanoseconds: 5000000)

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -292,6 +292,12 @@ struct PolygonMembershipResolverTests {
         return gate
     }
 
+    private func yieldUntil(_ condition: () -> Bool) async {
+        for _ in 0 ..< 1000 where !condition() {
+            await Task.yield()
+        }
+    }
+
     /// Lets a just-started task reach its first suspension point.
     private func settle() async {
         for _ in 0 ..< 20 {

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -272,12 +272,6 @@ struct PolygonMembershipResolverTests {
         return gate
     }
 
-    private func yieldUntil(_ condition: () -> Bool) async {
-        for _ in 0 ..< 1000 where !condition() {
-            await Task.yield()
-        }
-    }
-
     /// Lets a just-started task reach its first suspension point.
     private func settle() async {
         for _ in 0 ..< 20 {

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -214,31 +214,81 @@ struct PolygonMembershipResolverTests {
     /// A wake requires a fresh fix; a foreground pass does not. Skipping the wake behind an
     /// in-flight foreground would drop exactly the pass that runs BECAUSE the device moved, and
     /// nothing retries it.
+    ///
+    /// `async let` does not order task start-up, and a request count cannot tell "skipped" from
+    /// "coalesced into the pending request" — so the first pass is held inside its request and the
+    /// assertion is on the skip decision itself.
     @Test
     func evaluateAllPolygons_givenFreshRequiredDuringForegroundPass_expectNotSkipped() async {
-        let setup = await makeSetup(fix: nil)
+        let logger = LoggerMock()
+        let setup = await makeSetup(fix: nil, logger: logger)
         await registerPolygons(setup, ids: ["1", "2"])
-        let counter = countingRequests(setup)
+        let gate = gatingRequests(setup)
 
         async let foreground: Void = setup.resolver.evaluateAllPolygons()
+        await yieldUntil { !gate.releases.isEmpty }
         async let wake: Void = setup.resolver.evaluateAllPolygons(requiresFreshFix: true)
+        await settle()
+        gate.releaseAll()
         _ = await(foreground, wake)
 
-        #expect(counter.count == 2)
+        #expect(skipCount(logger) == 0)
     }
 
     /// The converse still holds: a weaker pass behind a fresh one adds nothing.
     @Test
     func evaluateAllPolygons_givenForegroundDuringFreshPass_expectSkipped() async {
-        let setup = await makeSetup(fix: nil)
+        let logger = LoggerMock()
+        let setup = await makeSetup(fix: nil, logger: logger)
         await registerPolygons(setup, ids: ["1", "2"])
-        let counter = countingRequests(setup)
+        let gate = gatingRequests(setup)
 
         async let wake: Void = setup.resolver.evaluateAllPolygons(requiresFreshFix: true)
+        await yieldUntil { !gate.releases.isEmpty }
         async let foreground: Void = setup.resolver.evaluateAllPolygons()
+        await settle()
+        gate.releaseAll()
         _ = await(wake, foreground)
 
-        #expect(counter.count == 1)
+        #expect(skipCount(logger) == 1)
+    }
+
+    /// Holds each pass inside its location request until released, so a second pass always starts
+    /// against a known in-flight state.
+    private final class RequestGate {
+        var releases: [() -> Void] = []
+        func releaseAll() {
+            let pending = releases
+            releases = []
+            pending.forEach { $0() }
+        }
+    }
+
+    private func gatingRequests(_ setup: Setup) -> RequestGate {
+        let gate = RequestGate()
+        setup.fixResolver.requestFreshFix = { [weak fixResolver = setup.fixResolver] in
+            gate.releases.append { fixResolver?.handleRequestFailure() }
+        }
+        return gate
+    }
+
+    private func yieldUntil(_ condition: () -> Bool) async {
+        for _ in 0 ..< 1000 where !condition() {
+            await Task.yield()
+        }
+    }
+
+    /// Lets a just-started task reach its first suspension point.
+    private func settle() async {
+        for _ in 0 ..< 20 {
+            await Task.yield()
+        }
+    }
+
+    private func skipCount(_ logger: LoggerMock) -> Int {
+        logger.debugReceivedInvocations
+            .filter { $0.message.contains("Skipped polygon evaluation pass") }
+            .count
     }
 
     // MARK: - Circle fences pass through untouched

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -286,6 +286,22 @@ struct PolygonMembershipResolverTests {
         #expect(await setup.storage.getPolygonMembership()["1"] == nil)
     }
 
+    /// The first wake of a process holds no fix of its own, so there was nothing for the freshness
+    /// comparison to reject — and CoreLocation's cached fix, which is exactly the pre-movement one,
+    /// answered the forced request.
+    @Test
+    func handleTransition_givenFreshFixRequiredOnFirstWake_expectNoVerdictFromSystemCache() async {
+        let setup = await makeSetup(fix: nil) // the forced request fails
+        // No fix delivered to this resolver yet: a cold process with only CoreLocation's cache.
+        setup.fixResolver.systemCachedFix = { fix(latitude: 0, longitude: 0) }
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter, occurredAt: Date())
+
+        #expect(await setup.emitter.snapshot().isEmpty)
+        #expect(await setup.storage.getPolygonMembership()["1"] == nil)
+    }
+
     /// A stored ring that no longer builds is not a circle. Forwarding it would fire a customer
     /// enter anywhere inside the covering circle — the polygon's whole annulus included.
     @Test

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -243,6 +243,12 @@ struct PolygonMembershipResolverTests {
         await yieldUntil { !gate.releases.isEmpty }
         async let secondWake: Void = setup.resolver.evaluateAllPolygons(requiresFreshFix: true)
         await settle()
+        // One entry, not two: the second wake COALESCED onto the in-flight request rather than
+        // issuing its own. Pinned because it bounds what not-skipping buys — the second wake is
+        // answered by a request that predates its own crossing, and when that shared request fails
+        // both wakes end undecided. Not skipping is still the better of the two, but the guarantee
+        // is "it gets an answer", not "it gets a fix of its own".
+        #expect(gate.releases.count == 1, "expected the second wake to coalesce, got \(gate.releases.count) requests")
         gate.releaseAll()
         _ = await(firstWake, secondWake)
 
@@ -385,6 +391,52 @@ struct PolygonMembershipResolverTests {
         let delivered = await setup.emitter.snapshot()
         #expect(delivered.count == 1, "verdict was refused; got \(delivered)")
         #expect(delivered.first?.transition == .enter)
+        #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
+    }
+
+    /// Resolves through `locationManager(_:didUpdateLocations:)` rather than the direct
+    /// `handleResolvedFix` seam every other test in this suite uses. That seam bypasses the
+    /// delegate's own filters — the `movementFixMaxAge` echo check, `horizontalAccuracy > 0`, and
+    /// the invalid-coordinate drop — so nothing here exercised them until this test.
+    @Test
+    func handleTransition_givenFixArrivingThroughTheDelegate_expectEnterDelivered() async {
+        let setup = await makeSetup(fix: nil)
+        setup.fixResolver.requestFreshFix = { [weak fixResolver = setup.fixResolver] in
+            fixResolver?.locationManager(CLLocationManager(), didUpdateLocations: [
+                fix(latitude: 0, longitude: 0)
+            ])
+        }
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter, occurredAt: Date())
+
+        let delivered = await setup.emitter.snapshot()
+        #expect(delivered.count == 1)
+        #expect(delivered.first?.transition == .enter)
+    }
+
+    /// KNOWN LIMIT, pinned so it cannot change silently. CoreLocation can echo its cached fix as a
+    /// new manager's first delivery, and the delegate accepts an echo inside `movementFixMaxAge`.
+    /// On the first pass of a process there is no delivered fix to be newer than, so that echo
+    /// reaches a verdict: a cold wake can be decided by a fix up to `movementFixMaxAge` older than
+    /// the wake — several hundred metres at speed. Narrowing it needs an assumed-speed constant and
+    /// belongs with the ≤17 work; if this test starts failing, someone has done that deliberately.
+    @Test
+    func handleTransition_givenColdProcessAndEchoedPreWakeFix_expectVerdictFromTheStaleEcho() async {
+        let setup = await makeSetup(fix: nil) // cold: nothing delivered, no system cache
+        let preWakeFix = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            altitude: 0, horizontalAccuracy: 5, verticalAccuracy: 5,
+            timestamp: Date(timeIntervalSinceNow: -20) // stale, but inside movementFixMaxAge
+        )
+        setup.fixResolver.requestFreshFix = { [weak fixResolver = setup.fixResolver] in
+            fixResolver?.locationManager(CLLocationManager(), didUpdateLocations: [preWakeFix])
+        }
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter, occurredAt: Date())
+
+        #expect(await setup.emitter.snapshot().count == 1)
         #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
     }
 

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -449,11 +449,14 @@ struct PolygonMembershipResolverTests {
     @Test
     func evaluateAllPolygons_givenStaleDeliveredFixAndFreshSystemCache_expectTheFreshOneDecides() async {
         let setup = await makeSetup(fix: nil)
-        // Delivered a while ago and ~1.1 km away: outside the polygon.
+        // Delivered ~1.1 km away, outside the polygon, and only 20 s old — deliberately INSIDE
+        // `movementFixMaxAge`. A fix old enough for the decision's own age gate to reject would
+        // make this test pass on that gate rather than on the defect, and the defect's whole range
+        // is inside the gate.
         setup.fixResolver.handleResolvedFix(CLLocation(
             coordinate: CLLocationCoordinate2D(latitude: 0.01, longitude: 0.01),
             altitude: 0, horizontalAccuracy: 5, verticalAccuracy: 5,
-            timestamp: Date(timeIntervalSinceNow: -600)
+            timestamp: Date(timeIntervalSinceNow: -20)
         ))
         // The system cache has moved on and sits inside the polygon, well within the age gate.
         setup.fixResolver.systemCachedFix = {
@@ -470,6 +473,29 @@ struct PolygonMembershipResolverTests {
         #expect(delivered.count == 1, "decided from the stale delivered fix; got \(delivered)")
         #expect(delivered.first?.transition == .enter)
         #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
+    }
+
+    /// Pins the coupling the forced-fresh branch rests on. `isFresh` can be true while `latestFix`
+    /// is arbitrarily stale — `resolve` sets it for a young enough CALLER-SUPPLIED fix without
+    /// requesting or recording. The forced-fresh path is only safe from that because it passes
+    /// `cached: nil` and so can never take the fast path. Nothing in the type system enforces it,
+    /// and an obvious-looking "avoid a request" optimisation there would hand a stale fix a fresh
+    /// flag. If this test fails, that is what happened.
+    @Test
+    func handleTransition_givenFreshRequiredAndStaleHeldFix_expectNoVerdictFromIt() async {
+        let setup = await makeSetup(fix: nil) // the forced request fails
+        // Held, inside the polygon, and young enough that the fast path WOULD accept it as fresh.
+        setup.fixResolver.handleResolvedFix(CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            altitude: 0, horizontalAccuracy: 5, verticalAccuracy: 5,
+            timestamp: Date(timeIntervalSinceNow: -20)
+        ))
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter, occurredAt: Date())
+
+        #expect(await setup.emitter.snapshot().isEmpty)
+        #expect(await setup.storage.getPolygonMembership()["1"] == nil)
     }
 
     /// A wake fires BECAUSE the device moved, so the fix it already holds describes where it was.

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -440,6 +440,38 @@ struct PolygonMembershipResolverTests {
         #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
     }
 
+    /// A pass that does NOT require a fresh fix must act on the newest position available, not on
+    /// the last one this resolver happened to deliver. `resolve` answers from the caller's cached
+    /// fix without requesting when that fix is young enough, and takes that fast path without
+    /// recording it — so `latestFix` can still be an old delivered fix while the fresh system fix
+    /// is the very thing that let the pass proceed. Reading `latestFix` first evaluated foreground
+    /// passes at the stale position.
+    @Test
+    func evaluateAllPolygons_givenStaleDeliveredFixAndFreshSystemCache_expectTheFreshOneDecides() async {
+        let setup = await makeSetup(fix: nil)
+        // Delivered a while ago and ~1.1 km away: outside the polygon.
+        setup.fixResolver.handleResolvedFix(CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 0.01, longitude: 0.01),
+            altitude: 0, horizontalAccuracy: 5, verticalAccuracy: 5,
+            timestamp: Date(timeIntervalSinceNow: -600)
+        ))
+        // The system cache has moved on and sits inside the polygon, well within the age gate.
+        setup.fixResolver.systemCachedFix = {
+            CLLocation(
+                coordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0),
+                altitude: 0, horizontalAccuracy: 5, verticalAccuracy: 5, timestamp: Date()
+            )
+        }
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+
+        await setup.resolver.evaluateAllPolygons()
+
+        let delivered = await setup.emitter.snapshot()
+        #expect(delivered.count == 1, "decided from the stale delivered fix; got \(delivered)")
+        #expect(delivered.first?.transition == .enter)
+        #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
+    }
+
     /// A wake fires BECAUSE the device moved, so the fix it already holds describes where it was.
     /// When the forced request fails, falling back to that fix re-affirms the stale verdict — the
     /// exact silent miss the fresh-fix rule exists to prevent — so no verdict must be reached.

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -251,6 +251,22 @@ struct PolygonMembershipResolverTests {
         #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
     }
 
+    /// A wake fires BECAUSE the device moved, so the fix it already holds describes where it was.
+    /// When the forced request fails, falling back to that fix re-affirms the stale verdict — the
+    /// exact silent miss the fresh-fix rule exists to prevent — so no verdict must be reached.
+    @Test
+    func handleTransition_givenFreshFixRequiredButRequestFails_expectNoVerdictFromHeldFix() async {
+        let setup = await makeSetup(fix: nil) // the forced request fails
+        // Seed a pre-wake fix that is inside the polygon and still within `movementFixMaxAge`.
+        setup.fixResolver.handleResolvedFix(fix(latitude: 0, longitude: 0))
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter)
+
+        #expect(await setup.emitter.snapshot().isEmpty)
+        #expect(await setup.storage.getPolygonMembership()["1"] == nil)
+    }
+
     /// A stored ring that no longer builds is not a circle. Forwarding it would fire a customer
     /// enter anywhere inside the covering circle — the polygon's whole annulus included.
     @Test

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -35,6 +35,13 @@ struct PolygonMembershipResolverTests {
         LocationData(latitude: 0.0016, longitude: -0.0016)
     ]
 
+    /// An age that predates the wake yet stays inside `movementFixMaxAge`. Deliberately far from
+    /// that 30 s cap rather than just under it: the gate is `-timestamp.timeIntervalSinceNow`
+    /// evaluated at decision time, so the offset is really a wall-clock budget for everything
+    /// between the stamp and the decision. A 20 s stamp aged past the cap on a loaded CI runner and
+    /// the pass emitted nothing.
+    private static let ageInsideGate: TimeInterval = 5
+
     private func polygonGeofence(
         id: String = "1",
         transitionTypes: Set<GeofenceTransition> = [.enter, .exit],
@@ -426,14 +433,15 @@ struct PolygonMembershipResolverTests {
     /// On the first pass of a process there is no delivered fix to be newer than, so that echo
     /// reaches a verdict: a cold wake can be decided by a fix up to `movementFixMaxAge` older than
     /// the wake — several hundred metres at speed. Narrowing it needs an assumed-speed constant and
-    /// belongs with the ≤17 work; if this test starts failing, someone has done that deliberately.
+    /// belongs with the ≤17 work; if this test starts failing, rule out `ageInsideGate` before
+    /// concluding someone narrowed it deliberately.
     @Test
     func handleTransition_givenColdProcessAndEchoedPreWakeFix_expectVerdictFromTheStaleEcho() async {
         let setup = await makeSetup(fix: nil) // cold: nothing delivered, no system cache
         let preWakeFix = CLLocation(
             coordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0),
             altitude: 0, horizontalAccuracy: 5, verticalAccuracy: 5,
-            timestamp: Date(timeIntervalSinceNow: -20) // stale, but inside movementFixMaxAge
+            timestamp: Date(timeIntervalSinceNow: -Self.ageInsideGate)
         )
         setup.fixResolver.requestFreshFix = { [weak fixResolver = setup.fixResolver] in
             fixResolver?.locationManager(CLLocationManager(), didUpdateLocations: [preWakeFix])
@@ -455,14 +463,14 @@ struct PolygonMembershipResolverTests {
     @Test
     func evaluateAllPolygons_givenStaleDeliveredFixAndFreshSystemCache_expectTheFreshOneDecides() async {
         let setup = await makeSetup(fix: nil)
-        // Delivered ~1.1 km away, outside the polygon, and only 20 s old — deliberately INSIDE
+        // Delivered ~1.1 km away, outside the polygon, and deliberately INSIDE
         // `movementFixMaxAge`. A fix old enough for the decision's own age gate to reject would
         // make this test pass on that gate rather than on the defect, and the defect's whole range
         // is inside the gate.
         setup.fixResolver.handleResolvedFix(CLLocation(
             coordinate: CLLocationCoordinate2D(latitude: 0.01, longitude: 0.01),
             altitude: 0, horizontalAccuracy: 5, verticalAccuracy: 5,
-            timestamp: Date(timeIntervalSinceNow: -20)
+            timestamp: Date(timeIntervalSinceNow: -Self.ageInsideGate)
         ))
         // The system cache has moved on and sits inside the polygon, well within the age gate.
         setup.fixResolver.systemCachedFix = {
@@ -494,7 +502,7 @@ struct PolygonMembershipResolverTests {
         setup.fixResolver.handleResolvedFix(CLLocation(
             coordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0),
             altitude: 0, horizontalAccuracy: 5, verticalAccuracy: 5,
-            timestamp: Date(timeIntervalSinceNow: -20)
+            timestamp: Date(timeIntervalSinceNow: -Self.ageInsideGate)
         ))
         await setup.storage.setCachedGeofences([polygonGeofence()])
 

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -211,6 +211,36 @@ struct PolygonMembershipResolverTests {
         #expect(counter.count == 1)
     }
 
+    /// A wake requires a fresh fix; a foreground pass does not. Skipping the wake behind an
+    /// in-flight foreground would drop exactly the pass that runs BECAUSE the device moved, and
+    /// nothing retries it.
+    @Test
+    func evaluateAllPolygons_givenFreshRequiredDuringForegroundPass_expectNotSkipped() async {
+        let setup = await makeSetup(fix: nil)
+        await registerPolygons(setup, ids: ["1", "2"])
+        let counter = countingRequests(setup)
+
+        async let foreground: Void = setup.resolver.evaluateAllPolygons()
+        async let wake: Void = setup.resolver.evaluateAllPolygons(requiresFreshFix: true)
+        _ = await(foreground, wake)
+
+        #expect(counter.count == 2)
+    }
+
+    /// The converse still holds: a weaker pass behind a fresh one adds nothing.
+    @Test
+    func evaluateAllPolygons_givenForegroundDuringFreshPass_expectSkipped() async {
+        let setup = await makeSetup(fix: nil)
+        await registerPolygons(setup, ids: ["1", "2"])
+        let counter = countingRequests(setup)
+
+        async let wake: Void = setup.resolver.evaluateAllPolygons(requiresFreshFix: true)
+        async let foreground: Void = setup.resolver.evaluateAllPolygons()
+        _ = await(wake, foreground)
+
+        #expect(counter.count == 1)
+    }
+
     // MARK: - Circle fences pass through untouched
 
     @Test

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -147,12 +147,6 @@ struct PolygonMembershipResolverTests {
         logger.debugReceivedInvocations.contains { $0.message.contains(needle) }
     }
 
-    private func yieldUntil(_ condition: () -> Bool) async {
-        for _ in 0 ..< 1000 where !condition() {
-            await Task.yield()
-        }
-    }
-
     /// The same ring shifted a degree away, so a point decisive INSIDE the original is decisively
     /// outside this one.
     private func movedPolygonGeofence(id: String = "1") -> Geofence {
@@ -231,6 +225,26 @@ struct PolygonMembershipResolverTests {
         await settle()
         gate.releaseAll()
         _ = await(foreground, wake)
+
+        #expect(skipCount(logger) == 0)
+    }
+
+    /// Two wakes are not interchangeable just because both demand a fresh fix. The in-flight one
+    /// asked for its fix before the crossing that caused this one, so yielding to it drops the
+    /// second crossing entirely — there is no retry behind a wake.
+    @Test
+    func evaluateAllPolygons_givenFreshRequiredDuringFreshPass_expectNotSkipped() async {
+        let logger = LoggerMock()
+        let setup = await makeSetup(fix: nil, logger: logger)
+        await registerPolygons(setup, ids: ["1", "2"])
+        let gate = gatingRequests(setup)
+
+        async let firstWake: Void = setup.resolver.evaluateAllPolygons(requiresFreshFix: true)
+        await yieldUntil { !gate.releases.isEmpty }
+        async let secondWake: Void = setup.resolver.evaluateAllPolygons(requiresFreshFix: true)
+        await settle()
+        gate.releaseAll()
+        _ = await(firstWake, secondWake)
 
         #expect(skipCount(logger) == 0)
     }

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -36,10 +36,12 @@ struct PolygonMembershipResolverTests {
     ]
 
     /// An age that predates the wake yet stays inside `movementFixMaxAge`. Deliberately far from
-    /// that 30 s cap rather than just under it: the gate is `-timestamp.timeIntervalSinceNow`
-    /// evaluated at decision time, so the offset is really a wall-clock budget for everything
-    /// between the stamp and the decision. A 20 s stamp aged past the cap on a loaded CI runner and
-    /// the pass emitted nothing.
+    /// that 30 s cap rather than just under it: the binding check is at DELIVERY, in
+    /// `MovementFixResolver.locationManager(_:didUpdateLocations:)`, which refuses a fix past the
+    /// cap WITHOUT resuming the request — so the offset is a wall-clock budget for everything
+    /// between the stamp and the delivery hook. A 20 s stamp overran it on a loaded runner: the
+    /// echo was refused, the forced request ran to its 10 s timeout, and the pass emitted nothing.
+    /// A failure here therefore reads as a slow test, not as an undecided verdict.
     private static let ageInsideGate: TimeInterval = 5
 
     private func polygonGeofence(
@@ -489,12 +491,15 @@ struct PolygonMembershipResolverTests {
         #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
     }
 
-    /// Pins the coupling the forced-fresh branch rests on. `isFresh` can be true while `latestFix`
-    /// is arbitrarily stale — `resolve` sets it for a young enough CALLER-SUPPLIED fix without
-    /// requesting or recording. The forced-fresh path is only safe from that because it passes
-    /// `cached: nil` and so can never take the fast path. Nothing in the type system enforces it,
-    /// and an obvious-looking "avoid a request" optimisation there would hand a stale fix a fresh
-    /// flag. If this test fails, that is what happened.
+    /// Pins that a failed forced request never falls back to the held fix.
+    ///
+    /// What refuses it is the timestamp comparison, NOT the `cached: nil` coupling: `resolve`'s fast
+    /// path completes synchronously without recording, so `resolved` and `priorTimestamp` are both
+    /// read from the same `latestFix` and the strict `>` can never hold. The coupling earns its
+    /// place against the opposite failure — a current system cache short-circuiting the request,
+    /// leaving that same comparison to refuse a fix that was genuinely fresh — and
+    /// `handleTransition_givenSystemCacheAlwaysCurrent_expectEnterStillDelivered` is what fails if
+    /// it is removed.
     @Test
     func handleTransition_givenFreshRequiredAndStaleHeldFix_expectNoVerdictFromIt() async {
         let setup = await makeSetup(fix: nil) // the forced request fails

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -647,11 +647,11 @@ struct PolygonMembershipResolverTests {
         let requested = Flag()
         setup.fixResolver.requestFreshFix = { requested.value = true }
 
-        async let pass: Void = setup.resolver.evaluateMembership(geofenceIds: ["1"], reason: "test")
+        async let pass: Bool = setup.resolver.evaluateMembership(geofenceIds: ["1"], reason: "test")
         await yieldUntil { requested.value }
         await setup.storage.setCachedGeofences([movedPolygonGeofence()])
         setup.fixResolver.handleResolvedFix(fix(latitude: 0, longitude: 0))
-        await pass
+        _ = await pass
 
         #expect(await setup.emitter.snapshot().isEmpty)
         #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .outside)
@@ -665,10 +665,10 @@ struct PolygonMembershipResolverTests {
         let requested = Flag()
         setup.fixResolver.requestFreshFix = { requested.value = true }
 
-        async let pass: Void = setup.resolver.evaluateMembership(geofenceIds: ["1"], reason: "test")
+        async let pass: Bool = setup.resolver.evaluateMembership(geofenceIds: ["1"], reason: "test")
         await yieldUntil { requested.value }
         setup.fixResolver.handleResolvedFix(fix(latitude: 0, longitude: 0))
-        await pass
+        _ = await pass
 
         #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
         #expect(await setup.emitter.snapshot().map(\.transition) == [.enter])
@@ -1074,5 +1074,46 @@ struct PolygonMembershipResolverTests {
 
         #expect(await setup.emitter.snapshot().isEmpty)
         #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .outside)
+    }
+
+    // MARK: - Newly registered polygons
+
+    /// The two passes a refresh starts must not disagree. `evaluatePolygonsAfterMovement` forces a
+    /// fresh fix; while this pass decided from the cached one, a single refresh could deliver an
+    /// enter from a position up to `movementFixMaxAge` old and then its own correcting exit.
+    @Test
+    func evaluateNewlyRegistered_givenCachedInsideAndFreshOutside_expectOnlyTheFreshVerdict() async {
+        let setup = await makeSetup(fix: fix(latitude: 0.01, longitude: 0.01))
+        // Held, inside, and young enough that the cached path would have accepted it.
+        setup.fixResolver.handleResolvedFix(CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            altitude: 0, horizontalAccuracy: 5, verticalAccuracy: 5,
+            timestamp: Date(timeIntervalSinceNow: -Self.ageInsideGate)
+        ))
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+
+        await setup.resolver.evaluateNewlyRegistered(geofenceIds: ["1"])
+
+        #expect(await setup.emitter.snapshot().isEmpty, "decided from the cached fix and emitted an enter")
+        #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .outside)
+    }
+
+    /// The fallback the forced request needs: enter-when-inside is owed for a polygon the device is
+    /// standing in, and the movement pass fails on the same request, so a failed request must not
+    /// cost the enter outright.
+    @Test
+    func evaluateNewlyRegistered_givenTheForcedRequestFails_expectTheCachedFixStillDecides() async {
+        let setup = await makeSetup(fix: nil) // the forced request fails
+        setup.fixResolver.handleResolvedFix(CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            altitude: 0, horizontalAccuracy: 5, verticalAccuracy: 5,
+            timestamp: Date(timeIntervalSinceNow: -Self.ageInsideGate)
+        ))
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+
+        await setup.resolver.evaluateNewlyRegistered(geofenceIds: ["1"])
+
+        #expect(await setup.emitter.snapshot().map(\.transition) == [.enter])
+        #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
     }
 }

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -358,6 +358,36 @@ struct PolygonMembershipResolverTests {
         #expect(await setup.storage.getPolygonMembership()["3"] == nil)
     }
 
+    /// The regression a simulator drive caught and no unit test could see. CoreLocation's own cache
+    /// advances on its own, so a system fix is always about as fresh as anything a request can
+    /// return. Taking the forced-fresh baseline from `cachedFix` — which reports the newest of both
+    /// sources — made that baseline unbeatable, and every polygon verdict came back "no usable fix".
+    ///
+    /// The seam is LIVE here on purpose. Every other test in this suite stubs `systemCachedFix` to
+    /// nil so it never touches CoreLocation, and that is exactly why the bug was invisible: the one
+    /// input that caused it was switched off everywhere.
+    @Test
+    func handleTransition_givenSystemCacheAlwaysCurrent_expectEnterStillDelivered() async {
+        let setup = await makeSetup(fix: fix(latitude: 0, longitude: 0))
+        // Stands in for a cache the OS keeps refreshing: every read is "now", so it is never older
+        // than the fix the request delivers.
+        setup.fixResolver.systemCachedFix = { [weak fixResolver = setup.fixResolver] in
+            _ = fixResolver
+            return CLLocation(
+                coordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0),
+                altitude: 0, horizontalAccuracy: 5, verticalAccuracy: 5, timestamp: Date()
+            )
+        }
+        await setup.storage.setCachedGeofences([polygonGeofence()])
+
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter, occurredAt: Date())
+
+        let delivered = await setup.emitter.snapshot()
+        #expect(delivered.count == 1, "verdict was refused; got \(delivered)")
+        #expect(delivered.first?.transition == .enter)
+        #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
+    }
+
     /// A wake fires BECAUSE the device moved, so the fix it already holds describes where it was.
     /// When the forced request fails, falling back to that fix re-affirms the stale verdict — the
     /// exact silent miss the fresh-fix rule exists to prevent — so no verdict must be reached.

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -251,6 +251,25 @@ struct PolygonMembershipResolverTests {
         #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
     }
 
+    /// The pass resolves ONE fix for every polygon. A per-polygon "first one pays" flag would clear
+    /// after the first evaluation even when it got no fresh fix, silently downgrading polygon two
+    /// onward to the pre-wake fix — so assert the second polygon is undecided too, not just the first.
+    @Test
+    func evaluateAllPolygons_givenFreshFixRequiredButRequestFails_expectEveryPolygonUndecided() async {
+        let setup = await makeSetup(fix: nil) // the forced request fails
+        setup.fixResolver.handleResolvedFix(fix(latitude: 0, longitude: 0)) // pre-wake fix, inside
+        await setup.storage.recordRegistration(
+            center: LocationData(latitude: 0, longitude: 0), businessIds: ["1", "3"]
+        )
+        await setup.storage.setCachedGeofences([polygonGeofence(), polygonGeofence(id: "3")])
+
+        await setup.resolver.evaluateAllPolygons(requiresFreshFix: true)
+
+        #expect(await setup.emitter.snapshot().isEmpty)
+        #expect(await setup.storage.getPolygonMembership()["1"] == nil)
+        #expect(await setup.storage.getPolygonMembership()["3"] == nil)
+    }
+
     /// A wake fires BECAUSE the device moved, so the fix it already holds describes where it was.
     /// When the forced request fails, falling back to that fix re-affirms the stale verdict — the
     /// exact silent miss the fresh-fix rule exists to prevent — so no verdict must be reached.
@@ -261,7 +280,7 @@ struct PolygonMembershipResolverTests {
         setup.fixResolver.handleResolvedFix(fix(latitude: 0, longitude: 0))
         await setup.storage.setCachedGeofences([polygonGeofence()])
 
-        await setup.resolver.handleTransition(identifier: "1", transition: .enter)
+        await setup.resolver.handleTransition(identifier: "1", transition: .enter, occurredAt: Date())
 
         #expect(await setup.emitter.snapshot().isEmpty)
         #expect(await setup.storage.getPolygonMembership()["1"] == nil)

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonWakeRadiusTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonWakeRadiusTests.swift
@@ -63,12 +63,24 @@ struct PolygonWakeRadiusTests {
         #expect(r == 1000)
     }
 
-    /// Outside every covering circle, nothing can be crossed before its own enter fires.
+    /// No boundary within the refresh radius, so there is nothing to tighten for.
     @Test
-    func radius_givenDeviceOutsideCoveringCircle_expectConfiguredRefreshRadius() {
+    func radius_givenNoBoundaryWithinRefreshRadius_expectConfiguredRefreshRadius() {
         let faraway = LocationData(latitude: 31.45, longitude: 74.17)
         let r = PolygonWakeRadius.radius(at: faraway, registeredPolygons: [polygon(id: "1")], config: config())
         #expect(r == 1000)
+    }
+
+    /// Outside the covering circle but near the ring. A covering-circle enter does not re-arm the
+    /// trigger, so if the radius ignored polygons the device has not yet reached, the device would
+    /// carry a wide trigger into the circle and across the boundary — no wake, no OS event, and an
+    /// exit over an unchanged belief on the way out, making the whole visit silent.
+    @Test
+    func radius_givenDeviceOutsideCoveringCircleButNearBoundary_expectDistanceToBoundary() {
+        // ~600 m north of centre: beyond the 500 m covering circle, ~400 m from the ring's north edge.
+        let approaching = LocationData(latitude: 31.37539, longitude: 74.17)
+        let r = PolygonWakeRadius.radius(at: approaching, registeredPolygons: [polygon(id: "1")], config: config())
+        #expect(r > 360 && r < 440, "got \(r)")
     }
 
     @Test

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonWakeRadiusTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonWakeRadiusTests.swift
@@ -1,0 +1,122 @@
+@testable import CioInternalCommon
+@testable import CioLocationGeofence
+import Foundation
+import Testing
+
+@Suite("PolygonWakeRadius")
+struct PolygonWakeRadiusTests {
+    private static let center = LocationData(latitude: 31.37, longitude: 74.17)
+
+    private func config(localRefresh: Double = 1000) -> GeofenceConfig {
+        GeofenceConfig(
+            localRefreshTriggerRadius: localRefresh,
+            remoteFetchRefreshTriggerRadius: 5000,
+            remoteFetchRefreshExpiry: 86400,
+            duplicateEventsExpiry: 3600,
+            maxBusinessGeofences: 19,
+            maxMonitoringDistance: 50000
+        )
+    }
+
+    /// ~400 m square around `center`; the venue at the middle sits ~200 m from the nearest edge.
+    private func polygon(id: String, coveringRadius: Double = 500) -> Geofence {
+        let ring = [
+            LocationData(latitude: 31.3682, longitude: 74.1679),
+            LocationData(latitude: 31.3682, longitude: 74.1721),
+            LocationData(latitude: 31.3718, longitude: 74.1721),
+            LocationData(latitude: 31.3718, longitude: 74.1679)
+        ]
+        return Geofence(
+            id: id, latitude: Self.center.latitude, longitude: Self.center.longitude,
+            radius: coveringRadius, name: id, transitionTypes: [.enter, .exit],
+            lastUpdated: Date(timeIntervalSince1970: 0), vertices: ring
+        )
+    }
+
+    /// A ~4 km square around `center`, so its boundary is far from anything the tests probe.
+    private func widePolygon(id: String) -> Geofence {
+        let ring = [
+            LocationData(latitude: 31.35, longitude: 74.15),
+            LocationData(latitude: 31.35, longitude: 74.19),
+            LocationData(latitude: 31.39, longitude: 74.19),
+            LocationData(latitude: 31.39, longitude: 74.15)
+        ]
+        return Geofence(
+            id: id, latitude: Self.center.latitude, longitude: Self.center.longitude,
+            radius: 5000, name: id, transitionTypes: [.enter, .exit],
+            lastUpdated: Date(timeIntervalSince1970: 0), vertices: ring
+        )
+    }
+
+    private func circle(id: String, radius: Double = 300) -> Geofence {
+        Geofence(
+            id: id, latitude: Self.center.latitude, longitude: Self.center.longitude,
+            radius: radius, name: id, transitionTypes: [.enter, .exit],
+            lastUpdated: Date(timeIntervalSince1970: 0), vertices: nil
+        )
+    }
+
+    /// A workspace with no polygons must behave exactly as it does today.
+    @Test
+    func radius_givenNoPolygons_expectConfiguredRefreshRadius() {
+        let r = PolygonWakeRadius.radius(at: Self.center, registeredPolygons: [circle(id: "1")], config: config())
+        #expect(r == 1000)
+    }
+
+    /// Outside every covering circle, nothing can be crossed before its own enter fires.
+    @Test
+    func radius_givenDeviceOutsideCoveringCircle_expectConfiguredRefreshRadius() {
+        let faraway = LocationData(latitude: 31.45, longitude: 74.17)
+        let r = PolygonWakeRadius.radius(at: faraway, registeredPolygons: [polygon(id: "1")], config: config())
+        #expect(r == 1000)
+    }
+
+    @Test
+    func radius_givenDeviceInsidePolygon_expectDistanceToNearestBoundary() {
+        let r = PolygonWakeRadius.radius(at: Self.center, registeredPolygons: [polygon(id: "1")], config: config())
+        // ~200 m to the nearest edge of the 400 m square.
+        #expect(r > 190 && r < 210, "got \(r)")
+    }
+
+    /// The NEAREST boundary wins: a distant polygon must not let the device walk into a close one.
+    @Test
+    func radius_givenTwoPolygons_expectNearestBoundaryWins() {
+        let near = LocationData(latitude: 31.3717, longitude: 74.17) // ~11 m inside the north edge
+        // The wide polygon's boundary is ~2 km away; the narrow one's is ~11 m. Sizing by the
+        // farthest instead of the nearest would return ~1000 m (capped) and let the device walk
+        // straight through the near boundary unwoken.
+        let wideOnly = PolygonWakeRadius.radius(at: near, registeredPolygons: [widePolygon(id: "far")], config: config())
+        #expect(wideOnly == 1000, "control: wide polygon alone should cap at config, got \(wideOnly)")
+
+        let both = PolygonWakeRadius.radius(
+            at: near, registeredPolygons: [widePolygon(id: "far"), polygon(id: "near")], config: config()
+        )
+        #expect(both == GeofenceConstants.polygonWakeMinRadius, "got \(both)")
+    }
+
+    /// The floor is what stops the trigger shrinking into the range the OS promotes unreliably.
+    @Test
+    func radius_givenBoundaryNearerThanFloor_expectFloor() {
+        let onEdge = LocationData(latitude: 31.37179, longitude: 74.17)
+        let r = PolygonWakeRadius.radius(at: onEdge, registeredPolygons: [polygon(id: "1")], config: config())
+        #expect(r == GeofenceConstants.polygonWakeMinRadius, "got \(r)")
+    }
+
+    /// Never larger than the configured refresh radius, even when the boundary is far off.
+    @Test
+    func radius_givenBoundaryBeyondRefreshRadius_expectCappedAtConfig() {
+        let r = PolygonWakeRadius.radius(
+            at: Self.center, registeredPolygons: [widePolygon(id: "1")], config: config(localRefresh: 150)
+        )
+        #expect(r == 150, "got \(r)")
+    }
+
+    /// A config below the floor cannot push the trigger into the range the OS drops.
+    @Test
+    func radius_givenConfigBelowFloor_expectFloorWins() {
+        let r = PolygonWakeRadius.radius(
+            at: Self.center, registeredPolygons: [polygon(id: "1")], config: config(localRefresh: 50)
+        )
+        #expect(r == GeofenceConstants.polygonWakeMinRadius, "got \(r)")
+    }
+}

--- a/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
+++ b/Tests/LocationGeofence/Geofence/Stub/MockGeofenceRegionMonitor.swift
@@ -237,11 +237,12 @@ final class MockGeofenceRegionMonitor: GeofenceRegionMonitoring {
         transition: GeofenceTransition,
         location: LocationData?,
         occurredAt: Date = Date(),
+        locationIsFresh: Bool = true,
         eventCircle: MonitoredCircle? = nil
     ) {
         let circle = eventCircle ?? registeredGeometry[identifier].map {
             MonitoredCircle(center: $0.center, radius: $0.radius, maximumRadius: maximumMonitoringRadius)
         }
-        onTransition?(identifier, transition, location, occurredAt, circle)
+        onTransition?(identifier, transition, location, occurredAt, locationIsFresh, circle)
     }
 }

--- a/Tests/LocationGeofence/GeofenceModuleSetupTests.swift
+++ b/Tests/LocationGeofence/GeofenceModuleSetupTests.swift
@@ -48,7 +48,7 @@ struct GeofenceModuleSetupTests {
         defer { f.cleanup() }
 
         let (refreshSignal, refreshContinuation) = AsyncStream<Void>.makeStream()
-        f.spyCoordinator.refreshClosure = { _, _ in
+        f.spyCoordinator.refreshClosure = { _, _, _ in
             refreshContinuation.yield()
             return .success(())
         }
@@ -89,7 +89,7 @@ struct GeofenceModuleSetupTests {
         defer { f.cleanup() }
 
         let (refreshSignal, refreshContinuation) = AsyncStream<(Double, Double)>.makeStream()
-        f.spyCoordinator.refreshClosure = { lat, lon in
+        f.spyCoordinator.refreshClosure = { lat, lon, _ in
             refreshContinuation.yield((lat, lon))
             return .success(())
         }
@@ -116,7 +116,7 @@ struct GeofenceModuleSetupTests {
         await f.di.geofenceStorage.recordRegistration(center: LocationData(latitude: 10, longitude: 20), businessIds: ["g1"])
 
         let (refreshSignal, refreshContinuation) = AsyncStream<(Double, Double)>.makeStream()
-        f.spyCoordinator.refreshClosure = { lat, lon in
+        f.spyCoordinator.refreshClosure = { lat, lon, _ in
             refreshContinuation.yield((lat, lon))
             return .success(())
         }
@@ -137,7 +137,7 @@ struct GeofenceModuleSetupTests {
         let f = Fixture(cachedLocation: LocationData(latitude: 7, longitude: 8), identifiedUserId: nil)
         defer { f.cleanup() }
 
-        f.spyCoordinator.refreshClosure = { _, _ in .success(()) }
+        f.spyCoordinator.refreshClosure = { _, _, _ in .success(()) }
 
         f.wire()
         // The user gate is synchronous (no Task spawned), so nothing can have run.
@@ -174,7 +174,7 @@ struct GeofenceModuleSetupTests {
         f.stub.onGetLastKnown = { readContinuation.yield() }
 
         let (refreshSignal, refreshContinuation) = AsyncStream<(Double, Double)>.makeStream()
-        f.spyCoordinator.refreshClosure = { lat, lon in
+        f.spyCoordinator.refreshClosure = { lat, lon, _ in
             refreshContinuation.yield((lat, lon))
             return .success(())
         }
@@ -210,7 +210,7 @@ struct GeofenceModuleSetupTests {
         f.stub.onGetLastKnown = { readContinuation.yield() }
 
         let (refreshSignal, refreshContinuation) = AsyncStream<(Double, Double)>.makeStream()
-        f.spyCoordinator.refreshClosure = { lat, lon in
+        f.spyCoordinator.refreshClosure = { lat, lon, _ in
             refreshContinuation.yield((lat, lon))
             return .success(())
         }
@@ -243,7 +243,7 @@ struct GeofenceModuleSetupTests {
         defer { f.cleanup() }
 
         let (refreshSignal, refreshContinuation) = AsyncStream<(Double, Double)>.makeStream()
-        f.spyCoordinator.refreshClosure = { lat, lon in
+        f.spyCoordinator.refreshClosure = { lat, lon, _ in
             refreshContinuation.yield((lat, lon))
             return .success(())
         }
@@ -274,7 +274,7 @@ struct GeofenceModuleSetupTests {
         defer { f.cleanup() }
 
         let (refreshSignal, refreshContinuation) = AsyncStream<Void>.makeStream()
-        f.spyCoordinator.refreshClosure = { _, _ in
+        f.spyCoordinator.refreshClosure = { _, _, _ in
             refreshContinuation.yield()
             return .success(())
         }

--- a/Tests/Mocks/LocationGeofence/AutoMockable.generated.swift
+++ b/Tests/Mocks/LocationGeofence/AutoMockable.generated.swift
@@ -264,14 +264,14 @@ class GeofenceSyncCoordinatorMock: @unchecked Sendable, GeofenceSyncCoordinator,
     }
 
     /// The arguments from the *last* time the function was called.
-    private let _refreshReceivedArguments: CioInternalCommon.Synchronized<(latitude: Double, longitude: Double)?> = .init(nil)
-    var refreshReceivedArguments: (latitude: Double, longitude: Double)? {
+    private let _refreshReceivedArguments: CioInternalCommon.Synchronized<(latitude: Double, longitude: Double, anchorIsLiveFix: Bool)?> = .init(nil)
+    var refreshReceivedArguments: (latitude: Double, longitude: Double, anchorIsLiveFix: Bool)? {
         _refreshReceivedArguments.wrappedValue
     }
 
     /// Arguments from *all* of the times that the function was called.
-    private let _refreshReceivedInvocations: CioInternalCommon.Synchronized<[(latitude: Double, longitude: Double)]> = .init([])
-    var refreshReceivedInvocations: [(latitude: Double, longitude: Double)] {
+    private let _refreshReceivedInvocations: CioInternalCommon.Synchronized<[(latitude: Double, longitude: Double, anchorIsLiveFix: Bool)]> = .init([])
+    var refreshReceivedInvocations: [(latitude: Double, longitude: Double, anchorIsLiveFix: Bool)] {
         _refreshReceivedInvocations.wrappedValue
     }
 
@@ -287,15 +287,15 @@ class GeofenceSyncCoordinatorMock: @unchecked Sendable, GeofenceSyncCoordinator,
      The closure has first priority to return a value for the mocked function. If the closure returns `nil`,
      then the mock will attempt to return the value for `refreshReturnValue`
      */
-    var refreshClosure: ((Double, Double) -> Result<Void, GeofenceSyncError>)?
+    var refreshClosure: ((Double, Double, Bool) -> Result<Void, GeofenceSyncError>)?
 
-    /// Mocked function for `refresh(latitude: Double, longitude: Double)`. Your opportunity to return a mocked value and check result of mock in test code.
-    func refresh(latitude: Double, longitude: Double) -> Result<Void, GeofenceSyncError> {
+    /// Mocked function for `refresh(latitude: Double, longitude: Double, anchorIsLiveFix: Bool)`. Your opportunity to return a mocked value and check result of mock in test code.
+    func refresh(latitude: Double, longitude: Double, anchorIsLiveFix: Bool) -> Result<Void, GeofenceSyncError> {
         mockCalled = true
         _refreshCallsCount += 1
-        _refreshReceivedArguments.wrappedValue = (latitude: latitude, longitude: longitude)
-        _refreshReceivedInvocations.append((latitude: latitude, longitude: longitude))
-        return refreshClosure.map { $0(latitude, longitude) } ?? refreshReturnValue
+        _refreshReceivedArguments.wrappedValue = (latitude: latitude, longitude: longitude, anchorIsLiveFix: anchorIsLiveFix)
+        _refreshReceivedInvocations.append((latitude: latitude, longitude: longitude, anchorIsLiveFix: anchorIsLiveFix))
+        return refreshClosure.map { $0(latitude, longitude, anchorIsLiveFix) } ?? refreshReturnValue
     }
 
     // MARK: - handleMovement

--- a/Tests/Mocks/LocationGeofence/AutoMockable.generated.swift
+++ b/Tests/Mocks/LocationGeofence/AutoMockable.generated.swift
@@ -312,14 +312,14 @@ class GeofenceSyncCoordinatorMock: @unchecked Sendable, GeofenceSyncCoordinator,
     }
 
     /// The arguments from the *last* time the function was called.
-    private let _handleMovementReceivedArguments: CioInternalCommon.Synchronized<(latitude: Double, longitude: Double)?> = .init(nil)
-    var handleMovementReceivedArguments: (latitude: Double, longitude: Double)? {
+    private let _handleMovementReceivedArguments: CioInternalCommon.Synchronized<(latitude: Double, longitude: Double, anchorIsLiveFix: Bool)?> = .init(nil)
+    var handleMovementReceivedArguments: (latitude: Double, longitude: Double, anchorIsLiveFix: Bool)? {
         _handleMovementReceivedArguments.wrappedValue
     }
 
     /// Arguments from *all* of the times that the function was called.
-    private let _handleMovementReceivedInvocations: CioInternalCommon.Synchronized<[(latitude: Double, longitude: Double)]> = .init([])
-    var handleMovementReceivedInvocations: [(latitude: Double, longitude: Double)] {
+    private let _handleMovementReceivedInvocations: CioInternalCommon.Synchronized<[(latitude: Double, longitude: Double, anchorIsLiveFix: Bool)]> = .init([])
+    var handleMovementReceivedInvocations: [(latitude: Double, longitude: Double, anchorIsLiveFix: Bool)] {
         _handleMovementReceivedInvocations.wrappedValue
     }
 
@@ -335,15 +335,15 @@ class GeofenceSyncCoordinatorMock: @unchecked Sendable, GeofenceSyncCoordinator,
      The closure has first priority to return a value for the mocked function. If the closure returns `nil`,
      then the mock will attempt to return the value for `handleMovementReturnValue`
      */
-    var handleMovementClosure: ((Double, Double) -> Result<Void, GeofenceSyncError>)?
+    var handleMovementClosure: ((Double, Double, Bool) -> Result<Void, GeofenceSyncError>)?
 
-    /// Mocked function for `handleMovement(latitude: Double, longitude: Double)`. Your opportunity to return a mocked value and check result of mock in test code.
-    func handleMovement(latitude: Double, longitude: Double) -> Result<Void, GeofenceSyncError> {
+    /// Mocked function for `handleMovement(latitude: Double, longitude: Double, anchorIsLiveFix: Bool)`. Your opportunity to return a mocked value and check result of mock in test code.
+    func handleMovement(latitude: Double, longitude: Double, anchorIsLiveFix: Bool) -> Result<Void, GeofenceSyncError> {
         mockCalled = true
         _handleMovementCallsCount += 1
-        _handleMovementReceivedArguments.wrappedValue = (latitude: latitude, longitude: longitude)
-        _handleMovementReceivedInvocations.append((latitude: latitude, longitude: longitude))
-        return handleMovementClosure.map { $0(latitude, longitude) } ?? handleMovementReturnValue
+        _handleMovementReceivedArguments.wrappedValue = (latitude: latitude, longitude: longitude, anchorIsLiveFix: anchorIsLiveFix)
+        _handleMovementReceivedInvocations.append((latitude: latitude, longitude: longitude, anchorIsLiveFix: anchorIsLiveFix))
+        return handleMovementClosure.map { $0(latitude, longitude, anchorIsLiveFix) } ?? handleMovementReturnValue
     }
 
     // MARK: - reset


### PR DESCRIPTION
Part of [MBL-2291](https://linear.app/customerio/issue/MBL-2291)

Replaces #1247 and #1248 (both closed). Approach proposed by @mahmoud in review.

Drops the per-polygon tripwire. The single movement trigger is sized dynamically instead:

```
r = max(100, min(localRefreshTriggerRadius,
                 nearest boundary among polygons whose covering circle contains the device))
```

One region instead of one per active polygon, so `maxBusinessGeofences` is honoured exactly — 5 active polygons used to register 14 business fences against a stated 19. No polygon nearby means the old radius, so circle-only workspaces are unchanged.

A trigger sized to a boundary fires far more often than the re-rank radius, so movements inside that radius take a cheap pass: re-arm the wake, re-evaluate membership, nothing else. It must not `recordRegistration` — that would move the anchor re-ranking is measured from and re-ranking would never come due.

**Evidence.** Simulator, iOS 26.5, v2 mock, driven past a circle control, a polygon crossed through the interior, and a polygon whose covering circle the route enters but whose polygon it misses by 200 m: **exactly 4 events** — control enter/exit, interior enter/exit, annulus silent. Same as the tripwire design with one region instead of three. Registration model v9: 106,822 cases, 0 violations, 4 negative controls all biting.

**The circle is sized from any nearby boundary, not only from one the device already stands inside.** A covering-circle enter does not re-arm the trigger, so a device that entered a circle while still inside a wide trigger would carry that trigger across the polygon boundary — no OS event, no wake, and an exit over an unchanged `outside` belief on the way out. The whole visit silent rather than late, and worse the larger the annulus.

**Cost of that, stated plainly.** `r = max(100, min(cfg, d))` means at most one wake per 100 m travelled, so wakes/km run 1 at d >= 1000, 2 at d = 500, and 10 at the floor. Because the circle is centred on the DEVICE, that rate applies to travel in every direction once any boundary is within ~100 m — including travel directly away from the fence — where before it applied only inside a covering circle. A stationary device produces none, r regrows as the device leaves, and the min picks the nearest boundary so 10/km is the ceiling however many polygons are registered. The 100 m floor is now the sole bound on that whole band.

**A boundary-sized circle needs an anchor that is the device.** The launch and identify refresh anchor on the stored registration centre, and a movement pass whose fresh-fix request fails completes with the cached fix that prompted it. Provenance is therefore reported by the resolver and travels with the transition, rather than being inferred from which caller it is; only a held fix gets the tight radius. A 100 m circle around a stale point is one the device may already be outside — a spurious cycle on 17+, and on the classic path a trigger that never fires.

**Residual, stated because the classic path will have to close it.** "Held fix" means no older than `movementFixMaxAge` (30 s), which is the definition of not-stale everywhere else — but it is not "the device is here": at speed that anchor is a few hundred metres old against a 100 m floor. On 17+ the cost is one spurious re-arm cycle that self-corrects. Sizing the radius against the fix's own age needs an assumed-speed constant, so it belongs with the ≤17 work rather than here; the chosen radius is logged beside the fix's age so a drive can tell a spurious cycle from a real one.

**Known limit, unchanged from the tripwire design:** a boundary nearer than the 100 m floor can be crossed before the wake fires. Below that the OS promotes crossings too unreliably for the wake to exist, so it is late rather than lost.

A wake fires *because* the device moved, so the fix it already holds describes where it was — answering from it re-affirms the old verdict and swallows the crossing (measured: a 26 s fix at 20 m/s is 520 m stale). Later commits close the four ways that still leaked: a wake no longer skips behind any pass already in flight, because nothing retries behind a wake — though what the second wake gains is an answer, not a fix of its own: its request coalesces onto the one in flight, so if that fails both end undecided; a forced-fresh request that fails no longer falls back to the held fix; the pass resolves **one** fix up front rather than clearing a per-polygon flag that a failed first request would leave off for every polygon after it; and a pass that requires a fresh fix acts on the resolver's own report of whether it answered from a delivered one, rather than inferring it from timestamps against a cache that advances on its own. Once the resolver has delivered anything, each later wake must beat it. On the FIRST pass of a process there is nothing to beat, and CoreLocation may echo its cached fix as a new manager's first delivery — so a cold wake is bounded by age alone, the same `movementFixMaxAge` the verdict gate already applies. Tightening that needs an assumed-speed constant and belongs with the ≤17 work; a test pins the current behaviour so it cannot change silently.

Also adds the verdict log line that made the original defect visible.

**The movement pass carries the user boundary.** It checked identity once before awaiting the
forced-fresh fix — the longest suspension in the feature — and the polygon set is read before that.
It now supplies the `isStillCurrent` the resolver re-checks after the fix and again before the emit.

The refetch branch re-evaluates registered polygons too. The local re-rank and the cheap wake pass already did; the refetch is taken on the largest movements of all, so a crossing made during that move was only caught for polygons the refetch happened to add.

513/513 `LocationGeofenceTests` pass on iOS 26. The simulator drive above was re-run three times on the final commit: 2 circle events, 2 polygon events, annulus silent, every time.

The foreground pass moved to `PolygonMembershipResolver+Foreground.swift` to stay under the
SwiftLint file cap. No behaviour change; three resolver members widened `private` → `internal`,
and nothing outside the two resolver files references them.

Three of these tests stamped their fix at `now - 20 s` against a 30 s age cap checked when the fix
is DELIVERED, leaving a 10 s wall-clock budget — enough for a loaded runner to overrun. One did go
red on #1262, as a 15 s timeout rather than an undecided verdict; the other two would have started
passing on the age gate instead of on the behaviour they pin. All three now use one named constant
at 5 s.

Two comments in the same file named the wrong mechanism and are corrected here: the age cap's
binding check is at delivery, not at the decision, and `givenFreshRequiredAndStaleHeldFix` pins the
no-fallback rule rather than the `cached: nil` coupling it claimed — that coupling is pinned by
`givenSystemCacheAlwaysCurrent_expectEnterStillDelivered`.

**Bugbot follow-up.** A refresh starts two passes: `evaluatePolygonsAfterMovement` forces a fresh
fix, while the newly-registered pass decided from the cached one, which is accepted up to
`movementFixMaxAge` old. With a cached fix inside and a fresh one outside, one refresh delivered an
enter and then its own correcting exit. Both passes now force a fresh fix and share the coalesced
request; the cached fix stays only as the fallback for a failed request, where it cannot contradict
anything because the movement pass has failed too and its verdict is older evidence than any later
fresh one.

Stack: #1239 (merged) → #1240 (merged) → #1244 (merged) → #1245 → #1246 → #1249 → **this** → #1259 → #1262.

















