### PR TITLE
feat(inbox): replace visual inbox empty-state text with a dimmed bell

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
+++ b/Apps/APN-UIKit/APN UIKit/AppDelegate.swift
@@ -97,16 +97,35 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 .build()
         )
         MessagingInApp
-            .initialize(withConfig: MessagingInAppConfigBuilder(
-                siteId: settings.inApp.siteId,
-                region: settings.inApp.region.toCIORegion()
-            ).build())
+            .initialize(
+                withConfig: MessagingInAppConfigBuilder(
+                    siteId: settings.inApp.siteId,
+                    region: settings.inApp.region.toCIORegion()
+                )
+                .setNotificationInboxAccessibilityLabels(Self.inboxAccessibilityLabels)
+                .build()
+            )
             .setEventListener(self)
 
         // Visual Notification Inbox action listener. Observational here (logs each callback and
         // returns `false` so the SDK runs its default action handling). A host that wants to
         // intercept an action returns `true` from `messageActionTaken`.
         MessagingInApp.shared.setInboxEventListener(inboxEventListener)
+    }
+
+    /// VoiceOver labels for the Visual Notification Inbox. The SDK ships none of its own, so no English
+    /// leaks into a localized app; the host supplies them in its language. `bellWithUnreadCount` is a
+    /// closure so the app can apply its own plural rules. A real app would read these from
+    /// `Localizable.strings` rather than hardcoding them.
+    private static var inboxAccessibilityLabels: NotificationInboxAccessibilityLabels {
+        NotificationInboxAccessibilityLabels(
+            bell: "Notifications",
+            bellWithUnreadCount: { count in
+                count == 1 ? "Notifications, 1 unread" : "Notifications, \(count) unread"
+            },
+            loadingIndicator: "Loading inbox",
+            emptyState: "No notifications"
+        )
     }
 
     // Register Live Activities as an SDK-managed module. It initializes during

--- a/Sources/MessagingInApp/Config/MessagingInAppConfigBuilder.swift
+++ b/Sources/MessagingInApp/Config/MessagingInAppConfigBuilder.swift
@@ -19,6 +19,7 @@ public class MessagingInAppConfigBuilder {
     private let siteId: String
     private let region: Region
     private var colorScheme: ColorScheme = .auto
+    private var notificationInboxAccessibilityLabels = NotificationInboxAccessibilityLabels()
 
     /// Initializes new `MessagingInAppConfigBuilder` with required configuration options.
     /// - Parameters:
@@ -35,12 +36,23 @@ public class MessagingInAppConfigBuilder {
         return self
     }
 
+    /// Sets the VoiceOver labels for the Visual Notification Inbox UI (bell, unread badge, loading and
+    /// empty states). The SDK ships no default labels, so provide these in your app's language if you
+    /// want the inbox to be announced by assistive technologies.
+    /// See ``NotificationInboxAccessibilityLabels``.
+    @discardableResult
+    public func setNotificationInboxAccessibilityLabels(_ labels: NotificationInboxAccessibilityLabels) -> MessagingInAppConfigBuilder {
+        notificationInboxAccessibilityLabels = labels
+        return self
+    }
+
     /// Builds and returns `MessagingInAppConfigOptions` instance from the configured properties.
     public func build() -> MessagingInAppConfigOptions {
         MessagingInAppConfigOptions(
             siteId: siteId,
             region: region,
-            colorScheme: colorScheme
+            colorScheme: colorScheme,
+            notificationInboxAccessibilityLabels: notificationInboxAccessibilityLabels
         )
     }
 }
@@ -56,6 +68,17 @@ public extension MessagingInAppConfigBuilder {
     private enum Keys: String {
         case siteId
         case region
+        case notificationInboxAccessibilityLabels
+    }
+
+    /// Keys of the `notificationInboxAccessibilityLabels` sub-dictionary. `bellWithUnreadCount` is a
+    /// template string carrying a `{count}` placeholder, because wrapper SDK configuration crosses a
+    /// bridge that carries data but not closures.
+    private enum LabelKeys: String {
+        case bell
+        case bellWithUnreadCount
+        case loadingIndicator
+        case emptyState
     }
 
     /// Constructs `MessagingInAppConfigOptions` by parsing and applying configurations from provided dictionary.
@@ -90,6 +113,16 @@ public extension MessagingInAppConfigBuilder {
             case "dark": builder.setColorScheme(.dark)
             default: builder.setColorScheme(.auto)
             }
+        }
+
+        if let labels = config[Keys.notificationInboxAccessibilityLabels.rawValue] as? [String: Any] {
+            builder.setNotificationInboxAccessibilityLabels(NotificationInboxAccessibilityLabels(
+                bell: labels[LabelKeys.bell.rawValue] as? String,
+                bellWithUnreadCount: (labels[LabelKeys.bellWithUnreadCount.rawValue] as? String)
+                    .map(NotificationInboxAccessibilityLabels.unreadCountTemplate),
+                loadingIndicator: labels[LabelKeys.loadingIndicator.rawValue] as? String,
+                emptyState: labels[LabelKeys.emptyState.rawValue] as? String
+            ))
         }
 
         return builder.build()

