### PR TITLE
test: bump deadlock detection timeout from 30s to 60s (MBL-1706)

### DIFF
--- a/Tests/Common/Synchronized/SynchronizedTests.swift
+++ b/Tests/Common/Synchronized/SynchronizedTests.swift
@@ -238,12 +238,9 @@ struct SynchronizedEquatableTests {
     }
 
     // Calls a == b and b == a concurrently. Without the ObjectIdentifier lock-ordering in ==,
-    // this reliably deadlocks. The timeout converts a hang into a test failure.
-    //
-    // MBL-1706: Bumped from 30s to 60s. Shared CI runners under load can take >30s to complete
-    // 2000 concurrent DispatchGroup operations, causing flaky failures (~25 in 77 test.yml runs
-    // since Jul 2026). A genuine deadlock still trips 60s; the extra headroom avoids false
-    // positives on busy runners.
+    // this reliably deadlocks. The timeout converts a hang into a test failure. 60s instead of
+    // 30s: busy CI runners can exceed 30s for the 2000 concurrent operations; a genuine deadlock
+    // still trips 60s.
     @Test func equalsConcurrentlyDoesNotDeadlock() {
         let a = Synchronized(1)
         let b = Synchronized(1)

--- a/Tests/Common/Synchronized/SynchronizedTests.swift
+++ b/Tests/Common/Synchronized/SynchronizedTests.swift
@@ -238,7 +238,12 @@ struct SynchronizedEquatableTests {
     }
 
     // Calls a == b and b == a concurrently. Without the ObjectIdentifier lock-ordering in ==,
-    // this reliably deadlocks. The 30s timeout converts a hang into a test failure.
+    // this reliably deadlocks. The timeout converts a hang into a test failure.
+    //
+    // MBL-1706: Bumped from 30s to 60s. Shared CI runners under load can take >30s to complete
+    // 2000 concurrent DispatchGroup operations, causing flaky failures (~25 in 77 test.yml runs
+    // since Jul 2026). A genuine deadlock still trips 60s; the extra headroom avoids false
+    // positives on busy runners.
     @Test func equalsConcurrentlyDoesNotDeadlock() {
         let a = Synchronized(1)
         let b = Synchronized(1)
@@ -255,7 +260,7 @@ struct SynchronizedEquatableTests {
             }
         }
 
-        #expect(group.wait(timeout: .now() + 30) == .success)
+        #expect(group.wait(timeout: .now() + 60) == .success)
     }
 }
 


### PR DESCRIPTION
Bumps the timeout for the concurrent deadlock detection test from 30s to 60s. The test spawns 2000 concurrent DispatchGroup operations to verify the Synchronized equality operator doesn't deadlock. On shared CI runners under load, these can exceed 30s and cause false positives. A genuine deadlock still trips 60s.

This test failed ~25 times in 77 runs since Jul 14, most recent on main Sep 9. We'll compare the next 2 weeks against the ~3 failures/week baseline. If flakes persist, fallback is reducing iterations to 500.

[MBL-1706](https://linear.app/customerio/issue/MBL-1706)