### PR TITLE
fix(deps): update Faraday security pin to 1.10.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Security pins for transitive deps (MBL-1696)
 gem "addressable", "2.9.0"
-gem "faraday", "1.10.5"
+gem "faraday", "1.10.6"
 gem "aws-sdk-s3", "1.208.0"
 gem "rexml", "3.4.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
     emoji_regex (3.2.3)
     excon (1.7.0)
       logger
-    faraday (1.10.5)
+    faraday (1.10.6)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -254,7 +254,7 @@ PLATFORMS
 DEPENDENCIES
   addressable (= 2.9.0)
   aws-sdk-s3 (= 1.208.0)
-  faraday (= 1.10.5)
+  faraday (= 1.10.6)
   fastlane
   fastlane-plugin-firebase_app_distribution
   minitest (~> 5.25)


### PR DESCRIPTION
Updates the Faraday pin in both `Gemfile` and the regenerated `Gemfile.lock` to 1.10.6, fixing CVE-2026-54297 while keeping compatibility with the locked Fastlane 2.237.0 dependencies. A lockfile-only update leaves the 1.10.5 Gemfile pin in place and fails Bundler's frozen-lock check.

Fixes #1252. Tracks [MBL-2385](https://linear.app/customerio/issue/MBL-2385). Supersedes #1256; thanks to @begininvoke for the report and proposed dependency update.

Validated locally with Ruby 3.4.4 and Bundler 2.6.9:
- Regenerated the lockfile with `bundle lock --update faraday --conservative`; only Faraday changed.
- `BUNDLE_FROZEN=true bundle install` passed.
- Loaded Faraday 1.10.6 and Fastlane 2.237.0 together, and ran `bundle exec fastlane --version`.
- Normal nested query parsing passed; 5,000 nested parameters were rejected with `Faraday::Error` instead of overflowing the stack.
- Built the MessagingPushAPN module for the iOS 26.5 simulator.

- [ ] CI checks pass.
- [ ] Teammate review and approval.

Release sequence: after review, merge this as a `fix(deps):` change to publish an iOS patch release containing the corrected repository build dependencies. Once that release is available, update all native iOS pins in [Flutter #405](https://github.com/customerio/customerio-flutter/pull/405) to the published version, rerun validation, and merge Flutter for one patch release. Faraday is Ruby build tooling and is not bundled into the native SDK runtime.
