### PR TITLE
chore(geofence): record polygon geometry in the fence catalog

### DIFF
--- a/Sources/LocationGeofence/Api/GeofenceApiRegion+Catalog.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiRegion+Catalog.swift
@@ -22,11 +22,11 @@ extension GeofenceApiRegion {
     /// element before joining, so it is the only intra-pair character that survives the pipeline.
     var catalogRing: [String]? {
         guard let ring = geometry?.coordinates.first, !ring.isEmpty else { return nil }
-        return ring.compactMap { position in
-            guard position.count >= 2 else { return nil }
-            // Rendered before `usableRegion` drops invalid coordinates, so a malformed payload can
-            // reach this. `%.5f` turns 1e300 into 309 digits, and a ring of those is tens of KB in
-            // one line — that the server sent garbage is the useful record, not the garbage.
+        // Rendered before `usableRegion` drops invalid coordinates, so a malformed payload reaches
+        // this. Every position is kept, bad ones as `bad`: `%.5f` turns 1e300 into 309 digits, and
+        // dropping them instead would leave `nv` counting vertices the ring does not show.
+        return ring.map { position in
+            guard position.count >= 2 else { return "bad_bad" }
             return "\(Self.catalogCoordinate(position[1], max: 90))_\(Self.catalogCoordinate(position[0], max: 180))"
         }
     }

--- a/Sources/LocationGeofence/Api/GeofenceApiRegion+Catalog.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiRegion+Catalog.swift
@@ -13,7 +13,12 @@ extension GeofenceApiRegion {
 
     var catalogRadius: Double? { radius ?? enclosingCircle?.baseRadiusM }
 
-    /// Outer ring as `lat_lon` pairs — the SDK's order, not GeoJSON's reversed one.
+    /// Outer ring as `lat_lon` pairs — the SDK's order, not GeoJSON's reversed one — and the
+    /// CANONICAL ring: consecutive duplicates collapsed and the closing vertex dropped, which is
+    /// what membership is computed against and what Android's `nv` counts. Counting the wire ring
+    /// instead would report one extra vertex for every closed GeoJSON ring, and a consumer applying
+    /// the "fewer pairs than `nv` means truncated" rule would then refuse every correct polygon
+    /// from one platform.
     ///
     /// Placement and eyeballing only, never a membership input: the field truncates, and a partial
     /// ring is still a valid-looking polygon. `nv` is the authoritative vertex count.
@@ -25,10 +30,28 @@ extension GeofenceApiRegion {
         // Rendered before `usableRegion` drops invalid coordinates, so a malformed payload reaches
         // this. Every position is kept, bad ones as `bad`: `%.5f` turns 1e300 into 309 digits, and
         // dropping them instead would leave `nv` counting vertices the ring does not show.
-        return ring.map { position in
+        return Self.canonicalised(ring).map { position in
             guard position.count >= 2 else { return "bad_bad" }
             return "\(Self.catalogCoordinate(position[1], max: 90))_\(Self.catalogCoordinate(position[0], max: 180))"
         }
+    }
+
+    /// The same two steps `PolygonRegion.init(vertices:)` applies — collapse consecutive
+    /// duplicates, drop a closing vertex — but deliberately without its validity rejection: a ring
+    /// the SDK will not monitor is exactly the one worth recording.
+    ///
+    /// Compares the positions rather than the rendered pairs, so two different unreadable
+    /// positions stay two. Exact equality where `PolygonRegion` allows longitude wrap, so a ring
+    /// closing on +180/-180 counts one higher here; GeoJSON requires the closing position to
+    /// repeat the first exactly, and such a fence records a `bad` pair anyway.
+    private static func canonicalised(_ ring: [[Double]]) -> [[Double]] {
+        var open: [[Double]] = []
+        open.reserveCapacity(ring.count)
+        for position in ring where open.last != position {
+            open.append(position)
+        }
+        if open.count > 1, open.first == open.last { open.removeLast() }
+        return open
     }
 
     private static func catalogCoordinate(_ value: Double, max: Double) -> String {

--- a/Sources/LocationGeofence/Api/GeofenceApiRegion+Catalog.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiRegion+Catalog.swift
@@ -1,0 +1,38 @@
+import CioInternalCommon
+import Foundation
+
+/// What the fence catalog records, resolved per shape so a polygon is placeable.
+extension GeofenceApiRegion {
+    var catalogShape: String { carriesPolygonFields ? "polygon" : "circle" }
+
+    /// The monitored circle: a circle's own centre, a polygon's enclosing circle.
+    var catalogCenter: LocationData? {
+        if let latitude, let longitude { return LocationData(latitude: latitude, longitude: longitude) }
+        return enclosingCircle.map { LocationData(latitude: $0.latitude, longitude: $0.longitude) }
+    }
+
+    var catalogRadius: Double? { radius ?? enclosingCircle?.baseRadiusM }
+
+    /// Outer ring as `lat_lon` pairs — the SDK's order, not GeoJSON's reversed one.
+    ///
+    /// Placement and eyeballing only, never a membership input: the field truncates, and a partial
+    /// ring is still a valid-looking polygon. `nv` is the authoritative vertex count.
+    ///
+    /// Must stay in `GeofenceLog.composedKeys`. `_` is not a style choice — `list` sanitizes every
+    /// element before joining, so it is the only intra-pair character that survives the pipeline.
+    var catalogRing: [String]? {
+        guard let ring = geometry?.coordinates.first, !ring.isEmpty else { return nil }
+        return ring.compactMap { position in
+            guard position.count >= 2 else { return nil }
+            // Rendered before `usableRegion` drops invalid coordinates, so a malformed payload can
+            // reach this. `%.5f` turns 1e300 into 309 digits, and a ring of those is tens of KB in
+            // one line — that the server sent garbage is the useful record, not the garbage.
+            return "\(Self.catalogCoordinate(position[1], max: 90))_\(Self.catalogCoordinate(position[0], max: 180))"
+        }
+    }
+
+    private static func catalogCoordinate(_ value: Double, max: Double) -> String {
+        guard value.isFinite, abs(value) <= max else { return "bad" }
+        return String(format: "%.5f", value)
+    }
+}

--- a/Sources/LocationGeofence/Api/GeofenceApiRegion+Catalog.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiRegion+Catalog.swift
@@ -47,8 +47,10 @@ extension GeofenceApiRegion {
     /// the SDK will not monitor is exactly the one worth recording.
     ///
     /// Compares the positions rather than the rendered pairs, so two different unreadable
-    /// positions stay two. Its exact-equality comparison cannot disagree with the kernel about a
-    /// fence the kernel accepted, because an accepted fence never reaches here.
+    /// positions stay two. Its exact equality DOES disagree with the kernel's wrap-tolerant
+    /// `samePosition` — a ring closing at +180 that opened at -180 keeps its closing vertex here
+    /// and loses it there. That is safe only because an accepted fence takes the kernel's list
+    /// above and never reaches this function; it is not a property of the comparison.
     private static func canonicalised(_ ring: [[Double]]) -> [[Double]] {
         var open: [[Double]] = []
         open.reserveCapacity(ring.count)

--- a/Sources/LocationGeofence/Api/GeofenceApiRegion+Catalog.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiRegion+Catalog.swift
@@ -27,9 +27,15 @@ extension GeofenceApiRegion {
     /// element before joining, so it is the only intra-pair character that survives the pipeline.
     var catalogRing: [String]? {
         guard let ring = geometry?.coordinates.first, !ring.isEmpty else { return nil }
-        // Rendered before `usableRegion` drops invalid coordinates, so a malformed payload reaches
-        // this. Every position is kept, bad ones as `bad`: `%.5f` turns 1e300 into 309 digits, and
-        // dropping them instead would leave `nv` counting vertices the ring does not show.
+        // The geometry kernel's own list when the region resolves, so the catalog can never report
+        // a different ring from the one membership is computed against — including at the
+        // antimeridian, where the kernel tolerates longitude wrap and the fallback below does not.
+        if case .success(let geofence) = toDomain(), let vertices = geofence.vertices {
+            return vertices.map { "\(Self.catalogCoordinate($0.latitude, max: 90))_\(Self.catalogCoordinate($0.longitude, max: 180))" }
+        }
+        // Reached only for a ring the kernel REJECTED, which is the case worth recording and the
+        // one it cannot answer. Bad positions are kept as `bad`: `%.5f` turns 1e300 into 309
+        // digits, and dropping them would leave `nv` counting vertices the ring does not show.
         return Self.canonicalised(ring).map { position in
             guard position.count >= 2 else { return "bad_bad" }
             return "\(Self.catalogCoordinate(position[1], max: 90))_\(Self.catalogCoordinate(position[0], max: 180))"
@@ -41,9 +47,8 @@ extension GeofenceApiRegion {
     /// the SDK will not monitor is exactly the one worth recording.
     ///
     /// Compares the positions rather than the rendered pairs, so two different unreadable
-    /// positions stay two. Exact equality where `PolygonRegion` allows longitude wrap, so a ring
-    /// closing on +180/-180 counts one higher here; GeoJSON requires the closing position to
-    /// repeat the first exactly, and such a fence records a `bad` pair anyway.
+    /// positions stay two. Its exact-equality comparison cannot disagree with the kernel about a
+    /// fence the kernel accepted, because an accepted fence never reaches here.
     private static func canonicalised(_ ring: [[Double]]) -> [[Double]] {
         var open: [[Double]] = []
         open.reserveCapacity(ring.count)

--- a/Sources/LocationGeofence/Api/GeofenceApiRegion+Catalog.swift
+++ b/Sources/LocationGeofence/Api/GeofenceApiRegion+Catalog.swift
@@ -1,17 +1,55 @@
 import CioInternalCommon
 import Foundation
 
+/// The shape the catalog reports, one branch per outcome of the mapper's own `shape` switch.
+/// A closed set, so `sh` stays groupable even when the server sends something unrecognized —
+/// the token it actually sent is already on `registration.rejected`.
+enum GeofenceCatalogShape: String {
+    case circle
+    case polygon
+    /// Polygon fields with no discriminator. Dropped by the mapper as `undescribedShape`.
+    case undescribed
+    /// A shape the server named that this version cannot monitor.
+    case unknown
+}
+
 /// What the fence catalog records, resolved per shape so a polygon is placeable.
 extension GeofenceApiRegion {
-    var catalogShape: String { carriesPolygonFields ? "polygon" : "circle" }
-
-    /// The monitored circle: a circle's own centre, a polygon's enclosing circle.
-    var catalogCenter: LocationData? {
-        if let latitude, let longitude { return LocationData(latitude: latitude, longitude: longitude) }
-        return enclosingCircle.map { LocationData(latitude: $0.latitude, longitude: $0.longitude) }
+    /// Normalized exactly as `toDomain` normalizes it — trimmed, lowercased, blank treated as
+    /// absent — because a capture is only interpretable if `sh` names the shape the SDK actually
+    /// monitored. `carriesPolygonFields` alone disagreed on mixed payloads.
+    private var normalizedShape: String? {
+        let named = shape?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return named?.isEmpty == true ? nil : named
     }
 
-    var catalogRadius: Double? { radius ?? enclosingCircle?.baseRadiusM }
+    var catalogShape: GeofenceCatalogShape {
+        switch normalizedShape {
+        case nil: return carriesPolygonFields ? .undescribed : .circle
+        case "circle": return .circle
+        case "polygon": return .polygon
+        default: return .unknown
+        }
+    }
+
+    /// The monitored circle. Which fields win follows the shape, not their mere presence: an
+    /// explicit `shape: "circle"` carrying stray geometry is monitored by its flat fields, and a
+    /// `shape: "polygon"` carrying flat fields is monitored by its enclosing circle. The other
+    /// source stays as a fallback so a half-populated payload is still placeable.
+    var catalogCenter: LocationData? {
+        let flat = latitude.flatMap { lat in longitude.map { LocationData(latitude: lat, longitude: $0) } }
+        let enclosing = enclosingCircle.map { LocationData(latitude: $0.latitude, longitude: $0.longitude) }
+        return prefersEnclosingCircle ? enclosing ?? flat : flat ?? enclosing
+    }
+
+    var catalogRadius: Double? {
+        prefersEnclosingCircle ? enclosingCircle?.baseRadiusM ?? radius : radius ?? enclosingCircle?.baseRadiusM
+    }
+
+    /// Both shapes the mapper resolves through `resolvedPolygon()`, which reads the enclosing circle.
+    private var prefersEnclosingCircle: Bool {
+        catalogShape == .polygon || catalogShape == .undescribed
+    }
 
     /// Outer ring as `lat_lon` pairs — the SDK's order, not GeoJSON's reversed one — and the
     /// CANONICAL ring: consecutive duplicates collapsed and the closing vertex dropped, which is

--- a/Sources/LocationGeofence/GeofenceLogTail.swift
+++ b/Sources/LocationGeofence/GeofenceLogTail.swift
@@ -87,7 +87,7 @@ enum GeofenceLog {
 
     /// The only values that compose the format's separators on purpose. Everything else is an
     /// untrusted token — region identifiers are workspace-authored and can hold anything.
-    private static let composedKeys: Set<String> = ["ranked", "evicted", "ids", "gs", "tt"]
+    private static let composedKeys: Set<String> = ["ranked", "evicted", "ids", "gs", "tt", "ring"]
 
     /// Applied to every finished value. Only whitespace, which is what separates one `key=value`
     /// from the next — the value's own structure is already the caller's business.

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -162,9 +162,16 @@ extension Logger {
                         // spaces, commas and `=`, all of which would break the parser's split.
                         ("name", region.name),
                         ("gs", GeofenceLog.list(region.geosetIds ?? [])),
-                        ("lat", GeofenceLog.num(region.latitude, 5)),
-                        ("lon", GeofenceLog.num(region.longitude, 5)),
-                        ("rad", GeofenceLog.num(region.radius, 0)),
+                        ("sh", region.catalogShape),
+                        // A polygon has no lat/lon/radius on the wire; these fall back to its
+                        // enclosing circle, which is the circle the OS monitors.
+                        ("lat", GeofenceLog.num(region.catalogCenter?.latitude, 5)),
+                        ("lon", GeofenceLog.num(region.catalogCenter?.longitude, 5)),
+                        ("rad", GeofenceLog.num(region.catalogRadius, 0)),
+                        // `nv` is authoritative: `ring` truncates, so it is for placement only and
+                        // never a membership input.
+                        ("nv", GeofenceLog.int(region.catalogRing?.count)),
+                        ("ring", GeofenceLog.list(region.catalogRing ?? [], limit: 64)),
                         ("tt", GeofenceLog.list(region.transitionTypes ?? []))
                     ]),
                 geofenceTag

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -162,7 +162,7 @@ extension Logger {
                         // spaces, commas and `=`, all of which would break the parser's split.
                         ("name", region.name),
                         ("gs", GeofenceLog.list(region.geosetIds ?? [])),
-                        ("sh", region.catalogShape),
+                        ("sh", region.catalogShape.rawValue),
                         // A polygon has no lat/lon/radius on the wire; these fall back to its
                         // enclosing circle, which is the circle the OS monitors.
                         ("lat", GeofenceLog.num(region.catalogCenter?.latitude, 5)),

--- a/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
@@ -505,8 +505,12 @@ struct GeofenceLogTailTests {
     /// A ring in GeoJSON order (longitude first) and CLOSED, as the wire sends it — the closing
     /// position repeats the first, which the catalog must drop.
     private func catalogPolygonRegion(id: String = "22250", vertices: Int = 4) -> GeofenceApiRegion {
+        // A regular ring, NOT a diagonal. Collinear points enclose no area, so the kernel rejects
+        // them and every catalog assertion silently exercises the fallback instead of the branch
+        // that reads the kernel's own list.
         var ring = (0 ..< vertices).map { i -> [Double] in
-            [55.18 + Double(i) / 10000, 25.10 + Double(i) / 10000]
+            let angle = 2 * Double.pi * Double(i) / Double(vertices)
+            return [55.184004 + 0.0015 * cos(angle), 25.109908 + 0.0015 * sin(angle)]
         }
         if let first = ring.first { ring.append(first) }
         return GeofenceApiRegion(
@@ -588,8 +592,9 @@ struct GeofenceLogTailTests {
             #expect(fields["lon"] == "55.18400")
             #expect(fields["rad"] == "625")
             #expect(fields["nv"] == "4")
-            // `lat_lon`, the SDK's order — the wire's is reversed.
-            #expect(fields["ring"]?.hasPrefix("25.10000_55.18000") == true)
+            // `lat_lon`, the SDK's order — the wire sends `lon,lat`. First vertex is at angle 0,
+            // so its longitude is the offset one and its latitude the centre's.
+            #expect(fields["ring"]?.hasPrefix("25.10991_55.18550") == true)
         }
     }
 
@@ -612,6 +617,39 @@ struct GeofenceLogTailTests {
 
     /// `ring` truncates. `nv` is what lets a consumer notice and refuse, rather than compute
     /// membership against a partial ring that still looks like a valid polygon.
+    /// Pins the branch that reads the geometry kernel's own vertex list rather than re-deriving
+    /// canonicalisation here. The two only disagree across the antimeridian: the kernel's
+    /// `samePosition` unwraps longitude, so a ring closing at +180 that opened at -180 loses its
+    /// closing vertex, while an exact comparison keeps it. `nv` is therefore 4 through the kernel
+    /// and 5 through the fallback — the one input that tells which path ran.
+    @Test
+    func fenceCatalog_givenRingClosingAcrossTheAntimeridian_expectTheKernelsRing() {
+        withDiagnostics(true) {
+            let logger = CapturingLogger()
+            let ring: [[Double]] = [
+                [-180.0, 25.00], [-179.99, 25.00], [-179.99, 25.01], [-180.0, 25.01],
+                // Same meridian as the first position, opposite sign.
+                [180.0, 25.00]
+            ]
+            let region = GeofenceApiRegion(
+                id: "22251", name: "Antimeridian", shape: "polygon",
+                latitude: nil, longitude: nil, radius: nil,
+                geometry: GeofenceApiGeometry(type: "Polygon", coordinates: [ring]),
+                enclosingCircle: GeofenceApiEnclosingCircle(latitude: 25.005, longitude: -179.995, baseRadiusM: 700),
+                carriesPolygonFields: true, externalId: nil,
+                transitionTypes: ["enter"], lastUpdated: 0, geosetIds: nil, metadata: nil
+            )
+            logger.geofenceApiFetchResult(returnedCount: 1, elapsed: 0.4, regions: [region])
+
+            guard let message = logger.messages.last, let fields = parseTail(message) else {
+                Issue.record("no parseable tail in '\(logger.messages.last ?? "<nothing>")'")
+                return
+            }
+            #expect(fields["nv"] == "4", "5 means the fallback ran and kept the wrapped closing vertex")
+            #expect(fields["ring"]?.split(separator: ",").count == 4)
+        }
+    }
+
     @Test
     func fenceCatalog_givenRingBeyondTheLimit_expectCountStaysAuthoritative() {
         withDiagnostics(true) {

--- a/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
@@ -682,6 +682,34 @@ struct GeofenceLogTailTests {
         }
     }
 
+    /// A position with fewer than two coordinates used to be dropped, leaving `nv` counting
+    /// vertices the ring never showed — `nv=0` with no ring reads as "polygon with no vertices"
+    /// rather than "ring unusable".
+    @Test
+    func fenceCatalog_givenMalformedPositions_expectCountAndRingAgree() {
+        withDiagnostics(true) {
+            let logger = CapturingLogger()
+            let region = GeofenceApiRegion(
+                id: "44480", name: nil, shape: "polygon",
+                latitude: nil, longitude: nil, radius: nil,
+                geometry: GeofenceApiGeometry(type: "Polygon", coordinates: [[[1.0], [2.0]]]),
+                enclosingCircle: GeofenceApiEnclosingCircle(latitude: 25.1, longitude: 55.18, baseRadiusM: 400),
+                carriesPolygonFields: true, externalId: nil,
+                transitionTypes: ["enter"], lastUpdated: 0, geosetIds: nil, metadata: nil
+            )
+            logger.geofenceApiFetchResult(returnedCount: 1, elapsed: 0.4, regions: [region])
+
+            guard let message = logger.messages.last, let fields = parseTail(message) else {
+                Issue.record("no parseable tail in '\(logger.messages.last ?? "<nothing>")'")
+                return
+            }
+            #expect(fields["nv"] == "2")
+            #expect(fields["ring"] == "bad_bad,bad_bad")
+            // Still placeable by its circle, which is the point of recording it at all.
+            #expect(fields["lat"] == "25.10000")
+        }
+    }
+
     @Test
     func fenceCatalog_givenNameWithSeparators_expectSanitizedButReadable() {
         withDiagnostics(true) {

--- a/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
@@ -502,11 +502,13 @@ struct GeofenceLogTailTests {
 
     // MARK: - Fence catalog
 
-    /// A square ring, GeoJSON order (longitude first) as the wire sends it.
+    /// A ring in GeoJSON order (longitude first) and CLOSED, as the wire sends it — the closing
+    /// position repeats the first, which the catalog must drop.
     private func catalogPolygonRegion(id: String = "22250", vertices: Int = 4) -> GeofenceApiRegion {
-        let ring = (0 ..< vertices).map { i -> [Double] in
+        var ring = (0 ..< vertices).map { i -> [Double] in
             [55.18 + Double(i) / 10000, 25.10 + Double(i) / 10000]
         }
+        if let first = ring.first { ring.append(first) }
         return GeofenceApiRegion(
             id: id,
             name: "Polygon Test",
@@ -707,6 +709,26 @@ struct GeofenceLogTailTests {
             #expect(fields["ring"] == "bad_bad,bad_bad")
             // Still placeable by its circle, which is the point of recording it at all.
             #expect(fields["lat"] == "25.10000")
+        }
+    }
+
+    /// `nv` counts the canonical ring, not the wire ring. A GeoJSON ring closes on itself, so
+    /// counting what arrived would report one extra vertex for every polygon — and a consumer
+    /// applying "fewer pairs than nv means truncated" would refuse every correct Android polygon.
+    /// Agreed with the Android side; both platforms count the unclosed ring.
+    @Test
+    func fenceCatalog_givenClosedWireRing_expectClosingVertexDropped() {
+        withDiagnostics(true) {
+            let logger = CapturingLogger()
+            logger.geofenceApiFetchResult(returnedCount: 1, elapsed: 0.4, regions: [catalogPolygonRegion(vertices: 4)])
+
+            guard let message = logger.messages.last, let fields = parseTail(message) else {
+                Issue.record("no parseable tail in '\(logger.messages.last ?? "<nothing>")'")
+                return
+            }
+            // The wire carried 5 positions; the canonical ring is 4.
+            #expect(fields["nv"] == "4")
+            #expect(fields["ring"]?.split(separator: ",").count == 4)
         }
     }
 

--- a/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
@@ -622,6 +622,47 @@ struct GeofenceLogTailTests {
     /// `samePosition` unwraps longitude, so a ring closing at +180 that opened at -180 loses its
     /// closing vertex, while an exact comparison keeps it. `nv` is therefore 4 through the kernel
     /// and 5 through the fallback — the one input that tells which path ran.
+    /// The mixed-field cases. `carriesPolygonFields` alone made the catalog disagree with the
+    /// mapper about what is monitored — the one thing a capture has to get right.
+    @Test
+    func fenceCatalog_givenMixedFields_expectTheShapeTheMapperMonitors() {
+        withDiagnostics(true) {
+            func fields(shape: String?, flat: Bool, geometry: Bool) -> [String: String]? {
+                let ring: [[Double]] = [[55.1, 25.1], [55.2, 25.1], [55.2, 25.2], [55.1, 25.1]]
+                let region = GeofenceApiRegion(
+                    id: "mix", name: nil, shape: shape,
+                    latitude: flat ? 10.0 : nil, longitude: flat ? 20.0 : nil, radius: flat ? 300 : nil,
+                    geometry: geometry ? GeofenceApiGeometry(type: "Polygon", coordinates: [ring]) : nil,
+                    enclosingCircle: GeofenceApiEnclosingCircle(latitude: 25.15, longitude: 55.15, baseRadiusM: 900),
+                    carriesPolygonFields: geometry, externalId: nil,
+                    transitionTypes: ["enter"], lastUpdated: 0, geosetIds: nil, metadata: nil
+                )
+                let logger = CapturingLogger()
+                logger.geofenceApiFetchResult(returnedCount: 1, elapsed: 0.1, regions: [region])
+                return parseTail(logger.messages.last ?? "")
+            }
+
+            // Explicit circle carrying stray geometry: monitored as a circle, by its flat fields.
+            let strayGeometry = fields(shape: "circle", flat: true, geometry: true)
+            #expect(strayGeometry?["sh"] == "circle")
+            #expect(strayGeometry?["rad"] == "300")
+
+            // Explicit polygon carrying flat fields: monitored by its enclosing circle.
+            let flatPolygon = fields(shape: "polygon", flat: true, geometry: true)
+            #expect(flatPolygon?["sh"] == "polygon")
+            #expect(flatPolygon?["rad"] == "900")
+
+            // Normalization matches the mapper's: padded and mixed case are the same shape.
+            #expect(fields(shape: "  Polygon ", flat: false, geometry: true)?["sh"] == "polygon")
+            // Blank is not a shape the server named.
+            #expect(fields(shape: "   ", flat: true, geometry: false)?["sh"] == "circle")
+            // Polygon fields, no discriminator — the mapper drops this; the catalog names it.
+            #expect(fields(shape: nil, flat: false, geometry: true)?["sh"] == "undescribed")
+            // A shape this version cannot monitor.
+            #expect(fields(shape: "hexagon", flat: true, geometry: false)?["sh"] == "unknown")
+        }
+    }
+
     @Test
     func fenceCatalog_givenRingClosingAcrossTheAntimeridian_expectTheKernelsRing() {
         withDiagnostics(true) {

--- a/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
@@ -502,6 +502,29 @@ struct GeofenceLogTailTests {
 
     // MARK: - Fence catalog
 
+    /// A square ring, GeoJSON order (longitude first) as the wire sends it.
+    private func catalogPolygonRegion(id: String = "22250", vertices: Int = 4) -> GeofenceApiRegion {
+        let ring = (0 ..< vertices).map { i -> [Double] in
+            [55.18 + Double(i) / 10000, 25.10 + Double(i) / 10000]
+        }
+        return GeofenceApiRegion(
+            id: id,
+            name: "Polygon Test",
+            shape: "polygon",
+            latitude: nil,
+            longitude: nil,
+            radius: nil,
+            geometry: GeofenceApiGeometry(type: "Polygon", coordinates: [ring]),
+            enclosingCircle: GeofenceApiEnclosingCircle(latitude: 25.109908, longitude: 55.184004, baseRadiusM: 625),
+            carriesPolygonFields: true,
+            externalId: nil,
+            transitionTypes: ["enter", "exit"],
+            lastUpdated: 0,
+            geosetIds: ["4471"],
+            metadata: nil
+        )
+    }
+
     private func catalogRegion(id: String = "11125", name: String? = "Momo Dubai Test") -> GeofenceApiRegion {
         GeofenceApiRegion(
             id: id,
@@ -543,6 +566,119 @@ struct GeofenceLogTailTests {
             for key in ["id", "name", "gs", "lat", "lon", "rad", "tt"] {
                 #expect(fields[key] != nil, "missing \(key)= in '\(message)'")
             }
+        }
+    }
+
+    /// A polygon carries no lat/lon/radius on the wire. Before this, all three were dropped and the
+    /// fence catalogued unplaceable — the one thing the catalog exists to prevent.
+    @Test
+    func fenceCatalog_givenPolygon_expectEnclosingCircleAndRing() {
+        withDiagnostics(true) {
+            let logger = CapturingLogger()
+            logger.geofenceApiFetchResult(returnedCount: 1, elapsed: 0.4, regions: [catalogPolygonRegion()])
+
+            guard let message = logger.messages.last, let fields = parseTail(message) else {
+                Issue.record("no parseable tail in '\(logger.messages.last ?? "<nothing>")'")
+                return
+            }
+            #expect(fields["sh"] == "polygon")
+            #expect(fields["lat"] == "25.10991")
+            #expect(fields["lon"] == "55.18400")
+            #expect(fields["rad"] == "625")
+            #expect(fields["nv"] == "4")
+            // `lat_lon`, the SDK's order — the wire's is reversed.
+            #expect(fields["ring"]?.hasPrefix("25.10000_55.18000") == true)
+        }
+    }
+
+    @Test
+    func fenceCatalog_givenCircle_expectShapeAndNoRing() {
+        withDiagnostics(true) {
+            let logger = CapturingLogger()
+            logger.geofenceApiFetchResult(returnedCount: 1, elapsed: 0.4, regions: [catalogRegion()])
+
+            guard let message = logger.messages.last, let fields = parseTail(message) else {
+                Issue.record("no parseable tail in '\(logger.messages.last ?? "<nothing>")'")
+                return
+            }
+            #expect(fields["sh"] == "circle")
+            #expect(fields["rad"] == "150")
+            #expect(fields["nv"] == nil)
+            #expect(fields["ring"] == nil)
+        }
+    }
+
+    /// `ring` truncates. `nv` is what lets a consumer notice and refuse, rather than compute
+    /// membership against a partial ring that still looks like a valid polygon.
+    @Test
+    func fenceCatalog_givenRingBeyondTheLimit_expectCountStaysAuthoritative() {
+        withDiagnostics(true) {
+            let logger = CapturingLogger()
+            logger.geofenceApiFetchResult(
+                returnedCount: 1, elapsed: 0.4, regions: [catalogPolygonRegion(vertices: 70)]
+            )
+
+            guard let message = logger.messages.last, let fields = parseTail(message) else {
+                Issue.record("no parseable tail in '\(logger.messages.last ?? "<nothing>")'")
+                return
+            }
+            #expect(fields["nv"] == "70")
+            #expect(fields["ring"]?.hasSuffix(",+6") == true, "expected a truncation marker in '\(message)'")
+        }
+    }
+
+    /// The malformed-but-placeable case, and the catalog's whole reason to exist: the ring failed
+    /// to decode, so the fence is still worth recording by the circle the OS was given.
+    @Test
+    func fenceCatalog_givenPolygonWhoseRingDidNotDecode_expectPlaceableWithoutRing() {
+        withDiagnostics(true) {
+            let logger = CapturingLogger()
+            var region = catalogPolygonRegion()
+            region = GeofenceApiRegion(
+                id: region.id, name: region.name, shape: "polygon",
+                latitude: nil, longitude: nil, radius: nil,
+                geometry: nil,
+                enclosingCircle: GeofenceApiEnclosingCircle(latitude: 25.109908, longitude: 55.184004, baseRadiusM: 625),
+                carriesPolygonFields: true, externalId: nil,
+                transitionTypes: ["enter"], lastUpdated: 0, geosetIds: nil, metadata: nil
+            )
+            logger.geofenceApiFetchResult(returnedCount: 1, elapsed: 0.4, regions: [region])
+
+            guard let message = logger.messages.last, let fields = parseTail(message) else {
+                Issue.record("no parseable tail in '\(logger.messages.last ?? "<nothing>")'")
+                return
+            }
+            #expect(fields["sh"] == "polygon")
+            #expect(fields["lat"] == "25.10991")
+            #expect(fields["rad"] == "625")
+            #expect(fields["ring"] == nil)
+            #expect(fields["nv"] == nil)
+        }
+    }
+
+    /// A coordinate off the wire is rendered before anything drops invalid regions. `%.5f` on 1e300
+    /// is 309 digits, so the record says the server sent garbage instead of carrying it.
+    @Test
+    func fenceCatalog_givenAbsurdCoordinate_expectItRecordedAsBad() {
+        withDiagnostics(true) {
+            let logger = CapturingLogger()
+            let region = GeofenceApiRegion(
+                id: "33375", name: nil, shape: "polygon",
+                latitude: nil, longitude: nil, radius: nil,
+                geometry: GeofenceApiGeometry(type: "Polygon", coordinates: [[[1e300, 25.1], [55.18, 25.11]]]),
+                enclosingCircle: GeofenceApiEnclosingCircle(latitude: 25.1, longitude: 55.18, baseRadiusM: 400),
+                carriesPolygonFields: true, externalId: nil,
+                transitionTypes: ["enter"], lastUpdated: 0, geosetIds: nil, metadata: nil
+            )
+            logger.geofenceApiFetchResult(returnedCount: 1, elapsed: 0.4, regions: [region])
+
+            guard let message = logger.messages.last, let fields = parseTail(message) else {
+                Issue.record("no parseable tail in '\(logger.messages.last ?? "<nothing>")'")
+                return
+            }
+            #expect(fields["nv"] == "2", "a bad vertex still counts")
+            #expect(fields["ring"]?.hasPrefix("25.10000_bad") == true, "got '\(fields["ring"] ?? "")'")
+            #expect(message.count < 500, "one absurd coordinate should not blow up the line")
         }
     }
 


### PR DESCRIPTION
Part of [MBL-2418](https://linear.app/customerio/issue/MBL-2418).

The fence catalog records `lat`/`lon`/`rad` per fence so a drive can be replayed later. A polygon carries none of those on the wire — it has `enclosingCircle` and `geometry` instead — so all three were dropped and a polygon catalogued as id, name, geoset and transitions: unplaceable. This appeared when main's diagnostics merged onto the polygon branch and started running against data they predate.

## What it does

- `sh` = `circle` | `polygon`
- `lat`/`lon`/`rad` fall back to the enclosing circle for a polygon. `rad` is the backend's radius, unpadded
- `nv` = vertex count, `ring` = outer ring as `lat_lon` pairs (SDK order; the wire is GeoJSON, reversed)
- `ring` joins `composedKeys`, otherwise sanitizing folds the pair separators into the intra-pair ones and the list parses as one run-together token

`ring` is for placement only, never a membership input: it truncates at 64, and a partial ring is still a valid-looking polygon. `nv` is authoritative so a consumer can detect truncation and refuse.

A coordinate is rendered before invalid regions are dropped, so a malformed one records as `bad` rather than 309 digits.

Field names agreed with Android, who have the same gap — theirs catalogues a polygon as a placeable circle ~1 km too large, so it fails silently where ours fails visibly.

## Tests

568/568 `LocationGeofenceTests`. Five catalog tests: polygon, circle, truncation marker with `nv` intact, ring that failed to decode (still placeable by its circle), and an absurd coordinate.

## Stack

1. #1263 `mbl-2418-a` polygon fence catalog ← **this PR**
2. #1264 `mbl-2418-b` polygon logs onto the tail convention + `GeofenceLogTail` coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