--- a/Sources/MessagingInApp/Config/MessagingInAppConfigOptions.swift
+++ b/Sources/MessagingInApp/Config/MessagingInAppConfigOptions.swift
@@ -7,4 +7,7 @@ public struct MessagingInAppConfigOptions {
     public let siteId: String
     public let region: Region
     public let colorScheme: ColorScheme
+    /// Host-provided VoiceOver labels for the Visual Notification Inbox UI. All nil by default (the SDK
+    /// emits no strings of its own). See ``NotificationInboxAccessibilityLabels``.
+    public let notificationInboxAccessibilityLabels: NotificationInboxAccessibilityLabels
 }

--- a/Sources/MessagingInApp/Config/NotificationInboxAccessibilityLabels.swift
+++ b/Sources/MessagingInApp/Config/NotificationInboxAccessibilityLabels.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Host-provided accessibility (VoiceOver) labels for the Visual Notification Inbox UI —
+/// ``NotificationInboxView``, ``NotificationInboxBell`` and ``NotificationInboxOverlay``.
+///
+/// The SDK ships **no** text of its own in the visual inbox: the empty state is an icon and the loading
+/// state is the system spinner, so nothing on screen needs translating. Accessibility labels are the
+/// one place a string is still needed, and because the SDK cannot know the host app's language, every
+/// label is optional and **nil by default**. A nil label emits no accessibility label for that element:
+/// the empty-state icon is hidden from VoiceOver, the loading spinner is not focusable, and the bell
+/// stays focusable and tappable but unnamed (hiding it would leave VoiceOver users no way into the
+/// inbox). Provide values in whatever language your app ships in — typically from your own
+/// `Localizable.strings`.
+///
+/// ## Usage
+/// ```swift
+/// MessagingInAppConfigBuilder(siteId: siteId, region: .US)
+///     .setNotificationInboxAccessibilityLabels(NotificationInboxAccessibilityLabels(
+///         bell: NSLocalizedString("inbox.bell", comment: ""),
+///         bellWithUnreadCount: { count in
+///             String.localizedStringWithFormat(NSLocalizedString("inbox.unread_count", comment: ""), count)
+///         },
+///         loadingIndicator: NSLocalizedString("inbox.loading", comment: ""),
+///         emptyState: NSLocalizedString("inbox.empty", comment: "")
+///     ))
+///     .build()
+/// ```
+///
+/// Threading: `bellWithUnreadCount` is invoked on the main thread while the bell renders, each time the
+/// unread count changes. Keep it cheap and side-effect free.
+public struct NotificationInboxAccessibilityLabels {
+    /// Label for the inbox bell button. Also used when the bell shows an unread badge but
+    /// `bellWithUnreadCount` is not provided. nil → the bell is announced as an unnamed button.
+    public let bell: String?
+
+    /// Builds the bell's label when it shows an unread badge, given the unread count. A closure (not a
+    /// template) so hosts can apply their language's plural rules. nil → falls back to `bell`.
+    ///
+    /// The badge itself is always hidden from VoiceOver, so the count is announced only through this
+    /// label — never as bare digits appended to the button.
+    public let bellWithUnreadCount: ((Int) -> String)?
+
+    /// Label announced for the loading spinner. nil → the spinner is not an accessibility element.
+    public let loadingIndicator: String?
+
+    /// Label announced for the empty-state icon. nil → the icon is hidden from assistive technologies.
+    public let emptyState: String?
+
+    public init(
+        bell: String? = nil,
+        bellWithUnreadCount: ((Int) -> String)? = nil,
+        loadingIndicator: String? = nil,
+        emptyState: String? = nil
+    ) {
+        self.bell = bell
+        self.bellWithUnreadCount = bellWithUnreadCount
+        self.loadingIndicator = loadingIndicator
+        self.emptyState = emptyState
+    }
+
+    /// Placeholder replaced by the unread count in ``unreadCountTemplate(_:)``.
+    ///
+    /// Internal: it exists only for the wrapper SDKs, whose configuration crosses a bridge that carries
+    /// data but not closures. Native hosts pass a closure and never need this.
+    static let countPlaceholder = "{count}"
+
+    /// Builds a `bellWithUnreadCount` closure from a template string containing ``countPlaceholder``,
+    /// e.g. `"{count} unread notifications"`. Used by the wrapper-configuration path in
+    /// ``MessagingInAppConfigBuilder/build(from:)``; a template without the placeholder is returned
+    /// verbatim for every count.
+    static func unreadCountTemplate(_ template: String) -> (Int) -> String {
+        { count in template.replacingOccurrences(of: countPlaceholder, with: String(count)) }
+    }
+}

