### PR TITLE
chore(geofence): keep polygon belief across an OS eviction

### DIFF
--- a/Sources/LocationGeofence/Storage/GeofenceStorage+PolygonMembership.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage+PolygonMembership.swift
@@ -117,13 +117,6 @@ extension GeofenceStorage {
 }
 
 extension GeofenceState {
-    /// Drops one identifier's belief, for a reseed that has already decided the stored circle
-    /// baseline can no longer be trusted: kept, a belief of "inside" formed before an unmonitored
-    /// gap swallows the next real enter as no-change.
-    mutating func dropPolygonBelief(for identifier: String) {
-        polygonMembership?.removeValue(forKey: identifier)
-    }
-
     /// Drops polygon belief for geofences a registration no longer covers, on the same rule the
     /// monitor records use: a polygon outside the registered set is no longer being evaluated, so a
     /// retained belief would go stale and suppress the enter owed when the device comes back to it.

--- a/Sources/LocationGeofence/Storage/GeofenceStorage.swift
+++ b/Sources/LocationGeofence/Storage/GeofenceStorage.swift
@@ -110,7 +110,7 @@ actor GeofenceStorage {
     /// `forceReseed` overrides that preservation. The caller sets it when the OS stopped monitoring
     /// the condition since the last registration: the device can cross while unmonitored, so the
     /// persisted state is no longer known to match reality and keeping it would suppress the next
-    /// genuine crossing. Polygon belief reseeds with it, for the same reason.
+    /// genuine crossing. Polygon belief is NOT reseeded with it — see `clearMonitorRegionRecord`.
     func recordMonitorRegistration(
         identifier: String,
         transitionTypes: Set<GeofenceTransition>,
@@ -133,7 +133,6 @@ actor GeofenceStorage {
             lastStateChangedAt: preserved ? existing?.lastStateChangedAt : now
         )
         state.monitorRegionRecords = records
-        if forceReseed { state.dropPolygonBelief(for: identifier) }
         saveToDisk(state)
     }
 
@@ -184,14 +183,14 @@ actor GeofenceStorage {
     /// Drops the baseline for a condition the OS stopped monitoring, so the next registration
     /// reseeds from the device's real position rather than carrying a state it may have left while
     /// unmonitored — an unchanged-geometry re-register would preserve that stale value.
-    /// Drops both the OS-facing baseline and the polygon belief: the region is no longer monitored,
-    /// so a belief kept across the gap would suppress the next real enter as no-change if the device
-    /// left the polygon while nothing was watching.
+    ///
+    /// Polygon belief deliberately SURVIVES: a crossing during the gap is unknowable, so every rule
+    /// guesses, and dropping guesses "it left" — a device that stayed then looks brand new, and a
+    /// brand-new polygon found inside delivers an enter the customer already had. Keeping still
+    /// yields the exit when it did leave; it loses only left-AND-returned, the rarest case.
     func clearMonitorRegionRecord(identifier: String) {
         var state = loadFromDisk() ?? GeofenceState()
-        let hadRecord = state.monitorRegionRecords?.removeValue(forKey: identifier) != nil
-        let hadBelief = state.polygonMembership?.removeValue(forKey: identifier) != nil
-        guard hadRecord || hadBelief else { return }
+        guard state.monitorRegionRecords?.removeValue(forKey: identifier) != nil else { return }
         saveToDisk(state)
     }
 

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -1164,10 +1164,17 @@ struct PolygonMembershipResolverTests {
     /// What the OS reporting a covering circle unmonitored actually does to storage: the deferred
     /// clear, then the next registration reseeding the circle baseline.
     private func evictCoveringCircle(_ setup: Setup, id: String) async {
+        let center = LocationData(latitude: 0, longitude: 0)
+        // Seeded first: the clear only removes a monitor record that exists, so without this the
+        // `.unmonitored` half is a no-op and only the reseed would be under test.
+        await setup.storage.recordMonitorRegistration(
+            identifier: id, transitionTypes: [.enter, .exit], initialState: .enter,
+            center: center, radius: 300
+        )
         await setup.storage.clearMonitorRegionRecord(identifier: id)
         await setup.storage.recordMonitorRegistration(
             identifier: id, transitionTypes: [.enter, .exit], initialState: .exit,
-            center: LocationData(latitude: 0, longitude: 0), radius: 300, forceReseed: true
+            center: center, radius: 300, forceReseed: true
         )
     }
 }

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipResolverTests.swift
@@ -1116,4 +1116,58 @@ struct PolygonMembershipResolverTests {
         #expect(await setup.emitter.snapshot().map(\.transition) == [.enter])
         #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
     }
+
+    // MARK: - Belief across an OS eviction
+
+    /// The eviction sequence end to end: the `.unmonitored` clear, then the re-registration that
+    /// reseeds the circle baseline, then a pass. The device never left, so the surviving belief
+    /// makes this a no-change and the customer gets no second enter for a visit already reported.
+    @Test
+    func evaluateAllPolygons_givenEvictionWhileStillInside_expectNoDuplicateEnter() async {
+        let setup = await makeSetup(fix: fix(latitude: 0, longitude: 0))
+        await registerPolygons(setup, ids: ["1"])
+        // Dated behind the fix: `makeSetup` builds the CLLocation first, so a belief stamped now
+        // would postdate it and the pass would be refused as a newer decision without evaluating.
+        let before = Date().addingTimeInterval(-60)
+        _ = await setup.storage.recordPolygonMembership(
+            .inside, forIdentifier: "1", onlyIfBeliefPredates: before
+        )
+        await evictCoveringCircle(setup, id: "1")
+
+        await setup.resolver.evaluateAllPolygons()
+
+        #expect(await setup.emitter.snapshot().isEmpty)
+        #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .inside)
+        // Proves the pass actually decided: a confirming evaluation refreshes the evidence stamp,
+        // so without this the assertions above also hold when nothing was evaluated at all.
+        let stamp = await setup.storage.getPolygonMembership()["1"]?.lastChangedAt
+        #expect(stamp.map { $0 > before } == true)
+    }
+
+    /// Same eviction, but the device left during the gap. The retained `inside` belief is what
+    /// makes the verdict a change; dropped, this lands on the create path and the exit is lost.
+    @Test
+    func evaluateAllPolygons_givenEvictionThenDeviceLeft_expectExitDelivered() async {
+        let setup = await makeSetup(fix: fix(latitude: 0.0020, longitude: 0))
+        await registerPolygons(setup, ids: ["1"])
+        _ = await setup.storage.recordPolygonMembership(
+            .inside, forIdentifier: "1", onlyIfBeliefPredates: Date().addingTimeInterval(-60)
+        )
+        await evictCoveringCircle(setup, id: "1")
+
+        await setup.resolver.evaluateAllPolygons()
+
+        #expect(await setup.emitter.snapshot().map(\.transition) == [.exit])
+        #expect(await setup.storage.getPolygonMembership()["1"]?.membership == .outside)
+    }
+
+    /// What the OS reporting a covering circle unmonitored actually does to storage: the deferred
+    /// clear, then the next registration reseeding the circle baseline.
+    private func evictCoveringCircle(_ setup: Setup, id: String) async {
+        await setup.storage.clearMonitorRegionRecord(identifier: id)
+        await setup.storage.recordMonitorRegistration(
+            identifier: id, transitionTypes: [.enter, .exit], initialState: .exit,
+            center: LocationData(latitude: 0, longitude: 0), radius: 300, forceReseed: true
+        )
+    }
 }

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipStorageTests.swift
@@ -119,13 +119,31 @@ struct PolygonMembershipStorageTests {
     @Test
     func clearMonitorRegionRecord_expectPolygonBeliefKept() async {
         let storage = await makeStorage()
+        let center = LocationData(latitude: 0, longitude: 0)
+        // A monitor record has to exist for its removal to be observable; without one the
+        // "record is gone" assertion below would pass whatever the method did.
+        await storage.recordMonitorRegistration(
+            identifier: "1", transitionTypes: [.enter, .exit], initialState: .exit,
+            center: center, radius: 100
+        )
         _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
 
         await storage.clearMonitorRegionRecord(identifier: "1")
 
         #expect(await storage.getPolygonMembership()["1"]?.membership == .inside)
-        // The circle baseline really was reseeded — this is not a no-op that happens to keep belief.
         #expect(await storage.getMonitorRegionRecords()["1"] == nil)
+    }
+
+    /// The clear now keys off the monitor record alone, so with no record there is nothing to
+    /// persist. A belief written by a wake pass during the gap must not be collateral of that.
+    @Test
+    func clearMonitorRegionRecord_givenNoMonitorRecord_expectBeliefUntouched() async {
+        let storage = await makeStorage()
+        _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
+
+        await storage.clearMonitorRegionRecord(identifier: "1")
+
+        #expect(await storage.getPolygonMembership()["1"]?.membership == .inside)
     }
 
     /// Device left during the gap. The retained `inside` belief is what makes the verdict a

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipStorageTests.swift
@@ -128,21 +128,9 @@ struct PolygonMembershipStorageTests {
         #expect(await storage.getMonitorRegionRecords()["1"] == nil)
     }
 
-    /// Column 1 of the eviction trade: the device never left. The belief survives, so the
-    /// re-evaluation after re-registration is a no-change and no duplicate enter is delivered.
-    @Test
-    func clearMonitorRegionRecord_givenDeviceStillInside_expectNoDuplicateEnter() async {
-        let storage = await makeStorage()
-        _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
-
-        await storage.clearMonitorRegionRecord(identifier: "1")
-
-        #expect(await storage.recordPolygonMembership(.inside, forIdentifier: "1") == .suppressedNoChange)
-    }
-
-    /// Column 2: the device left during the gap. The retained `inside` belief is what makes the
-    /// verdict a change, so the exit is delivered. Dropped, this became `.suppressedInitialOutside`
-    /// and the customer kept an enter with no exit.
+    /// Device left during the gap. The retained `inside` belief is what makes the verdict a
+    /// change; without it the exit lands on the create path and is swallowed as an initial
+    /// outside, leaving the customer with an enter and no exit.
     @Test
     func clearMonitorRegionRecord_givenDeviceLeftDuringGap_expectExitDelivered() async {
         let storage = await makeStorage()
@@ -153,17 +141,18 @@ struct PolygonMembershipStorageTests {
         #expect(await storage.recordPolygonMembership(.outside, forIdentifier: "1") == .deliver(.exit))
     }
 
-    /// Column 3, the case this trade gives up and the one the #1244 review asked for: the device
-    /// left and came back while nothing was watching. Both edges are missed. Pinned deliberately so
-    /// the loss is visible rather than discovered in the field.
+    /// A verdict of `inside` after the gap is a no-change, which is both the win and the loss of
+    /// keeping the belief. A device that never left gets no duplicate enter — the point of the
+    /// change. A device that left and returned unseen gets neither its exit nor its re-enter, and
+    /// the two are indistinguishable here because the OS was not evaluating: nothing local can tell
+    /// them apart. The accepted loss is pinned rather than left to be discovered in the field.
     @Test
-    func clearMonitorRegionRecord_givenDeviceLeftAndReturnedDuringGap_expectBothEdgesMissed() async {
+    func clearMonitorRegionRecord_givenInsideVerdictAfterGap_expectNoChangeEitherWay() async {
         let storage = await makeStorage()
         _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
 
         await storage.clearMonitorRegionRecord(identifier: "1")
 
-        // Nothing observed the departure or the return; the next verdict simply agrees with belief.
         #expect(await storage.recordPolygonMembership(.inside, forIdentifier: "1") == .suppressedNoChange)
     }
 

--- a/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Polygon/PolygonMembershipStorageTests.swift
@@ -113,25 +113,64 @@ struct PolygonMembershipStorageTests {
         #expect(await storage.recordPolygonMembership(.inside, forIdentifier: "1") == .deliver(.enter))
     }
 
-    /// The OS reporting the covering circle unmonitored reseeds the circle baseline; the polygon
-    /// belief has to go with it. Kept, it would suppress the next real enter as no-change if the
-    /// device left the polygon while nothing was watching.
+    /// The OS reporting the covering circle unmonitored reseeds the CIRCLE baseline only. Dropping
+    /// the belief too would make a device that never moved look like a brand-new polygon, and a
+    /// brand-new polygon found inside delivers an enter — a second one the customer already had.
     @Test
-    func clearMonitorRegionRecord_expectPolygonBeliefClearedToo() async {
+    func clearMonitorRegionRecord_expectPolygonBeliefKept() async {
         let storage = await makeStorage()
         _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
 
         await storage.clearMonitorRegionRecord(identifier: "1")
 
-        #expect(await storage.getPolygonMembership()["1"] == nil)
-        #expect(await storage.recordPolygonMembership(.inside, forIdentifier: "1") == .deliver(.enter))
+        #expect(await storage.getPolygonMembership()["1"]?.membership == .inside)
+        // The circle baseline really was reseeded — this is not a no-op that happens to keep belief.
+        #expect(await storage.getMonitorRegionRecords()["1"] == nil)
     }
 
-    /// The deferred clear can be skipped when a re-registration overtakes it, and then `forceReseed`
-    /// is the only thing standing between an unmonitored gap and a swallowed enter. It reseeds the
-    /// circle baseline, so it has to reseed the belief too.
+    /// Column 1 of the eviction trade: the device never left. The belief survives, so the
+    /// re-evaluation after re-registration is a no-change and no duplicate enter is delivered.
     @Test
-    func recordMonitorRegistration_givenForceReseed_expectPolygonBeliefCleared() async {
+    func clearMonitorRegionRecord_givenDeviceStillInside_expectNoDuplicateEnter() async {
+        let storage = await makeStorage()
+        _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
+
+        await storage.clearMonitorRegionRecord(identifier: "1")
+
+        #expect(await storage.recordPolygonMembership(.inside, forIdentifier: "1") == .suppressedNoChange)
+    }
+
+    /// Column 2: the device left during the gap. The retained `inside` belief is what makes the
+    /// verdict a change, so the exit is delivered. Dropped, this became `.suppressedInitialOutside`
+    /// and the customer kept an enter with no exit.
+    @Test
+    func clearMonitorRegionRecord_givenDeviceLeftDuringGap_expectExitDelivered() async {
+        let storage = await makeStorage()
+        _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
+
+        await storage.clearMonitorRegionRecord(identifier: "1")
+
+        #expect(await storage.recordPolygonMembership(.outside, forIdentifier: "1") == .deliver(.exit))
+    }
+
+    /// Column 3, the case this trade gives up and the one the #1244 review asked for: the device
+    /// left and came back while nothing was watching. Both edges are missed. Pinned deliberately so
+    /// the loss is visible rather than discovered in the field.
+    @Test
+    func clearMonitorRegionRecord_givenDeviceLeftAndReturnedDuringGap_expectBothEdgesMissed() async {
+        let storage = await makeStorage()
+        _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
+
+        await storage.clearMonitorRegionRecord(identifier: "1")
+
+        // Nothing observed the departure or the return; the next verdict simply agrees with belief.
+        #expect(await storage.recordPolygonMembership(.inside, forIdentifier: "1") == .suppressedNoChange)
+    }
+
+    /// `forceReseed` reseeds the circle baseline for the same eviction, and parts company with the
+    /// belief for the same reason `clearMonitorRegionRecord` does.
+    @Test
+    func recordMonitorRegistration_givenForceReseed_expectPolygonBeliefKept() async {
         let storage = await makeStorage()
         let center = LocationData(latitude: 0, longitude: 0)
         _ = await storage.recordPolygonMembership(.inside, forIdentifier: "1")
@@ -141,8 +180,8 @@ struct PolygonMembershipStorageTests {
             center: center, radius: 100, forceReseed: true
         )
 
-        #expect(await storage.getPolygonMembership()["1"] == nil)
-        #expect(await storage.recordPolygonMembership(.inside, forIdentifier: "1") == .deliver(.enter))
+        #expect(await storage.getPolygonMembership()["1"]?.membership == .inside)
+        #expect(await storage.recordPolygonMembership(.inside, forIdentifier: "1") == .suppressedNoChange)
     }
 
     /// The ordinary sync path re-registers every identifier. Dropping belief there would re-fire an


### PR DESCRIPTION
Part of [MBL-2291](https://linear.app/customerio/issue/MBL-2291/ios-implement-responsive-on-device-polygon-monitoring)

When CLMonitor reports a polygon's covering circle unmonitored, the circle baseline is reseeded and — until this PR — the polygon belief was dropped with it, on both the `.unmonitored` path and the `forceReseed` re-registration behind it.

**This reverses part of what @mahmoud-elmorabea asked for in the #1244 review, deliberately.** That request weighed one of three cases; the other two were not on the table then, and one of them only became reachable once #1250 started re-evaluating polygons after registration. The table below is the whole argument — please push back on it rather than on the diff.

## Why the belief has to survive

Whether the device crossed during the gap is **unknowable**: the OS was not watching. Every rule is therefore a guess, and dropping guesses "it left".

| device during the gap | drop (before) | keep (this PR) |
|---|---|---|
| stayed inside | looks brand new → **duplicate enter** | no-change, silent ✓ |
| left, stayed out | create path → **exit never delivered** | **exit delivered** ✓ |
| left and returned | correct enter | both edges missed |

Dropping is wrong in the two common columns. The asymmetry that makes it bite is that a *brand-new* polygon found inside deliberately delivers an enter — the polygon counterpart of enter-when-inside — so a discarded belief turns a device that never moved into a second enter. Circles don't have this: no baseline plus an event is `.suppressedNoBaseline`, silent.

**Keeping never produces a false event; dropping does.** The column it gives up degrades to a *missed* event, and it is the rarest — it needs the device to leave *and* return with no evaluation pass in between.

## The belief is not stale while the OS is away

An eviction touches monitor-local state only. It never changes `monitoredGeofenceIds`, and `evaluateAllPolygons` filters on the registered set rather than on OS monitoring state — so **movement-trigger wakes and foreground passes keep evaluating the polygon with real fixes throughout the gap**. The belief being kept may be seconds old, not a guess left over from before the eviction. This is also what narrows the lost column: it requires no pass to have run between the two crossings, meaning the device moved less than the wake radius and the app never came to the foreground.

## Tests

518/518 `LocationGeofenceTests` pass on iOS 26. Lint and format clean. +7 / −15 production lines.

Storage covers each column and the changed guard shape; two resolver tests drive the real sequence end to end and assert what a customer receives.

The resolver tests originally exercised only half of an eviction: their helper wrote no monitor record, so `clearMonitorRegionRecord` found nothing to remove and returned early. It seeds one now — reverting only the clear's belief drop fails both resolver tests, where before it changed nothing there. Raised by @Shahroz16 in review.

**Negative-controlled:** restoring either drop fails only that site's tests, and the resolver case fails *by emitting the duplicate enter* rather than by a bare assertion.

Two of the new tests were vacuous on the first attempt and the fix is worth knowing about: the harness builds its fix before the test writes its belief, so the fix predated the belief, the write was refused as `.suppressedNewerDecision`, and `emitter.isEmpty` passed because nothing executed. The stayed-inside case now also asserts the evidence stamp advanced, which an unexecuted pass cannot satisfy.

## Not verified

- **Strict concurrency** could not be run: `Common/Util/UIKitWrapper.swift:34` errors under `-strict-concurrency=complete` and `Common` is a dependency of every module, so nothing downstream compiles. `GeofenceStorage` is an `actor` and this change only removes state mutation.
- **No device or simulator run** — reproducing this needs a real CLMonitor budget eviction.

## Stack

1. #1239 `mbl-2290-a` geometry kernel (merged)
2. #1240 `mbl-2290-b` wire contract (merged)
3. #1244 `mbl-2291-a` membership layer (merged)
4. #1245 `mbl-2291-b` membership resolver
5. #1246 `mbl-2291-c` monitor wiring
6. #1249 `mbl-2290-c` antimeridian fix
7. #1250 `mbl-2291-f` shared dynamic movement circle
8. #1259 `mbl-2291-h` belief survives eviction ← **this PR**
9. #1262 `mbl-2291-g` event circle generation



