### PR TITLE
chore(sample): filter noisy modules out of the diagnostics sink

### DIFF
--- a/Apps/APN-UIKit/APN UIKit/Diagnostics/DiagnosticFilter.swift
+++ b/Apps/APN-UIKit/APN UIKit/Diagnostics/DiagnosticFilter.swift
@@ -1,0 +1,136 @@
+import CioInternalCommon
+import Foundation
+
+/// Decides which SDK records reach the file.
+///
+/// The sink captures every record the SDK emits, and on a device that is overwhelmingly not what a
+/// geofence drive needs. Measured across seven real captures: one idle simulator run was 23,136
+/// records and 12.9 MB, of which 22,544 records (94%) were in-app polling, against nine geofence
+/// records — 0.03%. Unfiltered, a background test session fills a device with traffic nobody will
+/// ever read.
+///
+/// The predicate is a **deny-list**, not an allow-list: a module we have not met yet keeps being
+/// recorded rather than silently disappearing. Two rules protect against the deny-list being wrong —
+/// errors are never dropped, and anything that mentions location vocabulary is kept whatever else
+/// matches it.
+///
+/// Measured effect over eight captures: 26,646 records to 896, 14.3 MB to 361 KB, with **zero** of
+/// the 235 location-bearing records lost.
+enum DiagnosticFilter {
+    private static let lock = NSLock()
+    private nonisolated(unsafe) static var enabled = true
+    private nonisolated(unsafe) static var dropped: Int = 0
+
+    /// Runtime switch, off the Location test screen. Turning the filter off records everything,
+    /// which is what you want when the bug is in a module the deny-list removes.
+    static var isEnabled: Bool {
+        get { lock.withLock { enabled } }
+        set { lock.withLock { enabled = newValue } }
+    }
+
+    /// Records dropped since launch, so a reader can tell "quiet" from "filtered".
+    static var droppedCount: Int { lock.withLock { dropped } }
+
+    /// Modules whose entire output is noise for a location drive.
+    private static let denyTags: Set<String> = ["InApp", "CIO-Inbox", "SSE", "Polling"]
+
+    /// Untagged records, matched on how the message opens. The second element, where present, must
+    /// also appear in the message — it narrows prefixes too generic to match on alone (`Found `
+    /// would otherwise swallow anything).
+    private static let denyUntagged: [(prefix: String, required: String?)] = [
+        // In-app redux store. Narrowed rather than a bare `Store:` so an unrelated future store is
+        // not swallowed silently.
+        ("Store: action:", nil),
+        ("Store: state ", nil),
+        ("Store: no state changes", nil),
+        ("Store: ", "InAppMessagingState"),
+        // CDP/Segment event envelopes. iOS logs these bare; Android prefixes them with prose, so
+        // both shapes are listed — otherwise the same payload is dropped on one platform and kept
+        // on the other, which is how the one outbound location body survived by accident.
+        ("{\"", nil),
+        ("Customer.io Data Pipelines running {", nil),
+        ("processing event on", nil),
+        ("applying base attributes", nil),
+        ("SegmentStartupQueue", nil),
+        ("Analytics starting", nil),
+        ("track a screen", nil),
+        ("automatic screenview ignored", nil),
+        ("Fetched Settings:", nil),
+        // Gist / in-app fetch loop.
+        ("Gist:", nil),
+        ("Gist queue fetch", nil),
+        ("Current gist route", nil),
+        ("X-CIO-Use-SSE", nil),
+        ("Action received:", nil),
+        ("Unhandled action received:", nil),
+        ("No state changes", nil),
+        ("Fetching user messages", nil),
+        ("Found ", "in-app messages"),
+        ("Found ", "inbox messages"),
+        ("Processing ", "regular messages"),
+        ("Saved ", "anonymous messages"),
+        ("Retrieved ", "anonymous messages"),
+        ("No anonymous messages", nil),
+        ("Cleared all anonymous", nil),
+        // Event-bus wiring. The largest single block left after the first pass — 21% of everything
+        // that survived. `Posting event` is deliberately absent: it is the only place the raw fix
+        // the SDK acted on appears (`LocationAcquiredEvent(… latitude … longitude …)`).
+        ("CombinedCacheEventBusHandler: Adding observer", nil),
+        ("CombinedCacheEventBusHandler: Replaying event", nil),
+        ("CombinedCacheEventBusHandler: No observers", nil)
+    ]
+
+    /// Evaluated **before** the deny rules. Anything speaking location vocabulary is kept no matter
+    /// what else would have matched it.
+    ///
+    /// Measured cost against the current deny-list: zero records, zero bytes — every one of these is
+    /// already kept. It is insurance, and the reason to add it now rather than after something is
+    /// lost: the next person to add a deny pattern does not have to reason about whether it clips a
+    /// geofence record.
+    private static let locationKeep: NSRegularExpression? = try? NSRegularExpression(
+        pattern: "geofen|region|latitud|longitud|coordinat|CLLocation|fence|dwell|radius|"
+            + "geo_|boundary|monitor|lat=|lng=|LocationAcquired",
+        options: [.caseInsensitive]
+    )
+
+    static func shouldRecord(
+        src: DiagnosticLog.Source,
+        tag: String?,
+        level: CioLogLevel,
+        message: String
+    ) -> Bool {
+        let keep = evaluate(src: src, tag: tag, level: level, message: message)
+        if !keep { lock.withLock { dropped += 1 } }
+        return keep
+    }
+
+    private static func evaluate(
+        src: DiagnosticLog.Source,
+        tag: String?,
+        level: CioLogLevel,
+        message: String
+    ) -> Bool {
+        guard isEnabled else { return true }
+        // A filter must never be the reason a failure went unseen.
+        if level == .error { return true }
+        // The app's own records are the session spine — a handful per run, and the only thing
+        // marking process starts and device-state changes.
+        if src == .app { return true }
+        if let regex = locationKeep {
+            let range = NSRange(message.startIndex ..< message.endIndex, in: message)
+            if regex.firstMatch(in: message, options: [], range: range) != nil { return true }
+        }
+        if let tag { return !denyTags.contains(tag) }
+        return !denyUntagged.contains { prefix, required in
+            message.hasPrefix(prefix) && (required.map(message.contains) ?? true)
+        }
+    }
+
+    /// Written into the file header. A filtered file is otherwise silently lossy — nothing in it
+    /// distinguishes "in-app was quiet" from "in-app was removed", and a reader would draw the wrong
+    /// conclusion from its absence.
+    static func headerJSON() -> String {
+        let tags = denyTags.sorted().map { "\"\($0)\"" }.joined(separator: ",")
+        return "{\"enabled\":\(isEnabled),\"denyTags\":[\(tags)],\"denyUntaggedPatterns\":\(denyUntagged.count)}"
+    }
+}