--- a/Sources/MessagingInApp/Inbox/Data/VisualInboxSPI.swift
+++ b/Sources/MessagingInApp/Inbox/Data/VisualInboxSPI.swift
@@ -57,6 +57,12 @@ public protocol VisualInboxProvider: Sendable {
     /// branding. Nil when no branding is cached; individual fields are nil when not configured.
     func brandingChrome() async -> VisualInboxChrome?
 
+    /// Host-configured VoiceOver labels for the inbox UI (`MessagingInAppConfigBuilder
+    /// .setNotificationInboxAccessibilityLabels`). All-nil when the host configured none: the UI then
+    /// emits no accessibility strings of its own. Synchronous — it is module config, not repository
+    /// state — and read per render so late SDK initialization is still picked up.
+    func accessibilityLabels() -> NotificationInboxAccessibilityLabels
+
     /// Marks a message opened via the existing headless plumbing (no new mutation path). Looked up
     /// by the snapshot id so the overlay never has to hold an internal `InboxMessage`.
     /// - Returns: `true` if a matching message was still present in the store and the mark was
@@ -114,6 +120,10 @@ final class VisualInboxProviderImpl: VisualInboxProvider, @unchecked Sendable {
         self.repository = repository
         self.inbox = inbox
         self.inAppMessageManager = inAppMessageManager
+    }
+
+    func accessibilityLabels() -> NotificationInboxAccessibilityLabels {
+        MessagingInAppImplementation.currentNotificationInboxAccessibilityLabels
     }
 
     func load() async {

--- a/Sources/MessagingInApp/MessagingInAppImplementation.swift
+++ b/Sources/MessagingInApp/MessagingInAppImplementation.swift
@@ -8,6 +8,12 @@ class MessagingInAppImplementation: MessagingInAppInstance {
     // for subscribers; this static provides the immediate value for rendering.
     @Atomic static var currentColorScheme: ColorScheme = .auto
 
+    /// Host-configured Visual Inbox accessibility labels, published for the inbox UI module (via the
+    /// `VisualInboxProvider` SPI) the same way `currentColorScheme` is: the UI module has no access to
+    /// this module's config instance, only to the shared DI graph. Read at render time rather than
+    /// captured, so inbox UI constructed before `initialize(withConfig:)` still sees the host's labels.
+    @Atomic static var currentNotificationInboxAccessibilityLabels = NotificationInboxAccessibilityLabels()
+
     private let moduleConfig: MessagingInAppConfigOptions
 
     private let logger: Logger
@@ -27,6 +33,7 @@ class MessagingInAppImplementation: MessagingInAppInstance {
         self.notificationInbox = diGraph.notificationInbox
 
         Self.currentColorScheme = moduleConfig.colorScheme
+        Self.currentNotificationInboxAccessibilityLabels = moduleConfig.notificationInboxAccessibilityLabels
         subscribeToInAppMessageState()
     }
 

--- a/Sources/MessagingInbox/InboxBellGlyphView.swift
+++ b/Sources/MessagingInbox/InboxBellGlyphView.swift
@@ -1,0 +1,55 @@
+import Foundation
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// The inbox bell glyph, shared by the bell button and the empty state so both draw identical art.
+///
+/// Renders the workspace's branding SVG (`patterns.inbox.floatingIcon.svg`, pre-parsed once by
+/// ``VisualInboxModel`` into an ``InboxBellGlyph``) when present, otherwise the bundled default bell
+/// asset. Both are tinted with `tint`. Purely decorative: callers attach any accessibility label.
+@available(iOS 13.0, *)
+struct InboxBellGlyphView: View {
+    let glyph: InboxBellGlyph?
+    let tint: Color
+
+    var body: some View {
+        if let glyph {
+            // Fill each <path> INDEPENDENTLY (like the browser) with its OWN declared fill rule so
+            // overlapping paths don't flip each other's winding parity (MBL-2123). Uniform tint → the
+            // stack reads as one glyph.
+            ZStack {
+                ForEach(Array(glyph.subpaths.enumerated()), id: \.offset) { _, subpath in
+                    InboxBellIcon(subpath: subpath.path, viewBox: glyph.viewBox)
+                        .fill(tint, style: FillStyle(eoFill: subpath.usesEvenOddFill))
+                }
+            }
+        } else {
+            // `decorative:` matters for accessibility, not just rendering: `Image(_:bundle:)` labels
+            // itself with its asset name, and an unlabeled bell button derives its own label from its
+            // children — so the plain initializer makes VoiceOver announce "cio-inbox-bell" whenever
+            // the host configures no labels and branding supplies no SVG. Decorative keeps the glyph
+            // out of the accessibility tree, leaving the button unnamed as intended.
+            Image(decorative: "cio-inbox-bell", bundle: .cioInboxResources)
+                .renderingMode(.template)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .foregroundColor(tint)
+        }
+    }
+}
+
+@available(iOS 13.0, *)
+extension View {
+    /// Applies a host-configured accessibility label, or leaves the view unlabeled when the host
+    /// provided none. The SDK never falls back to English copy of its own.
+    /// `.accessibility(label:)` is the iOS 13-safe form; `.accessibilityLabel` is iOS 14+.
+    @ViewBuilder
+    func inboxAccessibilityLabel(_ label: String?) -> some View {
+        if let label {
+            accessibility(label: Text(label))
+        } else {
+            self
+        }
+    }
+}
+#endif

--- a/Sources/MessagingInbox/NotificationInboxBell.swift
+++ b/Sources/MessagingInbox/NotificationInboxBell.swift
@@ -80,9 +80,18 @@ struct InboxBellView: View {
         // visible badge and the accessibility label key off this, so VoiceOver never announces a count
         // the workspace chose to hide.
         let showsUnreadCount = model.unopenedCount > 0 && (model.chrome?.showUnreadBadge ?? true)
+        // The SDK ships no strings of its own: the label comes from the host's
+        // `NotificationInboxAccessibilityLabels` — the count-aware closure while the badge shows
+        // (falling back to the plain bell label), the plain bell label otherwise, or none at all when
+        // unconfigured, leaving an unnamed-but-reachable button. VoiceOver never announces a count the
+        // workspace chose to hide, because `showsUnreadCount` gates both.
+        let labels = model.accessibilityLabels
+        let accessibilityLabel = showsUnreadCount
+            ? labels.bellWithUnreadCount?(model.unopenedCount) ?? labels.bell
+            : labels.bell
         return Button(action: onTap, label: {
             ZStack(alignment: .topTrailing) {
-                bellGlyph(colors: colors)
+                InboxBellGlyphView(glyph: model.bellGlyph, tint: colors.bellIcon)
                     .frame(width: 26, height: 26)
                     .frame(width: 56, height: 56)
                     .background(colors.bellBackground)
@@ -104,35 +113,15 @@ struct InboxBellView: View {
                         .background(colors.badge)
                         .clipShape(Capsule())
                         .offset(x: 4, y: -4)
+                        // The badge is decorative: a button folds its children's text into its own
+                        // label, so leaving the digits visible to VoiceOver would append a bare number
+                        // to an otherwise unnamed bell. The count reaches VoiceOver only through the
+                        // host's `bellWithUnreadCount` label.
+                        .accessibility(hidden: true)
                 }
             }
         })
-        // `.accessibility(label:)` is the iOS 13-safe form; `.accessibilityLabel` is iOS 14+.
-        .accessibility(label: Text(showsUnreadCount ? "Notifications, \(model.unopenedCount) unread" : "Notifications"))
-    }
-
-    /// The bell glyph: the workspace's branding SVG (`floatingIcon.svg`) when present and parseable
-    /// (pre-built once by the model), otherwise the bundled default bell asset. Both are tinted with
-    /// the branding glyph color.
-    @ViewBuilder
-    private func bellGlyph(colors: ResolvedInboxColors) -> some View {
-        if let glyph = model.bellGlyph {
-            // Fill each <path> INDEPENDENTLY (like the browser) with its OWN declared fill rule so
-            // overlapping paths don't flip each other's winding parity (MBL-2123). Uniform tint → the
-            // stack reads as one glyph.
-            ZStack {
-                ForEach(Array(glyph.subpaths.enumerated()), id: \.offset) { _, subpath in
-                    InboxBellIcon(subpath: subpath.path, viewBox: glyph.viewBox)
-                        .fill(colors.bellIcon, style: FillStyle(eoFill: subpath.usesEvenOddFill))
-                }
-            }
-        } else {
-            Image("cio-inbox-bell", bundle: .cioInboxResources)
-                .renderingMode(.template)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .foregroundColor(colors.bellIcon)
-        }
+        .inboxAccessibilityLabel(accessibilityLabel)
     }
 }
 

--- a/Sources/MessagingInbox/NotificationInboxView.swift
+++ b/Sources/MessagingInbox/NotificationInboxView.swift
@@ -10,8 +10,9 @@ import UIKit
 ///
 /// Embed it directly in a host screen (a sheet, a tab, a dedicated inbox screen) to render the
 /// inbox's messages natively via **Jist** from the server-provided templates + branding theme. It
-/// shows a loading spinner while fetching, an empty "all caught up" state when there are no messages,
-/// and the rendered list otherwise.
+/// shows a loading spinner while fetching, a dimmed inbox bell when there are no messages, and the
+/// rendered list otherwise. Neither state contains text, so nothing needs localizing; VoiceOver labels
+/// come from the host via `MessagingInAppConfigBuilder.setNotificationInboxAccessibilityLabels`.
 ///
 /// Behavior preserved from ``NotificationInboxOverlay``: tap-to-dismiss (web parity), relative dates,
 /// no-template skip, host action callback + default navigation, mark-opened, and shown reporting.
@@ -123,7 +124,7 @@ struct InboxListView: View {
     }
 
     /// Panel body driven by load state: nothing when the inbox is hidden, spinner while loading,
-    /// empty placeholder when visible-but-empty, otherwise the Jist-rendered list.
+    /// dimmed bell when visible-but-empty, otherwise the Jist-rendered list.
     @ViewBuilder
     private var content: some View {
         if case .hidden = model.state {
@@ -135,11 +136,17 @@ struct InboxListView: View {
             // Genuinely caught up: visible with NO messages at all. Keyed off the full message list
             // (not `renderableMessages`) so messages that merely lack a template don't read as
             // "caught up". (When embedded standalone; the overlay hides chrome entirely in that case.)
+            // Rendered as the workspace's own bell, dimmed — no text: the SDK cannot know the host's
+            // language, and a faint glyph reads as "nothing here" without words. The alpha is
+            // deliberate: fainter reads as a rendering failure, stronger reads as a tappable control.
+            // Decorative for VoiceOver unless the host supplied an `emptyState` label.
             VStack {
                 Spacer()
-                Text("You're all caught up")
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
+                InboxBellGlyphView(glyph: model.bellGlyph, tint: .secondary)
+                    .frame(width: Self.emptyStateGlyphSize, height: Self.emptyStateGlyphSize)
+                    .opacity(Self.emptyStateGlyphOpacity)
+                    .accessibility(hidden: model.accessibilityLabels.emptyState == nil)
+                    .inboxAccessibilityLabel(model.accessibilityLabels.emptyState)
                 Spacer()
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -149,7 +156,7 @@ struct InboxListView: View {
             // this view is public on iOS 13.
             VStack {
                 Spacer()
-                InboxLoadingSpinner()
+                InboxLoadingSpinner(accessibilityLabel: model.accessibilityLabels.loadingIndicator)
                 Spacer()
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -161,6 +168,10 @@ struct InboxListView: View {
     /// Top inset above the first message row so it doesn't hug the sheet grabber (MBL-2122), matching
     /// the comfortable top margin of the web inbox. Single, easily-tunable value.
     private static let listTopInset: CGFloat = 16
+
+    /// Empty-state bell size and dimming. Kept in sync with the Android inbox (50dp, 0.22 alpha).
+    private static let emptyStateGlyphSize: CGFloat = 50
+    private static let emptyStateGlyphOpacity: Double = 0.22
 
     private var messageList: some View {
         // Branding-first row divider (falls back to the system separator color).
@@ -280,14 +291,31 @@ struct InboxListView: View {
 
 /// iOS 13-compatible loading spinner. SwiftUI's `ProgressView` is iOS 14+, but ``NotificationInboxView``
 /// is public on iOS 13, so the loading state wraps UIKit's `UIActivityIndicatorView` instead.
+///
+/// `accessibilityLabel` is the host-configured `loadingIndicator` label. When nil the spinner is not an
+/// accessibility element at all, so VoiceOver skips it rather than focusing an unnamed control.
 @available(iOS 13.0, *)
 private struct InboxLoadingSpinner: UIViewRepresentable {
+    let accessibilityLabel: String?
+
     func makeUIView(context: Context) -> UIActivityIndicatorView {
         let indicator = UIActivityIndicatorView(style: .medium)
         indicator.startAnimating()
+        apply(to: indicator)
         return indicator
     }
 
-    func updateUIView(_ uiView: UIActivityIndicatorView, context: Context) {}
+    func updateUIView(_ uiView: UIActivityIndicatorView, context: Context) {
+        apply(to: uiView)
+    }
+
+    private func apply(to indicator: UIActivityIndicatorView) {
+        // Assigning a label alone does not make a `UIView` an accessibility element, so the flag has to
+        // be set explicitly — and cleared again when the host supplies no label, so VoiceOver never
+        // focuses a nameless spinner.
+        indicator.isAccessibilityElement = accessibilityLabel != nil
+        indicator.accessibilityLabel = accessibilityLabel
+        indicator.accessibilityTraits = accessibilityLabel == nil ? .none : .updatesFrequently
+    }
 }
 #endif

--- a/Sources/MessagingInbox/VisualInboxModel.swift
+++ b/Sources/MessagingInbox/VisualInboxModel.swift
@@ -53,6 +53,14 @@ final class VisualInboxModel: ObservableObject {
 
     private let provider: VisualInboxProvider
 
+    /// Host-configured VoiceOver labels (all nil unless the host set them). Computed rather than
+    /// captured at init: a SwiftUI view can be constructed before `MessagingInApp.initialize` runs, and
+    /// a captured value would pin the empty defaults for the lifetime of the model. Reading module
+    /// config is cheap enough to do per render.
+    var accessibilityLabels: NotificationInboxAccessibilityLabels {
+        provider.accessibilityLabels()
+    }
+
     /// SDK logger for [CIO-Inbox] diagnostics (e.g. the no-template skip in item 4).
     private let logger: Logger = DIGraphShared.shared.logger
 

--- a/Tests/MessagingInApp/APITest.swift
+++ b/Tests/MessagingInApp/APITest.swift
@@ -30,6 +30,13 @@ class MessagingInAppAPITest: UnitTest {
         try skipRunningTest()
 
         _ = MessagingInAppConfigBuilder(siteId: "", region: .US)
+            .setColorScheme(.auto)
+            .setNotificationInboxAccessibilityLabels(NotificationInboxAccessibilityLabels(
+                bell: "",
+                bellWithUnreadCount: { count in "\(count)" },
+                loadingIndicator: "",
+                emptyState: ""
+            ))
             .build()
 
         let configOptions: [String: Any] = [:]

--- a/Tests/MessagingInApp/Config/MessagingInAppConfigBuilderTest.swift
+++ b/Tests/MessagingInApp/Config/MessagingInAppConfigBuilderTest.swift
@@ -14,6 +14,87 @@ class MessagingInAppConfigBuilderTest: UnitTest {
         XCTAssertEqual(config.region, givenRegion)
     }
 
+    func test_build_givenNoNotificationInboxAccessibilityLabels_expectAllNil() {
+        let config = MessagingInAppConfigBuilder(siteId: String.random, region: .US).build()
+
+        XCTAssertNil(config.notificationInboxAccessibilityLabels.bell)
+        XCTAssertNil(config.notificationInboxAccessibilityLabels.bellWithUnreadCount)
+        XCTAssertNil(config.notificationInboxAccessibilityLabels.loadingIndicator)
+        XCTAssertNil(config.notificationInboxAccessibilityLabels.emptyState)
+    }
+
+    func test_setNotificationInboxAccessibilityLabels_expectLabelsOnConfig() {
+        let config = MessagingInAppConfigBuilder(siteId: String.random, region: .US)
+            .setNotificationInboxAccessibilityLabels(NotificationInboxAccessibilityLabels(
+                bell: "Aviseringar",
+                bellWithUnreadCount: { count in count == 1 ? "1 oläst avisering" : "\(count) olästa aviseringar" },
+                loadingIndicator: "Laddar",
+                emptyState: "Inga aviseringar"
+            ))
+            .build()
+
+        XCTAssertEqual(config.notificationInboxAccessibilityLabels.bell, "Aviseringar")
+        XCTAssertEqual(config.notificationInboxAccessibilityLabels.bellWithUnreadCount?(1), "1 oläst avisering")
+        XCTAssertEqual(config.notificationInboxAccessibilityLabels.bellWithUnreadCount?(4), "4 olästa aviseringar")
+        XCTAssertEqual(config.notificationInboxAccessibilityLabels.loadingIndicator, "Laddar")
+        XCTAssertEqual(config.notificationInboxAccessibilityLabels.emptyState, "Inga aviseringar")
+    }
+
+    func test_initializeFromDictionaryWithNotificationInboxAccessibilityLabels_expectLabelsAndTemplate() throws {
+        let givenDict: [String: Any] = [
+            "inApp": [
+                "siteId": String.random,
+                "notificationInboxAccessibilityLabels": [
+                    "bell": "Aviseringar",
+                    "bellWithUnreadCount": "{count} olästa aviseringar",
+                    "loadingIndicator": "Laddar",
+                    "emptyState": "Inga aviseringar"
+                ]
+            ]
+        ]
+
+        let config = try XCTUnwrap(MessagingInAppConfigBuilder.build(from: givenDict))
+
+        XCTAssertEqual(config.notificationInboxAccessibilityLabels.bell, "Aviseringar")
+        XCTAssertEqual(config.notificationInboxAccessibilityLabels.bellWithUnreadCount?(2), "2 olästa aviseringar")
+        XCTAssertEqual(config.notificationInboxAccessibilityLabels.loadingIndicator, "Laddar")
+        XCTAssertEqual(config.notificationInboxAccessibilityLabels.emptyState, "Inga aviseringar")
+    }
+
+    func test_initializeFromDictionaryWithPartialNotificationInboxAccessibilityLabels_expectMissingAndNonStringNil() throws {
+        let givenDict: [String: Any] = [
+            "inApp": [
+                "siteId": String.random,
+                "notificationInboxAccessibilityLabels": [
+                    "emptyState": "Inga aviseringar",
+                    "bell": 42
+                ]
+            ]
+        ]
+
+        let config = try XCTUnwrap(MessagingInAppConfigBuilder.build(from: givenDict))
+
+        XCTAssertNil(config.notificationInboxAccessibilityLabels.bell)
+        XCTAssertNil(config.notificationInboxAccessibilityLabels.bellWithUnreadCount)
+        XCTAssertNil(config.notificationInboxAccessibilityLabels.loadingIndicator)
+        XCTAssertEqual(config.notificationInboxAccessibilityLabels.emptyState, "Inga aviseringar")
+    }
+
+    func test_initializeFromDictionaryWithoutNotificationInboxAccessibilityLabels_expectAllNil() throws {
+        let givenDict: [String: Any] = [
+            "inApp": [
+                "siteId": String.random
+            ]
+        ]
+
+        let config = try XCTUnwrap(MessagingInAppConfigBuilder.build(from: givenDict))
+
+        XCTAssertNil(config.notificationInboxAccessibilityLabels.bell)
+        XCTAssertNil(config.notificationInboxAccessibilityLabels.bellWithUnreadCount)
+        XCTAssertNil(config.notificationInboxAccessibilityLabels.loadingIndicator)
+        XCTAssertNil(config.notificationInboxAccessibilityLabels.emptyState)
+    }
+
     func test_initializeFromDictionaryWithCustomValues_expectCorrectValues() {
         let givenSiteId = String.random
         let givenRegion = "EU"

--- a/Tests/MessagingInApp/Config/NotificationInboxAccessibilityLabelsTest.swift
+++ b/Tests/MessagingInApp/Config/NotificationInboxAccessibilityLabelsTest.swift
@@ -1,0 +1,33 @@
+@testable import CioMessagingInApp
+import SharedTests
+import XCTest
+
+class NotificationInboxAccessibilityLabelsTest: UnitTest {
+    func test_init_givenNoArguments_expectAllLabelsNil() {
+        let labels = NotificationInboxAccessibilityLabels()
+
+        XCTAssertNil(labels.bell)
+        XCTAssertNil(labels.bellWithUnreadCount)
+        XCTAssertNil(labels.loadingIndicator)
+        XCTAssertNil(labels.emptyState)
+    }
+
+    func test_unreadCountTemplate_givenPlaceholder_expectCountSubstituted() {
+        let label = NotificationInboxAccessibilityLabels.unreadCountTemplate("{count} olästa aviseringar")
+
+        XCTAssertEqual(label(3), "3 olästa aviseringar")
+        XCTAssertEqual(label(12), "12 olästa aviseringar")
+    }
+
+    func test_unreadCountTemplate_givenMultiplePlaceholders_expectAllSubstituted() {
+        let label = NotificationInboxAccessibilityLabels.unreadCountTemplate("{count} / {count}")
+
+        XCTAssertEqual(label(7), "7 / 7")
+    }
+
+    func test_unreadCountTemplate_givenNoPlaceholder_expectTemplateVerbatim() {
+        let label = NotificationInboxAccessibilityLabels.unreadCountTemplate("Unread notifications")
+
+        XCTAssertEqual(label(5), "Unread notifications")
+    }
+}

--- a/Tests/MessagingInbox/VisualInboxModelTests.swift
+++ b/Tests/MessagingInbox/VisualInboxModelTests.swift
@@ -33,6 +33,25 @@ final class VisualInboxModelTests: XCTestCase {
         XCTAssertEqual(model.state, .visible(messageCount: 3))
     }
 
+    func test_accessibilityLabels_readsProviderAtAccessTime_notAtInit() {
+        let provider = FakeVisualInboxProvider()
+        let model = VisualInboxModel(provider: provider)
+
+        // Nothing configured when the model was constructed: the inbox stays unlabeled.
+        XCTAssertNil(model.accessibilityLabels.bell)
+
+        // Host initializes the SDK after the view was built — the labels must still be picked up.
+        provider.stubAccessibilityLabels = NotificationInboxAccessibilityLabels(
+            bell: "Aviseringar",
+            emptyState: "Inga aviseringar"
+        )
+
+        XCTAssertEqual(model.accessibilityLabels.bell, "Aviseringar")
+        XCTAssertEqual(model.accessibilityLabels.emptyState, "Inga aviseringar")
+        XCTAssertNil(model.accessibilityLabels.loadingIndicator)
+        XCTAssertNil(model.accessibilityLabels.bellWithUnreadCount)
+    }
+
     func test_refresh_whenProviderHidden_thenStateIsHidden() async {
         let provider = FakeVisualInboxProvider()
         provider.stubState = .hidden(reason: "no selected messages")
@@ -547,6 +566,13 @@ private final class FakeVisualInboxProvider: VisualInboxProvider, @unchecked Sen
     var initialSnapshot: VisualInboxSnapshot?
     private var observeContinuation: AsyncStream<VisualInboxSnapshot>.Continuation?
     private let observeLock = NSLock()
+
+    /// Labels the fake reports as module config; all-nil by default like production without host config.
+    var stubAccessibilityLabels = NotificationInboxAccessibilityLabels()
+
+    func accessibilityLabels() -> NotificationInboxAccessibilityLabels {
+        stubAccessibilityLabels
+    }
 
     func load() async {}
 

--- a/api-docs/CioMessagingInApp.api
+++ b/api-docs/CioMessagingInApp.api
@@ -169,6 +169,7 @@ public final class CioMessagingInApp.MessagingInApp {
 public final class CioMessagingInApp.MessagingInAppConfigBuilder {
 	public fun init(siteId: String, region: Region);
 	public fun func setColorScheme(_ colorScheme: ColorScheme) -> MessagingInAppConfigBuilder;
+	public fun func setNotificationInboxAccessibilityLabels(_ labels: NotificationInboxAccessibilityLabels) -> MessagingInAppConfigBuilder;
 	public fun func build() -> MessagingInAppConfigOptions;
 }
 public enum CioMessagingInApp.MessagingInAppConfigBuilderError {
@@ -177,6 +178,7 @@ public final class CioMessagingInApp.MessagingInAppConfigOptions {
 	public final val siteId: String;
 	public final val region: Region;
 	public final val colorScheme: ColorScheme;
+	public final val notificationInboxAccessibilityLabels: NotificationInboxAccessibilityLabels;
 }
 public interface CioMessagingInApp.MessagingInAppInstance {
 	public var inbox: any NotificationInbox;
@@ -203,6 +205,13 @@ public interface CioMessagingInApp.NotificationInbox {
 	public fun func notifyMessageActionTaken(message: InboxMessage, actionValue: String, actionName: String) -> Boolean;
 	public fun func notifyMessageShown(message: InboxMessage);
 	public fun func messages(topic: String?) -> AsyncStream<List<InboxMessage>>;
+}
+public final class CioMessagingInApp.NotificationInboxAccessibilityLabels {
+	public final val bell: String?;
+	public final val bellWithUnreadCount: ((Int) -> String)?;
+	public final val loadingIndicator: String?;
+	public final val emptyState: String?;
+	public fun init(bell: String? = nil, bellWithUnreadCount: ((Int) -> String)? = nil, loadingIndicator: String? = nil, emptyState: String? = nil);
 }
 public interface CioMessagingInApp.NotificationInboxChangeListener {
 	public fun func onMessagesChanged(messages: List<InboxMessage>);
@@ -251,6 +260,7 @@ public interface CioMessagingInApp.VisualInboxProvider {
 	public fun func templatesJSON() async -> List<String: Any>?;
 	public fun func themeJSON() async -> List<String: Any>?;
 	public fun func brandingChrome() async -> VisualInboxChrome?;
+	public fun func accessibilityLabels() -> NotificationInboxAccessibilityLabels;
 	public fun func markOpened(messageId: String) async -> Boolean;
 	public fun func dismiss(messageId: String) async -> Boolean;
 	public fun func handleMessageAction(messageId: String, actionName: String, actionValue: String) async -> VisualInboxActionOutcome;


### PR DESCRIPTION
Removes the Visual Notification Inbox's hardcoded English copy and accessibility labels: the empty state becomes the workspace's own bell glyph (dimmed, no text), and host apps supply any accessibility labels themselves via `InboxAccessibilityLabels` on the in-app module config.

Pairs with customerio/customerio-android#834.

🤖 Generated with [Claude Code](https://claude.com/claude-code)