### PR TITLE
chore(geofence): record the fetched fence catalog, and stamp each log file with its own header

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/Diagnostics/DiagnosticLog.swift
+++ b/Apps/APN-UIKit/APN UIKit/Diagnostics/DiagnosticLog.swift
@@ -66,7 +66,7 @@ final class DiagnosticLog: @unchecked Sendable {
         startMono = DiagnosticClock.monotonicNanos()
 
         // The SDK's diagnostic tail is enabled by the CIOGeofenceDiagnostics Info.plist key.
-        writer.open(header: fileHeaderLine())
+        writer.open { [weak self] in self?.fileHeaderLine() ?? "" }
         deviceState.start(onChange: makeDeviceStateHandler())
         installDispatcher()
 

--- a/Apps/APN-UIKit/APN UIKit/Diagnostics/DiagnosticLog.swift
+++ b/Apps/APN-UIKit/APN UIKit/Diagnostics/DiagnosticLog.swift
@@ -66,7 +66,7 @@ final class DiagnosticLog: @unchecked Sendable {
         startMono = DiagnosticClock.monotonicNanos()
 
         // The SDK's diagnostic tail is enabled by the CIOGeofenceDiagnostics Info.plist key.
-        writer.open { [weak self] in self?.fileHeaderLine() ?? "" }
+        openWriter()
         deviceState.start(onChange: makeDeviceStateHandler())
         installDispatcher()
 
@@ -78,6 +78,16 @@ final class DiagnosticLog: @unchecked Sendable {
                 + "ev=session.start io=obs schema=\(DiagnosticLogSchema.version) "
                 + "dir=\(DiagnosticLog.directory.lastPathComponent)"
         )
+    }
+
+    /// `nonisolated` for the same reason as `installDispatcher` below: the writer calls this
+    /// closure from `openCurrentFile`, which runs on whichever thread emitted the record that
+    /// rotated the file — never guaranteed to be main. Formed inside `@MainActor start()` the
+    /// closure would inherit that isolation and hard-trap under Swift 6 on the first day rollover
+    /// that happens off the main thread. Nothing it reads is main-actor state, so hoisting it here
+    /// costs nothing and matches the fix already applied to the dispatcher.
+    private nonisolated func openWriter() {
+        writer.open { [weak self] in self?.fileHeaderLine() ?? "" }
     }
 
     /// `nonisolated` on purpose: a closure formed inside a `@MainActor` method inherits that
@@ -153,7 +163,8 @@ final class DiagnosticLog: @unchecked Sendable {
 
     /// First line of every file. `boot` matters: `mono` values are only comparable to each other
     /// within a single boot, so a file that does not name its boot cannot be aligned with another.
-    private func fileHeaderLine() -> String {
+    /// `nonisolated`: called from the writer's thread on every file rotation, not just at start.
+    private nonisolated func fileHeaderLine() -> String {
         let bundle = Bundle.main
         let appVersion = bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
         let appBuild = bundle.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"

--- a/Apps/APN-UIKit/APN UIKit/Diagnostics/DiagnosticLogWriter.swift
+++ b/Apps/APN-UIKit/APN UIKit/Diagnostics/DiagnosticLogWriter.swift
@@ -14,7 +14,10 @@ final class DiagnosticLogWriter: @unchecked Sendable {
     private let lock = NSLock()
 
     private var fd: Int32 = -1
-    private var header = ""
+    /// Rebuilt on every open, not stored as a string. The header describes the file it heads: a
+    /// process that outlives a day rolls to a new file, and re-writing the original string there
+    /// stamped it with the old session's timestamp — and the old timezone.
+    private var headerProvider: (() -> String)?
     private var currentPath = ""
     /// Counts records since the last check that the file we hold open still exists.
     private var writesSinceExistenceCheck = 0
@@ -48,10 +51,10 @@ final class DiagnosticLogWriter: @unchecked Sendable {
 
     // MARK: - Opening
 
-    func open(header: String) {
+    func open(headerProvider: @escaping () -> String) {
         lock.lock()
         defer { lock.unlock() }
-        self.header = header
+        self.headerProvider = headerProvider
         openCurrentFile(now: Date())
     }
 
@@ -105,6 +108,7 @@ final class DiagnosticLogWriter: @unchecked Sendable {
         // The header repeats on every open, not just on a new file. A same-day relaunch reuses
         // the file but restarts the monotonic clock and may carry a different build, so without
         // this every record after the first process is correlated to the wrong session.
+        let header = headerProvider?() ?? ""
         if !header.isEmpty { write(header) }
     }
 

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+InitialEnter.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+InitialEnter.swift
@@ -30,12 +30,16 @@ extension GeofenceSyncCoordinatorImpl {
         guard !newInside.isEmpty else { return }
         // Deliver off the refresh gate (like the binder does for real crossings) so a slow send can't
         // stall the next refresh; `trackTransition` persists first, so an interrupted send is retried.
-        Task { [transitionEmitter, contextStore] in
+        Task { [transitionEmitter, contextStore, logger] in
             for region in newInside {
                 // Re-check per iteration: the diff was computed for `expectedUserId`, and each awaited
                 // send can span a sign-out/switch that the tracker would otherwise stamp to whoever is
                 // current — so stop the batch the moment identity changes.
                 guard contextStore.currentUserId == expectedUserId else { return }
+                // Marked before the emit: downstream this is an ordinary crossing, so without a
+                // record here nothing distinguishes an enter the SDK invented from one the person
+                // drove through.
+                logger.geofenceTransitionSynthesized(geofenceId: region.id, transition: .enter)
                 await transitionEmitter.trackTransition(geofenceId: region.id, transition: .enter)
             }
         }

--- a/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
+++ b/Sources/LocationGeofence/Coordinator/GeofenceSyncCoordinator+Refresh.swift
@@ -24,7 +24,7 @@ extension GeofenceSyncCoordinatorImpl {
             response = value
             // The count off the wire, before local filtering — the difference between what the
             // server offered and what survived ranking is the thing worth being able to see.
-            logger.geofenceApiFetchResult(returnedCount: value.geofences.count, elapsed: fetchElapsed)
+            logger.geofenceApiFetchResult(returnedCount: value.geofences.count, elapsed: fetchElapsed, regions: value.geofences)
         case .failure(let error):
             logger.geofenceSyncFetchFailed(error: error)
             return .failure(.fetchFailed(error))

--- a/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
@@ -206,9 +206,12 @@ final class GeofenceEventTracker: @unchecked Sendable {
 
         if success {
             _ = await pendingStore.remove(key: metric.key)
-            logger.geofenceEventTracked(geofenceId: effective.geofenceId, transition: effective.transition)
+            logger.geofenceDeliverySent(geofenceId: effective.geofenceId, transition: effective.transition, via: "http")
+        } else {
+            // Row stays for the next flush. Logged rather than left silent: an accepted crossing
+            // still in the queue and one the SDK never saw are the same absence otherwise.
+            logger.geofenceDeliveryFailed(geofenceId: effective.geofenceId, transition: effective.transition, retry: true)
         }
-        // HTTP failure: row stays for next flush.
     }
 
     /// Replay via EventBus → DataPipeline, which then owns delivery and retry. We drop our copy
@@ -251,7 +254,7 @@ final class GeofenceEventTracker: @unchecked Sendable {
             geosetId: metric.geosetId,
             metadata: metric.metadata
         ))
-        logger.geofenceEventTracked(geofenceId: metric.geofenceId, transition: metric.transition)
+        logger.geofenceDeliveryQueued(geofenceId: metric.geofenceId, transition: metric.transition, via: "event_bus")
     }
 }
 

--- a/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
@@ -193,24 +193,22 @@ final class GeofenceEventTracker: @unchecked Sendable {
 
         let effective = await resolvingLiveValues(metric)
 
-        let success = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+        // The error is carried out, not collapsed to a Bool: `delivery.failed` reports why, and
+        // whether retrying can help, which a Bool cannot express.
+        let outcome = await withCheckedContinuation { (continuation: CheckedContinuation<Result<Void, BackgroundDeliveryHttpError>, Never>) in
             deliveryTracker.trackMetric(metric: effective, userId: effective.userId) { result in
-                switch result {
-                case .success:
-                    continuation.resume(returning: true)
-                case .failure:
-                    continuation.resume(returning: false)
-                }
+                continuation.resume(returning: result)
             }
         }
 
-        if success {
+        switch outcome {
+        case .success:
             _ = await pendingStore.remove(key: metric.key)
             logger.geofenceDeliverySent(geofenceId: effective.geofenceId, transition: effective.transition, via: "http")
-        } else {
+        case .failure(let error):
             // Row stays for the next flush. Logged rather than left silent: an accepted crossing
             // still in the queue and one the SDK never saw are the same absence otherwise.
-            logger.geofenceDeliveryFailed(geofenceId: effective.geofenceId, transition: effective.transition, retry: true)
+            logger.geofenceDeliveryFailed(geofenceId: effective.geofenceId, transition: effective.transition, error: error)
         }
     }
 

--- a/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
@@ -136,6 +136,10 @@ final class GeofenceEventTracker: @unchecked Sendable {
             await storage.releaseCooldown(key: cooldownKey)
             return []
         }
+        // The crossing is now the SDK's responsibility and will be retried until it lands, so this
+        // is the point a replay can assert on. Logged before delivery is attempted: everything
+        // after this depends on the network.
+        logger.geofenceTransitionAccepted(geofenceId: geofenceId, transition: transition, rows: metrics.count)
 
         // Hold a background-task assertion across delivery so the OS doesn't suspend us mid-send when
         // it woke us only briefly for the transition. Deliver concurrently so N geosets don't

--- a/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
@@ -136,9 +136,10 @@ final class GeofenceEventTracker: @unchecked Sendable {
             await storage.releaseCooldown(key: cooldownKey)
             return []
         }
-        // The crossing is now the SDK's responsibility and will be retried until it lands, so this
-        // is the point a replay can assert on. Logged before delivery is attempted: everything
-        // after this depends on the network.
+        // The SDK has accepted the crossing and written it down; that is the fact replay asserts
+        // on, and it is complete here. What happens to the row afterwards is delivery's business
+        // and is reported by the `delivery.*` family — this record deliberately promises nothing
+        // about it.
         logger.geofenceTransitionAccepted(geofenceId: geofenceId, transition: transition, rows: metrics.count)
 
         // Hold a background-task assertion across delivery so the OS doesn't suspend us mid-send when
@@ -193,8 +194,8 @@ final class GeofenceEventTracker: @unchecked Sendable {
 
         let effective = await resolvingLiveValues(metric)
 
-        // The error is carried out, not collapsed to a Bool: `delivery.failed` reports why, and
-        // whether retrying can help, which a Bool cannot express.
+        // The error is carried out, not collapsed to a Bool, so `delivery.failed` can report a
+        // reason — an offline device and a misconfigured one are otherwise identical in the log.
         let outcome = await withCheckedContinuation { (continuation: CheckedContinuation<Result<Void, BackgroundDeliveryHttpError>, Never>) in
             deliveryTracker.trackMetric(metric: effective, userId: effective.userId) { result in
                 continuation.resume(returning: result)

--- a/Sources/LocationGeofence/GeofenceLogTail.swift
+++ b/Sources/LocationGeofence/GeofenceLogTail.swift
@@ -87,7 +87,7 @@ enum GeofenceLog {
 
     /// The only values that compose the format's separators on purpose. Everything else is an
     /// untrusted token — region identifiers are workspace-authored and can hold anything.
-    private static let composedKeys: Set<String> = ["ranked", "evicted", "ids"]
+    private static let composedKeys: Set<String> = ["ranked", "evicted", "ids", "gs", "tt"]
 
     /// Applied to every finished value. Only whitespace, which is what separates one `key=value`
     /// from the next — the value's own structure is already the caller's business.

--- a/Sources/LocationGeofence/GeofenceLogTail.swift
+++ b/Sources/LocationGeofence/GeofenceLogTail.swift
@@ -264,3 +264,20 @@ extension Logger {
         GeofenceLog.tail(ev, io, fields())
     }
 }
+
+/// Diagnostic vocabulary for the monitor's dedup decision. Lives with the rest of the tail
+/// rather than on the storage type: the token is a log contract, and `GeofenceStorage` is already
+/// at the module's file-length limit.
+extension GeofenceMonitorEventOutcome {
+    /// Stable token for the diagnostic tail. Without it every suppression here is indistinguishable
+    /// from the others — and from the OS never having delivered anything at all.
+    var diagnosticReason: String? {
+        switch self {
+        case .deliver: return nil
+        case .suppressedNoChange: return "no_state_change"
+        case .suppressedFilteredType: return "transition_type_not_registered"
+        case .suppressedNoBaseline: return "baseline_established"
+        case .suppressedNewerBaseline: return "newer_baseline"
+        }
+    }
+}

--- a/Sources/LocationGeofence/GeofenceLogTail.swift
+++ b/Sources/LocationGeofence/GeofenceLogTail.swift
@@ -46,7 +46,7 @@ private final class DiagnosticsGate: @unchecked Sendable {
 /// is gated.
 ///
 /// ```
-/// [Geofence] Tracked enter event for geofence notl_core || ev=transition.emitted io=out id=notl_core t=enter
+/// [Geofence] Accepted enter for geofence notl_core, queued 1 row(s) || ev=transition.accepted io=out id=notl_core t=enter n=1
 /// ```
 enum GeofenceLog {
     /// A parser splits on the **last** occurrence, and only if the remainder is all `key=value`.

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -120,7 +120,11 @@ extension Logger {
 
     /// Outcome of a nearby-geofence fetch. Classified as an **input**: replay feeds the response
     /// back rather than re-issuing the request.
-    func geofenceApiFetchResult(returnedCount: Int, elapsed: TimeInterval?) {
+    func geofenceApiFetchResult(
+        returnedCount: Int,
+        elapsed: TimeInterval?,
+        regions: [GeofenceApiRegion] = []
+    ) {
         debug(
             "Fetched \(returnedCount) nearby geofence(s) from the server"
                 + geofenceTail("api.fetch.result", .input, [
@@ -130,6 +134,37 @@ extension Logger {
                 ]),
             geofenceTag
         )
+        geofenceFenceCatalog(regions)
+    }
+
+    /// One record per fetched fence, describing the circle the server sent.
+    ///
+    /// Without it a capture names fences only by opaque id: a replay cannot place them, and nobody
+    /// reading the log can tell which geoset a crossing belonged to. Re-fetching the geometry from
+    /// the workspace later is not equivalent — fences move, so a drive replayed months on would
+    /// silently run against today's circles, and a capture from a customer has no workspace to ask.
+    ///
+    /// Gated whole rather than gated-tail: these records carry no prose worth emitting on their
+    /// own, so with diagnostics off they must not exist at all.
+    private func geofenceFenceCatalog(_ regions: [GeofenceApiRegion]) {
+        guard !regions.isEmpty, GeofenceDiagnostics.isEnabled else { return }
+        for region in regions {
+            debug(
+                "Geofence '\(region.id)' catalogued"
+                    + geofenceTail("fence.cataloged", .input, [
+                        ("id", region.id),
+                        // Sanitized like any other value: a workspace-authored name can contain
+                        // spaces, commas and `=`, all of which would break the parser's split.
+                        ("name", region.name),
+                        ("gs", GeofenceLog.list(region.geosetIds ?? [])),
+                        ("lat", GeofenceLog.num(region.latitude, 5)),
+                        ("lon", GeofenceLog.num(region.longitude, 5)),
+                        ("rad", GeofenceLog.num(region.radius, 0)),
+                        ("tt", GeofenceLog.list(region.transitionTypes ?? []))
+                    ]),
+                geofenceTag
+            )
+        }
     }
 
     /// Prose reports what was *requested* and reads exactly as it did before this instrumentation

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -39,17 +39,6 @@ enum GeofenceLaunchReason: String {
 extension Logger {
     // MARK: - Event tracking
 
-    func geofenceEventTracked(geofenceId: String, transition: GeofenceTransition) {
-        debug(
-            "Tracked \(transition.rawValue) event for geofence \(geofenceId)"
-                + geofenceTail("transition.emitted", .output, [
-                    ("id", geofenceId),
-                    ("t", transition.rawValue)
-                ]),
-            geofenceTag
-        )
-    }
-
     func geofenceEventSuppressed(geofenceId: String, transition: GeofenceTransition, cooldownRemaining: TimeInterval? = nil) {
         debug(
             "Suppressed duplicate \(transition.rawValue) event for geofence \(geofenceId), within cooldown"

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -298,34 +298,6 @@ extension Logger {
         )
     }
 
-    // MARK: - Baseline healing and contradiction
-
-    func geofenceBaselineHealed(identifier: String, transition: GeofenceTransition) {
-        info(
-            "Synthesized \(transition.rawValue) for region \(identifier): fresh fix contradicts stored baseline (OS never delivered the crossing)"
-                + geofenceTail("baseline.healed", .output, [
-                    ("id", identifier),
-                    ("t", transition.rawValue)
-                ]),
-            geofenceTag
-        )
-    }
-
-    func geofenceEventRefusedByContradiction(identifier: String, transition: GeofenceTransition, distanceFromCenter: Double, radius: Double, accuracy: Double) {
-        info(
-            "Refused OS \(transition.rawValue) for region \(identifier): a fresh fix contradicts it (distance \(Int(distanceFromCenter)) m, radius \(Int(radius)) m, accuracy \(Int(accuracy)) m)"
-                + geofenceTail("contradiction.refused", .output, [
-                    ("id", identifier),
-                    ("t", transition.rawValue),
-                    ("dist", GeofenceLog.num(distanceFromCenter, 0)),
-                    ("rad", GeofenceLog.num(radius, 0)),
-                    ("edge", GeofenceLog.num(max(0, distanceFromCenter - radius), 0)),
-                    ("acc", GeofenceLog.num(accuracy))
-                ]),
-            geofenceTag
-        )
-    }
-
     // MARK: - Module state
 
     func geofenceSyncSupersededByUserChange() {

--- a/Sources/LocationGeofence/Logger+GeofenceDecision.swift
+++ b/Sources/LocationGeofence/Logger+GeofenceDecision.swift
@@ -1,0 +1,106 @@
+import CioInternalCommon
+import Foundation
+
+private let geofenceTag = "Geofence"
+
+// MARK: - Crossing decisions
+
+//
+// What the SDK concluded about a crossing, as opposed to what the OS handed it (`os.callback.*`)
+// or what happened to the event afterwards (`delivery.*`). This family is what replay asserts on.
+//
+// `transition.accepted` and `transition.synthesized` are shared with Android verbatim — same key,
+// same fields, same reason tokens — so one parser reads both. `baseline.refused` is iOS-only:
+// Android has no baseline heal, so there is nothing on that side to match.
+//
+// Grouped by meaning rather than by whichever file had room, which is how `transition.accepted`
+// ended up next to the permission records in the first place.
+
+extension Logger {
+    /// The SDK accepted a crossing and durably queued it — the decision replay asserts on.
+    ///
+    /// Distinct from the `delivery.*` family, which fires only once the row leaves. Neither of
+    /// those says the SDK judged the crossing real, and on an offline device they can trail it by
+    /// many minutes or never arrive, which makes them useless as a signal about geofencing. This
+    /// record makes no claim about what happens to the row next.
+    /// A field drive showed exactly that — one crossing surfaced 26 minutes late and another,
+    /// accepted and persisted, produced no positive record at all.
+    ///
+    /// `n` is the row count: one per geoset the fence belongs to, so a fan-out is visible as one
+    /// acceptance rather than inferred from the delivery records that follow.
+    func geofenceTransitionAccepted(geofenceId: String, transition: GeofenceTransition, rows: Int) {
+        debug(
+            "Accepted \(transition.rawValue) for geofence \(geofenceId), queued \(rows) row(s)"
+                + geofenceTail("transition.accepted", .output, [
+                    ("id", geofenceId),
+                    ("t", transition.rawValue),
+                    ("n", GeofenceLog.int(rows))
+                ]),
+            geofenceTag
+        )
+    }
+
+    func geofenceBaselineHealed(identifier: String, transition: GeofenceTransition) {
+        info(
+            "Synthesized \(transition.rawValue) for region \(identifier): fresh fix contradicts stored baseline (OS never delivered the crossing)"
+                + geofenceTail("baseline.healed", .output, [
+                    ("id", identifier),
+                    ("t", transition.rawValue)
+                ]),
+            geofenceTag
+        )
+    }
+
+    func geofenceEventRefusedByContradiction(identifier: String, transition: GeofenceTransition, distanceFromCenter: Double, radius: Double, accuracy: Double) {
+        info(
+            "Refused OS \(transition.rawValue) for region \(identifier): a fresh fix contradicts it (distance \(Int(distanceFromCenter)) m, radius \(Int(radius)) m, accuracy \(Int(accuracy)) m)"
+                + geofenceTail("contradiction.refused", .output, [
+                    ("id", identifier),
+                    ("t", transition.rawValue),
+                    ("dist", GeofenceLog.num(distanceFromCenter, 0)),
+                    ("rad", GeofenceLog.num(radius, 0)),
+                    ("edge", GeofenceLog.num(max(0, distanceFromCenter - radius), 0)),
+                    ("acc", GeofenceLog.num(accuracy))
+                ]),
+            geofenceTag
+        )
+    }
+
+    /// A heal decided a crossing was real and the dedup baseline refused it.
+    ///
+    /// `io=out` and its own key, deliberately not `os.callback.dropped`: nothing arrived from the
+    /// OS here. A heal synthesizes the transition from a fix, so reporting it as a dropped callback
+    /// invents an OS delivery that never happened and inflates the received-vs-dropped count —
+    /// the count that distinguishes "the OS never reported it" from "we discarded it", which is
+    /// the question a paired drive exists to answer.
+    func geofenceBaselineRefused(identifier: String, transition: GeofenceTransition, reason: String) {
+        debug(
+            "Baseline heal for region \(identifier) refused: \(reason)"
+                + geofenceTail("baseline.refused", .output, [
+                    ("id", identifier),
+                    ("t", transition.rawValue),
+                    ("why", reason)
+                ]),
+            geofenceTag
+        )
+    }
+
+    /// An ENTER the SDK invented because the device was already inside a newly-registered fence.
+    ///
+    /// Without it a synthesized enter is indistinguishable from a real crossing in the log — the
+    /// 2026-09-07 drive opened with exactly this, and only the surrounding context revealed it.
+    /// Matches the Android record of the same name and reason token so one parser reads both —
+    /// including hardcoding the reason rather than taking it as a parameter, so the prose and the
+    /// `why` token cannot drift apart at a second call site.
+    func geofenceTransitionSynthesized(geofenceId: String, transition: GeofenceTransition) {
+        debug(
+            "Geofence '\(geofenceId)': device already inside a newly-registered fence — synthesizing \(transition.rawValue)"
+                + geofenceTail("transition.synthesized", .output, [
+                    ("id", geofenceId),
+                    ("t", transition.rawValue),
+                    ("why", "initial_enter_inside")
+                ]),
+            geofenceTag
+        )
+    }
+}

--- a/Sources/LocationGeofence/Logger+GeofenceDelivery.swift
+++ b/Sources/LocationGeofence/Logger+GeofenceDelivery.swift
@@ -51,19 +51,18 @@ extension Logger {
     /// Previously silent, which is what made an offline drive unreadable: a crossing the SDK had
     /// accepted and was retrying was indistinguishable from one it never saw.
     ///
-    /// `why` and `retry` both come from the error, because without them an offline device and a
-    /// revoked API key produce byte-identical records — and the Android record of this name has
-    /// always carried `why`.
+    /// Reports `why` and nothing more. An earlier version also carried a `retry` flag; it was
+    /// wrong on the commonest path (a default-config cold wake has no persisted key and recovers
+    /// on the next foreground flush) and it meant something different from the Android field of
+    /// the same name. Delivery is out of the harness's scope either way, so the honest record is
+    /// what happened, not a prediction about what happens next.
     func geofenceDeliveryFailed(geofenceId: String, transition: GeofenceTransition, error: BackgroundDeliveryHttpError) {
-        let retry = error.isRetryable
         debug(
-            "Geofence '\(geofenceId)' \(transition.rawValue): delivery failed (\(error.diagnosticReason)); "
-                + (retry ? "row stays queued for the next flush" : "retrying cannot help")
+            "Geofence '\(geofenceId)' \(transition.rawValue): delivery failed (\(error.diagnosticReason)); row stays queued"
                 + geofenceTail("delivery.failed", .output, [
                     ("id", geofenceId),
                     ("t", transition.rawValue),
                     ("ok", GeofenceLog.bool(false)),
-                    ("retry", GeofenceLog.bool(retry)),
                     ("why", error.diagnosticReason)
                 ]),
             geofenceTag
@@ -72,29 +71,20 @@ extension Logger {
 }
 
 extension BackgroundDeliveryHttpError {
-    /// Stable token for the tail. Mirrors the Android `why` vocabulary on `delivery.failed`.
+    /// Stable token for the tail, so a reader can tell an offline device from a misconfigured one.
+    ///
+    /// Deliberately not paired with a retryable/permanent verdict: the SDK re-attempts every queued
+    /// row on every flush regardless, so any such flag would describe a theory rather than the
+    /// SDK's behaviour.
     var diagnosticReason: String {
         switch self {
         case .missingApiHost: return "missing_api_host"
         case .missingCdpApiKey: return "missing_cdp_api_key"
         case .invalidRequest: return "invalid_request"
         case .transport: return "transport"
-        case .http(let statusCode): return "http_\(statusCode)"
-        }
-    }
-
-    /// Whether another attempt with the same row and config could ever succeed.
-    ///
-    /// A missing host or key, a malformed request, and a 4xx other than 408/429 fail identically
-    /// forever. Reporting those as retryable made a permanent misconfiguration read as flaky
-    /// network — the two need different responses from whoever reads the log.
-    var isRetryable: Bool {
-        switch self {
-        case .transport: return true
-        case .missingApiHost, .missingCdpApiKey, .invalidRequest: return false
-        case .http(let statusCode):
-            if statusCode == 408 || statusCode == 429 { return true }
-            return !(400 ..< 500).contains(statusCode)
+        // `BackgroundDeliveryHttpClient` synthesizes 0 when there was no response at all, which is
+        // not a status a server ever sent.
+        case .http(let statusCode): return statusCode == 0 ? "no_response" : "http_\(statusCode)"
         }
     }
 }

--- a/Sources/LocationGeofence/Logger+GeofenceDelivery.swift
+++ b/Sources/LocationGeofence/Logger+GeofenceDelivery.swift
@@ -50,17 +50,51 @@ extension Logger {
     ///
     /// Previously silent, which is what made an offline drive unreadable: a crossing the SDK had
     /// accepted and was retrying was indistinguishable from one it never saw.
-    func geofenceDeliveryFailed(geofenceId: String, transition: GeofenceTransition, retry: Bool) {
+    ///
+    /// `why` and `retry` both come from the error, because without them an offline device and a
+    /// revoked API key produce byte-identical records — and the Android record of this name has
+    /// always carried `why`.
+    func geofenceDeliveryFailed(geofenceId: String, transition: GeofenceTransition, error: BackgroundDeliveryHttpError) {
+        let retry = error.isRetryable
         debug(
-            "Geofence '\(geofenceId)' \(transition.rawValue): delivery failed; "
-                + (retry ? "row stays queued for the next flush" : "not retrying")
+            "Geofence '\(geofenceId)' \(transition.rawValue): delivery failed (\(error.diagnosticReason)); "
+                + (retry ? "row stays queued for the next flush" : "retrying cannot help")
                 + geofenceTail("delivery.failed", .output, [
                     ("id", geofenceId),
                     ("t", transition.rawValue),
                     ("ok", GeofenceLog.bool(false)),
-                    ("retry", GeofenceLog.bool(retry))
+                    ("retry", GeofenceLog.bool(retry)),
+                    ("why", error.diagnosticReason)
                 ]),
             geofenceTag
         )
+    }
+}
+
+extension BackgroundDeliveryHttpError {
+    /// Stable token for the tail. Mirrors the Android `why` vocabulary on `delivery.failed`.
+    var diagnosticReason: String {
+        switch self {
+        case .missingApiHost: return "missing_api_host"
+        case .missingCdpApiKey: return "missing_cdp_api_key"
+        case .invalidRequest: return "invalid_request"
+        case .transport: return "transport"
+        case .http(let statusCode): return "http_\(statusCode)"
+        }
+    }
+
+    /// Whether another attempt with the same row and config could ever succeed.
+    ///
+    /// A missing host or key, a malformed request, and a 4xx other than 408/429 fail identically
+    /// forever. Reporting those as retryable made a permanent misconfiguration read as flaky
+    /// network — the two need different responses from whoever reads the log.
+    var isRetryable: Bool {
+        switch self {
+        case .transport: return true
+        case .missingApiHost, .missingCdpApiKey, .invalidRequest: return false
+        case .http(let statusCode):
+            if statusCode == 408 || statusCode == 429 { return true }
+            return !(400 ..< 500).contains(statusCode)
+        }
     }
 }

--- a/Sources/LocationGeofence/Logger+GeofenceDelivery.swift
+++ b/Sources/LocationGeofence/Logger+GeofenceDelivery.swift
@@ -1,0 +1,66 @@
+import CioInternalCommon
+import Foundation
+
+private let geofenceTag = "Geofence"
+
+// MARK: - Delivery
+
+//
+// Classified `out` and namespaced under `delivery.` so replay can drop the whole family: what
+// replay checks is that the SDK *accepted* a transition, not that it reached the backend. Kept
+// deliberately parallel to the Android records of the same names — one parser reads both, so a
+// key that means something different here is worse than a key that is missing.
+//
+// The distinction these exist to preserve: `transition.accepted` says the SDK judged the crossing
+// real and made it durable. Everything below depends on the network and says nothing about
+// geofencing. Before this split, the only positive record fired on delivery, so an offline device
+// looked as though it had missed crossings it had in fact handled correctly.
+
+extension Logger {
+    /// Left our hands over direct HTTP and was removed from the pending store.
+    func geofenceDeliverySent(geofenceId: String, transition: GeofenceTransition, via: String) {
+        debug(
+            "Geofence '\(geofenceId)' \(transition.rawValue): delivered (\(via)); removed from pending store"
+                + geofenceTail("delivery.sent", .output, [
+                    ("id", geofenceId),
+                    ("t", transition.rawValue),
+                    ("via", via)
+                ]),
+            geofenceTag
+        )
+    }
+
+    /// Handed to another queue that now owns delivery and retry.
+    ///
+    /// Not `delivery.sent`: the EventBus handoff resolving is the strongest signal available, and
+    /// it is explicitly not a durable-persistence ack — calling it "sent" would overstate it.
+    func geofenceDeliveryQueued(geofenceId: String, transition: GeofenceTransition, via: String) {
+        debug(
+            "Geofence '\(geofenceId)' \(transition.rawValue): handed to \(via), which owns delivery and retry from here"
+                + geofenceTail("delivery.queued", .output, [
+                    ("id", geofenceId),
+                    ("t", transition.rawValue),
+                    ("via", via)
+                ]),
+            geofenceTag
+        )
+    }
+
+    /// The send failed and the row stays queued.
+    ///
+    /// Previously silent, which is what made an offline drive unreadable: a crossing the SDK had
+    /// accepted and was retrying was indistinguishable from one it never saw.
+    func geofenceDeliveryFailed(geofenceId: String, transition: GeofenceTransition, retry: Bool) {
+        debug(
+            "Geofence '\(geofenceId)' \(transition.rawValue): delivery failed; "
+                + (retry ? "row stays queued for the next flush" : "not retrying")
+                + geofenceTail("delivery.failed", .output, [
+                    ("id", geofenceId),
+                    ("t", transition.rawValue),
+                    ("ok", GeofenceLog.bool(false)),
+                    ("retry", GeofenceLog.bool(retry))
+                ]),
+            geofenceTag
+        )
+    }
+}

--- a/Sources/LocationGeofence/Logger+GeofenceLifecycle.swift
+++ b/Sources/LocationGeofence/Logger+GeofenceLifecycle.swift
@@ -193,10 +193,10 @@ extension Logger {
 
     /// The SDK accepted a crossing and durably queued it — the decision replay asserts on.
     ///
-    /// Distinct from `transition.emitted`, which fires only once the row leaves: on the direct
-    /// path after HTTP success, on the backlog path after the EventBus handoff. Neither says the
-    /// SDK judged the crossing real, and on an offline device they can trail the crossing by many
-    /// minutes or never arrive, which makes them useless as a signal about geofencing itself.
+    /// Distinct from the `delivery.*` family, which fires only once the row leaves: after HTTP
+    /// success on the direct path, after the EventBus handoff on the backlog path. Neither says
+    /// the SDK judged the crossing real, and on an offline device they can trail the crossing by
+    /// many minutes or never arrive, which makes them useless as a signal about geofencing.
     /// A field drive showed exactly that — one crossing surfaced 26 minutes late and another,
     /// accepted and persisted, produced no positive record at all.
     ///

--- a/Sources/LocationGeofence/Logger+GeofenceLifecycle.swift
+++ b/Sources/LocationGeofence/Logger+GeofenceLifecycle.swift
@@ -191,6 +191,29 @@ extension Logger {
         )
     }
 
+    /// The SDK accepted a crossing and durably queued it — the decision replay asserts on.
+    ///
+    /// Distinct from `transition.emitted`, which fires only once the row leaves: on the direct
+    /// path after HTTP success, on the backlog path after the EventBus handoff. Neither says the
+    /// SDK judged the crossing real, and on an offline device they can trail the crossing by many
+    /// minutes or never arrive, which makes them useless as a signal about geofencing itself.
+    /// A field drive showed exactly that — one crossing surfaced 26 minutes late and another,
+    /// accepted and persisted, produced no positive record at all.
+    ///
+    /// `n` is the row count: one per geoset the fence belongs to, so a fan-out is visible as one
+    /// acceptance rather than inferred from the delivery records that follow.
+    func geofenceTransitionAccepted(geofenceId: String, transition: GeofenceTransition, rows: Int) {
+        debug(
+            "Accepted \(transition.rawValue) for geofence \(geofenceId), queued \(rows) row(s)"
+                + geofenceTail("transition.accepted", .output, [
+                    ("id", geofenceId),
+                    ("t", transition.rawValue),
+                    ("n", GeofenceLog.int(rows))
+                ]),
+            geofenceTag
+        )
+    }
+
     func geofenceCallbackDropped(identifier: String, transition: GeofenceTransition, reason: String) {
         debug(
             "OS \(transition.rawValue) for region \(identifier) not routed: \(reason)"

--- a/Sources/LocationGeofence/Logger+GeofenceLifecycle.swift
+++ b/Sources/LocationGeofence/Logger+GeofenceLifecycle.swift
@@ -191,25 +191,24 @@ extension Logger {
         )
     }
 
-    /// The SDK accepted a crossing and durably queued it — the decision replay asserts on.
+    /// Something worth reading in a log, deliberately outside the asserted vocabulary.
     ///
-    /// Distinct from the `delivery.*` family, which fires only once the row leaves: after HTTP
-    /// success on the direct path, after the EventBus handoff on the backlog path. Neither says
-    /// the SDK judged the crossing real, and on an offline device they can trail the crossing by
-    /// many minutes or never arrive, which makes them useless as a signal about geofencing.
-    /// A field drive showed exactly that — one crossing surfaced 26 minutes late and another,
-    /// accepted and persisted, produced no positive record at all.
+    /// `ev=info` is the bucket for records a human wants when explaining a capture but a scenario
+    /// must never assert on. Two reasons it exists rather than reusing a semantic key:
     ///
-    /// `n` is the row count: one per geoset the fence belongs to, so a fan-out is visible as one
-    /// acceptance rather than inferred from the delivery records that follow.
-    func geofenceTransitionAccepted(geofenceId: String, transition: GeofenceTransition, rows: Int) {
+    /// - Unexpected cases do not deserve invented semantics. Minting `os.callback.unusable` for
+    ///   every oddity grows the vocabulary faster than anyone can keep it aligned across platforms.
+    /// - More importantly, the obvious reuse is actively wrong. Filing these under
+    ///   `os.callback.dropped` would inflate the received-vs-dropped count — the count that
+    ///   separates "the OS never reported it" from "we discarded it", which is the question a
+    ///   paired drive exists to answer. Every real `os.callback.dropped` nets against an
+    ///   `os.callback.received`; these have no receipt to net against.
+    ///
+    /// `io=obs`, so the off-device transform drops the whole family rather than replaying it.
+    func geofenceInfo(_ reason: String, fields: [(String, String?)] = []) {
         debug(
-            "Accepted \(transition.rawValue) for geofence \(geofenceId), queued \(rows) row(s)"
-                + geofenceTail("transition.accepted", .output, [
-                    ("id", geofenceId),
-                    ("t", transition.rawValue),
-                    ("n", GeofenceLog.int(rows))
-                ]),
+            "Geofence note: \(reason.replacingOccurrences(of: "_", with: " "))"
+                + geofenceTail("info", .observation, [("why", reason)] + fields),
             geofenceTag
         )
     }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+BaselineHeal.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+BaselineHeal.swift
@@ -57,11 +57,19 @@ extension CLMonitorGeofenceMonitor {
                     fixAge: -fix.timestamp.timeIntervalSinceNow,
                     lastState: record.lastState
                 ) else { continue }
-                guard case .deliver = await self.storage.recordMonitorEvent(
+                // Logged for the same reason as the OS-event path: a heal that decides a crossing
+                // is real and is then refused by the baseline used to vanish. This is also the
+                // only site that can return `.suppressedNewerBaseline` — the OS path passes no
+                // evidence timestamp — so without this the token exists but can never print.
+                let outcome = await self.storage.recordMonitorEvent(
                     transition,
                     forIdentifier: identifier,
                     onlyIfBaselinePredates: fix.timestamp
-                ) else { continue }
+                )
+                guard case .deliver = outcome else {
+                    self.logDiscardedCallback(identifier: identifier, transition: transition, outcome: outcome)
+                    continue
+                }
                 self.logger.geofenceBaselineHealed(identifier: identifier, transition: transition)
                 self.onTransition?(
                     identifier,

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+BaselineHeal.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+BaselineHeal.swift
@@ -57,17 +57,20 @@ extension CLMonitorGeofenceMonitor {
                     fixAge: -fix.timestamp.timeIntervalSinceNow,
                     lastState: record.lastState
                 ) else { continue }
-                // Logged for the same reason as the OS-event path: a heal that decides a crossing
-                // is real and is then refused by the baseline used to vanish. This is also the
-                // only site that can return `.suppressedNewerBaseline` — the OS path passes no
-                // evidence timestamp — so without this the token exists but can never print.
+                // A heal that decides a crossing is real and is then refused by the baseline used
+                // to vanish. Reported as `baseline.refused`, not `os.callback.dropped`: nothing
+                // arrived from the OS on this path. This is also the only site that can return
+                // `.suppressedNewerBaseline` — the OS path passes no evidence timestamp — so
+                // without this the token exists but can never print.
                 let outcome = await self.storage.recordMonitorEvent(
                     transition,
                     forIdentifier: identifier,
                     onlyIfBaselinePredates: fix.timestamp
                 )
                 guard case .deliver = outcome else {
-                    self.logDiscardedCallback(identifier: identifier, transition: transition, outcome: outcome)
+                    if let reason = outcome.diagnosticReason {
+                        self.logger.geofenceBaselineRefused(identifier: identifier, transition: transition, reason: reason)
+                    }
                     continue
                 }
                 self.logger.geofenceBaselineHealed(identifier: identifier, transition: transition)

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Fixes.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+Fixes.swift
@@ -43,6 +43,21 @@ extension CLMonitorGeofenceMonitor {
         )
     }
 
+    /// Records a crossing the dedup baseline discarded, and why.
+    ///
+    /// Same reason `logReceivedCallback` lives here: the handler is at the file-length limit. And
+    /// the same reason it exists at all — CLMonitor delivers a crossing more than once (a field
+    /// drive saw every one arrive twice, 8-10 ms apart with identical fixes), and the duplicate is
+    /// absorbed by the baseline. Without this the discard is invisible, so `os.callback.received`
+    /// reads as a crossing count when it is really twice that, and a callback that vanishes here
+    /// cannot be told apart from the OS never delivering one.
+    ///
+    /// `.deliver` logs nothing: it is not a discard.
+    func logDiscardedCallback(identifier: String, transition: GeofenceTransition, outcome: GeofenceMonitorEventOutcome) {
+        guard let reason = outcome.diagnosticReason else { return }
+        logger.geofenceCallbackDropped(identifier: identifier, transition: transition, reason: reason)
+    }
+
     /// Internal (not private) only because it lives in a separate file from its callers.
     func currentLocationData() -> LocationData? {
         guard let location = bestKnownFix() else { return nil }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -301,7 +301,11 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
            await isEventContradictedByFreshFix(identifier: identifier, transition: transition, eventDate: event.date) {
             return
         }
-        guard case .deliver = await storage.recordMonitorEvent(transition, forIdentifier: identifier) else { return }
+        let outcome = await storage.recordMonitorEvent(transition, forIdentifier: identifier)
+        guard case .deliver = outcome else {
+            logDiscardedCallback(identifier: identifier, transition: transition, outcome: outcome)
+            return
+        }
         // No ownership re-check after the await: the baseline already advanced, so dropping here
         // loses the transition permanently — a sync's stop-all + re-add swap would eat a genuine
         // crossing that raced it. A region truly removed in that window delivers one last gated event.

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -254,7 +254,7 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
         case .unsatisfied:
             transition = .exit
         case .unknown:
-            return
+            return logger.geofenceInfo("os_state_unusable", fields: [("id", identifier), ("state", "unknown")])
         case .unmonitored:
             // CLMonitor gave up on the condition (e.g. condition budget exceeded). Drop the mirror
             // entry and the recorded circle so the next sync re-registers it. The stored baseline
@@ -289,7 +289,7 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
             }
             return
         @unknown default:
-            return
+            return logger.geofenceInfo("os_state_unusable", fields: [("id", identifier), ("state", "unhandled")])
         }
         // Logged before the gate and the dedup baseline: an event refused or deduped is still an
         // event the OS delivered, and the drives worth explaining are usually the ones where

--- a/Sources/LocationGeofence/Storage/GeofenceStorage.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage.swift
@@ -369,7 +369,7 @@ actor GeofenceStorage {
 
 /// Disposition of a state observed off `CLMonitor.events`, decided by
 /// `GeofenceStorage.recordMonitorEvent(_:forIdentifier:)`.
-enum GeofenceMonitorEventOutcome: Equatable, Sendable {
+enum GeofenceMonitorEventOutcome: Equatable, Sendable, CaseIterable {
     /// Genuine state change of a registered transition type — deliver it.
     case deliver
     /// Same state as the baseline — a CLMonitor re-emission (relaunch/unlock/foreground), not a crossing.

--- a/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
@@ -154,10 +154,7 @@ struct GeofenceLogTailTests {
 
     /// Runs `body` with diagnostics forced on or off, restoring the previous value after.
     private func withDiagnostics<T>(_ enabled: Bool, _ body: () throws -> T) rethrows -> T {
-        let previous = GeofenceDiagnostics.overrideForTesting
-        GeofenceDiagnostics.overrideForTesting = enabled
-        defer { GeofenceDiagnostics.overrideForTesting = previous }
-        return try body()
+        try DiagnosticsGateTesting.withDiagnostics(enabled, body)
     }
 
     @Test
@@ -406,6 +403,103 @@ struct GeofenceLogTailTests {
         withDiagnostics(true) {
             #expect(GeofenceLog.tail("probe", .output, fields()).contains("lat=37.45000"))
             #expect(builds == 1)
+        }
+    }
+
+    // MARK: - Fence catalog
+
+    private func catalogRegion(id: String = "11125", name: String? = "Momo Dubai Test") -> GeofenceApiRegion {
+        GeofenceApiRegion(
+            id: id,
+            name: name,
+            latitude: 25.109908,
+            longitude: 55.184004,
+            radius: 150,
+            externalId: nil,
+            transitionTypes: ["enter", "exit"],
+            lastUpdated: 0,
+            geosetIds: ["4471", "9002"],
+            metadata: nil
+        )
+    }
+
+    /// Deliberately absent from `invocations`: that table asserts the gated-*tail* contract, where
+    /// the gate strips detail and leaves the prose identical. The catalog is a different kind of
+    /// record — it exists only for diagnostics, so the gate removes it entirely. Emitting bare
+    /// "catalogued" lines to every customer's console would be noise, and moving the detail into
+    /// the prose to satisfy the table would leak coordinates with the gate off. These tests pin the
+    /// same contract the table would have.
+    @Test
+    func fenceCatalog_expectMachineKeyAndReplayClassification() {
+        withDiagnostics(true) {
+            let logger = CapturingLogger()
+            logger.geofenceApiFetchResult(returnedCount: 1, elapsed: 0.4, regions: [catalogRegion()])
+
+            guard let message = logger.messages.last, let fields = parseTail(message) else {
+                Issue.record("no parseable tail in '\(logger.messages.last ?? "<nothing>")'")
+                return
+            }
+            #expect(message.hasPrefix("[Geofence] "))
+            #expect(fields["ev"] == "fence.cataloged")
+            #expect(fields["io"] == "in")
+            for key in ["id", "name", "gs", "lat", "lon", "rad", "tt"] {
+                #expect(fields[key] != nil, "missing \(key)= in '\(message)'")
+            }
+        }
+    }
+
+    @Test
+    func fenceCatalog_givenNameWithSeparators_expectSanitizedButReadable() {
+        withDiagnostics(true) {
+            let logger = CapturingLogger()
+            logger.geofenceApiFetchResult(
+                returnedCount: 1,
+                elapsed: 0.4,
+                regions: [catalogRegion(name: "Momo Dubai, Test=1")]
+            )
+            guard let fields = parseTail(logger.messages.last ?? "") else {
+                Issue.record("no parseable tail")
+                return
+            }
+            let name = fields["name"] ?? ""
+            #expect(name.contains("Momo"))
+            #expect(!name.contains(" "))
+            #expect(!name.contains("="))
+        }
+    }
+
+    @Test
+    func fenceCatalog_givenGeosetList_expectSeparatorsPreserved() {
+        withDiagnostics(true) {
+            let logger = CapturingLogger()
+            logger.geofenceApiFetchResult(returnedCount: 1, elapsed: 0.4, regions: [catalogRegion()])
+            let fields = parseTail(logger.messages.last ?? "")
+            #expect(fields?["gs"] == "4471,9002")
+            #expect(fields?["tt"] == "enter,exit")
+            #expect(fields?["lat"] == "25.10991")
+            #expect(fields?["rad"] == "150")
+        }
+    }
+
+    @Test
+    func fenceCatalog_expectOneRecordPerFence() {
+        withDiagnostics(true) {
+            let logger = CapturingLogger()
+            logger.geofenceApiFetchResult(
+                returnedCount: 3,
+                elapsed: 0.4,
+                regions: [catalogRegion(id: "1"), catalogRegion(id: "2"), catalogRegion(id: "3")]
+            )
+            #expect(logger.messages.filter { $0.contains("ev=fence.cataloged") }.count == 3)
+        }
+    }
+
+    @Test
+    func fenceCatalog_givenDiagnosticsOff_expectNoCatalogRecords() {
+        withDiagnostics(false) {
+            let logger = CapturingLogger()
+            logger.geofenceApiFetchResult(returnedCount: 1, elapsed: 0.4, regions: [catalogRegion()])
+            #expect(!logger.messages.contains { $0.contains("catalogued") })
         }
     }
 }

--- a/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
@@ -79,6 +79,10 @@ struct GeofenceLogTailTests {
     /// *renamed key* on anything listed here fails loudly, which is the failure this exists to catch.
     private struct Invocation {
         let name: String
+        /// The `ev=` this record must emit. Pinned per row, not just collected into a set: a set
+        /// is identical whether two records keep their keys or swap them, and a swap silently
+        /// inverts what every capture says the SDK decided.
+        let ev: String
         let requiredKeys: [String]
         let run: (Logger) -> Void
     }
@@ -98,52 +102,54 @@ struct GeofenceLogTailTests {
     private var invocations: [Invocation] {
         let location = sampleLocation
         return [
-            Invocation(name: "invalidRegionDropped", requiredKeys: ["id", "why"]) { $0.geofenceInvalidRegionDropped("notl core") },
-            Invocation(name: "invalidCoordinates", requiredKeys: ["id", "why"]) { $0.geofenceInvalidCoordinatesForRegion("notl_core") },
-            Invocation(name: "monitoringFailed", requiredKeys: ["id", "ok"]) { $0.geofenceMonitoringFailed(region: "notl_core", error: GeofenceApiError.transport) },
-            Invocation(name: "streamFailed", requiredKeys: ["ok"]) { $0.geofenceMonitorEventStreamFailed(error: GeofenceApiError.transport) },
-            Invocation(name: "stoppedMonitoring", requiredKeys: ["id"]) { $0.geofenceMonitorStoppedMonitoringRegion("notl_core") },
-            Invocation(name: "regionsRegistered", requiredKeys: ["n", "ids", "mvmt"]) { $0.geofenceRegionsRegistered(identifiers: ["a", "b"], movementTrigger: "cio_movement_trigger") },
-            Invocation(name: "permissionUnavailable", requiredKeys: ["perm", "why"]) { $0.geofencePermissionUnavailable(currentStatus: .denied) },
-            Invocation(name: "backgroundUnavailable", requiredKeys: ["perm", "why"]) { $0.geofenceBackgroundDeliveryUnavailable(currentStatus: .authorizedWhenInUse) },
-            Invocation(name: "backgroundAvailable", requiredKeys: ["perm", "ok"]) { $0.geofenceBackgroundDeliveryAvailable(currentStatus: .authorizedAlways) },
-            Invocation(name: "moduleInitialized", requiredKeys: ["launch"]) { $0.geofenceModuleInitialized(launchReason: .appStart) },
-            Invocation(name: "moduleWoke", requiredKeys: ["launch"]) { $0.geofenceModuleWoke(launchReason: .locationEvent) },
-            Invocation(name: "callbackReceived", requiredKeys: ["id", "t", "buf", "fixsrc", "acc", "age", "sim", "evage"]) { $0.geofenceCallbackReceived(identifier: "notl_core", transition: .enter, fix: location, source: .managerCache, eventDate: Date(timeIntervalSinceNow: -3), buffered: false) },
-            Invocation(name: "callbackReceivedNoFix", requiredKeys: ["id", "t", "fixsrc"]) { $0.geofenceCallbackReceived(identifier: "notl_core", transition: .exit, fix: nil, source: .none) },
-            Invocation(name: "callbackDropped", requiredKeys: ["id", "t", "why"]) { $0.geofenceCallbackDropped(identifier: "notl_core", transition: .enter, reason: "movement_trigger_not_exit") },
-            Invocation(name: "fixReceived", requiredKeys: ["prov"]) { $0.geofenceFixReceived(location, source: "movement_pass") },
-            Invocation(name: "fixQuality", requiredKeys: ["fixsrc", "acc", "age"]) { $0.geofenceCallbackReceived(identifier: "q", transition: .enter, fix: location, source: .freshRequest) },
-            Invocation(name: "deliverySent", requiredKeys: ["id", "t", "via"]) { $0.geofenceDeliverySent(geofenceId: "notl_core", transition: .enter, via: "http") },
-            Invocation(name: "deliveryQueued", requiredKeys: ["id", "t", "via"]) { $0.geofenceDeliveryQueued(geofenceId: "notl_core", transition: .enter, via: "event_bus") },
-            Invocation(name: "deliveryFailed", requiredKeys: ["id", "t", "ok", "retry", "why"]) { $0.geofenceDeliveryFailed(geofenceId: "notl_core", transition: .exit, error: .transport) },
-            Invocation(name: "deliveryFailedPermanent", requiredKeys: ["id", "t", "ok", "retry", "why"]) { $0.geofenceDeliveryFailed(geofenceId: "notl_core", transition: .exit, error: .http(statusCode: 401)) },
-            Invocation(name: "transitionAccepted", requiredKeys: ["id", "t", "n"]) { $0.geofenceTransitionAccepted(geofenceId: "notl_core", transition: .enter, rows: 2) },
-            Invocation(name: "eventSuppressed", requiredKeys: ["id", "t", "why", "cd"]) { $0.geofenceEventSuppressed(geofenceId: "notl_core", transition: .enter, cooldownRemaining: 42) },
-            Invocation(name: "droppedAnonymous", requiredKeys: ["id", "t", "why"]) { $0.geofenceTransitionDroppedAnonymous(geofenceId: "notl_core", transition: .exit) },
-            Invocation(name: "pendingPersistFailed", requiredKeys: ["id", "t", "ok"]) { $0.geofencePendingPersistFailed(geofenceId: "notl_core", transition: .exit) },
-            Invocation(name: "syncSkipped", requiredKeys: ["why"]) { $0.geofenceSyncSkipped(reason: .noIdentifiedUser) },
-            Invocation(name: "syncSkippedFresh", requiredKeys: ["why"]) { $0.geofenceSyncSkippedFresh() },
-            Invocation(name: "syncFetchFailed", requiredKeys: ["ok", "why"]) { $0.geofenceSyncFetchFailed(error: .http(statusCode: 503)) },
-            Invocation(name: "apiFetchResult", requiredKeys: ["ok", "n", "ms"]) { $0.geofenceApiFetchResult(returnedCount: 30, elapsed: 0.42) },
-            Invocation(name: "syncCompleted", requiredKeys: ["n", "mvmt", "ms"]) { $0.geofenceSyncCompleted(requestedCount: 19, movementTriggerRequested: true, acceptedCount: 19, movementTriggerAccepted: true, elapsed: 1.5) },
-            Invocation(name: "registrationDiff", requiredKeys: ["nadd", "nrem", "nkeep"]) { $0.geofenceRegistrationDiff(added: 3, removed: 2, unchanged: 17) },
-            Invocation(name: "rankEvaluated", requiredKeys: ["ncand", "n", "ranked", "evicted"]) { $0.geofenceRankEvaluated(candidates: 30, selectedCount: 2, selected: ["a", "b"], evicted: ["c"], edgeDistances: ["a": 120, "b": 340]) },
-            Invocation(name: "movementTrigger", requiredKeys: ["tier"]) { $0.geofenceMovementTrigger(tier: .localRerank) },
-            Invocation(name: "movementTriggerRegistered", requiredKeys: ["rad"]) { $0.geofenceMovementTriggerRegistered(latitude: 43.2, longitude: -79.0, radius: 500) },
-            Invocation(name: "movementRearmed", requiredKeys: ["why"]) { $0.geofenceMovementRearmedAfterFailedRefresh() },
-            Invocation(name: "movementFixResolved", requiredKeys: ["age", "prov"]) { $0.geofenceMovementFixResolved(ageSeconds: 12.5, requested: true) },
-            Invocation(name: "movementFixStale", requiredKeys: ["age", "why"]) { $0.geofenceMovementFixStale(ageSeconds: 900) },
-            Invocation(name: "movementFixRequestFailed", requiredKeys: ["ok", "why", "ms"]) { $0.geofenceMovementFixRequestFailed(fallingBackToCached: true, elapsed: 5) },
-            Invocation(name: "baselineHealed", requiredKeys: ["id", "t"]) { $0.geofenceBaselineHealed(identifier: "notl_core", transition: .enter) },
-            Invocation(name: "contradictionRefused", requiredKeys: ["id", "t", "dist", "rad", "edge", "acc"]) { $0.geofenceEventRefusedByContradiction(identifier: "notl_core", transition: .enter, distanceFromCenter: 1400, radius: 1000, accuracy: 48) },
-            Invocation(name: "syncSuperseded", requiredKeys: ["why"]) { $0.geofenceSyncSupersededByUserChange() },
-            Invocation(name: "resetCompleted", requiredKeys: ["ok"]) { $0.geofenceResetCompleted() },
-            Invocation(name: "resetSuperseded", requiredKeys: ["ok", "why"]) { $0.geofenceResetSuperseded() },
-            Invocation(name: "firstRunRearm", requiredKeys: ["why"]) { $0.geofenceFirstRunRearm() },
-            Invocation(name: "regionsAdopted", requiredKeys: ["n"]) { $0.geofenceRegionsAdopted(count: 4) },
-            Invocation(name: "foregroundRearm", requiredKeys: ["n", "why"]) { $0.geofenceForegroundRearm(count: 4) },
-            Invocation(name: "storageLoaded", requiredKeys: ["n", "anchor"]) { $0.geofenceStorageLoaded(regionCount: 30, hasAnchor: true) }
+            Invocation(name: "invalidRegionDropped", ev: "registration.rejected", requiredKeys: ["id", "why"]) { $0.geofenceInvalidRegionDropped("notl core") },
+            Invocation(name: "invalidCoordinates", ev: "registration.rejected", requiredKeys: ["id", "why"]) { $0.geofenceInvalidCoordinatesForRegion("notl_core") },
+            Invocation(name: "monitoringFailed", ev: "os.monitor.failed", requiredKeys: ["id", "ok"]) { $0.geofenceMonitoringFailed(region: "notl_core", error: GeofenceApiError.transport) },
+            Invocation(name: "streamFailed", ev: "os.stream.failed", requiredKeys: ["ok"]) { $0.geofenceMonitorEventStreamFailed(error: GeofenceApiError.transport) },
+            Invocation(name: "stoppedMonitoring", ev: "os.monitor.stopped", requiredKeys: ["id"]) { $0.geofenceMonitorStoppedMonitoringRegion("notl_core") },
+            Invocation(name: "regionsRegistered", ev: "registration.applied", requiredKeys: ["n", "ids", "mvmt"]) { $0.geofenceRegionsRegistered(identifiers: ["a", "b"], movementTrigger: "cio_movement_trigger") },
+            Invocation(name: "permissionUnavailable", ev: "permission.changed", requiredKeys: ["perm", "why"]) { $0.geofencePermissionUnavailable(currentStatus: .denied) },
+            Invocation(name: "backgroundUnavailable", ev: "permission.changed", requiredKeys: ["perm", "why"]) { $0.geofenceBackgroundDeliveryUnavailable(currentStatus: .authorizedWhenInUse) },
+            Invocation(name: "backgroundAvailable", ev: "permission.changed", requiredKeys: ["perm", "ok"]) { $0.geofenceBackgroundDeliveryAvailable(currentStatus: .authorizedAlways) },
+            Invocation(name: "moduleInitialized", ev: "module.init", requiredKeys: ["launch"]) { $0.geofenceModuleInitialized(launchReason: .appStart) },
+            Invocation(name: "moduleWoke", ev: "module.wake", requiredKeys: ["launch"]) { $0.geofenceModuleWoke(launchReason: .locationEvent) },
+            Invocation(name: "callbackReceived", ev: "os.callback.received", requiredKeys: ["id", "t", "buf", "fixsrc", "acc", "age", "sim", "evage"]) { $0.geofenceCallbackReceived(identifier: "notl_core", transition: .enter, fix: location, source: .managerCache, eventDate: Date(timeIntervalSinceNow: -3), buffered: false) },
+            Invocation(name: "callbackReceivedNoFix", ev: "os.callback.received", requiredKeys: ["id", "t", "fixsrc"]) { $0.geofenceCallbackReceived(identifier: "notl_core", transition: .exit, fix: nil, source: .none) },
+            Invocation(name: "info", ev: "info", requiredKeys: ["why"]) { $0.geofenceInfo("os_state_unusable", fields: [("id", "notl_core"), ("state", "unknown")]) },
+            Invocation(name: "callbackDropped", ev: "os.callback.dropped", requiredKeys: ["id", "t", "why"]) { $0.geofenceCallbackDropped(identifier: "notl_core", transition: .enter, reason: "movement_trigger_not_exit") },
+            Invocation(name: "fixReceived", ev: "fix.received", requiredKeys: ["prov"]) { $0.geofenceFixReceived(location, source: "movement_pass") },
+            Invocation(name: "fixQuality", ev: "os.callback.received", requiredKeys: ["fixsrc", "acc", "age"]) { $0.geofenceCallbackReceived(identifier: "q", transition: .enter, fix: location, source: .freshRequest) },
+            Invocation(name: "deliverySent", ev: "delivery.sent", requiredKeys: ["id", "t", "via"]) { $0.geofenceDeliverySent(geofenceId: "notl_core", transition: .enter, via: "http") },
+            Invocation(name: "deliveryQueued", ev: "delivery.queued", requiredKeys: ["id", "t", "via"]) { $0.geofenceDeliveryQueued(geofenceId: "notl_core", transition: .enter, via: "event_bus") },
+            Invocation(name: "deliveryFailed", ev: "delivery.failed", requiredKeys: ["id", "t", "ok", "why"]) { $0.geofenceDeliveryFailed(geofenceId: "notl_core", transition: .exit, error: .transport) },
+            Invocation(name: "transitionAccepted", ev: "transition.accepted", requiredKeys: ["id", "t", "n"]) { $0.geofenceTransitionAccepted(geofenceId: "notl_core", transition: .enter, rows: 2) },
+            Invocation(name: "transitionSynthesized", ev: "transition.synthesized", requiredKeys: ["id", "t", "why"]) { $0.geofenceTransitionSynthesized(geofenceId: "notl_core", transition: .enter) },
+            Invocation(name: "baselineRefused", ev: "baseline.refused", requiredKeys: ["id", "t", "why"]) { $0.geofenceBaselineRefused(identifier: "notl_core", transition: .enter, reason: "newer_baseline") },
+            Invocation(name: "eventSuppressed", ev: "transition.suppressed", requiredKeys: ["id", "t", "why", "cd"]) { $0.geofenceEventSuppressed(geofenceId: "notl_core", transition: .enter, cooldownRemaining: 42) },
+            Invocation(name: "droppedAnonymous", ev: "transition.dropped", requiredKeys: ["id", "t", "why"]) { $0.geofenceTransitionDroppedAnonymous(geofenceId: "notl_core", transition: .exit) },
+            Invocation(name: "pendingPersistFailed", ev: "storage.write.failed", requiredKeys: ["id", "t", "ok"]) { $0.geofencePendingPersistFailed(geofenceId: "notl_core", transition: .exit) },
+            Invocation(name: "syncSkipped", ev: "sync.skipped", requiredKeys: ["why"]) { $0.geofenceSyncSkipped(reason: .noIdentifiedUser) },
+            Invocation(name: "syncSkippedFresh", ev: "sync.skipped", requiredKeys: ["why"]) { $0.geofenceSyncSkippedFresh() },
+            Invocation(name: "syncFetchFailed", ev: "api.fetch.result", requiredKeys: ["ok", "why"]) { $0.geofenceSyncFetchFailed(error: .http(statusCode: 503)) },
+            Invocation(name: "apiFetchResult", ev: "api.fetch.result", requiredKeys: ["ok", "n", "ms"]) { $0.geofenceApiFetchResult(returnedCount: 30, elapsed: 0.42) },
+            Invocation(name: "syncCompleted", ev: "sync.completed", requiredKeys: ["n", "mvmt", "ms"]) { $0.geofenceSyncCompleted(requestedCount: 19, movementTriggerRequested: true, acceptedCount: 19, movementTriggerAccepted: true, elapsed: 1.5) },
+            Invocation(name: "registrationDiff", ev: "registration.diff", requiredKeys: ["nadd", "nrem", "nkeep"]) { $0.geofenceRegistrationDiff(added: 3, removed: 2, unchanged: 17) },
+            Invocation(name: "rankEvaluated", ev: "rank.evaluated", requiredKeys: ["ncand", "n", "ranked", "evicted"]) { $0.geofenceRankEvaluated(candidates: 30, selectedCount: 2, selected: ["a", "b"], evicted: ["c"], edgeDistances: ["a": 120, "b": 340]) },
+            Invocation(name: "movementTrigger", ev: "movement.exit", requiredKeys: ["tier"]) { $0.geofenceMovementTrigger(tier: .localRerank) },
+            Invocation(name: "movementTriggerRegistered", ev: "movement.registered", requiredKeys: ["rad"]) { $0.geofenceMovementTriggerRegistered(latitude: 43.2, longitude: -79.0, radius: 500) },
+            Invocation(name: "movementRearmed", ev: "movement.rearmed", requiredKeys: ["why"]) { $0.geofenceMovementRearmedAfterFailedRefresh() },
+            Invocation(name: "movementFixResolved", ev: "movement.fix.resolved", requiredKeys: ["age", "prov"]) { $0.geofenceMovementFixResolved(ageSeconds: 12.5, requested: true) },
+            Invocation(name: "movementFixStale", ev: "movement.fix.requested", requiredKeys: ["age", "why"]) { $0.geofenceMovementFixStale(ageSeconds: 900) },
+            Invocation(name: "movementFixRequestFailed", ev: "movement.fix.failed", requiredKeys: ["ok", "why", "ms"]) { $0.geofenceMovementFixRequestFailed(fallingBackToCached: true, elapsed: 5) },
+            Invocation(name: "baselineHealed", ev: "baseline.healed", requiredKeys: ["id", "t"]) { $0.geofenceBaselineHealed(identifier: "notl_core", transition: .enter) },
+            Invocation(name: "contradictionRefused", ev: "contradiction.refused", requiredKeys: ["id", "t", "dist", "rad", "edge", "acc"]) { $0.geofenceEventRefusedByContradiction(identifier: "notl_core", transition: .enter, distanceFromCenter: 1400, radius: 1000, accuracy: 48) },
+            Invocation(name: "syncSuperseded", ev: "sync.superseded", requiredKeys: ["why"]) { $0.geofenceSyncSupersededByUserChange() },
+            Invocation(name: "resetCompleted", ev: "module.reset", requiredKeys: ["ok"]) { $0.geofenceResetCompleted() },
+            Invocation(name: "resetSuperseded", ev: "module.reset", requiredKeys: ["ok", "why"]) { $0.geofenceResetSuperseded() },
+            Invocation(name: "firstRunRearm", ev: "movement.rearmed", requiredKeys: ["why"]) { $0.geofenceFirstRunRearm() },
+            Invocation(name: "regionsAdopted", ev: "registration.adopted", requiredKeys: ["n"]) { $0.geofenceRegionsAdopted(count: 4) },
+            Invocation(name: "foregroundRearm", ev: "registration.rearmed", requiredKeys: ["n", "why"]) { $0.geofenceForegroundRearm(count: 4) },
+            Invocation(name: "storageLoaded", ev: "storage.loaded", requiredKeys: ["n", "anchor"]) { $0.geofenceStorageLoaded(regionCount: 30, hasAnchor: true) }
         ]
     }
 
@@ -173,7 +179,10 @@ struct GeofenceLogTailTests {
                     Issue.record("\(invocation.name): no parseable tail in '\(logger.messages.last ?? "<nothing logged>")'")
                     continue
                 }
-                #expect(fields["ev"] != nil, "\(invocation.name): missing ev=")
+                #expect(
+                    fields["ev"] == invocation.ev,
+                    "\(invocation.name): expected ev=\(invocation.ev), got '\(fields["ev"] ?? "<absent>")'"
+                )
                 #expect(
                     ["in", "out", "obs"].contains(fields["io"] ?? ""),
                     "\(invocation.name): io= must be in/out/obs, got '\(fields["io"] ?? "<absent>")'"
@@ -186,27 +195,84 @@ struct GeofenceLogTailTests {
     }
 
     @Test
-    func deliveryFailure_expectPermanentErrorsReportedNotRetryable() {
-        // Reporting a permanent failure as retryable made a misconfiguration read as flaky
-        // network off-device, which are opposite diagnoses: one needs a fix, one needs waiting.
-        let permanent: [BackgroundDeliveryHttpError] = [
-            .missingApiHost, .missingCdpApiKey, .invalidRequest,
-            .http(statusCode: 400), .http(statusCode: 401), .http(statusCode: 404)
+    func deliveryFailure_expectDistinctReasonTokenPerCause() {
+        // The token is the whole value of this record now that it carries no verdict: it is what
+        // separates an offline device from a misconfigured one when someone reads a drive.
+        let errors: [BackgroundDeliveryHttpError] = [
+            .missingApiHost, .missingCdpApiKey, .invalidRequest, .transport,
+            .http(statusCode: 401), .http(statusCode: 503)
         ]
-        let retryable: [BackgroundDeliveryHttpError] = [
-            .transport, .http(statusCode: 408), .http(statusCode: 429),
-            .http(statusCode: 500), .http(statusCode: 503)
-        ]
-        for error in permanent {
-            #expect(error.isRetryable == false, "\(error) should not be reported as retryable")
-        }
-        for error in retryable {
-            #expect(error.isRetryable == true, "\(error) should be reported as retryable")
-        }
-        // Tokens ride a whitespace-split tail and must tell the cases apart.
-        let tokens = (permanent + retryable).map(\.diagnosticReason)
+        let tokens = errors.map(\.diagnosticReason)
+        #expect(Set(tokens).count == tokens.count, "two causes share a token: \(tokens)")
+        // Tokens ride a whitespace-split tail.
         #expect(tokens.allSatisfy { !$0.contains(" ") }, "a reason token contains whitespace")
-        #expect(Set(tokens).count == tokens.count, "duplicate reason tokens: \(tokens)")
+        // 0 is synthesized when there was no response at all; reporting it as a status invites
+        // the reader to believe the backend answered.
+        #expect(BackgroundDeliveryHttpError.http(statusCode: 0).diagnosticReason == "no_response")
+        #expect(BackgroundDeliveryHttpError.http(statusCode: 503).diagnosticReason == "http_503")
+    }
+
+    @Test
+    func everyRecord_expectTheDeclaredVocabulary() {
+        // Companion to the per-row `ev` pin above, catching what a per-row check cannot: a key
+        // removed from the module entirely, or a row added to the table without being declared
+        // here. It does NOT see a record that exists in the module but was never added to the
+        // table — `seen` is built from the table, not from the source. `fence.cataloged` is the
+        // standing proof of that limit.
+        //
+        // `fence.cataloged` is absent on purpose: it is emitted by a private helper driven through
+        // `api.fetch.result`, so it cannot be a row here. It carries its own `ev` assertion in
+        // `fenceCatalog_...` below. Every other key the module emits is listed.
+        let expected: Set = [
+            "api.fetch.result",
+            "baseline.healed",
+            "baseline.refused",
+            "contradiction.refused",
+            "delivery.failed",
+            "delivery.queued",
+            "delivery.sent",
+            "fix.received",
+            "info",
+            "module.init",
+            "module.reset",
+            "module.wake",
+            "movement.exit",
+            "movement.fix.failed",
+            "movement.fix.requested",
+            "movement.fix.resolved",
+            "movement.rearmed",
+            "movement.registered",
+            "os.callback.dropped",
+            "os.callback.received",
+            "os.monitor.failed",
+            "os.monitor.stopped",
+            "os.stream.failed",
+            "permission.changed",
+            "rank.evaluated",
+            "registration.adopted",
+            "registration.applied",
+            "registration.diff",
+            "registration.rearmed",
+            "registration.rejected",
+            "storage.loaded",
+            "storage.write.failed",
+            "sync.completed",
+            "sync.skipped",
+            "sync.superseded",
+            "transition.accepted",
+            "transition.dropped",
+            "transition.suppressed",
+            "transition.synthesized"
+        ]
+        var seen: Set<String> = []
+        withDiagnostics(true) {
+            for invocation in invocations {
+                let logger = CapturingLogger()
+                invocation.run(logger)
+                if let ev = parseTail(logger.messages.last ?? "")?["ev"] { seen.insert(ev) }
+            }
+        }
+        #expect(seen == expected, "vocabulary drift.\n  added:   \(seen.subtracting(expected).sorted())\n  missing: \(expected.subtracting(seen).sorted())")
     }
 
     @Test

--- a/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
@@ -116,7 +116,8 @@ struct GeofenceLogTailTests {
             Invocation(name: "fixQuality", requiredKeys: ["fixsrc", "acc", "age"]) { $0.geofenceCallbackReceived(identifier: "q", transition: .enter, fix: location, source: .freshRequest) },
             Invocation(name: "deliverySent", requiredKeys: ["id", "t", "via"]) { $0.geofenceDeliverySent(geofenceId: "notl_core", transition: .enter, via: "http") },
             Invocation(name: "deliveryQueued", requiredKeys: ["id", "t", "via"]) { $0.geofenceDeliveryQueued(geofenceId: "notl_core", transition: .enter, via: "event_bus") },
-            Invocation(name: "deliveryFailed", requiredKeys: ["id", "t", "ok", "retry"]) { $0.geofenceDeliveryFailed(geofenceId: "notl_core", transition: .exit, retry: true) },
+            Invocation(name: "deliveryFailed", requiredKeys: ["id", "t", "ok", "retry", "why"]) { $0.geofenceDeliveryFailed(geofenceId: "notl_core", transition: .exit, error: .transport) },
+            Invocation(name: "deliveryFailedPermanent", requiredKeys: ["id", "t", "ok", "retry", "why"]) { $0.geofenceDeliveryFailed(geofenceId: "notl_core", transition: .exit, error: .http(statusCode: 401)) },
             Invocation(name: "transitionAccepted", requiredKeys: ["id", "t", "n"]) { $0.geofenceTransitionAccepted(geofenceId: "notl_core", transition: .enter, rows: 2) },
             Invocation(name: "eventSuppressed", requiredKeys: ["id", "t", "why", "cd"]) { $0.geofenceEventSuppressed(geofenceId: "notl_core", transition: .enter, cooldownRemaining: 42) },
             Invocation(name: "droppedAnonymous", requiredKeys: ["id", "t", "why"]) { $0.geofenceTransitionDroppedAnonymous(geofenceId: "notl_core", transition: .exit) },
@@ -182,6 +183,30 @@ struct GeofenceLogTailTests {
                 }
             }
         }
+    }
+
+    @Test
+    func deliveryFailure_expectPermanentErrorsReportedNotRetryable() {
+        // Reporting a permanent failure as retryable made a misconfiguration read as flaky
+        // network off-device, which are opposite diagnoses: one needs a fix, one needs waiting.
+        let permanent: [BackgroundDeliveryHttpError] = [
+            .missingApiHost, .missingCdpApiKey, .invalidRequest,
+            .http(statusCode: 400), .http(statusCode: 401), .http(statusCode: 404)
+        ]
+        let retryable: [BackgroundDeliveryHttpError] = [
+            .transport, .http(statusCode: 408), .http(statusCode: 429),
+            .http(statusCode: 500), .http(statusCode: 503)
+        ]
+        for error in permanent {
+            #expect(error.isRetryable == false, "\(error) should not be reported as retryable")
+        }
+        for error in retryable {
+            #expect(error.isRetryable == true, "\(error) should be reported as retryable")
+        }
+        // Tokens ride a whitespace-split tail and must tell the cases apart.
+        let tokens = (permanent + retryable).map(\.diagnosticReason)
+        #expect(tokens.allSatisfy { !$0.contains(" ") }, "a reason token contains whitespace")
+        #expect(Set(tokens).count == tokens.count, "duplicate reason tokens: \(tokens)")
     }
 
     @Test

--- a/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
@@ -115,6 +115,7 @@ struct GeofenceLogTailTests {
             Invocation(name: "fixReceived", requiredKeys: ["prov"]) { $0.geofenceFixReceived(location, source: "movement_pass") },
             Invocation(name: "fixQuality", requiredKeys: ["fixsrc", "acc", "age"]) { $0.geofenceCallbackReceived(identifier: "q", transition: .enter, fix: location, source: .freshRequest) },
             Invocation(name: "eventTracked", requiredKeys: ["id", "t"]) { $0.geofenceEventTracked(geofenceId: "notl_core", transition: .enter) },
+            Invocation(name: "transitionAccepted", requiredKeys: ["id", "t", "n"]) { $0.geofenceTransitionAccepted(geofenceId: "notl_core", transition: .enter, rows: 2) },
             Invocation(name: "eventSuppressed", requiredKeys: ["id", "t", "why", "cd"]) { $0.geofenceEventSuppressed(geofenceId: "notl_core", transition: .enter, cooldownRemaining: 42) },
             Invocation(name: "droppedAnonymous", requiredKeys: ["id", "t", "why"]) { $0.geofenceTransitionDroppedAnonymous(geofenceId: "notl_core", transition: .exit) },
             Invocation(name: "pendingPersistFailed", requiredKeys: ["id", "t", "ok"]) { $0.geofencePendingPersistFailed(geofenceId: "notl_core", transition: .exit) },

--- a/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
@@ -376,19 +376,19 @@ struct GeofenceLogTailTests {
         // field, but it must not be applied to a value that composed those separators on purpose.
         // Folding them turned `ids=a,b` into `ids=a_b` and `ranked=x:120` into `ranked=x_120`,
         // which no unit test noticed and a device capture did.
-        GeofenceDiagnostics.overrideForTesting = true
-        defer { GeofenceDiagnostics.overrideForTesting = nil }
-        let logger = CapturingLogger()
-        logger.geofenceRankEvaluated(
-            candidates: 3,
-            selectedCount: 2,
-            selected: ["alpha", "beta"],
-            evicted: ["gamma"],
-            edgeDistances: ["alpha": 120, "beta": 340]
-        )
-        let message = logger.messages.last ?? ""
-        #expect(message.contains("ranked=alpha:120,beta:340"), "ranked lost its separators: \(message)")
-        #expect(message.contains("evicted=gamma"), "evicted malformed: \(message)")
+        withDiagnostics(true) {
+            let logger = CapturingLogger()
+            logger.geofenceRankEvaluated(
+                candidates: 3,
+                selectedCount: 2,
+                selected: ["alpha", "beta"],
+                evicted: ["gamma"],
+                edgeDistances: ["alpha": 120, "beta": 340]
+            )
+            let message = logger.messages.last ?? ""
+            #expect(message.contains("ranked=alpha:120,beta:340"), "ranked lost its separators: \(message)")
+            #expect(message.contains("evicted=gamma"), "evicted malformed: \(message)")
+        }
     }
 
     @Test
@@ -458,15 +458,15 @@ struct GeofenceLogTailTests {
         // The whitespace test elsewhere passes whether or not token fields are sanitized, because
         // `tail` folds whitespace for every value. It never covered the characters the format
         // itself uses, and every `id` call site went unprotected behind it.
-        GeofenceDiagnostics.overrideForTesting = true
-        defer { GeofenceDiagnostics.overrideForTesting = nil }
-        for raw in ["store,north", "a=b", "aisle:3", "wing|west"] {
-            let logger = CapturingLogger()
-            logger.geofenceTransitionAccepted(geofenceId: raw, transition: .enter, rows: 1)
-            let tail = parseTail(logger.messages.last ?? "")
-            #expect(tail?["id"] != nil, "no id for \(raw)")
-            let id = tail?["id"] ?? ""
-            #expect(!id.contains(where: { "=,:|".contains($0) }), "id kept a separator: \(id)")
+        withDiagnostics(true) {
+            for raw in ["store,north", "a=b", "aisle:3", "wing|west"] {
+                let logger = CapturingLogger()
+                logger.geofenceTransitionAccepted(geofenceId: raw, transition: .enter, rows: 1)
+                let tail = parseTail(logger.messages.last ?? "")
+                #expect(tail?["id"] != nil, "no id for \(raw)")
+                let id = tail?["id"] ?? ""
+                #expect(!id.contains(where: { "=,:|".contains($0) }), "id kept a separator: \(id)")
+            }
         }
     }
 

--- a/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
@@ -114,7 +114,9 @@ struct GeofenceLogTailTests {
             Invocation(name: "callbackDropped", requiredKeys: ["id", "t", "why"]) { $0.geofenceCallbackDropped(identifier: "notl_core", transition: .enter, reason: "movement_trigger_not_exit") },
             Invocation(name: "fixReceived", requiredKeys: ["prov"]) { $0.geofenceFixReceived(location, source: "movement_pass") },
             Invocation(name: "fixQuality", requiredKeys: ["fixsrc", "acc", "age"]) { $0.geofenceCallbackReceived(identifier: "q", transition: .enter, fix: location, source: .freshRequest) },
-            Invocation(name: "eventTracked", requiredKeys: ["id", "t"]) { $0.geofenceEventTracked(geofenceId: "notl_core", transition: .enter) },
+            Invocation(name: "deliverySent", requiredKeys: ["id", "t", "via"]) { $0.geofenceDeliverySent(geofenceId: "notl_core", transition: .enter, via: "http") },
+            Invocation(name: "deliveryQueued", requiredKeys: ["id", "t", "via"]) { $0.geofenceDeliveryQueued(geofenceId: "notl_core", transition: .enter, via: "event_bus") },
+            Invocation(name: "deliveryFailed", requiredKeys: ["id", "t", "ok", "retry"]) { $0.geofenceDeliveryFailed(geofenceId: "notl_core", transition: .exit, retry: true) },
             Invocation(name: "transitionAccepted", requiredKeys: ["id", "t", "n"]) { $0.geofenceTransitionAccepted(geofenceId: "notl_core", transition: .enter, rows: 2) },
             Invocation(name: "eventSuppressed", requiredKeys: ["id", "t", "why", "cd"]) { $0.geofenceEventSuppressed(geofenceId: "notl_core", transition: .enter, cooldownRemaining: 42) },
             Invocation(name: "droppedAnonymous", requiredKeys: ["id", "t", "why"]) { $0.geofenceTransitionDroppedAnonymous(geofenceId: "notl_core", transition: .exit) },
@@ -324,7 +326,7 @@ struct GeofenceLogTailTests {
     func sanitize_givenWhitespaceInIdentifier_expectFolded() {
         withDiagnostics(true) {
             let logger = CapturingLogger()
-            logger.geofenceEventTracked(geofenceId: "niagara on the lake", transition: .enter)
+            logger.geofenceTransitionAccepted(geofenceId: "niagara on the lake", transition: .enter, rows: 1)
 
             // Workspace-authored identifiers can contain anything; the parser splits on whitespace.
             #expect(parseTail(logger.messages.last ?? "")?["id"] == "niagara_on_the_lake")
@@ -369,7 +371,7 @@ struct GeofenceLogTailTests {
         defer { GeofenceDiagnostics.overrideForTesting = nil }
         for raw in ["store,north", "a=b", "aisle:3", "wing|west"] {
             let logger = CapturingLogger()
-            logger.geofenceEventTracked(geofenceId: raw, transition: .enter)
+            logger.geofenceTransitionAccepted(geofenceId: raw, transition: .enter, rows: 1)
             let tail = parseTail(logger.messages.last ?? "")
             #expect(tail?["id"] != nil, "no id for \(raw)")
             let id = tail?["id"] ?? ""

--- a/Tests/LocationGeofence/Geofence/Monitor/GeofenceMonitorOwnershipTests.swift
+++ b/Tests/LocationGeofence/Geofence/Monitor/GeofenceMonitorOwnershipTests.swift
@@ -52,10 +52,7 @@ struct GeofenceMonitorOwnershipTests {
     /// nothing and pass against the very bug they are meant to catch — verified by running them
     /// against the unfixed monitor.
     private func withDiagnostics<T>(_ enabled: Bool, _ body: () throws -> T) rethrows -> T {
-        let previous = GeofenceDiagnostics.overrideForTesting
-        GeofenceDiagnostics.overrideForTesting = enabled
-        defer { GeofenceDiagnostics.overrideForTesting = previous }
-        return try body()
+        try DiagnosticsGateTesting.withDiagnostics(enabled, body)
     }
 
     private func hostRegion() -> CLCircularRegion {
@@ -109,21 +106,19 @@ struct GeofenceMonitorOwnershipTests {
     /// the queue drains. Nothing may be recorded in the meantime.
     @Test
     func regionEvent_givenBufferedAndNotOurs_expectNothingRecorded() async {
-        let previous = GeofenceDiagnostics.overrideForTesting
-        GeofenceDiagnostics.overrideForTesting = true
-        defer { GeofenceDiagnostics.overrideForTesting = previous }
+        await DiagnosticsGateTesting.withDiagnostics(true) {
+            let logger = CapturingLogger()
+            let monitor = CoreLocationGeofenceMonitor(logger: logger)
 
-        let logger = CapturingLogger()
-        let monitor = CoreLocationGeofenceMonitor(logger: logger)
+            monitor.locationManager(CLLocationManager(), didEnterRegion: hostRegion())
+            monitor.setOnTransition { _, _, _ in }
+            // Let the drain task run; it is dispatched onto the main actor.
+            await Task.yield()
 
-        monitor.locationManager(CLLocationManager(), didEnterRegion: hostRegion())
-        monitor.setOnTransition { _, _, _ in }
-        // Let the drain task run; it is dispatched onto the main actor.
-        await Task.yield()
-
-        #expect(
-            logger.messages.allSatisfy { !$0.contains("os.callback.received") },
-            "drained a buffered crossing for a region we do not own: \(logger.messages)"
-        )
+            #expect(
+                logger.messages.allSatisfy { !$0.contains("os.callback.received") },
+                "drained a buffered crossing for a region we do not own: \(logger.messages)"
+            )
+        }
     }
 }

--- a/Tests/LocationGeofence/Geofence/Monitor/GeofenceMonitorOwnershipTests.swift
+++ b/Tests/LocationGeofence/Geofence/Monitor/GeofenceMonitorOwnershipTests.swift
@@ -106,19 +106,21 @@ struct GeofenceMonitorOwnershipTests {
     /// the queue drains. Nothing may be recorded in the meantime.
     @Test
     func regionEvent_givenBufferedAndNotOurs_expectNothingRecorded() async {
-        await DiagnosticsGateTesting.withDiagnostics(true) {
-            let logger = CapturingLogger()
-            let monitor = CoreLocationGeofenceMonitor(logger: logger)
+        let logger = CapturingLogger()
+        let monitor = CoreLocationGeofenceMonitor(logger: logger)
 
-            monitor.locationManager(CLLocationManager(), didEnterRegion: hostRegion())
-            monitor.setOnTransition { _, _, _ in }
-            // Let the drain task run; it is dispatched onto the main actor.
-            await Task.yield()
+        monitor.locationManager(CLLocationManager(), didEnterRegion: hostRegion())
+        monitor.setOnTransition { _, _, _ in }
+        // Let the drain task run; it is dispatched onto the main actor.
+        await Task.yield()
 
-            #expect(
-                logger.messages.allSatisfy { !$0.contains("os.callback.received") },
-                "drained a buffered crossing for a region we do not own: \(logger.messages)"
-            )
-        }
+        // Asserted on the identifier, like the unbuffered sibling above, rather than on the tail's
+        // `ev=`. The identifier rides in the prose, which is emitted whatever the diagnostics gate
+        // says, so this needs no gate — and it is the stronger check: it fails whether or not the
+        // tail happens to be on, where an `ev=` assertion passes vacuously with the gate off.
+        #expect(
+            logger.messages.allSatisfy { !$0.contains(Self.hostIdentifier) },
+            "drained a buffered crossing for a region we do not own: \(logger.messages)"
+        )
     }
 }

--- a/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
@@ -916,14 +916,11 @@ struct GeofenceStorageTests {
         // The monitor logs this token when it discards a callback.
         //
         // A case added with no token at all is already a compile error — `diagnosticReason`
-        // switches exhaustively with no `default`. What the compiler cannot catch is a case
-        // wired to `nil`, which `logDiscardedCallback` then swallows silently; that is what the
-        // `!= nil` assertions below exist for. An unattributable disappearance is
-        // indistinguishable from the OS never delivering at all.
-        let cases: [GeofenceMonitorEventOutcome] = [
-            .deliver, .suppressedNoChange, .suppressedFilteredType,
-            .suppressedNoBaseline, .suppressedNewerBaseline
-        ]
+        // switches exhaustively with no `default`. What the compiler cannot catch is a case wired
+        // to `nil`, which the caller's `if let` then swallows silently. Driven off `allCases` so
+        // that a newly added case is covered too; a hand-written list would simply not mention it.
+        // An unattributable disappearance is indistinguishable from the OS never delivering at all.
+        let cases = GeofenceMonitorEventOutcome.allCases
         for outcome in cases {
             if case .deliver = outcome {
                 #expect(outcome.diagnosticReason == nil, "deliver is not a discard and must log nothing")

--- a/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
@@ -910,4 +910,28 @@ struct GeofenceStorageTests {
 
         #expect(await storage.recordMonitorEvent(.enter, forIdentifier: "g1") == .suppressedNoChange)
     }
+
+    @Test
+    func diagnosticReason_expectEverySuppressionNamedAndDeliverSilent() {
+        // The monitor logs this token when it discards a callback. A new case added without a
+        // token would discard silently again, which is the gap this exists to close — an
+        // unattributable disappearance is indistinguishable from the OS never delivering at all.
+        let cases: [GeofenceMonitorEventOutcome] = [
+            .deliver, .suppressedNoChange, .suppressedFilteredType,
+            .suppressedNoBaseline, .suppressedNewerBaseline
+        ]
+        for outcome in cases {
+            if case .deliver = outcome {
+                #expect(outcome.diagnosticReason == nil, "deliver is not a discard and must log nothing")
+            } else {
+                let reason = outcome.diagnosticReason
+                #expect(reason != nil, "\(outcome) has no diagnostic token")
+                // Tokens ride in a whitespace-split tail, so a space would break the parser.
+                #expect(!(reason ?? " ").contains(" "), "\(outcome): token must not contain whitespace")
+            }
+        }
+        // Distinct reasons, or two different discards read as the same thing off-device.
+        let tokens = cases.compactMap(\.diagnosticReason)
+        #expect(Set(tokens).count == tokens.count, "duplicate tokens: \(tokens)")
+    }
 }

--- a/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
@@ -913,9 +913,13 @@ struct GeofenceStorageTests {
 
     @Test
     func diagnosticReason_expectEverySuppressionNamedAndDeliverSilent() {
-        // The monitor logs this token when it discards a callback. A new case added without a
-        // token would discard silently again, which is the gap this exists to close — an
-        // unattributable disappearance is indistinguishable from the OS never delivering at all.
+        // The monitor logs this token when it discards a callback.
+        //
+        // A case added with no token at all is already a compile error — `diagnosticReason`
+        // switches exhaustively with no `default`. What the compiler cannot catch is a case
+        // wired to `nil`, which `logDiscardedCallback` then swallows silently; that is what the
+        // `!= nil` assertions below exist for. An unattributable disappearance is
+        // indistinguishable from the OS never delivering at all.
         let cases: [GeofenceMonitorEventOutcome] = [
             .deliver, .suppressedNoChange, .suppressedFilteredType,
             .suppressedNoBaseline, .suppressedNewerBaseline

--- a/Tests/LocationGeofence/Geofence/Stub/DiagnosticsGate+Testing.swift
+++ b/Tests/LocationGeofence/Geofence/Stub/DiagnosticsGate+Testing.swift
@@ -1,0 +1,33 @@
+@testable import CioLocationGeofence
+import Foundation
+
+/// `GeofenceDiagnostics.overrideForTesting` is process-global, and swift-testing's `.serialized`
+/// orders tests *within* a suite, not across them. Two suites both flipping the gate therefore
+/// raced: one asserting "no diagnostic keys with the gate off" would intermittently observe the
+/// other's `true`, roughly one run in four.
+///
+/// Every test that touches the gate takes this lock for the whole of its body, which serializes
+/// them across suite boundaries without restructuring either suite.
+enum DiagnosticsGateTesting {
+    private static let lock = NSRecursiveLock()
+
+    /// Runs `body` with the gate forced on or off, restoring the previous value after.
+    static func withDiagnostics<T>(_ enabled: Bool, _ body: () throws -> T) rethrows -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        let previous = GeofenceDiagnostics.overrideForTesting
+        GeofenceDiagnostics.overrideForTesting = enabled
+        defer { GeofenceDiagnostics.overrideForTesting = previous }
+        return try body()
+    }
+
+    /// Async variant, for tests that must await inside the guarded region.
+    static func withDiagnostics<T>(_ enabled: Bool, _ body: () async throws -> T) async rethrows -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        let previous = GeofenceDiagnostics.overrideForTesting
+        GeofenceDiagnostics.overrideForTesting = enabled
+        defer { GeofenceDiagnostics.overrideForTesting = previous }
+        return try await body()
+    }
+}

--- a/Tests/LocationGeofence/Geofence/Stub/DiagnosticsGate+Testing.swift
+++ b/Tests/LocationGeofence/Geofence/Stub/DiagnosticsGate+Testing.swift
@@ -8,6 +8,13 @@ import Foundation
 ///
 /// Every test that touches the gate takes this lock for the whole of its body, which serializes
 /// them across suite boundaries without restructuring either suite.
+///
+/// **Synchronous only, deliberately.** An `async` variant existed and deadlocked: a lock held
+/// across an `await` can be released on a different cooperative-pool thread than took it, so
+/// `unlock()` fails with EPERM and every later caller blocks forever. It hung the whole target
+/// intermittently. No lock can be held across a suspension point, so the fix is not a better lock
+/// — a test that needs the gate must not await inside it. The one test that did now asserts on
+/// prose instead, which needs no gate at all.
 enum DiagnosticsGateTesting {
     private static let lock = NSRecursiveLock()
 
@@ -19,15 +26,5 @@ enum DiagnosticsGateTesting {
         GeofenceDiagnostics.overrideForTesting = enabled
         defer { GeofenceDiagnostics.overrideForTesting = previous }
         return try body()
-    }
-
-    /// Async variant, for tests that must await inside the guarded region.
-    static func withDiagnostics<T>(_ enabled: Bool, _ body: () async throws -> T) async rethrows -> T {
-        lock.lock()
-        defer { lock.unlock() }
-        let previous = GeofenceDiagnostics.overrideForTesting
-        GeofenceDiagnostics.overrideForTesting = enabled
-        defer { GeofenceDiagnostics.overrideForTesting = previous }
-        return try await body()
     }
 }


### PR DESCRIPTION
iOS half of the pair with customerio-android#842. Two diagnostics follow-ups plus a flake fix, all found while using the sink on a real drive.

### 1. Record the fetched fence catalog

A capture named fences only by opaque id. Nobody reading a log could tell which geoset a crossing belonged to, and a replay could not place the circles at all — the scenario transform emitted `fixture.api.fetch body:null` because the geometry is nowhere in the log.

`GeofenceApiRegion` already carries `name`, `latitude`, `longitude`, `radius` and `geosetIds`, and we discarded all of it. Each successful fetch now emits one record per fence, behind the existing `CIOGeofenceDiagnostics` gate:

```
ev=fence.cataloged io=in id=11125 name=Momo_Dubai_Test gs=4471 lat=25.10967 lon=55.18406 rad=150 tt=enter,exit
```

Re-fetching the geometry from the workspace at replay time is **not** equivalent: fences move, so a drive replayed months later would silently run against today's circles rather than the ones it crossed — and a capture from a customer or an opted-in tester has no workspace to query.

Names are sanitized like any other value; a workspace-authored name can contain spaces, commas and `=`, each of which would break the parser's split. `gs` and `tt` join the composed-key set alongside `ids`, since their commas are structure rather than untrusted input.

Gated **whole** rather than gated-tail, and so deliberately absent from the `invocations` table that asserts the gated-tail contract — `proseHalf_expectIdenticalWhicheverWayTheGateIsSet` catches the difference immediately. These records carry no prose worth emitting on their own, and moving the detail into the prose to satisfy that table would leak coordinates with the gate off. Their own tests pin the same guarantees.

### 2. Rebuild the file header per file

The header was built once at launch and re-written verbatim on every open, so a process outliving a day stamped each rolled-over file with the original session's timestamp — and, since the iOS header carries `tz`, the original timezone.

That second part is reachable *because of* the recent timezone fix: a zone change now correctly opens a new file named for the new zone, and until this change stamped it with the old one.

Observed on a device: four consecutive daily files, every one reading `ts=2026-09-02T23:53:44.454`.

### 3. Fix a test flake introduced in #1243

`GeofenceDiagnostics.overrideForTesting` is process-global, and swift-testing's `.serialized` orders tests *within* a suite, not across them. `GeofenceMonitorOwnershipTests` forcing the gate on overlapped `GeofenceLogTailTests` asserting it was off — `everyRecord_givenDiagnosticsOff_expectNoDiagnosticKeyAnywhere` failed roughly one run in four with 83 issues. **This flake is on `main` today.** Both suites now take a shared lock around any body that touches the gate.

### Verification

- 374 geofence tests pass, up from 369
- swiftformat and `swiftlint --strict` clean on every changed file
- APN-UIKit builds
- End to end: injecting the new records into the real Dubai drive capture turns `fixture.api.fetch body:null` into the full geometry for both fetches