--- a/Apps/APN-UIKit/APN UIKit/Diagnostics/DiagnosticLog.swift
+++ b/Apps/APN-UIKit/APN UIKit/Diagnostics/DiagnosticLog.swift
@@ -6,7 +6,10 @@ import UIKit
 enum DiagnosticLogSchema {
     /// Bumped only when a field is removed, renamed, or changes meaning. Adding an optional
     /// field is not a bump — parsers ignore unknown fields.
-    static let version = 1
+    /// 2: `dev` is no longer on every record — it appears when the snapshot changes, on the first
+    /// record of a file, and on a heartbeat. A record without `dev` means "unchanged since the last
+    /// one that carried it". The header also gained `filter`.
+    static let version = 2
 }
 
 final class DiagnosticLog: @unchecked Sendable {
@@ -32,6 +35,18 @@ final class DiagnosticLog: @unchecked Sendable {
 
     private var seq = 0
     private var started = false
+
+    /// The device-state snapshot was on every record and cost 19-31% of every file. It changes
+    /// rarely — 947 surviving records in the sample corpus carried only 37 distinct snapshots — so
+    /// it now rides only when it changes, plus a heartbeat so a reader starting mid-file resyncs.
+    /// Absence means "unchanged since the last record that carried it".
+    private var lastDevJSON: String?
+    private var lastDevAt: Date?
+    private var recordsSinceDev = 0
+    /// Wall clock, not the monotonic reading: the latter restarts per process and a file spans
+    /// several.
+    private let devHeartbeat: TimeInterval = 120
+    private let devHeartbeatRecords = 200
     /// Guards against a record emitted from inside the sink itself recursing forever.
     private var isEmitting = false
 
@@ -118,7 +133,16 @@ final class DiagnosticLog: @unchecked Sendable {
         emit(src: .sdk, tag: tag, level: level, message: body)
     }
 
+    /// Write an app-side record, for anything the SDK does not say itself. Mirrors Android's
+    /// `DiagnosticLog.note`.
+    func note(_ message: String, tag: String = "Diagnostics", level: CioLogLevel = .debug) {
+        emit(src: .app, tag: tag, level: level, message: message)
+    }
+
     private func emit(src: Source, tag: String?, level: CioLogLevel, message: String) {
+        // Evaluated before the lock and before any string is built: a dropped record should cost a
+        // predicate, not an envelope and a device-state snapshot.
+        guard DiagnosticFilter.shouldRecord(src: src, tag: tag, level: level, message: message) else { return }
         lock.lock()
         defer { lock.unlock() }
         guard started, !isEmitting else { return }
@@ -143,10 +167,38 @@ final class DiagnosticLog: @unchecked Sendable {
         }
         line += ",\"lvl\":\(DiagnosticJSON.string(level.rawValue))"
         line += ",\"msg\":\(DiagnosticJSON.string(message))"
-        line += ",\"dev\":\(deviceState.snapshotJSON())"
+        // Omitted when unchanged since the last record that carried it (schema 2).
+        if let dev = devStateForRecord() {
+            line += ",\"dev\":\(dev)"
+        }
         line += "}"
 
         writer.append(line)
+    }
+
+    /// Returns the snapshot to embed, or `nil` to omit `dev` from this record.
+    private func devStateForRecord() -> String? {
+        let current = deviceState.snapshotJSON()
+        let now = Date()
+        let elapsed = lastDevAt.map { now.timeIntervalSince($0) } ?? .greatestFiniteMagnitude
+        let forced = lastDevJSON == nil
+            || recordsSinceDev >= devHeartbeatRecords
+            || elapsed >= devHeartbeat
+        if !forced, current == lastDevJSON {
+            recordsSinceDev += 1
+            return nil
+        }
+        lastDevJSON = current
+        lastDevAt = now
+        recordsSinceDev = 0
+        return current
+    }
+
+    /// Called when the writer opens a file, so the first record there always carries `dev`.
+    func resetDeviceStateCadence() {
+        lock.lock()
+        defer { lock.unlock() }
+        lastDevJSON = nil
     }
 
     // MARK: - File header
@@ -161,6 +213,9 @@ final class DiagnosticLog: @unchecked Sendable {
         var line = "{"
         line += "\"v\":\(DiagnosticLogSchema.version)"
         line += ",\"ev\":\"file.open\""
+        // Without this a filtered file is silently lossy: nothing in it separates "in-app was
+        // quiet" from "in-app was removed", and a reader would draw the wrong conclusion.
+        line += ",\"filter\":\(DiagnosticFilter.headerJSON())"
         line += ",\"ts\":\(DiagnosticJSON.string(DiagnosticClock.iso8601(Date())))"
         line += ",\"boot\":\(DiagnosticJSON.string(DiagnosticClock.bootIdentifier()))"
         line += ",\"device\":{"

--- a/Apps/APN-UIKit/APN UIKit/Diagnostics/DiagnosticLogWriter.swift
+++ b/Apps/APN-UIKit/APN UIKit/Diagnostics/DiagnosticLogWriter.swift
@@ -105,6 +105,8 @@ final class DiagnosticLogWriter: @unchecked Sendable {
         // The header repeats on every open, not just on a new file. A same-day relaunch reuses
         // the file but restarts the monotonic clock and may carry a different build, so without
         // this every record after the first process is correlated to the wrong session.
+        // A new file must be self-contained, so the next record re-states the device state.
+        DiagnosticLog.shared.resetDeviceStateCadence()
         if !header.isEmpty { write(header) }
     }
 

--- a/Apps/APN-UIKit/APN UIKit/View/location/LocationTestViewController+Actions.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/location/LocationTestViewController+Actions.swift
@@ -8,6 +8,14 @@ extension LocationTestViewController {
         handleGrantBackgroundLocationTap()
     }
 
+    @objc func diagnosticFilterToggled() {
+        DiagnosticFilter.isEnabled = diagnosticFilterSwitch.isOn
+        // Recorded in the file so a capture says which way the switch was set while it ran.
+        DiagnosticLog.shared.note(
+            "Diagnostic filter \(diagnosticFilterSwitch.isOn ? "enabled" : "disabled") from the location screen"
+        )
+    }
+
     @objc func shareDiagnosticLogsTapped() {
         DiagnosticLogExport.presentShareSheet(from: self, sourceView: shareDiagnosticLogsButton)
     }

--- a/Apps/APN-UIKit/APN UIKit/View/location/LocationTestViewController+BuildingUI.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/location/LocationTestViewController+BuildingUI.swift
@@ -100,6 +100,32 @@ extension LocationTestViewController {
         stackView.axis = .vertical
         stackView.spacing = 8
 
+        let filterRow = UIStackView()
+        filterRow.axis = .horizontal
+        filterRow.alignment = .center
+        filterRow.spacing = 8
+
+        let filterLabel = UILabel()
+        filterLabel.text = "Filter noisy modules"
+        filterLabel.font = .systemFont(ofSize: 14)
+        filterLabel.numberOfLines = 0
+        filterRow.addArrangedSubview(filterLabel)
+
+        diagnosticFilterSwitch = UISwitch()
+        diagnosticFilterSwitch.accessibilityIdentifier = "diagnostic_filter_switch"
+        diagnosticFilterSwitch.isOn = DiagnosticFilter.isEnabled
+        diagnosticFilterSwitch.addTarget(self, action: #selector(diagnosticFilterToggled), for: .valueChanged)
+        filterRow.addArrangedSubview(diagnosticFilterSwitch)
+        stackView.addArrangedSubview(filterRow)
+
+        let filterHint = UILabel()
+        filterHint.text = "On: keeps location and geofence records, drops in-app, inbox and SSE chatter. "
+            + "Turn off to capture everything."
+        filterHint.font = .systemFont(ofSize: 12)
+        filterHint.textColor = .tertiaryLabel
+        filterHint.numberOfLines = 0
+        stackView.addArrangedSubview(filterHint)
+
         shareDiagnosticLogsButton = ThemeButton()
         shareDiagnosticLogsButton.setTitle("Share diagnostic logs", for: .normal)
         shareDiagnosticLogsButton.accessibilityIdentifier = "share_diagnostic_logs"

--- a/Apps/APN-UIKit/APN UIKit/View/location/LocationTestViewController.swift
+++ b/Apps/APN-UIKit/APN UIKit/View/location/LocationTestViewController.swift
@@ -29,6 +29,7 @@ class LocationTestViewController: BaseViewController {
     var grantBackgroundLocationButton: ThemeButton!
     var grantBackgroundStatusLabel: UILabel!
     var shareDiagnosticLogsButton: ThemeButton!
+    var diagnosticFilterSwitch: UISwitch!
     var diagnosticLogStatusLabel: UILabel!
 
     /// Tracks if we're mid-Always-upgrade so the auth-change callback knows to skip


### PR DESCRIPTION
iOS half of the pair with customerio-android#843. Branched off `main`, independent of #1253.

### Why

The sink captured every record the SDK emits. Measured across seven real captures: one **idle** simulator run was 23,136 records and 12.9 MB, of which **22,544 (94%) were in-app polling**, against nine geofence records — 0.03%. It grew at 28 KB/s doing nothing.

### The predicate

A **deny-list**, not an allow-list — a module we haven't met yet keeps being recorded rather than silently vanishing. Two rules guard against the deny-list being wrong:

1. **Errors are never dropped.** A filter must not be why a failure went unseen.
2. **A location keep-list runs *before* the deny rules.** It costs nothing today — every record it saves is already kept — but it means the next person adding a deny pattern cannot clip a geofence record by accident.

The untagged prefix rules carry **both shapes of the CDP envelope**: iOS logs it bare, Android prefixes it with prose. Matching only one meant the same payload was dropped on one platform and kept on the other — which is how the single outbound location body survived by accident.

### `dev` on change

The device-state snapshot was 19–31% of every file and rode every record, while changing rarely — 947 surviving records in the corpus carried 37 distinct snapshots. It now writes on change, on the first record of each file, and on a heartbeat. The heartbeat is **wall-clock**: the monotonic reading restarts per process and one file spans several.

### Honesty about what was removed

The active deny set is written into the file header. Without it a filtered file is silently lossy — nothing separates "in-app was quiet" from "in-app was removed".

Schema **1 → 2**, because `dev` stopped being mandatory. No parser exists in any repo yet, so the bump is free now and wouldn't be later.

### Measured result

Over all eight captures including the 2026-09-05 Dubai drive:

| | before | after |
|---|---|---|
| records | 26,646 | **896** (3.4%) |
| bytes | 14.3 MB | **361 KB** (2.5%) |
| location-bearing records lost | — | **0** of 235 |
| distinct geofence event kinds in the Dubai drive | 19 | **19** |

Per-capture retention ranges 10–48%; the 0.4% simulator figure is a pure in-app stress run and shouldn't anchor expectations.

### Toggle

A switch on the Location screen turns filtering off for when the bug *is* in a module the deny-list removes. The flip is itself recorded, so a capture says which way it was set. `note()` is added to `DiagnosticLog` to match Android's app-side record API.

### Verification

- APN-UIKit builds; swiftformat and `swiftlint --strict` clean on every changed file
- Predicate validated by replaying all eight real captures — that harness is a parallel Python implementation and can drift from the Swift, which is worth knowing when reading the numbers above