### PR TITLE
ci: run iOS lint on Linux instead of a macOS runner

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,4 +11,12 @@ concurrency:
 
 jobs:
   lint:
+    # Points at the branch, not @main, while we prove the Linux runner reports exactly what the
+    # macOS runner does. Flip to ios-lint-linux.yml@main once mobile-ci-tools#<PR> merges.
+    uses: customerio/mobile-ci-tools/.github/workflows/ios-lint-linux.yml@ci/ios-lint-ubuntu
+
+  # TEMPORARY, delete before this PR leaves draft. Runs today's macOS lint on the same commit
+  # so the two jobs can be compared side by side. They are expected to agree on everything:
+  # the same files formatted, the same autocorrections, and no net diff.
+  lint-macos-baseline:
     uses: customerio/mobile-ci-tools/.github/workflows/ios-lint.yml@main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,12 +11,5 @@ concurrency:
 
 jobs:
   lint:
-    # Points at the branch, not @main, while we prove the Linux runner reports exactly what the
-    # macOS runner does. Flip to ios-lint-linux.yml@main once mobile-ci-tools#<PR> merges.
+    # Branch pin, not @main, until mobile-ci-tools#17 merges. Flip it then.
     uses: customerio/mobile-ci-tools/.github/workflows/ios-lint-linux.yml@ci/ios-lint-ubuntu
-
-  # TEMPORARY, delete before this PR leaves draft. Runs today's macOS lint on the same commit
-  # so the two jobs can be compared side by side. They are expected to agree on everything:
-  # the same files formatted, the same autocorrections, and no net diff.
-  lint-macos-baseline:
-    uses: customerio/mobile-ci-tools/.github/workflows/ios-lint.yml@main


### PR DESCRIPTION
Points Lint at customerio/mobile-ci-tools#17. Lint needs no Xcode yet holds one of the org's five macOS slots.

Compared against the macOS job on the same commit: same files formatted, same autocorrections, same clean diff, 0 violations. 1m19s against 23s in-job, versus a median 22 minute wait for a slot.

Flip to `@main` once #17 merges. `customerio-ios-fcm` follows.

The two red test checks are an unrelated known flake; this PR only touches a lint workflow.