### PR TITLE
chore(push): stop one bad row discarding the whole pending delivery queue

### DIFF
--- a/Sources/Common/Service/Push/PendingPushDeliveryStore.swift
+++ b/Sources/Common/Service/Push/PendingPushDeliveryStore.swift
@@ -28,15 +28,11 @@ private enum PendingPushDeliveryAppGroupStorage {
 
 /// What a read of the pending-metrics file found.
 ///
-/// `unreadable` is a case of its own rather than an empty list because the two demand opposite
-/// handling: reported as "no rows", it lets the next append replace rows that are intact on disk.
-/// The state that does the damage is a read that fails while a write would still succeed —
-/// measured, since `Data.write(options: .atomic)` renames a temp file into place and needs
-/// permission on the directory, not on the target. Data Protection on the app group file is the
-/// suspected way a device reaches it, and the NSE is where it would bite, since a push can arrive
-/// before the first unlock after a reboot — but that chain is unverified.
+/// `unreadable` is separate from an empty list because reporting it as "no rows" lets the next
+/// append replace rows that are intact on disk. Reachable when a read fails but a write still
+/// succeeds — an atomic write renames a temp file, so it needs permission on the directory.
 public enum PendingPushDeliveryQueueRead: Equatable {
-    /// The file was read. Rows that did not decode are skipped, counted, and logged by the store.
+    /// Rows that did not decode are skipped and logged.
     case rows([PendingPushDeliveryMetric])
     /// The bytes could not be obtained. Nothing may be written over them.
     case unreadable
@@ -52,8 +48,8 @@ public protocol PendingPushDeliveryStore: AutoMockable {
     /// Appends a metric. When over capacity, drops the **oldest** entries. Returns `false` if the list could not be persisted.
     func append(_ metric: PendingPushDeliveryMetric) -> Bool
 
-    /// All pending metrics, oldest first. Returns an empty array when the file could not be read,
-    /// so a caller that must tell "no rows" from "could not tell" has to use ``read()`` instead.
+    /// All pending metrics, oldest first. Empty when the file could not be read — use ``read()``
+    /// where that difference matters.
     func loadAll() -> [PendingPushDeliveryMetric]
 
     /// The pending queue, or `unreadable` when the bytes could not be obtained.
@@ -80,8 +76,7 @@ public final class CioAppGroupPendingPushDeliveryStore: PendingPushDeliveryStore
 
     /// Designated initializer. When `appGroupId` is non-nil it is used directly; otherwise the identifier
     /// is inferred from `processBundleIdentifier` using the format `group.{bundleId}.cio`.
-    /// - Parameter fileManager: Seam for tests — the app group container does not exist in a unit
-    ///   test host, so the concrete store is otherwise unreachable. Production always passes the default.
+    /// - Parameter fileManager: Test seam; the app group container does not exist in a test host.
     init(
         appGroupId: String?,
         processBundleIdentifier: String?,
@@ -128,8 +123,7 @@ public final class CioAppGroupPendingPushDeliveryStore: PendingPushDeliveryStore
         var success = false
 
         NSFileCoordinator().coordinate(readingItemAt: fileURL, options: [], writingItemAt: fileURL, options: .forReplacing, error: &coordError) { readURL, writeURL in
-            // Refuses to write over an unreadable file. The alternative is to treat it as empty,
-            // which replaces a queue whose rows are intact on disk — the pre-first-unlock case.
+            // Never write over a file we could not read: treating it as empty replaces intact rows.
             guard case .rows(var items) = readItems(from: readURL) else { return }
             items.append(metric)
             if items.count > maxEntries {
@@ -155,8 +149,7 @@ public final class CioAppGroupPendingPushDeliveryStore: PendingPushDeliveryStore
     }
 
     public func read() -> PendingPushDeliveryQueueRead {
-        // No resolved file means the app group is unavailable, so no write ever landed and none
-        // can. Reported as unreadable rather than empty so an append cannot be built on it.
+        // No app group, so no write can land either. Unreadable, so no append is built on it.
         guard let fileURL = metricsFileURL else { return .unreadable }
 
         var coordError: NSError?
@@ -228,9 +221,8 @@ public final class CioAppGroupPendingPushDeliveryStore: PendingPushDeliveryStore
         return success
     }
 
-    /// Decodes one row without failing the array. A row the current schema cannot read is skipped
-    /// and counted; a single `try?` around the whole array discarded every other row with it, and
-    /// every field here is non-optional, so schema evolution alone can trigger it.
+    /// Decodes one row without failing the array. Every field is non-optional, so schema
+    /// evolution alone can drop a row — and one `try?` around the array dropped the rest with it.
     private struct DecodedRow: Decodable {
         let metric: PendingPushDeliveryMetric?
 
@@ -253,15 +245,12 @@ public final class CioAppGroupPendingPushDeliveryStore: PendingPushDeliveryStore
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         guard let rows = try? decoder.decode([DecodedRow].self, from: data) else {
-            // The bytes came back but are not a row array. Unlike a read failure there is nothing
-            // to preserve, so the queue reads as empty and the next write reclaims the file.
+            // Read fine but not a row array: nothing to preserve, so the next write reclaims it.
             logger.error("Pending push delivery store: file is not a row array, starting fresh")
             return .rows([])
         }
         let decoded = rows.compactMap(\.metric)
         if decoded.count < rows.count {
-            // The count is the record: a backlog that shrank and one that was thrown away are the
-            // same observation without it.
             logger.error("Pending push delivery store: skipped \(rows.count - decoded.count) of \(rows.count) row(s) that did not decode")
         }
         return .rows(decoded)

--- a/Sources/Common/Service/Push/PendingPushDeliveryStore.swift
+++ b/Sources/Common/Service/Push/PendingPushDeliveryStore.swift
@@ -26,6 +26,19 @@ private enum PendingPushDeliveryAppGroupStorage {
     }
 }
 
+/// What a read of the pending-metrics file found.
+///
+/// `unreadable` is a case of its own rather than an empty list because the two demand opposite
+/// handling: an append that treats an unreadable file as an empty queue replaces rows that are
+/// intact on disk and merely out of reach. The NSE meets that case — it runs on a push that can
+/// arrive before the first unlock after a reboot, when the app group file is still protected.
+public enum PendingPushDeliveryQueueRead: Equatable {
+    /// The file was read. `droppedRows` counts rows that did not decode and were skipped.
+    case rows([PendingPushDeliveryMetric], droppedRows: Int)
+    /// The bytes could not be obtained. Nothing may be written over them.
+    case unreadable
+}
+
 /// Reads and writes pending push delivery metrics in the app group (file-backed JSON list).
 /// The Notification Service Extension appends before starting the delivery HTTP request; the coordinator removes an entry after that request succeeds. The host app may also dequeue remaining rows on Data Pipeline startup.
 public protocol PendingPushDeliveryStore: AutoMockable {
@@ -36,8 +49,12 @@ public protocol PendingPushDeliveryStore: AutoMockable {
     /// Appends a metric. When over capacity, drops the **oldest** entries. Returns `false` if the list could not be persisted.
     func append(_ metric: PendingPushDeliveryMetric) -> Bool
 
-    /// All pending metrics, oldest first.
+    /// All pending metrics, oldest first. Returns an empty array when the file could not be read,
+    /// so a caller that must tell "no rows" from "could not tell" has to use ``read()`` instead.
     func loadAll() -> [PendingPushDeliveryMetric]
+
+    /// The pending queue, or `unreadable` when the bytes could not be obtained.
+    func read() -> PendingPushDeliveryQueueRead
 
     /// Removes one pending entry by id (e.g. after successful delivery in the NSE).
     /// Returns `true` when the entry was found and removed, `false` when the entry was not found or the file could not be updated.
@@ -60,13 +77,16 @@ public final class CioAppGroupPendingPushDeliveryStore: PendingPushDeliveryStore
 
     /// Designated initializer. When `appGroupId` is non-nil it is used directly; otherwise the identifier
     /// is inferred from `processBundleIdentifier` using the format `group.{bundleId}.cio`.
+    /// - Parameter fileManager: Seam for tests — the app group container does not exist in a unit
+    ///   test host, so the concrete store is otherwise unreachable. Production always passes the default.
     init(
         appGroupId: String?,
         processBundleIdentifier: String?,
-        logger: Logger
+        logger: Logger,
+        fileManager: FileManager = .default
     ) {
         self.logger = logger
-        self.fileManager = .default
+        self.fileManager = fileManager
         self.maxEntries = PendingPushDeliveryMetricsConstants.maxEntries
 
         if let explicitId = appGroupId {
@@ -105,7 +125,9 @@ public final class CioAppGroupPendingPushDeliveryStore: PendingPushDeliveryStore
         var success = false
 
         NSFileCoordinator().coordinate(readingItemAt: fileURL, options: [], writingItemAt: fileURL, options: .forReplacing, error: &coordError) { readURL, writeURL in
-            var items = readItems(from: readURL)
+            // Refuses to write over an unreadable file. The alternative is to treat it as empty,
+            // which replaces a queue whose rows are intact on disk — the pre-first-unlock case.
+            guard case .rows(var items, _) = readItems(from: readURL) else { return }
             items.append(metric)
             if items.count > maxEntries {
                 items = Array(items.suffix(maxEntries))
@@ -125,19 +147,27 @@ public final class CioAppGroupPendingPushDeliveryStore: PendingPushDeliveryStore
     }
 
     public func loadAll() -> [PendingPushDeliveryMetric] {
-        guard let fileURL = metricsFileURL else { return [] }
+        guard case .rows(let rows, _) = read() else { return [] }
+        return rows
+    }
+
+    public func read() -> PendingPushDeliveryQueueRead {
+        // No resolved file means the app group is unavailable, so no write ever landed and none
+        // can. Reported as unreadable rather than empty so an append cannot be built on it.
+        guard let fileURL = metricsFileURL else { return .unreadable }
 
         var coordError: NSError?
-        var items: [PendingPushDeliveryMetric] = []
+        var result: PendingPushDeliveryQueueRead = .unreadable
 
         NSFileCoordinator().coordinate(readingItemAt: fileURL, options: [], error: &coordError) { readURL in
-            items = readItems(from: readURL)
+            result = readItems(from: readURL)
         }
 
         if let error = coordError {
-            logger.error("Pending push delivery store: coordination error on loadAll — \(error.localizedDescription)")
+            logger.error("Pending push delivery store: coordination error on read — \(error.localizedDescription)")
+            return .unreadable
         }
-        return items
+        return result
     }
 
     public func remove(id: UUID) -> Bool {
@@ -147,7 +177,7 @@ public final class CioAppGroupPendingPushDeliveryStore: PendingPushDeliveryStore
         var wasRemoved = false
 
         NSFileCoordinator().coordinate(readingItemAt: fileURL, options: [], writingItemAt: fileURL, options: .forReplacing, error: &coordError) { readURL, writeURL in
-            let items = readItems(from: readURL)
+            guard case .rows(let items, _) = readItems(from: readURL) else { return }
             let filtered = items.filter { $0.id != id }
             guard filtered.count != items.count else {
                 // Entry not found — nothing to write.
@@ -175,7 +205,7 @@ public final class CioAppGroupPendingPushDeliveryStore: PendingPushDeliveryStore
         var success = false
 
         NSFileCoordinator().coordinate(readingItemAt: fileURL, options: [], writingItemAt: fileURL, options: .forReplacing, error: &coordError) { readURL, writeURL in
-            let items = readItems(from: readURL)
+            guard case .rows(let items, _) = readItems(from: readURL) else { return }
             let filtered = items.filter { !ids.contains($0.id) }
             guard filtered.count != items.count else {
                 // None of the ids were present — nothing to write, but the requested ids were not removed.
@@ -195,19 +225,44 @@ public final class CioAppGroupPendingPushDeliveryStore: PendingPushDeliveryStore
         return success
     }
 
-    private func readItems(from fileURL: URL) -> [PendingPushDeliveryMetric] {
-        do {
-            let data = try Data(contentsOf: fileURL)
-            let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
-            return try decoder.decode([PendingPushDeliveryMetric].self, from: data)
-        } catch let error as NSError where error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError {
-            return []
-        } catch {
-            // Corrupted or unreadable JSON — treat as empty so the next write overwrites it.
-            logger.debug("Pending push delivery store: unreadable file, starting fresh — \(error.localizedDescription)")
-            return []
+    /// Decodes one row without failing the array. A row the current schema cannot read is skipped
+    /// and counted; a single `try?` around the whole array discarded every other row with it, and
+    /// every field here is non-optional, so schema evolution alone can trigger it.
+    private struct DecodedRow: Decodable {
+        let metric: PendingPushDeliveryMetric?
+
+        init(from decoder: Decoder) throws {
+            self.metric = try? PendingPushDeliveryMetric(from: decoder)
         }
+    }
+
+    private func readItems(from fileURL: URL) -> PendingPushDeliveryQueueRead {
+        let data: Data
+        do {
+            data = try Data(contentsOf: fileURL)
+        } catch let error as NSError where error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError {
+            return .rows([], droppedRows: 0)
+        } catch {
+            logger.error("Pending push delivery store: file could not be read, leaving it intact — \(error.localizedDescription)")
+            return .unreadable
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let rows = try? decoder.decode([DecodedRow].self, from: data) else {
+            // The bytes came back but are not a row array. Unlike a read failure there is nothing
+            // to preserve, so the queue reads as empty and the next write reclaims the file.
+            logger.error("Pending push delivery store: file is not a row array, starting fresh")
+            return .rows([], droppedRows: 0)
+        }
+        let decoded = rows.compactMap(\.metric)
+        let dropped = rows.count - decoded.count
+        if dropped > 0 {
+            // The count is the record: a backlog that shrank and one that was thrown away are the
+            // same observation without it.
+            logger.error("Pending push delivery store: skipped \(dropped) of \(rows.count) row(s) that did not decode")
+        }
+        return .rows(decoded, droppedRows: dropped)
     }
 
     private func save(_ items: [PendingPushDeliveryMetric], to fileURL: URL) -> Bool {

--- a/Sources/Common/Service/Push/PendingPushDeliveryStore.swift
+++ b/Sources/Common/Service/Push/PendingPushDeliveryStore.swift
@@ -29,12 +29,15 @@ private enum PendingPushDeliveryAppGroupStorage {
 /// What a read of the pending-metrics file found.
 ///
 /// `unreadable` is a case of its own rather than an empty list because the two demand opposite
-/// handling: an append that treats an unreadable file as an empty queue replaces rows that are
-/// intact on disk and merely out of reach. The NSE meets that case — it runs on a push that can
-/// arrive before the first unlock after a reboot, when the app group file is still protected.
+/// handling: reported as "no rows", it lets the next append replace rows that are intact on disk.
+/// The state that does the damage is a read that fails while a write would still succeed —
+/// measured, since `Data.write(options: .atomic)` renames a temp file into place and needs
+/// permission on the directory, not on the target. Data Protection on the app group file is the
+/// suspected way a device reaches it, and the NSE is where it would bite, since a push can arrive
+/// before the first unlock after a reboot — but that chain is unverified.
 public enum PendingPushDeliveryQueueRead: Equatable {
-    /// The file was read. `droppedRows` counts rows that did not decode and were skipped.
-    case rows([PendingPushDeliveryMetric], droppedRows: Int)
+    /// The file was read. Rows that did not decode are skipped, counted, and logged by the store.
+    case rows([PendingPushDeliveryMetric])
     /// The bytes could not be obtained. Nothing may be written over them.
     case unreadable
 }
@@ -127,7 +130,7 @@ public final class CioAppGroupPendingPushDeliveryStore: PendingPushDeliveryStore
         NSFileCoordinator().coordinate(readingItemAt: fileURL, options: [], writingItemAt: fileURL, options: .forReplacing, error: &coordError) { readURL, writeURL in
             // Refuses to write over an unreadable file. The alternative is to treat it as empty,
             // which replaces a queue whose rows are intact on disk — the pre-first-unlock case.
-            guard case .rows(var items, _) = readItems(from: readURL) else { return }
+            guard case .rows(var items) = readItems(from: readURL) else { return }
             items.append(metric)
             if items.count > maxEntries {
                 items = Array(items.suffix(maxEntries))
@@ -147,7 +150,7 @@ public final class CioAppGroupPendingPushDeliveryStore: PendingPushDeliveryStore
     }
 
     public func loadAll() -> [PendingPushDeliveryMetric] {
-        guard case .rows(let rows, _) = read() else { return [] }
+        guard case .rows(let rows) = read() else { return [] }
         return rows
     }
 
@@ -177,7 +180,7 @@ public final class CioAppGroupPendingPushDeliveryStore: PendingPushDeliveryStore
         var wasRemoved = false
 
         NSFileCoordinator().coordinate(readingItemAt: fileURL, options: [], writingItemAt: fileURL, options: .forReplacing, error: &coordError) { readURL, writeURL in
-            guard case .rows(let items, _) = readItems(from: readURL) else { return }
+            guard case .rows(let items) = readItems(from: readURL) else { return }
             let filtered = items.filter { $0.id != id }
             guard filtered.count != items.count else {
                 // Entry not found — nothing to write.
@@ -205,7 +208,7 @@ public final class CioAppGroupPendingPushDeliveryStore: PendingPushDeliveryStore
         var success = false
 
         NSFileCoordinator().coordinate(readingItemAt: fileURL, options: [], writingItemAt: fileURL, options: .forReplacing, error: &coordError) { readURL, writeURL in
-            guard case .rows(let items, _) = readItems(from: readURL) else { return }
+            guard case .rows(let items) = readItems(from: readURL) else { return }
             let filtered = items.filter { !ids.contains($0.id) }
             guard filtered.count != items.count else {
                 // None of the ids were present — nothing to write, but the requested ids were not removed.
@@ -241,7 +244,7 @@ public final class CioAppGroupPendingPushDeliveryStore: PendingPushDeliveryStore
         do {
             data = try Data(contentsOf: fileURL)
         } catch let error as NSError where error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError {
-            return .rows([], droppedRows: 0)
+            return .rows([])
         } catch {
             logger.error("Pending push delivery store: file could not be read, leaving it intact — \(error.localizedDescription)")
             return .unreadable
@@ -253,16 +256,15 @@ public final class CioAppGroupPendingPushDeliveryStore: PendingPushDeliveryStore
             // The bytes came back but are not a row array. Unlike a read failure there is nothing
             // to preserve, so the queue reads as empty and the next write reclaims the file.
             logger.error("Pending push delivery store: file is not a row array, starting fresh")
-            return .rows([], droppedRows: 0)
+            return .rows([])
         }
         let decoded = rows.compactMap(\.metric)
-        let dropped = rows.count - decoded.count
-        if dropped > 0 {
+        if decoded.count < rows.count {
             // The count is the record: a backlog that shrank and one that was thrown away are the
             // same observation without it.
-            logger.error("Pending push delivery store: skipped \(dropped) of \(rows.count) row(s) that did not decode")
+            logger.error("Pending push delivery store: skipped \(rows.count - decoded.count) of \(rows.count) row(s) that did not decode")
         }
-        return .rows(decoded, droppedRows: dropped)
+        return .rows(decoded)
     }
 
     private func save(_ items: [PendingPushDeliveryMetric], to fileURL: URL) -> Bool {

--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -256,7 +256,7 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
             // An unreadable file is not an empty queue: the rows are still there and a later
             // launch will find them, so saying "nothing to flush" here would report the backlog
             // as cleared. The store logs why it could not be read.
-            guard case .rows(let pending, _) = store.read() else {
+            guard case .rows(let pending) = store.read() else {
                 logger.debug(
                     "Pending push delivery store: could not be read on MessagingPush startup, leaving it for a later launch"
                 )

--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -253,12 +253,13 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
         // Retain the task handle so tests can await it deterministically and teardown can drain it, preventing a
         // leaked flush from outliving its test. Production behavior is otherwise unchanged.
         pendingMetricsFlushTask = Task.detached(priority: .utility) {
-            // An unreadable file is not an empty queue: the rows are still there and a later
-            // launch will find them, so saying "nothing to flush" here would report the backlog
-            // as cleared. The store logs why it could not be read.
+            // An unreadable file is not an empty queue, so this must not say "nothing to flush":
+            // that reports a backlog as cleared. It does not promise a later launch either — the
+            // same result covers an app group that cannot be resolved at all, which is permanent.
+            // The store logs which of the two it was.
             guard case .rows(let pending) = store.read() else {
                 logger.debug(
-                    "Pending push delivery store: could not be read on MessagingPush startup, leaving it for a later launch"
+                    "Pending push delivery store: could not be read on MessagingPush startup; nothing was flushed and nothing was discarded"
                 )
                 return
             }

--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -253,10 +253,8 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
         // Retain the task handle so tests can await it deterministically and teardown can drain it, preventing a
         // leaked flush from outliving its test. Production behavior is otherwise unchanged.
         pendingMetricsFlushTask = Task.detached(priority: .utility) {
-            // An unreadable file is not an empty queue, so this must not say "nothing to flush":
-            // that reports a backlog as cleared. It does not promise a later launch either — the
-            // same result covers an app group that cannot be resolved at all, which is permanent.
-            // The store logs which of the two it was.
+            // Unreadable is not empty: "nothing to flush" would report a backlog as cleared. No
+            // later-launch promise either — an unresolvable app group gives the same result.
             guard case .rows(let pending) = store.read() else {
                 logger.debug(
                     "Pending push delivery store: could not be read on MessagingPush startup; nothing was flushed and nothing was discarded"

--- a/Sources/MessagingPush/MessagingPush.swift
+++ b/Sources/MessagingPush/MessagingPush.swift
@@ -253,7 +253,15 @@ public class MessagingPush: ModuleTopLevelObject<MessagingPushInstance>, Messagi
         // Retain the task handle so tests can await it deterministically and teardown can drain it, preventing a
         // leaked flush from outliving its test. Production behavior is otherwise unchanged.
         pendingMetricsFlushTask = Task.detached(priority: .utility) {
-            let pending = store.loadAll()
+            // An unreadable file is not an empty queue: the rows are still there and a later
+            // launch will find them, so saying "nothing to flush" here would report the backlog
+            // as cleared. The store logs why it could not be read.
+            guard case .rows(let pending, _) = store.read() else {
+                logger.debug(
+                    "Pending push delivery store: could not be read on MessagingPush startup, leaving it for a later launch"
+                )
+                return
+            }
             guard !pending.isEmpty else {
                 logger.debug(
                     "Pending push delivery store: nothing to flush on MessagingPush startup"

--- a/Tests/Common/Service/Push/PendingPushDeliveryStoreTests.swift
+++ b/Tests/Common/Service/Push/PendingPushDeliveryStoreTests.swift
@@ -128,6 +128,20 @@ final class CioAppGroupPendingPushDeliveryStoreTests: UnitTest {
         XCTAssertTrue(logged("could not be read, leaving it intact"))
     }
 
+    /// `remove(id:)` is the NSE success path, so it is the one that runs on every delivered push.
+    func test_remove_givenAnUnreadableFile_expectRefusedAndTheQueueUntouched() throws {
+        let store = makeStore()
+        let metric = makeMetric()
+        XCTAssertTrue(store.append(metric))
+        let before = try Data(contentsOf: metricsFile)
+        try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: metricsFile.path)
+
+        XCTAssertFalse(store.remove(id: metric.id))
+
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: metricsFile.path)
+        XCTAssertEqual(try Data(contentsOf: metricsFile), before)
+    }
+
     func test_removeAll_givenAnUnreadableFile_expectRefusedAndTheQueueUntouched() throws {
         let store = makeStore()
         let metric = makeMetric()

--- a/Tests/Common/Service/Push/PendingPushDeliveryStoreTests.swift
+++ b/Tests/Common/Service/Push/PendingPushDeliveryStoreTests.swift
@@ -75,17 +75,22 @@ final class CioAppGroupPendingPushDeliveryStoreTests: UnitTest {
         logger.errorReceivedInvocations.contains { $0.message.contains(needle) }
     }
 
-    /// The second row has no `device_id`. Every field on the metric is non-optional, so schema
-    /// evolution alone reaches this — and one of them used to discard the other rows with it.
-    private static let oneGoodOneBadRow = """
-    [
-      {"id":"6C7E1B2A-0000-4000-8000-000000000001","delivery_id":"d1","device_id":"token","event":"delivered","timestamp":"2023-11-14T22:13:20.000Z"},
-      {"id":"6C7E1B2A-0000-4000-8000-000000000002","delivery_id":"d2","event":"delivered","timestamp":"2023-11-14T22:13:21.000Z"}
-    ]
-    """
+    /// Written with the store's own encoder, then stripped of `device_id` on the second row, so the
+    /// rows differ from what it writes in exactly that one way. Every field on the metric is
+    /// non-optional, so schema evolution alone reaches this — and one bad row used to discard the rest.
+    private func plantOneGoodOneBadRow() throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let encoded = try encoder.encode([makeMetric(deliveryId: "d1"), makeMetric(deliveryId: "d2")])
+        var rows = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [[String: Any]])
+        XCTAssertEqual(rows.count, 2)
+        rows[1].removeValue(forKey: "device_id")
+        try plant(String(decoding: JSONSerialization.data(withJSONObject: rows), as: UTF8.self))
+    }
 
     func test_read_givenOneUndecodableRow_expectTheOtherRowSurvives() throws {
-        try plant(Self.oneGoodOneBadRow)
+        try plantOneGoodOneBadRow()
 
         guard case .rows(let rows) = makeStore().read() else {
             return XCTFail("expected rows, got unreadable")
@@ -96,7 +101,7 @@ final class CioAppGroupPendingPushDeliveryStoreTests: UnitTest {
     }
 
     func test_append_givenOneUndecodableRow_expectTheGoodRowKept() throws {
-        try plant(Self.oneGoodOneBadRow)
+        try plantOneGoodOneBadRow()
         let store = makeStore()
 
         XCTAssertTrue(store.append(makeMetric(deliveryId: "d3")))

--- a/Tests/Common/Service/Push/PendingPushDeliveryStoreTests.swift
+++ b/Tests/Common/Service/Push/PendingPushDeliveryStoreTests.swift
@@ -1,0 +1,160 @@
+@testable import CioInternalCommon
+@testable import CioInternalCommonMocks
+import Foundation
+import SharedTests
+import XCTest
+
+/// The app group container does not exist in a unit test host, so the concrete store resolves no
+/// file and returns early from everything. This stands one in for it.
+private final class StubAppGroupFileManager: FileManager {
+    let container: URL
+
+    init(container: URL) {
+        self.container = container
+        super.init()
+    }
+
+    override func containerURL(forSecurityApplicationGroupIdentifier groupIdentifier: String) -> URL? {
+        container
+    }
+}
+
+/// Resilience of the app-group pending queue: one undecodable row must not discard the rest, and
+/// a file that cannot be read must never be written over — the NSE runs on pushes that arrive
+/// before the first unlock after a reboot, when the app group file is still protected.
+final class CioAppGroupPendingPushDeliveryStoreTests: UnitTest {
+    private var container: URL!
+    private var logger: LoggerMock!
+
+    private var metricsFile: URL {
+        container
+            .appendingPathComponent(PendingPushDeliveryMetricsConstants.storageSubdirectoryName, isDirectory: true)
+            .appendingPathComponent(PendingPushDeliveryMetricsConstants.storageFileName, isDirectory: false)
+    }
+
+    override func setUp() {
+        super.setUp()
+        container = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: container, withIntermediateDirectories: true)
+        logger = LoggerMock()
+    }
+
+    override func tearDown() {
+        try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: metricsFile.path)
+        try? FileManager.default.removeItem(at: container)
+        super.tearDown()
+    }
+
+    private func makeStore() -> CioAppGroupPendingPushDeliveryStore {
+        CioAppGroupPendingPushDeliveryStore(
+            appGroupId: "group.test.app.cio",
+            processBundleIdentifier: "com.example.app",
+            logger: logger,
+            fileManager: StubAppGroupFileManager(container: container)
+        )
+    }
+
+    private func makeMetric(deliveryId: String = "d1") -> PendingPushDeliveryMetric {
+        PendingPushDeliveryMetric(
+            deliveryId: deliveryId,
+            deviceToken: "token",
+            event: .delivered,
+            timestamp: Date(timeIntervalSince1970: 1700000000)
+        )
+    }
+
+    private func plant(_ json: String) throws {
+        try FileManager.default.createDirectory(
+            at: metricsFile.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data(json.utf8).write(to: metricsFile)
+    }
+
+    private func logged(_ needle: String) -> Bool {
+        logger.errorReceivedInvocations.contains { $0.message.contains(needle) }
+    }
+
+    /// The second row has no `device_id`. Every field on the metric is non-optional, so schema
+    /// evolution alone reaches this — and one of them used to discard the other rows with it.
+    private static let oneGoodOneBadRow = """
+    [
+      {"id":"6C7E1B2A-0000-4000-8000-000000000001","delivery_id":"d1","device_id":"token","event":"delivered","timestamp":"2023-11-14T22:13:20.000Z"},
+      {"id":"6C7E1B2A-0000-4000-8000-000000000002","delivery_id":"d2","event":"delivered","timestamp":"2023-11-14T22:13:21.000Z"}
+    ]
+    """
+
+    func test_read_givenOneUndecodableRow_expectTheOtherRowSurvives() throws {
+        try plant(Self.oneGoodOneBadRow)
+
+        guard case .rows(let rows, let dropped) = makeStore().read() else {
+            return XCTFail("expected rows, got unreadable")
+        }
+
+        XCTAssertEqual(rows.map(\.deliveryId), ["d1"])
+        XCTAssertEqual(dropped, 1)
+        XCTAssertTrue(logged("skipped 1 of 2 row(s)"))
+    }
+
+    func test_append_givenOneUndecodableRow_expectTheGoodRowKept() throws {
+        try plant(Self.oneGoodOneBadRow)
+        let store = makeStore()
+
+        XCTAssertTrue(store.append(makeMetric(deliveryId: "d3")))
+
+        XCTAssertEqual(store.loadAll().map(\.deliveryId), ["d1", "d3"])
+    }
+
+    /// The defect. Modelled with a file the process may not read but whose directory it may still
+    /// write, which is the shape Data Protection produces: an atomic write would otherwise succeed
+    /// and replace rows that were never lost.
+    func test_append_givenAnUnreadableFile_expectRefusedAndTheQueueUntouched() throws {
+        let store = makeStore()
+        XCTAssertTrue(store.append(makeMetric()))
+        let before = try Data(contentsOf: metricsFile)
+        try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: metricsFile.path)
+
+        XCTAssertFalse(store.append(makeMetric(deliveryId: "d2")))
+
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: metricsFile.path)
+        XCTAssertEqual(try Data(contentsOf: metricsFile), before)
+    }
+
+    func test_read_givenAnUnreadableFile_expectUnreadableNotEmpty() throws {
+        let store = makeStore()
+        XCTAssertTrue(store.append(makeMetric()))
+        try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: metricsFile.path)
+
+        XCTAssertEqual(store.read(), .unreadable)
+        XCTAssertTrue(logged("could not be read, leaving it intact"))
+    }
+
+    func test_removeAll_givenAnUnreadableFile_expectRefusedAndTheQueueUntouched() throws {
+        let store = makeStore()
+        let metric = makeMetric()
+        XCTAssertTrue(store.append(metric))
+        let before = try Data(contentsOf: metricsFile)
+        try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: metricsFile.path)
+
+        XCTAssertFalse(store.removeAll(ids: [metric.id]))
+
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: metricsFile.path)
+        XCTAssertEqual(try Data(contentsOf: metricsFile), before)
+    }
+
+    /// Read succeeded and the bytes are not a row array, so unlike a read failure there is nothing
+    /// left to preserve — the next write reclaims the file.
+    func test_append_givenAFileThatIsNotARowArray_expectTheWriteProceeds() throws {
+        try plant("{\"not\":\"an array\"}")
+        let store = makeStore()
+
+        XCTAssertTrue(store.append(makeMetric()))
+
+        XCTAssertEqual(store.loadAll().map(\.deliveryId), ["d1"])
+        XCTAssertTrue(logged("not a row array"))
+    }
+
+    func test_read_givenNoFile_expectEmptyNotUnreadable() {
+        XCTAssertEqual(makeStore().read(), .rows([], droppedRows: 0))
+    }
+}

--- a/Tests/Common/Service/Push/PendingPushDeliveryStoreTests.swift
+++ b/Tests/Common/Service/Push/PendingPushDeliveryStoreTests.swift
@@ -87,12 +87,11 @@ final class CioAppGroupPendingPushDeliveryStoreTests: UnitTest {
     func test_read_givenOneUndecodableRow_expectTheOtherRowSurvives() throws {
         try plant(Self.oneGoodOneBadRow)
 
-        guard case .rows(let rows, let dropped) = makeStore().read() else {
+        guard case .rows(let rows) = makeStore().read() else {
             return XCTFail("expected rows, got unreadable")
         }
 
         XCTAssertEqual(rows.map(\.deliveryId), ["d1"])
-        XCTAssertEqual(dropped, 1)
         XCTAssertTrue(logged("skipped 1 of 2 row(s)"))
     }
 
@@ -155,6 +154,6 @@ final class CioAppGroupPendingPushDeliveryStoreTests: UnitTest {
     }
 
     func test_read_givenNoFile_expectEmptyNotUnreadable() {
-        XCTAssertEqual(makeStore().read(), .rows([], droppedRows: 0))
+        XCTAssertEqual(makeStore().read(), .rows([]))
     }
 }

--- a/Tests/MessagingPush/PushDeliveryFlushTests.swift
+++ b/Tests/MessagingPush/PushDeliveryFlushTests.swift
@@ -17,6 +17,7 @@ import XCTest
 final class MessagingPushPendingPushFlushTests: UnitTest {
     private var pendingStoreMock: PendingPushDeliveryStoreMock!
     private var pipelineMock: DataPipelineTrackingMock!
+    private var loggerMock: LoggerMock!
 
     private let pendingMetric = PendingPushDeliveryMetric(
         deliveryId: "pend-launch-1",
@@ -36,6 +37,11 @@ final class MessagingPushPendingPushFlushTests: UnitTest {
         pendingStoreMock = PendingPushDeliveryStoreMock()
         pendingStoreMock.underlyingAppGroupSuiteName = "group.test.app.cio"
         pipelineMock = DataPipelineTrackingMock()
+        // The empty and unreadable arms both track nothing and remove nothing, so the log line is
+        // the ONLY thing that tells them apart — without it the unreadable test asserts nothing
+        // the empty-queue test does not already assert.
+        loggerMock = LoggerMock()
+        diGraphShared.override(value: loggerMock, forType: Logger.self)
 
         // Override pipeline mock so it is scoped to this test and cleaned up between tests,
         // preventing a stale Task.detached from a prior test resolving the wrong mock instance.
@@ -128,17 +134,37 @@ final class MessagingPushPendingPushFlushTests: UnitTest {
         )
     }
 
+    private func debugLogged(_ needle: String) -> Bool {
+        loggerMock.debugReceivedInvocations.contains { $0.message.contains(needle) }
+    }
+
     /// An unreadable store is not an empty one. Reporting it as flushed is how a backlog that is
-    /// still on disk gets written off; the rows must be left for a later launch.
-    func test_initialize_whenStoreUnreadable_expectNothingTrackedOrRemoved() {
+    /// still on disk gets written off.
+    ///
+    /// The two negative assertions below are true of an empty queue as well, so the log
+    /// assertions are what make this test distinguish the arms at all.
+    func test_initialize_whenStoreUnreadable_expectNotTreatedAsEmpty() {
         pendingStoreMock.readReturnValue = .unreadable
         pendingStoreMock.removeAllReturnValue = true
 
         MessagingPush.initialize(withConfig: messagingPushConfigOptions)
         MessagingPush.awaitPendingMetricsFlushForTests()
 
+        XCTAssertTrue(debugLogged("could not be read"), "an unreadable queue must not be reported as an empty one")
+        XCTAssertFalse(debugLogged("nothing to flush"))
         XCTAssertEqual(pendingStoreMock.readCallsCount, 1)
-        XCTAssertEqual(pipelineMock.trackDeliveryEventCallsCount, 0, "an unreadable queue must not be reported as flushed")
-        XCTAssertEqual(pendingStoreMock.removeAllCallsCount, 0, "rows still on disk must be left for a later launch")
+        XCTAssertEqual(pipelineMock.trackDeliveryEventCallsCount, 0)
+        XCTAssertEqual(pendingStoreMock.removeAllCallsCount, 0)
+    }
+
+    /// The negative control for the test above: the empty arm must take the other branch.
+    func test_initialize_whenNoPendingMetrics_expectReportedAsEmptyNotUnreadable() {
+        pendingStoreMock.readReturnValue = .rows([])
+
+        MessagingPush.initialize(withConfig: messagingPushConfigOptions)
+        MessagingPush.awaitPendingMetricsFlushForTests()
+
+        XCTAssertTrue(debugLogged("nothing to flush"))
+        XCTAssertFalse(debugLogged("could not be read"))
     }
 }

--- a/Tests/MessagingPush/PushDeliveryFlushTests.swift
+++ b/Tests/MessagingPush/PushDeliveryFlushTests.swift
@@ -53,7 +53,7 @@ final class MessagingPushPendingPushFlushTests: UnitTest {
 
     func test_initialize_flushesPendingMetrics_readThenRemoveAllAfterEnqueue() {
         let metric = pendingMetric
-        pendingStoreMock.readReturnValue = .rows([metric], droppedRows: 0)
+        pendingStoreMock.readReturnValue = .rows([metric])
         pendingStoreMock.removeAllReturnValue = true
 
         MessagingPush.initialize(withConfig: messagingPushConfigOptions)
@@ -70,7 +70,7 @@ final class MessagingPushPendingPushFlushTests: UnitTest {
     }
 
     func test_initialize_whenNoPendingMetrics_expectReadOnlyNoRemoves() {
-        pendingStoreMock.readReturnValue = .rows([], droppedRows: 0)
+        pendingStoreMock.readReturnValue = .rows([])
 
         MessagingPush.initialize(withConfig: messagingPushConfigOptions)
         // Deterministically drain the scheduled flush so a leaked flush from a prior test cannot land here.
@@ -87,7 +87,7 @@ final class MessagingPushPendingPushFlushTests: UnitTest {
         diGraphShared.override(value: pendingStoreMock, forType: PendingPushDeliveryStore.self)
 
         let metric = pendingMetric
-        pendingStoreMock.readReturnValue = .rows([metric], droppedRows: 0)
+        pendingStoreMock.readReturnValue = .rows([metric])
         pendingStoreMock.removeAllReturnValue = true
 
         MessagingPush.initialize(withConfig: messagingPushConfigOptions)
@@ -104,7 +104,7 @@ final class MessagingPushPendingPushFlushTests: UnitTest {
     /// for the old `wait(for:timeout:)` race.
     func test_initialize_retainsFlushTaskHandle_soTeardownCanDrainIt() {
         let metric = pendingMetric
-        pendingStoreMock.readReturnValue = .rows([metric], droppedRows: 0)
+        pendingStoreMock.readReturnValue = .rows([metric])
         pendingStoreMock.removeAllReturnValue = true
 
         MessagingPush.initialize(withConfig: messagingPushConfigOptions)

--- a/Tests/MessagingPush/PushDeliveryFlushTests.swift
+++ b/Tests/MessagingPush/PushDeliveryFlushTests.swift
@@ -51,16 +51,16 @@ final class MessagingPushPendingPushFlushTests: UnitTest {
         nil
     }
 
-    func test_initialize_flushesPendingMetrics_loadAllThenRemoveAllAfterEnqueue() {
+    func test_initialize_flushesPendingMetrics_readThenRemoveAllAfterEnqueue() {
         let metric = pendingMetric
-        pendingStoreMock.loadAllReturnValue = [metric]
+        pendingStoreMock.readReturnValue = .rows([metric], droppedRows: 0)
         pendingStoreMock.removeAllReturnValue = true
 
         MessagingPush.initialize(withConfig: messagingPushConfigOptions)
         // Deterministically drain the scheduled flush instead of racing a 2s timeout.
         MessagingPush.awaitPendingMetricsFlushForTests()
 
-        XCTAssertEqual(pendingStoreMock.loadAllCallsCount, 1, "startup should read pending list from app group store")
+        XCTAssertEqual(pendingStoreMock.readCallsCount, 1, "startup should read pending list from app group store")
         XCTAssertEqual(pendingStoreMock.removeAllCallsCount, 1, "flushed rows should be batch-removed via removeAll(ids:)")
         XCTAssertEqual(pendingStoreMock.removeAllReceivedArguments, Set([metric.id]))
         XCTAssertEqual(pipelineMock.trackDeliveryEventCallsCount, 1, "each pending metric should be forwarded to DataPipeline")
@@ -69,25 +69,25 @@ final class MessagingPushPendingPushFlushTests: UnitTest {
         XCTAssertEqual(pipelineMock.trackDeliveryEventInvocations.first?.event, metric.event.rawValue)
     }
 
-    func test_initialize_whenNoPendingMetrics_expectLoadAllOnlyNoRemoves() {
-        pendingStoreMock.loadAllReturnValue = []
+    func test_initialize_whenNoPendingMetrics_expectReadOnlyNoRemoves() {
+        pendingStoreMock.readReturnValue = .rows([], droppedRows: 0)
 
         MessagingPush.initialize(withConfig: messagingPushConfigOptions)
         // Deterministically drain the scheduled flush so a leaked flush from a prior test cannot land here.
         MessagingPush.awaitPendingMetricsFlushForTests()
 
-        XCTAssertEqual(pendingStoreMock.loadAllCallsCount, 1)
+        XCTAssertEqual(pendingStoreMock.readCallsCount, 1)
         XCTAssertEqual(pendingStoreMock.removeAllCallsCount, 0, "removeAll should not be called when store is empty")
         XCTAssertEqual(pipelineMock.trackDeliveryEventCallsCount, 0, "no metrics should be forwarded when store is empty")
     }
 
-    func test_initialize_whenDataPipelineNotInitialized_expectLoadAllButNoTracking() {
+    func test_initialize_whenDataPipelineNotInitialized_expectReadButNoTracking() {
         // Simulate DataPipeline not being initialized — no DataPipelineTracking registered
         diGraphShared.reset()
         diGraphShared.override(value: pendingStoreMock, forType: PendingPushDeliveryStore.self)
 
         let metric = pendingMetric
-        pendingStoreMock.loadAllReturnValue = [metric]
+        pendingStoreMock.readReturnValue = .rows([metric], droppedRows: 0)
         pendingStoreMock.removeAllReturnValue = true
 
         MessagingPush.initialize(withConfig: messagingPushConfigOptions)
@@ -104,7 +104,7 @@ final class MessagingPushPendingPushFlushTests: UnitTest {
     /// for the old `wait(for:timeout:)` race.
     func test_initialize_retainsFlushTaskHandle_soTeardownCanDrainIt() {
         let metric = pendingMetric
-        pendingStoreMock.loadAllReturnValue = [metric]
+        pendingStoreMock.readReturnValue = .rows([metric], droppedRows: 0)
         pendingStoreMock.removeAllReturnValue = true
 
         MessagingPush.initialize(withConfig: messagingPushConfigOptions)
@@ -126,5 +126,19 @@ final class MessagingPushPendingPushFlushTests: UnitTest {
             1,
             "the retained flush should have forwarded the pending metric before teardown returns"
         )
+    }
+
+    /// An unreadable store is not an empty one. Reporting it as flushed is how a backlog that is
+    /// still on disk gets written off; the rows must be left for a later launch.
+    func test_initialize_whenStoreUnreadable_expectNothingTrackedOrRemoved() {
+        pendingStoreMock.readReturnValue = .unreadable
+        pendingStoreMock.removeAllReturnValue = true
+
+        MessagingPush.initialize(withConfig: messagingPushConfigOptions)
+        MessagingPush.awaitPendingMetricsFlushForTests()
+
+        XCTAssertEqual(pendingStoreMock.readCallsCount, 1)
+        XCTAssertEqual(pipelineMock.trackDeliveryEventCallsCount, 0, "an unreadable queue must not be reported as flushed")
+        XCTAssertEqual(pendingStoreMock.removeAllCallsCount, 0, "rows still on disk must be left for a later launch")
     }
 }

--- a/Tests/Mocks/Common/AutoMockable.generated.swift
+++ b/Tests/Mocks/Common/AutoMockable.generated.swift
@@ -2831,6 +2831,9 @@ public class PendingPushDeliveryStoreMock: @unchecked Sendable, PendingPushDeliv
         _loadAllCallsCount.wrappedValue = 0
 
         mockCalled = false // do last as resetting properties above can make this true
+        _readCallsCount.wrappedValue = 0
+
+        mockCalled = false // do last as resetting properties above can make this true
         _removeCallsCount.wrappedValue = 0
         _removeReceivedArguments.wrappedValue = nil
         _removeReceivedInvocations.wrappedValue = []
@@ -2923,6 +2926,40 @@ public class PendingPushDeliveryStoreMock: @unchecked Sendable, PendingPushDeliv
         mockCalled = true
         _loadAllCallsCount += 1
         return loadAllClosure.map { $0() } ?? loadAllReturnValue
+    }
+
+    // MARK: - read
+
+    /// Number of times the function was called.
+    private let _readCallsCount: CioInternalCommon.Synchronized<Int> = .init(0)
+    public var readCallsCount: Int {
+        _readCallsCount.wrappedValue
+    }
+
+    /// `true` if the function was ever called.
+    public var readCalled: Bool {
+        readCallsCount > 0
+    }
+
+    /// Value to return from the mocked function.
+    private let _readReturnValue: CioInternalCommon.Synchronized<PendingPushDeliveryQueueRead?> = .init(nil)
+    public var readReturnValue: PendingPushDeliveryQueueRead! {
+        get { _readReturnValue.wrappedValue }
+        set { _readReturnValue.wrappedValue = newValue }
+    }
+
+    /**
+     Set closure to get called when function gets called. Great way to test logic or return a value for the function.
+     The closure has first priority to return a value for the mocked function. If the closure returns `nil`,
+     then the mock will attempt to return the value for `readReturnValue`
+     */
+    public var readClosure: (() -> PendingPushDeliveryQueueRead)?
+
+    /// Mocked function for `read()`. Your opportunity to return a mocked value and check result of mock in test code.
+    public func read() -> PendingPushDeliveryQueueRead {
+        mockCalled = true
+        _readCallsCount += 1
+        return readClosure.map { $0() } ?? readReturnValue
     }
 
     // MARK: - remove

--- a/api-docs/internal/CioInternalCommon.api
+++ b/api-docs/internal/CioInternalCommon.api
@@ -91,6 +91,7 @@ public final class CioInternalCommon.CioAppGroupPendingPushDeliveryStore {
 	public final val appGroupSuiteName: String?;
 	public fun func append(_ metric: PendingPushDeliveryMetric) -> Boolean;
 	public fun func loadAll() -> List<PendingPushDeliveryMetric>;
+	public fun func read() -> PendingPushDeliveryQueueRead;
 	public fun func remove(id: UUID) -> Boolean;
 	public fun func removeAll(ids: Set<UUID>) -> Boolean;
 }
@@ -435,10 +436,13 @@ public final class CioInternalCommon.PendingPushDeliveryMetric {
 	public final val timestamp: Date;
 	public fun init(id: UUID = UUID(), deliveryId: String, deviceToken: String, event: Metric, timestamp: Date);
 }
+public enum CioInternalCommon.PendingPushDeliveryQueueRead {
+}
 public interface CioInternalCommon.PendingPushDeliveryStore {
 	public var appGroupSuiteName: String?;
 	public fun func append(_ metric: PendingPushDeliveryMetric) -> Boolean;
 	public fun func loadAll() -> List<PendingPushDeliveryMetric>;
+	public fun func read() -> PendingPushDeliveryQueueRead;
 	public fun func remove(id: UUID) -> Boolean;
 	public fun func removeAll(ids: Set<UUID>) -> Boolean;
 }


### PR DESCRIPTION
Part of [MBL-2413](https://linear.app/customerio/issue/MBL-2413). Same defect shape as #1265, in the store that backs push delivery — found because the geofence store was modelled on this one and copied the collapse with the shape.

The app-group file decoded as one array, so one undecodable row discarded the rest, and any read failure returned an empty list — the NSE's append then overwrote rows that were intact on disk. The NSE is where this bites: it runs on pushes that can arrive before the first unlock after a reboot, while the file is still protected.

Rows now decode one at a time and are counted. A read reports `unreadable` separately from empty, and `append`/`remove`/`removeAll` refuse to write over it.

Three calls worth a reviewer's opinion:
- `read()` is a new requirement on the public `PendingPushDeliveryStore`, so it is source-breaking for an external conformer. No default is possible — it could only be `.rows(loadAll())`, which is the bug.
- `loadAll()` stays public with no production caller. Deprecating it would warn in customer builds, so that is a product call rather than part of this fix.
- Geofence's `append` returns a 3-case outcome; this one stays `Bool`, because a failed append here still runs the delivery HTTP and only loses the retry backstop.

**Evidence:** reintroducing the collapse makes `test_append_givenAnUnreadableFile_expectRefusedAndTheQueueUntouched` fail with the file's bytes changed. 488 passed / 0 failed / 5 skipped across Common and MessagingPush, lint clean, api-docs baseline regenerated.

## Related

One ticket, one defect shape, two modules. Separate PRs because they sit on different bases and neither depends on the other.

1. #1265 geofence pending queue → `feature/geofence-polygons`
2. #1266 Common push delivery store → `main` ← **this PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
