### PR TITLE
chore(geofence): stop one bad row discarding the whole pending queue

### DIFF
--- a/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
@@ -205,6 +205,9 @@ final class GeofenceEventTracker: @unchecked Sendable {
         cooldownKey: String
     ) async {
         switch write {
+        // Unreachable: the one call site guards on `.persisted`. Kept total rather than narrowed
+        // so the compiler still lists the arms, but it must stay a no-op only while that guard
+        // holds — reaching here would release no cooldown and log nothing.
         case .persisted: return
         case .writeFailed:
             logger.geofencePendingPersistFailed(geofenceId: geofenceId, transition: transition)

--- a/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
@@ -126,14 +126,9 @@ final class GeofenceEventTracker: @unchecked Sendable {
         // Persist all rows in one atomic write: a per-row loop could save some and lose the rest on
         // an app kill, and the cooldown is already spent so the lost ones would never retry. Done
         // before requesting background time so durability never depends on the assertion.
-        let persisted = await pendingStore.append(metrics)
-        if !persisted {
-            // Persist-first failed (disk error): release the just-claimed cooldown so the next
-            // crossing retries from a clean state instead of being suppressed. Skip delivery — a row
-            // that never reached disk has nothing to retry, and sending it anyway would let its
-            // success-path remove(key:) drop a later same-second crossing's row (keys omit transitionId).
-            logger.geofencePendingPersistFailed(geofenceId: geofenceId, transition: transition)
-            await storage.releaseCooldown(key: cooldownKey)
+        let write = await pendingStore.append(metrics)
+        guard write == .persisted else {
+            await abandonUnpersisted(write, geofenceId: geofenceId, transition: transition, cooldownKey: cooldownKey)
             return []
         }
         // The SDK has accepted the crossing and written it down; that is the fact replay asserts
@@ -168,7 +163,7 @@ final class GeofenceEventTracker: @unchecked Sendable {
         // An unreadable queue is not an empty one. Both end this call without sending, but only
         // the first leaves rows on disk that a later trigger must come back for — so it must not
         // read as "nothing to flush" to anything added here later. The store logs which it was.
-        guard case .rows(let rows, _) = await pendingStore.read() else { return }
+        guard case .rows(let rows) = await pendingStore.read() else { return }
         let metrics = rows.filter { !excludedKeys.contains($0.key) }
         guard !metrics.isEmpty else { return }
         let persistedKey = contextStore.currentCdpApiKey
@@ -189,6 +184,35 @@ final class GeofenceEventTracker: @unchecked Sendable {
     }
 
     // MARK: - Private
+
+    /// Gives up a crossing whose rows never reached disk.
+    ///
+    /// Nothing was written in either case, but they are not the same event and must not share a
+    /// record: one is a write that failed, the other a write refused before it was tried, so an
+    /// unreadable queue survives. Both release the just-claimed cooldown so the next crossing
+    /// retries from a clean state instead of being suppressed.
+    ///
+    /// Both also skip delivery, for different reasons. On a failed write, sending anyway would let
+    /// the success-path `remove(key:)` drop a later same-second crossing's row (keys omit
+    /// transitionId). That hazard does NOT apply to a refusal — `remove` takes nothing out of a
+    /// file it cannot read — so this crossing is dropped by choice: the backlog we declined to
+    /// overwrite is worth more than one fresh row, and delivering un-persisted would make a failed
+    /// send unretryable and silent. The cost is real when the queue was in fact empty.
+    private func abandonUnpersisted(
+        _ write: PendingGeofenceQueueWrite,
+        geofenceId: String,
+        transition: GeofenceTransition,
+        cooldownKey: String
+    ) async {
+        switch write {
+        case .persisted: return
+        case .writeFailed:
+            logger.geofencePendingPersistFailed(geofenceId: geofenceId, transition: transition)
+        case .refusedUnreadable:
+            logger.geofenceTransitionDroppedQueueUnreadable(geofenceId: geofenceId, transition: transition)
+        }
+        await storage.releaseCooldown(key: cooldownKey)
+    }
 
     /// Fresh-transition delivery via direct HTTP. Failure leaves the row for `flushPending`.
     private func deliverFresh(metric: PendingGeofenceMetric) async {

--- a/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
+++ b/Sources/LocationGeofence/Event/GeofenceEventTracker.swift
@@ -165,7 +165,11 @@ final class GeofenceEventTracker: @unchecked Sendable {
     ///
     /// `excluding` skips rows the caller just persisted and already attempted itself.
     func flushPending(excluding excludedKeys: Set<String> = []) async {
-        let metrics = await pendingStore.loadAll().filter { !excludedKeys.contains($0.key) }
+        // An unreadable queue is not an empty one. Both end this call without sending, but only
+        // the first leaves rows on disk that a later trigger must come back for — so it must not
+        // read as "nothing to flush" to anything added here later. The store logs which it was.
+        guard case .rows(let rows, _) = await pendingStore.read() else { return }
+        let metrics = rows.filter { !excludedKeys.contains($0.key) }
         guard !metrics.isEmpty else { return }
         let persistedKey = contextStore.currentCdpApiKey
         if !contextStore.hasLiveCdpApiKeyProvider, let persistedKey, !persistedKey.isEmpty {
@@ -302,7 +306,7 @@ extension GeofenceEventTracker {
             )
             let tracker = GeofenceEventTracker(
                 storage: di.geofenceStorage,
-                pendingStore: PendingGeofenceMetricStore(),
+                pendingStore: PendingGeofenceMetricStore(logger: di.logger),
                 deliveryTracker: deliveryTracker,
                 contextStore: di.backgroundDeliveryContextStore,
                 eventBusHandler: di.eventBusHandler,

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -68,9 +68,16 @@ extension Logger {
     /// written and nothing failed to write. Deliberately not `storage.write.failed`: that record
     /// is `io=out` and says a write was attempted, and reporting a refusal as a failed write is
     /// the collapse the queue's own read/write split exists to prevent.
+    ///
+    /// Says no write was ATTEMPTED rather than that the queue was left intact: the same refusal
+    /// arises when the file's location cannot be resolved, where there is no queue to leave.
+    ///
+    /// Logged at `error` while the sibling anonymous drop logs at `debug` — one is an anomaly, the
+    /// other routine — so `transition.dropped` spans two levels. Anything filtering by level
+    /// before parsing the tail sees only part of the family.
     func geofenceTransitionDroppedQueueUnreadable(geofenceId: String, transition: GeofenceTransition) {
         error(
-            "Dropped \(transition.rawValue) for geofence \(geofenceId): the pending queue could not be read, so it was left intact rather than written over; cooldown released so the next crossing can retry"
+            "Dropped \(transition.rawValue) for geofence \(geofenceId): the pending queue could not be read, so no write was attempted; cooldown released so the next crossing can retry"
                 + geofenceTail("transition.dropped", .output, [
                     ("id", geofenceId),
                     ("t", transition.rawValue),

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -64,6 +64,23 @@ extension Logger {
         )
     }
 
+    /// The crossing was given up because the pending queue could not be READ, so nothing was
+    /// written and nothing failed to write. Deliberately not `storage.write.failed`: that record
+    /// is `io=out` and says a write was attempted, and reporting a refusal as a failed write is
+    /// the collapse the queue's own read/write split exists to prevent.
+    func geofenceTransitionDroppedQueueUnreadable(geofenceId: String, transition: GeofenceTransition) {
+        error(
+            "Dropped \(transition.rawValue) for geofence \(geofenceId): the pending queue could not be read, so it was left intact rather than written over; cooldown released so the next crossing can retry"
+                + geofenceTail("transition.dropped", .output, [
+                    ("id", geofenceId),
+                    ("t", transition.rawValue),
+                    ("why", "queue_unreadable")
+                ]),
+            geofenceTag,
+            nil
+        )
+    }
+
     func geofencePendingPersistFailed(geofenceId: String, transition: GeofenceTransition) {
         error(
             "Failed to persist \(transition.rawValue) event for geofence \(geofenceId) before send; cooldown released so the next crossing can retry"

--- a/Sources/LocationGeofence/Logger+GeofenceDelivery.swift
+++ b/Sources/LocationGeofence/Logger+GeofenceDelivery.swift
@@ -70,6 +70,57 @@ extension Logger {
     }
 }
 
+// MARK: - Pending queue reads
+
+//
+// Classified `in`: the queue file is an input the SDK reads back, and a replay that fed these
+// forward as outputs would invent deliveries. Both records exist because a shrinking backlog and
+// a vanished one used to look identical — one undecodable row discarded the whole queue silently.
+
+/// Why the pending queue file could not be turned into rows.
+enum GeofenceQueueReadFailure: String {
+    /// The bytes could not be obtained — Data Protection before first unlock, or an I/O error.
+    /// The rows are intact on disk, so nothing may be written over them.
+    case readFailed = "read_failed"
+    /// The bytes came back but are not a row array, so there is nothing left to preserve.
+    case notARowArray = "not_a_row_array"
+
+    var prose: String {
+        switch self {
+        case .readFailed: return "the file could not be read"
+        case .notARowArray: return "the file is not a row array"
+        }
+    }
+}
+
+extension Logger {
+    /// Rows skipped because they did not decode. The count travels because it is the only thing
+    /// that separates a backlog that shrank from one that was thrown away.
+    func geofenceQueueRowsDropped(count: Int, of total: Int) {
+        error(
+            "Pending geofence queue: skipped \(count) of \(total) row(s) that did not decode"
+                + geofenceTail("queue.rows_dropped", .input, [
+                    ("why", "decode_failed"),
+                    ("n", GeofenceLog.int(count)),
+                    ("total", GeofenceLog.int(total))
+                ]),
+            geofenceTag,
+            nil
+        )
+    }
+
+    /// The queue could not be read at all. `why` decides whether the rows survive: a read failure
+    /// leaves them on disk untouched, an unparseable file has already lost them.
+    func geofenceQueueUnreadable(reason: GeofenceQueueReadFailure) {
+        error(
+            "Pending geofence queue unreadable: \(reason.prose)"
+                + geofenceTail("queue.unreadable", .input, [("why", reason.rawValue)]),
+            geofenceTag,
+            nil
+        )
+    }
+}
+
 extension BackgroundDeliveryHttpError {
     /// Stable token for the tail, so a reader can tell an offline device from a misconfigured one.
     ///

--- a/Sources/LocationGeofence/Logger+GeofenceDelivery.swift
+++ b/Sources/LocationGeofence/Logger+GeofenceDelivery.swift
@@ -84,11 +84,14 @@ enum GeofenceQueueReadFailure: String {
     case readFailed = "read_failed"
     /// The bytes came back but are not a row array, so there is nothing left to preserve.
     case notARowArray = "not_a_row_array"
+    /// The file's location could not be resolved at all, so no read or write can ever succeed.
+    case noFileLocation = "no_file_location"
 
     var prose: String {
         switch self {
         case .readFailed: return "the file could not be read"
         case .notARowArray: return "the file is not a row array"
+        case .noFileLocation: return "the file location could not be resolved"
         }
     }
 }

--- a/Sources/LocationGeofence/Storage/PendingGeofenceMetricStore.swift
+++ b/Sources/LocationGeofence/Storage/PendingGeofenceMetricStore.swift
@@ -4,14 +4,26 @@ import Foundation
 /// What a read of the queue file found.
 ///
 /// `unreadable` is a case of its own rather than an empty list because the two demand opposite
-/// handling. The file carries `completeUntilFirstUserAuthentication`, so a geofence wake before
-/// the first unlock after a reboot cannot read it — and a read failure reported as "no rows" lets
-/// the next append overwrite a queue that was never actually lost.
+/// handling: reported as "no rows", it lets the next append replace a queue that is intact on
+/// disk. The state that does the damage is a read that fails while a write would still succeed —
+/// measured, since `Data.write(options: .atomic)` renames a temp file into place and needs
+/// permission on the directory, not on the target. Data Protection is the suspected way the
+/// device reaches it, but that chain is unverified: if the target's protection class also blocks
+/// the write, the old code failed safe by accident.
 enum PendingGeofenceQueueRead: Equatable {
-    /// The file was read. `droppedRows` counts rows that did not decode and were skipped.
-    case rows([PendingGeofenceMetric], droppedRows: Int)
+    /// The file was read. Rows that did not decode are skipped, counted, and logged by the store.
+    case rows([PendingGeofenceMetric])
     /// The bytes could not be obtained. Nothing may be written over them.
     case unreadable
+}
+
+/// The outcome of a write, kept apart because the caller reports them differently: nothing was
+/// written in either case, but only one of them is a write that failed.
+enum PendingGeofenceQueueWrite: Equatable {
+    case persisted
+    /// Refused before writing, because the existing queue could not be read.
+    case refusedUnreadable
+    case writeFailed
 }
 
 /// File-backed queue of geofence transition events awaiting direct-HTTP delivery.
@@ -52,13 +64,12 @@ actor PendingGeofenceMetricStore {
     /// Appends metrics in one read-modify-write so a transition's fan-out persists atomically —
     /// a crash can't save some rows and lose the rest. Rows whose `key` already exists (on disk
     /// or earlier in `metrics`) are a no-op. When over capacity, drops the **oldest** first.
-    /// Returns `false` if the file could not be read or persisted.
     ///
     /// Refuses to write over an unreadable file: the append would otherwise replace a queue whose
-    /// rows are intact on disk and merely out of reach, which is the pre-first-unlock case.
-    func append(_ metrics: [PendingGeofenceMetric]) -> Bool {
-        guard !metrics.isEmpty else { return true }
-        guard case .rows(var items, _) = read() else { return false }
+    /// rows are intact on disk and merely out of reach.
+    func append(_ metrics: [PendingGeofenceMetric]) -> PendingGeofenceQueueWrite {
+        guard !metrics.isEmpty else { return .persisted }
+        guard case .rows(var items) = read() else { return .refusedUnreadable }
         var keys = Set(items.map(\.key))
         for metric in metrics where keys.insert(metric.key).inserted {
             items.append(metric)
@@ -66,11 +77,11 @@ actor PendingGeofenceMetricStore {
         if items.count > Self.maxEntries {
             items = Array(items.suffix(Self.maxEntries))
         }
-        return saveToDisk(items)
+        return saveToDisk(items) ? .persisted : .writeFailed
     }
 
     /// The pending queue, oldest first, or `unreadable`. Callers must handle the two apart —
-    /// a caller that treats `unreadable` as an empty queue reintroduces the bug this returns for.
+    /// a caller that treats `unreadable` as an empty queue reintroduces the bug this exists for.
     func read() -> PendingGeofenceQueueRead {
         loadFromDisk()
     }
@@ -78,7 +89,7 @@ actor PendingGeofenceMetricStore {
     /// Removes one pending entry by key. Returns `true` when the entry was found and removed,
     /// `false` when it was absent, the file was unreadable, or the write failed.
     func remove(key: String) -> Bool {
-        guard case .rows(var items, _) = read() else { return false }
+        guard case .rows(var items) = read() else { return false }
         let originalCount = items.count
         items.removeAll { $0.key == key }
         guard items.count != originalCount else { return false }
@@ -89,9 +100,13 @@ actor PendingGeofenceMetricStore {
 
     private func loadFromDisk() -> PendingGeofenceQueueRead {
         // A nil URL means Application Support could not be resolved, so no write ever landed.
-        // Reported as unreadable rather than empty because `saveToDisk` cannot succeed either.
-        guard let url = fileURL() else { return .unreadable }
-        guard fileManager.fileExists(atPath: url.path) else { return .rows([], droppedRows: 0) }
+        // Reported as unreadable rather than empty because `saveToDisk` cannot succeed either —
+        // and logged, because every append and every flush then fails for the life of the process.
+        guard let url = fileURL() else {
+            logger.geofenceQueueUnreadable(reason: .noFileLocation)
+            return .unreadable
+        }
+        guard fileManager.fileExists(atPath: url.path) else { return .rows([]) }
         guard let data = try? Data(contentsOf: url) else {
             logger.geofenceQueueUnreadable(reason: .readFailed)
             return .unreadable
@@ -100,14 +115,13 @@ actor PendingGeofenceMetricStore {
             // The bytes came back but are not a row array. Unlike a read failure there is nothing
             // to preserve, so the queue reads as empty and the next write reclaims the file.
             logger.geofenceQueueUnreadable(reason: .notARowArray)
-            return .rows([], droppedRows: 0)
+            return .rows([])
         }
         let decoded = rows.compactMap(\.metric)
-        let dropped = rows.count - decoded.count
-        if dropped > 0 {
-            logger.geofenceQueueRowsDropped(count: dropped, of: rows.count)
+        if decoded.count < rows.count {
+            logger.geofenceQueueRowsDropped(count: rows.count - decoded.count, of: rows.count)
         }
-        return .rows(decoded, droppedRows: dropped)
+        return .rows(decoded)
     }
 
     /// Decodes one row without failing the array. A row the current schema cannot read is skipped

--- a/Sources/LocationGeofence/Storage/PendingGeofenceMetricStore.swift
+++ b/Sources/LocationGeofence/Storage/PendingGeofenceMetricStore.swift
@@ -1,6 +1,19 @@
 import CioInternalCommon
 import Foundation
 
+/// What a read of the queue file found.
+///
+/// `unreadable` is a case of its own rather than an empty list because the two demand opposite
+/// handling. The file carries `completeUntilFirstUserAuthentication`, so a geofence wake before
+/// the first unlock after a reboot cannot read it — and a read failure reported as "no rows" lets
+/// the next append overwrite a queue that was never actually lost.
+enum PendingGeofenceQueueRead: Equatable {
+    /// The file was read. `droppedRows` counts rows that did not decode and were skipped.
+    case rows([PendingGeofenceMetric], droppedRows: Int)
+    /// The bytes could not be obtained. Nothing may be written over them.
+    case unreadable
+}
+
 /// File-backed queue of geofence transition events awaiting direct-HTTP delivery.
 ///
 /// Same persistence shape as `PendingPushDeliveryStore` but in the app's container
@@ -20,14 +33,18 @@ actor PendingGeofenceMetricStore {
 
     private let fileManager: FileManager
     private let directoryURL: URL?
+    private let logger: Logger
 
     /// - Parameters:
+    ///   - logger: Reports rows skipped on read; the store is the only place that knows the count.
     ///   - fileManager: File manager used for I/O. Defaults to `.default`.
     ///   - directoryURL: Directory for the queue file. If `nil`, uses Application Support in the app container.
     init(
+        logger: Logger,
         fileManager: FileManager = .default,
         directoryURL: URL? = nil
     ) {
+        self.logger = logger
         self.fileManager = fileManager
         self.directoryURL = directoryURL
     }
@@ -35,10 +52,13 @@ actor PendingGeofenceMetricStore {
     /// Appends metrics in one read-modify-write so a transition's fan-out persists atomically —
     /// a crash can't save some rows and lose the rest. Rows whose `key` already exists (on disk
     /// or earlier in `metrics`) are a no-op. When over capacity, drops the **oldest** first.
-    /// Returns `false` if the file could not be persisted.
+    /// Returns `false` if the file could not be read or persisted.
+    ///
+    /// Refuses to write over an unreadable file: the append would otherwise replace a queue whose
+    /// rows are intact on disk and merely out of reach, which is the pre-first-unlock case.
     func append(_ metrics: [PendingGeofenceMetric]) -> Bool {
         guard !metrics.isEmpty else { return true }
-        var items = loadFromDisk()
+        guard case .rows(var items, _) = read() else { return false }
         var keys = Set(items.map(\.key))
         for metric in metrics where keys.insert(metric.key).inserted {
             items.append(metric)
@@ -49,14 +69,16 @@ actor PendingGeofenceMetricStore {
         return saveToDisk(items)
     }
 
-    /// All pending metrics, oldest first.
-    func loadAll() -> [PendingGeofenceMetric] {
+    /// The pending queue, oldest first, or `unreadable`. Callers must handle the two apart —
+    /// a caller that treats `unreadable` as an empty queue reintroduces the bug this returns for.
+    func read() -> PendingGeofenceQueueRead {
         loadFromDisk()
     }
 
-    /// Removes one pending entry by key. Returns `true` when the entry was found and removed.
+    /// Removes one pending entry by key. Returns `true` when the entry was found and removed,
+    /// `false` when it was absent, the file was unreadable, or the write failed.
     func remove(key: String) -> Bool {
-        var items = loadFromDisk()
+        guard case .rows(var items, _) = read() else { return false }
         let originalCount = items.count
         items.removeAll { $0.key == key }
         guard items.count != originalCount else { return false }
@@ -65,15 +87,38 @@ actor PendingGeofenceMetricStore {
 
     // MARK: - Private (file persistence)
 
-    private func loadFromDisk() -> [PendingGeofenceMetric] {
-        guard let url = fileURL(),
-              fileManager.fileExists(atPath: url.path),
-              let data = try? Data(contentsOf: url)
-        else {
-            return []
+    private func loadFromDisk() -> PendingGeofenceQueueRead {
+        // A nil URL means Application Support could not be resolved, so no write ever landed.
+        // Reported as unreadable rather than empty because `saveToDisk` cannot succeed either.
+        guard let url = fileURL() else { return .unreadable }
+        guard fileManager.fileExists(atPath: url.path) else { return .rows([], droppedRows: 0) }
+        guard let data = try? Data(contentsOf: url) else {
+            logger.geofenceQueueUnreadable(reason: .readFailed)
+            return .unreadable
         }
-        // Corrupted or unreadable JSON returns empty so the next write overwrites it.
-        return (try? Self.makeDecoder().decode([PendingGeofenceMetric].self, from: data)) ?? []
+        guard let rows = try? Self.makeDecoder().decode([DecodedRow].self, from: data) else {
+            // The bytes came back but are not a row array. Unlike a read failure there is nothing
+            // to preserve, so the queue reads as empty and the next write reclaims the file.
+            logger.geofenceQueueUnreadable(reason: .notARowArray)
+            return .rows([], droppedRows: 0)
+        }
+        let decoded = rows.compactMap(\.metric)
+        let dropped = rows.count - decoded.count
+        if dropped > 0 {
+            logger.geofenceQueueRowsDropped(count: dropped, of: rows.count)
+        }
+        return .rows(decoded, droppedRows: dropped)
+    }
+
+    /// Decodes one row without failing the array. A row the current schema cannot read is skipped
+    /// and counted; a single `try?` around the whole array discarded every other row with it, and
+    /// `userId`/`transitionId` are non-optional, so schema evolution alone can trigger it.
+    private struct DecodedRow: Decodable {
+        let metric: PendingGeofenceMetric?
+
+        init(from decoder: Decoder) throws {
+            self.metric = try? PendingGeofenceMetric(from: decoder)
+        }
     }
 
     private func saveToDisk(_ items: [PendingGeofenceMetric]) -> Bool {

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -177,7 +177,7 @@ struct GeofenceEventTrackerTests {
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
 
         let messages = logger.errorReceivedInvocations.map(\.message)
-        #expect(messages.contains { $0.contains("the pending queue could not be read") })
+        #expect(messages.contains { $0.contains("the pending queue could not be read, so no write was attempted") })
         #expect(!messages.contains { $0.contains("Failed to persist") })
         #expect(delivery.trackMetricCallsCount == 0)
         // The backlog it refused to write over is still byte-for-byte on disk.

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -39,6 +39,7 @@ struct GeofenceEventTrackerTests {
         contextStore: BackgroundDeliveryContextStore,
         eventBus: EventBusHandlerMock = EventBusHandlerMock(),
         dateUtil: DateUtil = DateUtilStub(),
+        logger: Logger = LoggerMock(),
         backgroundTaskRunner: BackgroundTaskRunner = NoBackgroundTaskRunner()
     ) -> GeofenceEventTracker {
         GeofenceEventTracker(
@@ -48,7 +49,7 @@ struct GeofenceEventTrackerTests {
             contextStore: contextStore,
             eventBusHandler: eventBus,
             dateUtil: dateUtil,
-            logger: LoggerMock(),
+            logger: logger,
             cooldownInterval: cooldownInterval,
             backgroundTaskRunner: backgroundTaskRunner
         )
@@ -136,6 +137,53 @@ struct GeofenceEventTrackerTests {
         #expect(delivery.trackMetricCallsCount == 0)
         // The cooldown claimed for this crossing was released, so the next crossing retries from a
         // clean state instead of being suppressed. A held cooldown would make this claim return false.
+        let remaining = await storage.tryAcquireCooldown(key: "user_42:geo_1:enter", now: dateUtil.now, interval: cooldownInterval)
+        #expect(remaining == nil)
+    }
+
+    /// The sibling of the test above, and the distinction the queue's read/write split exists for:
+    /// nothing was written here either, but no write was ever attempted. Reporting it as a failed
+    /// write would put an `io=out` `storage.write.failed` on a read that never touched the file.
+    @Test
+    func trackTransition_givenQueueUnreadable_expectRefusalNotAWriteFailure() async {
+        let dir = makeTempDirectory()
+        let queueFile = dir.appendingPathComponent("pending_geofence_metrics.json")
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: queueFile.path)
+            try? FileManager.default.removeItem(at: dir)
+        }
+        let pending = makePendingStore(directory: dir)
+        #expect(await pending.append([PendingGeofenceMetric(
+            geofenceId: "geo_old", transition: .enter, timestamp: Date(timeIntervalSince1970: 1),
+            userId: "user_42", name: nil, transitionId: "txn_old"
+        )]) == .persisted)
+        let before = try? Data(contentsOf: queueFile)
+        try? FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: queueFile.path)
+
+        let storage = makeStorage(directory: makeTempDirectory())
+        let dateUtil = DateUtilStub()
+        let logger = LoggerMock()
+        let delivery = GeofenceDeliveryTrackerMock()
+        delivery.trackMetricClosure = { _, _, onComplete in onComplete(.success(())) }
+        let tracker = makeTracker(
+            storage: storage,
+            pendingStore: pending,
+            deliveryTracker: delivery,
+            contextStore: makeContextStore(userId: "user_42"),
+            dateUtil: dateUtil,
+            logger: logger
+        )
+
+        await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
+
+        let messages = logger.errorReceivedInvocations.map(\.message)
+        #expect(messages.contains { $0.contains("the pending queue could not be read") })
+        #expect(!messages.contains { $0.contains("Failed to persist") })
+        #expect(delivery.trackMetricCallsCount == 0)
+        // The backlog it refused to write over is still byte-for-byte on disk.
+        try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: queueFile.path)
+        #expect((try? Data(contentsOf: queueFile)) == before)
+        // Same cooldown release as the write-failure path: the next crossing must not be suppressed.
         let remaining = await storage.tryAcquireCooldown(key: "user_42:geo_1:enter", now: dateUtil.now, interval: cooldownInterval)
         #expect(remaining == nil)
     }

--- a/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
+++ b/Tests/LocationGeofence/Geofence/Event/GeofenceEventTrackerTests.swift
@@ -19,7 +19,7 @@ struct GeofenceEventTrackerTests {
     }
 
     private func makePendingStore(directory: URL) -> PendingGeofenceMetricStore {
-        PendingGeofenceMetricStore(fileManager: .default, directoryURL: directory)
+        PendingGeofenceMetricStore(logger: LoggerMock(), fileManager: .default, directoryURL: directory)
     }
 
     private func makeContextStore(userId: String? = nil, cdpApiKey: String? = nil) -> BackgroundDeliveryContextStore {
@@ -82,7 +82,7 @@ struct GeofenceEventTrackerTests {
         #expect(delivery.trackMetricCallsCount == 1)
         #expect(delivery.trackMetricReceivedArguments?.userId == "user_42")
         #expect(postedGeofenceEvents(from: bus).isEmpty)
-        #expect(await pending.loadAll().isEmpty)
+        #expect(await pending.rows().isEmpty)
     }
 
     @Test
@@ -103,7 +103,7 @@ struct GeofenceEventTrackerTests {
 
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
 
-        #expect(await pending.loadAll().count == 1)
+        #expect(await pending.rows().count == 1)
     }
 
     @Test
@@ -196,7 +196,7 @@ struct GeofenceEventTrackerTests {
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
 
         #expect(delivery.trackMetricCallsCount == 1)
-        #expect(await pending.loadAll().isEmpty)
+        #expect(await pending.rows().isEmpty)
     }
 
     @Test
@@ -352,7 +352,7 @@ struct GeofenceEventTrackerTests {
                 userId: "user_42", name: nil, transitionId: "txn_2"
             )
         ])
-        #expect(await pending.loadAll().count == 2)
+        #expect(await pending.rows().count == 2)
 
         let delivery = GeofenceDeliveryTrackerMock()
         let bus = EventBusHandlerMock()
@@ -369,7 +369,7 @@ struct GeofenceEventTrackerTests {
         // Without an HTTP context (no cdpApiKey), replay falls back to EventBus → DataPipeline.
         #expect(postedGeofenceEvents(from: bus).count == 2)
         #expect(delivery.trackMetricCallsCount == 0)
-        #expect(await pending.loadAll().isEmpty)
+        #expect(await pending.rows().isEmpty)
     }
 
     @Test
@@ -406,7 +406,7 @@ struct GeofenceEventTrackerTests {
         // replay ships over the direct channel instead of waiting for the next launch.
         #expect(Set(delivery.trackMetricReceivedInvocations.map(\.metric.geofenceId)) == ["geo_1", "geo_2"])
         #expect(postedGeofenceEvents(from: bus).isEmpty)
-        #expect(await pending.loadAll().isEmpty)
+        #expect(await pending.rows().isEmpty)
     }
 
     @Test
@@ -436,7 +436,7 @@ struct GeofenceEventTrackerTests {
 
         // An HTTP failure keeps the row queued for the next trigger; it must not silently switch
         // channels — EventBus is the no-context fallback, not the failure fallback.
-        #expect(await pending.loadAll().count == 1)
+        #expect(await pending.rows().count == 1)
         #expect(postedGeofenceEvents(from: bus).isEmpty)
     }
 
@@ -498,7 +498,7 @@ struct GeofenceEventTrackerTests {
 
         #expect(postedGeofenceEvents(from: bus).count == 1)
         #expect(delivery.trackMetricCallsCount == 0)
-        #expect(await pending.loadAll().isEmpty)
+        #expect(await pending.rows().isEmpty)
         // The store holds the provider weakly; keep it alive through the flush above.
         withExtendedLifetime(liveProvider) {}
     }
@@ -530,7 +530,7 @@ struct GeofenceEventTrackerTests {
 
         #expect(Set(delivery.trackMetricReceivedInvocations.map(\.metric.geofenceId)) == ["geo_old", "geo_new"])
         #expect(postedGeofenceEvents(from: bus).isEmpty)
-        #expect(await pending.loadAll().isEmpty)
+        #expect(await pending.rows().isEmpty)
     }
 
     @Test
@@ -569,7 +569,7 @@ struct GeofenceEventTrackerTests {
         _ = await(flush1, flush2)
 
         #expect(Set(postedGeofenceEvents(from: bus).map(\.geofenceId)) == ["geo_1", "geo_2"])
-        #expect(await pending.loadAll().isEmpty)
+        #expect(await pending.rows().isEmpty)
     }
 
     @Test
@@ -613,13 +613,13 @@ struct GeofenceEventTrackerTests {
             break
         }
         // The replay is mid-flight; a suspension here must not lose the crossing — it is on disk.
-        #expect(await pending.loadAll().map(\.geofenceId).contains("geo_new"))
+        #expect(await pending.rows().map(\.geofenceId).contains("geo_new"))
         backlogRelease.continuation.yield()
         await tracking.value
 
         // Backlog delivered and removed; the failed fresh row stays for the next trigger, attempted
         // exactly once — the flush excluded it instead of re-sending on the same network.
-        #expect(await pending.loadAll().map(\.geofenceId) == ["geo_new"])
+        #expect(await pending.rows().map(\.geofenceId) == ["geo_new"])
         #expect(delivery.trackMetricReceivedInvocations.filter { $0.metric.geofenceId == "geo_new" }.count == 1)
     }
 
@@ -649,7 +649,7 @@ struct GeofenceEventTrackerTests {
         // The crossing replays the backlog over EventBus, then delivers itself over HTTP.
         #expect(postedGeofenceEvents(from: bus).map(\.geofenceId) == ["geo_old"])
         #expect(delivery.trackMetricReceivedInvocations.map(\.metric.geofenceId) == ["geo_new"])
-        #expect(await pending.loadAll().isEmpty)
+        #expect(await pending.rows().isEmpty)
     }
 
     @Test
@@ -680,7 +680,7 @@ struct GeofenceEventTrackerTests {
         #expect(delivery.trackMetricCallsCount == 0)
         // ...but the stamped backlog row still went out.
         #expect(postedGeofenceEvents(from: bus).map(\.transitionId) == ["txn_old"])
-        #expect(await pending.loadAll().isEmpty)
+        #expect(await pending.rows().isEmpty)
     }
 
     @Test
@@ -704,7 +704,7 @@ struct GeofenceEventTrackerTests {
 
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
         // Dropped at capture: nothing queued, nothing posted.
-        #expect(await pending.loadAll().isEmpty)
+        #expect(await pending.rows().isEmpty)
         #expect(postedGeofenceEvents(from: bus).isEmpty)
 
         contextStore.setUserId("user_42")
@@ -736,7 +736,7 @@ struct GeofenceEventTrackerTests {
 
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
 
-        let queued = await pending.loadAll()
+        let queued = await pending.rows()
         #expect(queued.first?.userId == "user_A")
     }
 
@@ -825,7 +825,7 @@ struct GeofenceEventTrackerTests {
 
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
 
-        #expect(await pending.loadAll().first?.name == "HQ")
+        #expect(await pending.rows().first?.name == "HQ")
     }
 
     @Test
@@ -844,7 +844,7 @@ struct GeofenceEventTrackerTests {
 
         await tracker.trackTransition(geofenceId: "geo_unknown", transition: .enter)
 
-        #expect(await pending.loadAll().first?.name == nil)
+        #expect(await pending.rows().first?.name == nil)
     }
 
     @Test
@@ -866,7 +866,7 @@ struct GeofenceEventTrackerTests {
 
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
 
-        #expect(await pending.loadAll().first?.name == nil)
+        #expect(await pending.rows().first?.name == nil)
     }
 
     // MARK: - Metadata (snapshot + prefer-live)
@@ -900,7 +900,7 @@ struct GeofenceEventTrackerTests {
 
         await tracker.trackTransition(geofenceId: "geo_1", transition: .enter)
 
-        #expect(await pending.loadAll().first?.metadata == ["category": .string("office")])
+        #expect(await pending.rows().first?.metadata == ["category": .string("office")])
     }
 
     @Test
@@ -1029,7 +1029,7 @@ struct GeofenceEventTrackerTests {
         #expect(metrics.allSatisfy { $0.transition == .enter })
         // All fan-out rows share one transitionId (same physical crossing); geosetId distinguishes them.
         #expect(Set(metrics.map(\.transitionId)).count == 1)
-        #expect(await pending.loadAll().isEmpty)
+        #expect(await pending.rows().isEmpty)
     }
 
     @Test
@@ -1126,7 +1126,7 @@ struct GeofenceEventTrackerTests {
 
         // Both fan-out rows persist independently; the pending-store key includes the
         // geosetId so the rows of one transition cannot collide with each other.
-        let persisted = await pending.loadAll()
+        let persisted = await pending.rows()
         #expect(persisted.count == 2)
         #expect(Set(persisted.compactMap(\.geosetId)) == ["set_y", "set_z"])
     }
@@ -1158,7 +1158,7 @@ struct GeofenceEventTrackerTests {
 
         await tracker.flushPending()
 
-        #expect(await pending.loadAll().isEmpty)
+        #expect(await pending.rows().isEmpty)
         let posted = postedGeofenceEvents(from: bus)
         #expect(posted.count == 2)
         #expect(Set(posted.compactMap(\.geosetId)) == ["set_y", "set_z"]) // delivery order is not guaranteed (concurrent)
@@ -1251,7 +1251,7 @@ struct GeofenceEventTrackerTests {
         // assertion is taken (that is only for the fresh HTTP send). The row is posted and drained.
         #expect(runner.callCount.wrappedValue == 0)
         #expect(postedGeofenceEvents(from: bus).count == 1)
-        #expect(await pending.loadAll().isEmpty)
+        #expect(await pending.rows().isEmpty)
     }
 }
 

--- a/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
@@ -149,7 +149,9 @@ struct GeofenceLogTailTests {
             Invocation(name: "firstRunRearm", ev: "movement.rearmed", requiredKeys: ["why"]) { $0.geofenceFirstRunRearm() },
             Invocation(name: "regionsAdopted", ev: "registration.adopted", requiredKeys: ["n"]) { $0.geofenceRegionsAdopted(count: 4) },
             Invocation(name: "foregroundRearm", ev: "registration.rearmed", requiredKeys: ["n", "why"]) { $0.geofenceForegroundRearm(count: 4) },
-            Invocation(name: "storageLoaded", ev: "storage.loaded", requiredKeys: ["n", "anchor"]) { $0.geofenceStorageLoaded(regionCount: 30, hasAnchor: true) }
+            Invocation(name: "storageLoaded", ev: "storage.loaded", requiredKeys: ["n", "anchor"]) { $0.geofenceStorageLoaded(regionCount: 30, hasAnchor: true) },
+            Invocation(name: "queueRowsDropped", ev: "queue.rows_dropped", requiredKeys: ["why", "n", "total"]) { $0.geofenceQueueRowsDropped(count: 1, of: 3) },
+            Invocation(name: "queueUnreadable", ev: "queue.unreadable", requiredKeys: ["why"]) { $0.geofenceQueueUnreadable(reason: .readFailed) }
         ]
     }
 
@@ -212,6 +214,52 @@ struct GeofenceLogTailTests {
         #expect(BackgroundDeliveryHttpError.http(statusCode: 503).diagnosticReason == "http_503")
     }
 
+    /// The module's whole diagnostic vocabulary, hoisted out of the test so the assertion stays
+    /// readable as rows are added.
+    private static let declaredVocabulary: Set<String> = [
+        "api.fetch.result",
+        "baseline.healed",
+        "baseline.refused",
+        "contradiction.refused",
+        "delivery.failed",
+        "delivery.queued",
+        "delivery.sent",
+        "fix.received",
+        "info",
+        "module.init",
+        "module.reset",
+        "module.wake",
+        "movement.exit",
+        "movement.fix.failed",
+        "movement.fix.requested",
+        "movement.fix.resolved",
+        "movement.rearmed",
+        "movement.registered",
+        "os.callback.dropped",
+        "os.callback.received",
+        "os.monitor.failed",
+        "os.monitor.stopped",
+        "os.stream.failed",
+        "permission.changed",
+        "queue.rows_dropped",
+        "queue.unreadable",
+        "rank.evaluated",
+        "registration.adopted",
+        "registration.applied",
+        "registration.diff",
+        "registration.rearmed",
+        "registration.rejected",
+        "storage.loaded",
+        "storage.write.failed",
+        "sync.completed",
+        "sync.skipped",
+        "sync.superseded",
+        "transition.accepted",
+        "transition.dropped",
+        "transition.suppressed",
+        "transition.synthesized"
+    ]
+
     @Test
     func everyRecord_expectTheDeclaredVocabulary() {
         // Companion to the per-row `ev` pin above, catching what a per-row check cannot: a key
@@ -223,47 +271,7 @@ struct GeofenceLogTailTests {
         // `fence.cataloged` is absent on purpose: it is emitted by a private helper driven through
         // `api.fetch.result`, so it cannot be a row here. It carries its own `ev` assertion in
         // `fenceCatalog_...` below. Every other key the module emits is listed.
-        let expected: Set = [
-            "api.fetch.result",
-            "baseline.healed",
-            "baseline.refused",
-            "contradiction.refused",
-            "delivery.failed",
-            "delivery.queued",
-            "delivery.sent",
-            "fix.received",
-            "info",
-            "module.init",
-            "module.reset",
-            "module.wake",
-            "movement.exit",
-            "movement.fix.failed",
-            "movement.fix.requested",
-            "movement.fix.resolved",
-            "movement.rearmed",
-            "movement.registered",
-            "os.callback.dropped",
-            "os.callback.received",
-            "os.monitor.failed",
-            "os.monitor.stopped",
-            "os.stream.failed",
-            "permission.changed",
-            "rank.evaluated",
-            "registration.adopted",
-            "registration.applied",
-            "registration.diff",
-            "registration.rearmed",
-            "registration.rejected",
-            "storage.loaded",
-            "storage.write.failed",
-            "sync.completed",
-            "sync.skipped",
-            "sync.superseded",
-            "transition.accepted",
-            "transition.dropped",
-            "transition.suppressed",
-            "transition.synthesized"
-        ]
+        let expected = Self.declaredVocabulary
         var seen: Set<String> = []
         withDiagnostics(true) {
             for invocation in invocations {

--- a/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
@@ -151,7 +151,8 @@ struct GeofenceLogTailTests {
             Invocation(name: "foregroundRearm", ev: "registration.rearmed", requiredKeys: ["n", "why"]) { $0.geofenceForegroundRearm(count: 4) },
             Invocation(name: "storageLoaded", ev: "storage.loaded", requiredKeys: ["n", "anchor"]) { $0.geofenceStorageLoaded(regionCount: 30, hasAnchor: true) },
             Invocation(name: "queueRowsDropped", ev: "queue.rows_dropped", requiredKeys: ["why", "n", "total"]) { $0.geofenceQueueRowsDropped(count: 1, of: 3) },
-            Invocation(name: "queueUnreadable", ev: "queue.unreadable", requiredKeys: ["why"]) { $0.geofenceQueueUnreadable(reason: .readFailed) }
+            Invocation(name: "queueUnreadable", ev: "queue.unreadable", requiredKeys: ["why"]) { $0.geofenceQueueUnreadable(reason: .readFailed) },
+            Invocation(name: "droppedQueueUnreadable", ev: "transition.dropped", requiredKeys: ["id", "t", "why"]) { $0.geofenceTransitionDroppedQueueUnreadable(geofenceId: "notl_core", transition: .enter) }
         ]
     }
 

--- a/Tests/LocationGeofence/Geofence/GeofenceMonitorBinderTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceMonitorBinderTests.swift
@@ -21,7 +21,7 @@ struct GeofenceMonitorBinderTests {
         )
         return GeofenceEventTracker(
             storage: storage,
-            pendingStore: PendingGeofenceMetricStore(),
+            pendingStore: PendingGeofenceMetricStore(logger: LoggerMock()),
             deliveryTracker: deliveryTracker,
             contextStore: contextStore,
             eventBusHandler: EventBusHandlerMock(),

--- a/Tests/LocationGeofence/Geofence/Storage/PendingGeofenceMetricStoreTests.swift
+++ b/Tests/LocationGeofence/Geofence/Storage/PendingGeofenceMetricStoreTests.swift
@@ -5,6 +5,14 @@ import Foundation
 import SharedTests
 import Testing
 
+/// No Application Support directory, so the store can resolve no file at all — the state a
+/// sandbox failure produces and the only one that reaches the no-location branch.
+private final class NoApplicationSupportFileManager: FileManager {
+    override func urls(for directory: FileManager.SearchPathDirectory, in domainMask: FileManager.SearchPathDomainMask) -> [URL] {
+        []
+    }
+}
+
 @Suite("PendingGeofenceMetricStore")
 struct PendingGeofenceMetricStoreTests {
     private func makeTempDirectory() -> URL {
@@ -53,7 +61,7 @@ struct PendingGeofenceMetricStoreTests {
         let appended = await store.append([metric])
         let items = await store.rows()
 
-        #expect(appended == true)
+        #expect(appended == .persisted)
         #expect(items.count == 1)
         #expect(items.first == metric)
     }
@@ -206,7 +214,7 @@ struct PendingGeofenceMetricStoreTests {
         let appended = await store.append(batch)
         let items = await store.rows()
 
-        #expect(appended == true)
+        #expect(appended == .persisted)
         #expect(items.count == 2)
         #expect(Set(items.map(\.geofenceId)) == ["geo_1", "geo_2"])
     }
@@ -231,7 +239,7 @@ struct PendingGeofenceMetricStoreTests {
         let appended = await store.append([rowY, rowZ])
         let items = await store.rows()
 
-        #expect(appended == true)
+        #expect(appended == .persisted)
         #expect(rowY.key != rowZ.key) // geoset suffix keeps fan-out rows distinct
         #expect(items.count == 2)
         #expect(Set(items.compactMap(\.geosetId)) == ["set_y", "set_z"])
@@ -247,7 +255,7 @@ struct PendingGeofenceMetricStoreTests {
         let appended = await store.append([])
         let items = await store.rows()
 
-        #expect(appended == true)
+        #expect(appended == .persisted)
         #expect(items.count == 1)
     }
 
@@ -342,6 +350,22 @@ struct PendingGeofenceMetricStoreTests {
     ]
     """
 
+    /// The one branch that returns `unreadable` without touching a file. It was silent, which in
+    /// this state means every append and every flush fails for the life of the process with
+    /// nothing in the log to say why.
+    @Test
+    func read_givenNoResolvableFileLocation_expectUnreadableAndLogged() async {
+        let logger = LoggerMock()
+        let store = PendingGeofenceMetricStore(
+            logger: logger,
+            fileManager: NoApplicationSupportFileManager(),
+            directoryURL: nil
+        )
+
+        #expect(await store.read() == .unreadable)
+        #expect(logger.errorReceivedInvocations.contains { $0.message.contains("the file location could not be resolved") })
+    }
+
     @Test
     func read_givenOneUndecodableRow_expectTheOtherRowSurvives() async throws {
         let dir = makeTempDirectory()
@@ -351,7 +375,7 @@ struct PendingGeofenceMetricStoreTests {
 
         let result = await store.read()
 
-        #expect(result == .rows([makeMetric()], droppedRows: 1))
+        #expect(result == .rows([makeMetric()]))
     }
 
     @Test
@@ -376,7 +400,7 @@ struct PendingGeofenceMetricStoreTests {
         try plant(Self.oneGoodOneBadRow, in: dir)
         let store = makeStore(directory: dir)
 
-        #expect(await store.append([makeMetric(geofenceId: "geo_3", transitionId: "txn_3")]))
+        #expect(await store.append([makeMetric(geofenceId: "geo_3", transitionId: "txn_3")]) == .persisted)
 
         #expect(await store.rows().map(\.geofenceId) == ["geo_1", "geo_3"])
     }
@@ -394,13 +418,13 @@ struct PendingGeofenceMetricStoreTests {
             try? FileManager.default.removeItem(at: dir)
         }
         let store = makeStore(directory: dir)
-        #expect(await store.append([makeMetric()]))
+        #expect(await store.append([makeMetric()]) == .persisted)
         let before = try Data(contentsOf: queueFile(in: dir))
         try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: queueFile(in: dir).path)
 
         let appended = await store.append([makeMetric(geofenceId: "geo_new", transitionId: "txn_new")])
 
-        #expect(appended == false)
+        #expect(appended == .refusedUnreadable)
         try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: queueFile(in: dir).path)
         #expect(try Data(contentsOf: queueFile(in: dir)) == before)
     }
@@ -446,7 +470,7 @@ struct PendingGeofenceMetricStoreTests {
         let logger = LoggerMock()
         let store = makeStore(directory: dir, logger: logger)
 
-        #expect(await store.append([makeMetric()]))
+        #expect(await store.append([makeMetric()]) == .persisted)
 
         #expect(await store.rows() == [makeMetric()])
         #expect(logger.errorReceivedInvocations.contains { $0.message.contains("unreadable: the file is not a row array") })

--- a/Tests/LocationGeofence/Geofence/Storage/PendingGeofenceMetricStoreTests.swift
+++ b/Tests/LocationGeofence/Geofence/Storage/PendingGeofenceMetricStoreTests.swift
@@ -1,4 +1,5 @@
 @testable import CioInternalCommon
+@testable import CioInternalCommonMocks
 @testable import CioLocationGeofence
 import Foundation
 import SharedTests
@@ -10,8 +11,8 @@ struct PendingGeofenceMetricStoreTests {
         FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
     }
 
-    private func makeStore(directory: URL) -> PendingGeofenceMetricStore {
-        PendingGeofenceMetricStore(fileManager: .default, directoryURL: directory)
+    private func makeStore(directory: URL, logger: Logger = LoggerMock()) -> PendingGeofenceMetricStore {
+        PendingGeofenceMetricStore(logger: logger, fileManager: .default, directoryURL: directory)
     }
 
     private func makeMetric(
@@ -37,7 +38,7 @@ struct PendingGeofenceMetricStoreTests {
         defer { try? FileManager.default.removeItem(at: dir) }
         let store = makeStore(directory: dir)
 
-        let items = await store.loadAll()
+        let items = await store.rows()
 
         #expect(items.isEmpty)
     }
@@ -50,7 +51,7 @@ struct PendingGeofenceMetricStoreTests {
         let metric = makeMetric()
 
         let appended = await store.append([metric])
-        let items = await store.loadAll()
+        let items = await store.rows()
 
         #expect(appended == true)
         #expect(items.count == 1)
@@ -71,7 +72,7 @@ struct PendingGeofenceMetricStoreTests {
 
         _ = await store.append([metric])
 
-        #expect(await store.loadAll().first?.metadata == ["category": .string("office"), "priority": .int(3)])
+        #expect(await store.rows().first?.metadata == ["category": .string("office"), "priority": .int(3)])
     }
 
     @Test
@@ -95,7 +96,7 @@ struct PendingGeofenceMetricStoreTests {
 
         _ = await store.append([first])
         _ = await store.append([second])
-        let items = await store.loadAll()
+        let items = await store.rows()
 
         #expect(items.count == 2)
         #expect(items[0] == first)
@@ -114,7 +115,7 @@ struct PendingGeofenceMetricStoreTests {
         for i in 0 ..< 105 {
             _ = await store.append([makeMetric(geofenceId: "geo_\(i)")])
         }
-        let items = await store.loadAll()
+        let items = await store.rows()
 
         #expect(items.count == 100)
         #expect(items.first?.geofenceId == "geo_5")
@@ -131,7 +132,7 @@ struct PendingGeofenceMetricStoreTests {
         for i in 0 ..< 100 {
             _ = await store.append([makeMetric(geofenceId: "geo_\(i)")])
         }
-        let items = await store.loadAll()
+        let items = await store.rows()
 
         #expect(items.count == 100)
         #expect(items.first?.geofenceId == "geo_0")
@@ -147,7 +148,7 @@ struct PendingGeofenceMetricStoreTests {
         // A single batch larger than the cap must trim to the newest 100 in that one write.
         let batch = (0 ..< 105).map { makeMetric(geofenceId: "geo_\($0)") }
         _ = await store.append(batch)
-        let items = await store.loadAll()
+        let items = await store.rows()
 
         #expect(items.count == 100)
         #expect(items.first?.geofenceId == "geo_5")
@@ -167,7 +168,7 @@ struct PendingGeofenceMetricStoreTests {
         _ = await store.append([toRemove])
 
         let removed = await store.remove(key: toRemove.key)
-        let items = await store.loadAll()
+        let items = await store.rows()
 
         #expect(removed == true)
         #expect(items.count == 1)
@@ -183,7 +184,7 @@ struct PendingGeofenceMetricStoreTests {
         _ = await store.append([metric])
 
         let removed = await store.remove(key: "nonexistent_key")
-        let items = await store.loadAll()
+        let items = await store.rows()
 
         #expect(removed == false)
         #expect(items.count == 1)
@@ -203,7 +204,7 @@ struct PendingGeofenceMetricStoreTests {
         // cooldown-slip or re-fan-out can't produce duplicate rows.
         let batch = [existing, makeMetric(geofenceId: "geo_2"), makeMetric(geofenceId: "geo_2")]
         let appended = await store.append(batch)
-        let items = await store.loadAll()
+        let items = await store.rows()
 
         #expect(appended == true)
         #expect(items.count == 2)
@@ -228,7 +229,7 @@ struct PendingGeofenceMetricStoreTests {
         )
 
         let appended = await store.append([rowY, rowZ])
-        let items = await store.loadAll()
+        let items = await store.rows()
 
         #expect(appended == true)
         #expect(rowY.key != rowZ.key) // geoset suffix keeps fan-out rows distinct
@@ -244,7 +245,7 @@ struct PendingGeofenceMetricStoreTests {
         _ = await store.append([makeMetric()])
 
         let appended = await store.append([])
-        let items = await store.loadAll()
+        let items = await store.rows()
 
         #expect(appended == true)
         #expect(items.count == 1)
@@ -277,7 +278,7 @@ struct PendingGeofenceMetricStoreTests {
         _ = await firstStore.append([metric])
 
         let secondStore = makeStore(directory: dir)
-        let items = await secondStore.loadAll()
+        let items = await secondStore.rows()
 
         #expect(items == [metric])
     }
@@ -305,7 +306,7 @@ struct PendingGeofenceMetricStoreTests {
                                 transitionId: "txn_\(i)_\(j)"
                             )])
                         case 1:
-                            _ = await store.loadAll()
+                            _ = await store.rows()
                         case 2:
                             _ = await store.remove(key: "geo_\(i)_\(j)_enter_0")
                         default:
@@ -316,7 +317,138 @@ struct PendingGeofenceMetricStoreTests {
             }
         }
 
-        let items = await store.loadAll()
+        let items = await store.rows()
         #expect(items.count <= 100)
+    }
+
+    // MARK: - Resilience to bad rows and unreadable files
+
+    /// The queue file path, so a test can plant bytes the encoder would never produce.
+    private func queueFile(in directory: URL) -> URL {
+        directory.appendingPathComponent("pending_geofence_metrics.json")
+    }
+
+    private func plant(_ json: String, in directory: URL) throws {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try Data(json.utf8).write(to: queueFile(in: directory))
+    }
+
+    /// A row missing `user_id` — the schema-evolution case, since `userId` is non-optional here
+    /// while Android's is nullable. One of these used to discard every other row with it.
+    private static let oneGoodOneBadRow = """
+    [
+      {"geofence_id":"geo_1","transition":"enter","timestamp":1700000000,"user_id":"user_store","transition_id":"txn_store"},
+      {"geofence_id":"geo_2","transition":"enter","timestamp":1700000001,"transition_id":"txn_broken"}
+    ]
+    """
+
+    @Test
+    func read_givenOneUndecodableRow_expectTheOtherRowSurvives() async throws {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try plant(Self.oneGoodOneBadRow, in: dir)
+        let store = makeStore(directory: dir)
+
+        let result = await store.read()
+
+        #expect(result == .rows([makeMetric()], droppedRows: 1))
+    }
+
+    @Test
+    func read_givenOneUndecodableRow_expectTheDropCounted() async throws {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try plant(Self.oneGoodOneBadRow, in: dir)
+        let logger = LoggerMock()
+        let store = makeStore(directory: dir, logger: logger)
+
+        _ = await store.read()
+
+        // The count is the record: a backlog that shrank and one that was thrown away are the
+        // same observation without it.
+        #expect(logger.errorReceivedInvocations.contains { $0.message.contains("skipped 1 of 2 row(s)") })
+    }
+
+    @Test
+    func append_givenOneUndecodableRow_expectTheGoodRowKept() async throws {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try plant(Self.oneGoodOneBadRow, in: dir)
+        let store = makeStore(directory: dir)
+
+        #expect(await store.append([makeMetric(geofenceId: "geo_3", transitionId: "txn_3")]))
+
+        #expect(await store.rows().map(\.geofenceId) == ["geo_1", "geo_3"])
+    }
+
+    /// The defect this ticket exists for. The file carries
+    /// `completeUntilFirstUserAuthentication`, so a geofence wake before the first unlock after a
+    /// reboot cannot read it — and an append that treats that as an empty queue overwrites rows
+    /// that were never lost. Modelled with a file the process may not read but whose directory it
+    /// may still write, which is the same shape: an atomic write would otherwise succeed.
+    @Test
+    func append_givenAnUnreadableFile_expectRefusedAndTheQueueUntouched() async throws {
+        let dir = makeTempDirectory()
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: queueFile(in: dir).path)
+            try? FileManager.default.removeItem(at: dir)
+        }
+        let store = makeStore(directory: dir)
+        #expect(await store.append([makeMetric()]))
+        let before = try Data(contentsOf: queueFile(in: dir))
+        try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: queueFile(in: dir).path)
+
+        let appended = await store.append([makeMetric(geofenceId: "geo_new", transitionId: "txn_new")])
+
+        #expect(appended == false)
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: queueFile(in: dir).path)
+        #expect(try Data(contentsOf: queueFile(in: dir)) == before)
+    }
+
+    @Test
+    func read_givenAnUnreadableFile_expectUnreadableNotEmpty() async throws {
+        let dir = makeTempDirectory()
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: queueFile(in: dir).path)
+            try? FileManager.default.removeItem(at: dir)
+        }
+        let logger = LoggerMock()
+        let store = makeStore(directory: dir, logger: logger)
+        _ = await store.append([makeMetric()])
+        try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: queueFile(in: dir).path)
+
+        #expect(await store.read() == .unreadable)
+        #expect(logger.errorReceivedInvocations.contains { $0.message.contains("unreadable: the file could not be read") })
+    }
+
+    @Test
+    func remove_givenAnUnreadableFile_expectRefused() async throws {
+        let dir = makeTempDirectory()
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: queueFile(in: dir).path)
+            try? FileManager.default.removeItem(at: dir)
+        }
+        let store = makeStore(directory: dir)
+        let metric = makeMetric()
+        _ = await store.append([metric])
+        try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: queueFile(in: dir).path)
+
+        #expect(await store.remove(key: metric.key) == false)
+    }
+
+    /// Read succeeded and the bytes are not a row array, so unlike a read failure there is nothing
+    /// left to preserve — the queue reads empty and the next write reclaims the file.
+    @Test
+    func append_givenAFileThatIsNotARowArray_expectTheWriteProceeds() async throws {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try plant("{\"not\":\"an array\"}", in: dir)
+        let logger = LoggerMock()
+        let store = makeStore(directory: dir, logger: logger)
+
+        #expect(await store.append([makeMetric()]))
+
+        #expect(await store.rows() == [makeMetric()])
+        #expect(logger.errorReceivedInvocations.contains { $0.message.contains("unreadable: the file is not a row array") })
     }
 }

--- a/Tests/LocationGeofence/Geofence/Stub/PendingGeofenceMetricStore+Testing.swift
+++ b/Tests/LocationGeofence/Geofence/Stub/PendingGeofenceMetricStore+Testing.swift
@@ -6,7 +6,7 @@ extension PendingGeofenceMetricStore {
     /// production callers must handle `unreadable` explicitly, which is the whole point of the
     /// enum, so a convenience that hides it does not belong in the store.
     func rows() -> [PendingGeofenceMetric] {
-        guard case .rows(let rows, _) = read() else { return [] }
+        guard case .rows(let rows) = read() else { return [] }
         return rows
     }
 }

--- a/Tests/LocationGeofence/Geofence/Stub/PendingGeofenceMetricStore+Testing.swift
+++ b/Tests/LocationGeofence/Geofence/Stub/PendingGeofenceMetricStore+Testing.swift
@@ -1,0 +1,12 @@
+@testable import CioLocationGeofence
+import Foundation
+
+extension PendingGeofenceMetricStore {
+    /// Rows only, for the tests that are not about the read outcome. Deliberately test-only:
+    /// production callers must handle `unreadable` explicitly, which is the whole point of the
+    /// enum, so a convenience that hides it does not belong in the store.
+    func rows() -> [PendingGeofenceMetric] {
+        guard case .rows(let rows, _) = read() else { return [] }
+        return rows
+    }
+}


### PR DESCRIPTION
Part of [MBL-2413](https://linear.app/customerio/issue/MBL-2413).

The pending geofence queue decoded as a single array, so one undecodable row discarded every other row. A read failure also returned an empty list, so the next append overwrote a queue that was intact on disk.

Rows now decode one at a time and skipped rows are counted. A read reports `unreadable` separately from empty, and `append`/`remove` refuse to write over it. `append` returns an outcome rather than a Bool, so a refusal is no longer logged as a failed write.

The state that loses the queue is a read that fails while a write still succeeds — an atomic write renames a temp file, so it needs permission on the directory, not the target. Data Protection is the suspected route on device; that part is unverified.

**Evidence:** reverting the append guard makes `append_givenAnUnreadableFile_expectRefusedAndTheQueueUntouched` fail with the queue file's bytes changed. LocationGeofenceTests 386/386, lint clean.

## Related

One ticket, one defect shape, two modules. Separate PRs because they sit on different bases and neither depends on the other.

1. #1265 geofence pending queue → `feature/geofence-polygons` ← **this PR**
2. #1266 Common push delivery store → `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
