### PR TITLE
chore(geofence): log the two fields the timing constants are calibrated from

### DIFF
--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -277,13 +277,18 @@ extension Logger {
         )
     }
 
-    func geofenceMovementFixResolved(ageSeconds: TimeInterval, requested: Bool) {
+    /// `spd` rides here and not only on `os.callback.received`: the wake margin is sized from how
+    /// far the device travels between passes, and this is the fix a pass actually uses. Speed at
+    /// OS-callback time is a different population — it only samples moments the OS chose to wake us.
+    func geofenceMovementFixResolved(ageSeconds: TimeInterval, requested: Bool, speed: CLLocationSpeed? = nil) {
         let source = requested ? "freshly requested" : "cached"
         debug(
             "Movement pass using \(source) fix, age \(String(format: "%.1f", ageSeconds))s"
                 + geofenceTail("movement.fix.resolved", .input, [
                     ("age", GeofenceLog.num(ageSeconds)),
-                    ("prov", requested ? "requested" : "cached")
+                    ("prov", requested ? "requested" : "cached"),
+                    // Negative means the fix carries no speed, which is not the same as stationary.
+                    ("spd", speed.flatMap { $0 >= 0 ? GeofenceLog.num($0) : nil })
                 ]),
             geofenceTag
         )

--- a/Sources/LocationGeofence/Logger+Geofence.swift
+++ b/Sources/LocationGeofence/Logger+Geofence.swift
@@ -268,87 +268,12 @@ extension Logger {
         )
     }
 
-    // MARK: - Movement trigger
-
-    func geofenceMovementTrigger(tier: HandleMovementTier) {
-        debug(
-            "Movement trigger EXIT: \(tier.rawValue)"
-                + geofenceTail("movement.exit", .input, [("tier", tier.rawValue)]),
-            geofenceTag
-        )
-    }
-
-    /// The re-centred bubble's own geometry. Region geometry is ungated — it is workspace
-    /// configuration, not user data — but this one is derived from the device's position, so it
-    /// travels with the same switch as a coordinate.
-    func geofenceMovementTriggerRegistered(latitude: Double, longitude: Double, radius: Double) {
-        let geometry: [(String, String?)] = [
-            ("rlat", GeofenceLog.num(latitude, 5)),
-            ("rlon", GeofenceLog.num(longitude, 5))
-        ]
-        debug(
-            "Movement trigger registered with radius \(Int(radius)) m"
-                + geofenceTail("movement.registered", .output, geometry + [("rad", GeofenceLog.num(radius, 0))]),
-            geofenceTag
-        )
-    }
-
-    func geofenceMovementRearmedAfterFailedRefresh() {
-        debug(
-            "Movement refresh failed; re-ranking from cache to re-arm the movement trigger"
-                + geofenceTail("movement.rearmed", .output, [("why", "refresh_failed")]),
-            geofenceTag
-        )
-    }
-
-    /// `spd` rides here and not only on `os.callback.received`: the wake margin is sized from how
-    /// far the device travels between passes, and this is the fix a pass actually uses. Speed at
-    /// OS-callback time is a different population — it only samples moments the OS chose to wake us.
-    func geofenceMovementFixResolved(ageSeconds: TimeInterval, requested: Bool, speed: CLLocationSpeed? = nil) {
-        let source = requested ? "freshly requested" : "cached"
-        debug(
-            "Movement pass using \(source) fix, age \(String(format: "%.1f", ageSeconds))s"
-                + geofenceTail("movement.fix.resolved", .input, [
-                    ("age", GeofenceLog.num(ageSeconds)),
-                    ("prov", requested ? "requested" : "cached"),
-                    // Negative means the fix carries no speed, which is not the same as stationary.
-                    ("spd", speed.flatMap { $0 >= 0 ? GeofenceLog.num($0) : nil })
-                ]),
-            geofenceTag
-        )
-    }
-
-    func geofenceMovementFixStale(ageSeconds: TimeInterval?) {
-        let age = ageSeconds.map { "\(String(format: "%.1f", $0))s old" } ?? "missing"
-        info(
-            "Cached fix is \(age); requesting a fresh fix for the movement pass"
-                + geofenceTail("movement.fix.requested", .output, [
-                    ("age", GeofenceLog.num(ageSeconds)),
-                    ("why", ageSeconds == nil ? "no_cached_fix" : "stale_cached_fix")
-                ]),
-            geofenceTag
-        )
-    }
-
     /// Positive record of an OS-delivered business transition. Without it a native delivery is
     /// only identifiable by the ABSENCE of a synthesized line, which makes the OS promotion rate
     /// inferred rather than measured. Logged at the monitors' dispatch sites, where provenance is
     /// known: the resolver's entry point also receives synthesized heals, which would inflate it.
     func geofenceOsTransitionReceived(identifier: String, transition: GeofenceTransition) {
         debug("OS delivered \(transition.rawValue) for region \(identifier)", geofenceTag)
-    }
-
-    func geofenceMovementFixRequestFailed(fallingBackToCached: Bool, elapsed: TimeInterval? = nil) {
-        let outcome = fallingBackToCached ? "falling back to the stale cached fix" : "no cached fix to fall back to"
-        info(
-            "Fresh-fix request failed or timed out; \(outcome)"
-                + geofenceTail("movement.fix.failed", .input, [
-                    ("ok", GeofenceLog.bool(false)),
-                    ("why", fallingBackToCached ? "fallback_cached" : "no_fallback"),
-                    ("ms", GeofenceLog.num(elapsed.map { $0 * 1000 }, 0))
-                ]),
-            geofenceTag
-        )
     }
 
     // MARK: - Module state

--- a/Sources/LocationGeofence/Logger+GeofenceDecision.swift
+++ b/Sources/LocationGeofence/Logger+GeofenceDecision.swift
@@ -51,6 +51,25 @@ extension Logger {
         )
     }
 
+    /// Every event arriving while a re-add record is held, with its distance in TIME from that add.
+    ///
+    /// The gate records only refusals, so `contradictionGateReplayWindow` could not be calibrated
+    /// from a drive: an event just outside the window and an event that was never a replay both
+    /// logged nothing. `dly` is the event's date minus the add, `win` whether the current bound
+    /// covered it — together, the distribution the constant is currently guessing at.
+    func geofenceContradictionEvaluated(identifier: String, transition: GeofenceTransition, delaySinceAdd: TimeInterval, insideWindow: Bool) {
+        debug(
+            "Event for region \(identifier) landed \(String(format: "%.3f", delaySinceAdd))s after its re-add"
+                + geofenceTail("contradiction.evaluated", .output, [
+                    ("id", identifier),
+                    ("t", transition.rawValue),
+                    ("dly", GeofenceLog.num(delaySinceAdd, 3)),
+                    ("win", GeofenceLog.bool(insideWindow))
+                ]),
+            geofenceTag
+        )
+    }
+
     func geofenceEventRefusedByContradiction(identifier: String, transition: GeofenceTransition, distanceFromCenter: Double, radius: Double, accuracy: Double) {
         info(
             "Refused OS \(transition.rawValue) for region \(identifier): a fresh fix contradicts it (distance \(Int(distanceFromCenter)) m, radius \(Int(radius)) m, accuracy \(Int(accuracy)) m)"

--- a/Sources/LocationGeofence/Logger+GeofenceMovement.swift
+++ b/Sources/LocationGeofence/Logger+GeofenceMovement.swift
@@ -1,0 +1,90 @@
+import CioInternalCommon
+import CoreLocation
+import Foundation
+
+private let geofenceTag = "Geofence"
+
+// MARK: - Movement trigger
+
+//
+// Split out of `Logger+Geofence.swift` for the file-length cap. The movement trigger is its own
+// mechanism — re-centring, the refetch tier, and the fix a pass runs on — and these records are
+// read together when calibrating the wake margin.
+
+extension Logger {
+    func geofenceMovementTrigger(tier: HandleMovementTier) {
+        debug(
+            "Movement trigger EXIT: \(tier.rawValue)"
+                + geofenceTail("movement.exit", .input, [("tier", tier.rawValue)]),
+            geofenceTag
+        )
+    }
+
+    /// The re-centred bubble's own geometry. Region geometry is ungated — it is workspace
+    /// configuration, not user data — but this one is derived from the device's position, so it
+    /// travels with the same switch as a coordinate.
+    func geofenceMovementTriggerRegistered(latitude: Double, longitude: Double, radius: Double) {
+        let geometry: [(String, String?)] = [
+            ("rlat", GeofenceLog.num(latitude, 5)),
+            ("rlon", GeofenceLog.num(longitude, 5))
+        ]
+        debug(
+            "Movement trigger registered with radius \(Int(radius)) m"
+                + geofenceTail("movement.registered", .output, geometry + [("rad", GeofenceLog.num(radius, 0))]),
+            geofenceTag
+        )
+    }
+
+    func geofenceMovementRearmedAfterFailedRefresh() {
+        debug(
+            "Movement refresh failed; re-ranking from cache to re-arm the movement trigger"
+                + geofenceTail("movement.rearmed", .output, [("why", "refresh_failed")]),
+            geofenceTag
+        )
+    }
+
+    /// `spd` rides here and not only on `os.callback.received`: the wake margin is sized from how
+    /// far the device travels between passes, and this is the fix a pass actually uses. Speed at
+    /// OS-callback time is a different population — it only samples moments the OS chose to wake us.
+    func geofenceMovementFixResolved(ageSeconds: TimeInterval, requested: Bool, speed: CLLocationSpeed? = nil, purpose: GeofenceFixPurpose? = nil) {
+        let source = requested ? "freshly requested" : "cached"
+        debug(
+            "Movement pass using \(source) fix, age \(String(format: "%.1f", ageSeconds))s"
+                + geofenceTail("movement.fix.resolved", .input, [
+                    ("age", GeofenceLog.num(ageSeconds)),
+                    ("prov", requested ? "requested" : "cached"),
+                    // Negative means the fix carries no speed, which is not the same as stationary.
+                    ("spd", speed.flatMap { $0 >= 0 ? GeofenceLog.num($0) : nil }),
+                    // Which decision asked. `prov` separates cached from requested; this separates
+                    // the five callers, whose speed samples are different populations.
+                    ("for", purpose?.rawValue)
+                ]),
+            geofenceTag
+        )
+    }
+
+    func geofenceMovementFixStale(ageSeconds: TimeInterval?) {
+        let age = ageSeconds.map { "\(String(format: "%.1f", $0))s old" } ?? "missing"
+        info(
+            "Cached fix is \(age); requesting a fresh fix for the movement pass"
+                + geofenceTail("movement.fix.requested", .output, [
+                    ("age", GeofenceLog.num(ageSeconds)),
+                    ("why", ageSeconds == nil ? "no_cached_fix" : "stale_cached_fix")
+                ]),
+            geofenceTag
+        )
+    }
+
+    func geofenceMovementFixRequestFailed(fallingBackToCached: Bool, elapsed: TimeInterval? = nil) {
+        let outcome = fallingBackToCached ? "falling back to the stale cached fix" : "no cached fix to fall back to"
+        info(
+            "Fresh-fix request failed or timed out; \(outcome)"
+                + geofenceTail("movement.fix.failed", .input, [
+                    ("ok", GeofenceLog.bool(false)),
+                    ("why", fallingBackToCached ? "fallback_cached" : "no_fallback"),
+                    ("ms", GeofenceLog.num(elapsed.map { $0 * 1000 }, 0))
+                ]),
+            geofenceTag
+        )
+    }
+}

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+BaselineHeal.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+BaselineHeal.swift
@@ -103,7 +103,7 @@ extension CLMonitorGeofenceMonitor {
     /// wins; the decision's fix-age guard applies to the result.
     private func resolveHealFix() async -> CLLocation? {
         await withCheckedContinuation { continuation in
-            movementFixResolver.resolve(cached: bestKnownFix()) { [weak self] _, _ in
+            movementFixResolver.resolve(cached: bestKnownFix(), purpose: .baselineHeal) { [weak self] _, _ in
                 continuation.resume(returning: self?.bestKnownFix())
             }
         }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+ContradictionGate.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+ContradictionGate.swift
@@ -101,7 +101,7 @@ extension CLMonitorGeofenceMonitor {
             return bestKnownFix()
         }
         let fix: CLLocation? = await withCheckedContinuation { continuation in
-            movementFixResolver.resolve(cached: bestKnownFix()) { [weak self] _, _ in
+            movementFixResolver.resolve(cached: bestKnownFix(), purpose: .contradictionGate) { [weak self] _, _ in
                 continuation.resume(returning: self?.bestKnownFix())
             }
         }

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+ContradictionGate.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+ContradictionGate.swift
@@ -53,9 +53,15 @@ extension CLMonitorGeofenceMonitor {
     /// gated no matter how late it drains — while a real crossing dated outside the window, before
     /// the add or minutes after it, stays ungated no matter when it is processed.
     func isEventContradictedByFreshFix(identifier: String, transition: GeofenceTransition, eventDate: Date) async -> Bool {
-        guard let readd = conditionReadds[identifier],
-              readd.replayWindowCovers(eventDate)
-        else { return false }
+        guard let readd = conditionReadds[identifier] else { return false }
+        let insideWindow = readd.replayWindowCovers(eventDate)
+        logger.geofenceContradictionEvaluated(
+            identifier: identifier,
+            transition: transition,
+            delaySinceAdd: eventDate.timeIntervalSince(readd.added),
+            insideWindow: insideWindow
+        )
+        guard insideWindow else { return false }
         let gateFix = await resolveGateFix()
         guard let gateFix, CLLocationCoordinate2DIsValid(gateFix.coordinate) else { return false }
         let center = CLLocation(latitude: readd.center.latitude, longitude: readd.center.longitude)

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -307,7 +307,7 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
             // The movement pass re-centers the trigger and measures displacement at these coords, so
             // a frozen cached fix pins the whole pipeline to a stale point — freshen it first.
             // Fire-and-forget so a slow fix can't stall the pending-event drain behind it.
-            movementFixResolver.resolve(cached: bestKnownFix()) { [weak self] location, isFresh in
+            movementFixResolver.resolve(cached: bestKnownFix(), purpose: .movement) { [weak self] location, isFresh in
                 self?.logger.geofenceOsTransitionReceived(identifier: identifier, transition: transition)
                 self?.onTransition?(identifier, transition, location, event.date, isFresh, self?.eventCircle(for: identifier, raisedAt: event.date) ?? .unknown)
             }

--- a/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor+PendingEvents.swift
+++ b/Sources/LocationGeofence/Monitor/CoreLocationGeofenceMonitor+PendingEvents.swift
@@ -117,7 +117,7 @@ extension CoreLocationGeofenceMonitor {
         circle: MonitoredCircle
     ) {
         if identifier == GeofenceConstants.movementTriggerIdentifier, transition == .exit {
-            movementFixResolver.resolve(cached: bestKnownFix()) { [weak self] location, isFresh in
+            movementFixResolver.resolve(cached: bestKnownFix(), purpose: .pendingEvents) { [weak self] location, isFresh in
                 self?.logger.geofenceOsTransitionReceived(identifier: identifier, transition: transition)
                 // Falling back to the captured location is a second layer of staleness on top of a
                 // failed request, so it can never be reported as current.

--- a/Sources/LocationGeofence/Monitor/MovementFixResolver.swift
+++ b/Sources/LocationGeofence/Monitor/MovementFixResolver.swift
@@ -4,6 +4,18 @@ import Foundation
 
 /// Ensures the fix attached to a movement-trigger EXIT is fresh before it drives a sync pass.
 ///
+/// Which decision asked for a fix. One resolver serves five call sites, so without this every
+/// `movement.fix.resolved` record joins one population — and the wake margin is calibrated from
+/// the movement one alone. No default: a new call site must say which it is, or it silently
+/// contaminates the sample.
+enum GeofenceFixPurpose: String {
+    case movement
+    case contradictionGate = "gate"
+    case baselineHeal = "heal"
+    case pendingEvents = "pending"
+    case polygon
+}
+
 /// `CLLocationManager.location` on a long-suspended process can stay frozen at the fix cached
 /// around process start, anchoring every movement pass (re-rank point, trigger re-center, the
 /// moved-beyond check) to a stale position for a whole trip. A cached fix older than
@@ -64,6 +76,8 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
     private var pendingCompletions: [(LocationData?, Bool) -> Void] = []
     /// Newest cached fix seen while a request is in flight — the fallback on failure/timeout.
     private var fallbackFix: CLLocation?
+    /// Purpose of the caller that started the in-flight request; see `resolve`.
+    private var pendingPurpose: GeofenceFixPurpose?
     private var timeoutTask: Task<Void, Never>?
     /// Monotonic start of the in-flight request, so a failure can report how long it waited —
     /// "timed out after 10s" and "failed immediately" are different faults.
@@ -103,10 +117,10 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
     /// is `fallbackFix` — which is by definition the stale fix that prompted the request. A caller
     /// that sizes anything to the coordinates needs that apart, and deriving it from the fix's age
     /// at the call site would put this rule in two more places to get wrong.
-    func resolve(cached: CLLocation?, completion: @escaping (LocationData?, Bool) -> Void) {
+    func resolve(cached: CLLocation?, purpose: GeofenceFixPurpose, completion: @escaping (LocationData?, Bool) -> Void) {
         let age = cached.map { -$0.timestamp.timeIntervalSinceNow }
         if let cached, let age, age <= maxAge {
-            logger.geofenceMovementFixResolved(ageSeconds: age, requested: false, speed: cached.speed)
+            logger.geofenceMovementFixResolved(ageSeconds: age, requested: false, speed: cached.speed, purpose: purpose)
             completion(locationData(from: cached), true)
             return
         }
@@ -116,6 +130,9 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
         }
         pendingCompletions.append(completion)
         guard pendingCompletions.count == 1 else { return }
+        // The initiator labels the record. Later callers coalesce onto this request and return
+        // through `completeAll` without logging, so one request still yields exactly one record.
+        pendingPurpose = purpose
         requestStartedAt = GeofenceLog.monotonicNow()
         startTimeout()
         holdBackgroundTimeUntilCompletion()
@@ -151,7 +168,7 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
     func handleResolvedFix(_ fix: CLLocation) {
         recordDeliveredFix(fix)
         guard !pendingCompletions.isEmpty else { return }
-        logger.geofenceMovementFixResolved(ageSeconds: -fix.timestamp.timeIntervalSinceNow, requested: true, speed: fix.speed)
+        logger.geofenceMovementFixResolved(ageSeconds: -fix.timestamp.timeIntervalSinceNow, requested: true, speed: fix.speed, purpose: pendingPurpose)
         completeAll(with: locationData(from: fix), isFresh: true)
     }
 
@@ -199,6 +216,7 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
         timeoutTask = nil
         fallbackFix = nil
         requestStartedAt = nil
+        pendingPurpose = nil
         currentRequestSignal?.complete()
         currentRequestSignal = nil
         let completions = pendingCompletions

--- a/Sources/LocationGeofence/Monitor/MovementFixResolver.swift
+++ b/Sources/LocationGeofence/Monitor/MovementFixResolver.swift
@@ -106,7 +106,7 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
     func resolve(cached: CLLocation?, completion: @escaping (LocationData?, Bool) -> Void) {
         let age = cached.map { -$0.timestamp.timeIntervalSinceNow }
         if let cached, let age, age <= maxAge {
-            logger.geofenceMovementFixResolved(ageSeconds: age, requested: false)
+            logger.geofenceMovementFixResolved(ageSeconds: age, requested: false, speed: cached.speed)
             completion(locationData(from: cached), true)
             return
         }
@@ -151,7 +151,7 @@ final class MovementFixResolver: NSObject, @preconcurrency CLLocationManagerDele
     func handleResolvedFix(_ fix: CLLocation) {
         recordDeliveredFix(fix)
         guard !pendingCompletions.isEmpty else { return }
-        logger.geofenceMovementFixResolved(ageSeconds: -fix.timestamp.timeIntervalSinceNow, requested: true)
+        logger.geofenceMovementFixResolved(ageSeconds: -fix.timestamp.timeIntervalSinceNow, requested: true, speed: fix.speed)
         completeAll(with: locationData(from: fix), isFresh: true)
     }
 

--- a/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
+++ b/Sources/LocationGeofence/Polygon/PolygonMembershipResolver.swift
@@ -357,7 +357,7 @@ final class PolygonMembershipResolver {
         // current as any answer a request can return and the guard below can never pass.
         let priorTimestamp = fixResolver.latestFix?.timestamp
         return await withCheckedContinuation { continuation in
-            fixResolver.resolve(cached: requiringFresh ? nil : fixResolver.cachedFix) { [weak self] _, isFresh in
+            fixResolver.resolve(cached: requiringFresh ? nil : fixResolver.cachedFix, purpose: .polygon) { [weak self] _, isFresh in
                 guard let self else { return continuation.resume(returning: nil) }
                 let resolved = fixResolver.latestFix
                 if requiringFresh {

--- a/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
@@ -138,7 +138,7 @@ struct GeofenceLogTailTests {
             Invocation(name: "movementTrigger", ev: "movement.exit", requiredKeys: ["tier"]) { $0.geofenceMovementTrigger(tier: .localRerank) },
             Invocation(name: "movementTriggerRegistered", ev: "movement.registered", requiredKeys: ["rad"]) { $0.geofenceMovementTriggerRegistered(latitude: 43.2, longitude: -79.0, radius: 500) },
             Invocation(name: "movementRearmed", ev: "movement.rearmed", requiredKeys: ["why"]) { $0.geofenceMovementRearmedAfterFailedRefresh() },
-            Invocation(name: "movementFixResolved", ev: "movement.fix.resolved", requiredKeys: ["age", "prov", "spd"]) { $0.geofenceMovementFixResolved(ageSeconds: 12.5, requested: true, speed: 13.4) },
+            Invocation(name: "movementFixResolved", ev: "movement.fix.resolved", requiredKeys: ["age", "prov", "spd", "for"]) { $0.geofenceMovementFixResolved(ageSeconds: 12.5, requested: true, speed: 13.4, purpose: .movement) },
             Invocation(name: "movementFixStale", ev: "movement.fix.requested", requiredKeys: ["age", "why"]) { $0.geofenceMovementFixStale(ageSeconds: 900) },
             Invocation(name: "movementFixRequestFailed", ev: "movement.fix.failed", requiredKeys: ["ok", "why", "ms"]) { $0.geofenceMovementFixRequestFailed(fallingBackToCached: true, elapsed: 5) },
             Invocation(name: "baselineHealed", ev: "baseline.healed", requiredKeys: ["id", "t"]) { $0.geofenceBaselineHealed(identifier: "notl_core", transition: .enter) },
@@ -195,6 +195,21 @@ struct GeofenceLogTailTests {
                     #expect(fields[key] != nil, "\(invocation.name): missing \(key)= in '\(message)'")
                 }
             }
+        }
+    }
+
+    /// One resolver serves five decisions, so a speed sample is only usable once you can tell
+    /// which asked for it — the wake margin is calibrated from the movement caller alone.
+    @Test
+    func movementFixResolved_expectTheAskingDecisionNamed() {
+        withDiagnostics(true) {
+            for purpose in [GeofenceFixPurpose.movement, .contradictionGate, .baselineHeal, .pendingEvents, .polygon] {
+                let logger = CapturingLogger()
+                logger.geofenceMovementFixResolved(ageSeconds: 1, requested: false, speed: 5, purpose: purpose)
+                #expect(parseTail(logger.messages.last ?? "")?["for"] == purpose.rawValue)
+            }
+            // Distinct tokens, or the split says nothing.
+            #expect(Set([GeofenceFixPurpose.movement, .contradictionGate, .baselineHeal, .pendingEvents, .polygon].map(\.rawValue)).count == 5)
         }
     }
 

--- a/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceLogTailTests.swift
@@ -138,10 +138,11 @@ struct GeofenceLogTailTests {
             Invocation(name: "movementTrigger", ev: "movement.exit", requiredKeys: ["tier"]) { $0.geofenceMovementTrigger(tier: .localRerank) },
             Invocation(name: "movementTriggerRegistered", ev: "movement.registered", requiredKeys: ["rad"]) { $0.geofenceMovementTriggerRegistered(latitude: 43.2, longitude: -79.0, radius: 500) },
             Invocation(name: "movementRearmed", ev: "movement.rearmed", requiredKeys: ["why"]) { $0.geofenceMovementRearmedAfterFailedRefresh() },
-            Invocation(name: "movementFixResolved", ev: "movement.fix.resolved", requiredKeys: ["age", "prov"]) { $0.geofenceMovementFixResolved(ageSeconds: 12.5, requested: true) },
+            Invocation(name: "movementFixResolved", ev: "movement.fix.resolved", requiredKeys: ["age", "prov", "spd"]) { $0.geofenceMovementFixResolved(ageSeconds: 12.5, requested: true, speed: 13.4) },
             Invocation(name: "movementFixStale", ev: "movement.fix.requested", requiredKeys: ["age", "why"]) { $0.geofenceMovementFixStale(ageSeconds: 900) },
             Invocation(name: "movementFixRequestFailed", ev: "movement.fix.failed", requiredKeys: ["ok", "why", "ms"]) { $0.geofenceMovementFixRequestFailed(fallingBackToCached: true, elapsed: 5) },
             Invocation(name: "baselineHealed", ev: "baseline.healed", requiredKeys: ["id", "t"]) { $0.geofenceBaselineHealed(identifier: "notl_core", transition: .enter) },
+            Invocation(name: "contradictionEvaluated", ev: "contradiction.evaluated", requiredKeys: ["id", "t", "dly", "win"]) { $0.geofenceContradictionEvaluated(identifier: "notl_core", transition: .enter, delaySinceAdd: 1.25, insideWindow: true) },
             Invocation(name: "contradictionRefused", ev: "contradiction.refused", requiredKeys: ["id", "t", "dist", "rad", "edge", "acc"]) { $0.geofenceEventRefusedByContradiction(identifier: "notl_core", transition: .enter, distanceFromCenter: 1400, radius: 1000, accuracy: 48) },
             Invocation(name: "syncSuperseded", ev: "sync.superseded", requiredKeys: ["why"]) { $0.geofenceSyncSupersededByUserChange() },
             Invocation(name: "resetCompleted", ev: "module.reset", requiredKeys: ["ok"]) { $0.geofenceResetCompleted() },
@@ -194,6 +195,25 @@ struct GeofenceLogTailTests {
         }
     }
 
+    /// CoreLocation reports -1 for "no speed", which is not the same as stationary. Carrying it
+    /// through would put a fabricated -1.0 into a calibration sample that averages speeds.
+    @Test
+    func movementFixResolved_givenNoSpeedOnTheFix_expectTheKeyOmitted() {
+        withDiagnostics(true) {
+            let stationary = CapturingLogger()
+            stationary.geofenceMovementFixResolved(ageSeconds: 1, requested: false, speed: 0)
+            #expect(parseTail(stationary.messages.last ?? "")?["spd"] == "0.0")
+
+            let unknown = CapturingLogger()
+            unknown.geofenceMovementFixResolved(ageSeconds: 1, requested: false, speed: -1)
+            #expect(parseTail(unknown.messages.last ?? "")?["spd"] == nil)
+
+            let absent = CapturingLogger()
+            absent.geofenceMovementFixResolved(ageSeconds: 1, requested: false)
+            #expect(parseTail(absent.messages.last ?? "")?["spd"] == nil)
+        }
+    }
+
     @Test
     func deliveryFailure_expectDistinctReasonTokenPerCause() {
         // The token is the whole value of this record now that it carries no verdict: it is what
@@ -212,6 +232,51 @@ struct GeofenceLogTailTests {
         #expect(BackgroundDeliveryHttpError.http(statusCode: 503).diagnosticReason == "http_503")
     }
 
+    /// The module's whole diagnostic vocabulary, hoisted out of the test so the assertion stays
+    /// readable as rows are added.
+    private static let declaredVocabulary: Set<String> = [
+        "api.fetch.result",
+        "baseline.healed",
+        "baseline.refused",
+        "contradiction.evaluated",
+        "contradiction.refused",
+        "delivery.failed",
+        "delivery.queued",
+        "delivery.sent",
+        "fix.received",
+        "info",
+        "module.init",
+        "module.reset",
+        "module.wake",
+        "movement.exit",
+        "movement.fix.failed",
+        "movement.fix.requested",
+        "movement.fix.resolved",
+        "movement.rearmed",
+        "movement.registered",
+        "os.callback.dropped",
+        "os.callback.received",
+        "os.monitor.failed",
+        "os.monitor.stopped",
+        "os.stream.failed",
+        "permission.changed",
+        "rank.evaluated",
+        "registration.adopted",
+        "registration.applied",
+        "registration.diff",
+        "registration.rearmed",
+        "registration.rejected",
+        "storage.loaded",
+        "storage.write.failed",
+        "sync.completed",
+        "sync.skipped",
+        "sync.superseded",
+        "transition.accepted",
+        "transition.dropped",
+        "transition.suppressed",
+        "transition.synthesized"
+    ]
+
     @Test
     func everyRecord_expectTheDeclaredVocabulary() {
         // Companion to the per-row `ev` pin above, catching what a per-row check cannot: a key
@@ -223,47 +288,7 @@ struct GeofenceLogTailTests {
         // `fence.cataloged` is absent on purpose: it is emitted by a private helper driven through
         // `api.fetch.result`, so it cannot be a row here. It carries its own `ev` assertion in
         // `fenceCatalog_...` below. Every other key the module emits is listed.
-        let expected: Set = [
-            "api.fetch.result",
-            "baseline.healed",
-            "baseline.refused",
-            "contradiction.refused",
-            "delivery.failed",
-            "delivery.queued",
-            "delivery.sent",
-            "fix.received",
-            "info",
-            "module.init",
-            "module.reset",
-            "module.wake",
-            "movement.exit",
-            "movement.fix.failed",
-            "movement.fix.requested",
-            "movement.fix.resolved",
-            "movement.rearmed",
-            "movement.registered",
-            "os.callback.dropped",
-            "os.callback.received",
-            "os.monitor.failed",
-            "os.monitor.stopped",
-            "os.stream.failed",
-            "permission.changed",
-            "rank.evaluated",
-            "registration.adopted",
-            "registration.applied",
-            "registration.diff",
-            "registration.rearmed",
-            "registration.rejected",
-            "storage.loaded",
-            "storage.write.failed",
-            "sync.completed",
-            "sync.skipped",
-            "sync.superseded",
-            "transition.accepted",
-            "transition.dropped",
-            "transition.suppressed",
-            "transition.synthesized"
-        ]
+        let expected = Self.declaredVocabulary
         var seen: Set<String> = []
         withDiagnostics(true) {
             for invocation in invocations {

--- a/Tests/LocationGeofence/Geofence/Monitor/MovementFixResolverTests.swift
+++ b/Tests/LocationGeofence/Geofence/Monitor/MovementFixResolverTests.swift
@@ -45,7 +45,7 @@ struct MovementFixResolverTests {
         let warm = MovementFixResolver(logger: LoggerMock())
         warm.systemCachedFix = { nil }
         warm.requestFreshFix = {}
-        warm.resolve(cached: makeFix(ageSeconds: 5)) { _, isFresh in freshness.append(isFresh) }
+        warm.resolve(cached: makeFix(ageSeconds: 5), purpose: .movement) { _, isFresh in freshness.append(isFresh) }
         #expect(freshness == [true]) // inside maxAge, answered without a request
 
         let delivered = MovementFixResolver(logger: LoggerMock())
@@ -53,13 +53,13 @@ struct MovementFixResolverTests {
         delivered.requestFreshFix = { [weak delivered] in
             delivered?.handleResolvedFix(makeFix(ageSeconds: 0))
         }
-        delivered.resolve(cached: makeFix(ageSeconds: 120)) { _, isFresh in freshness.append(isFresh) }
+        delivered.resolve(cached: makeFix(ageSeconds: 120), purpose: .movement) { _, isFresh in freshness.append(isFresh) }
         #expect(freshness == [true, true])
 
         let failed = MovementFixResolver(logger: LoggerMock())
         failed.systemCachedFix = { nil }
         failed.requestFreshFix = { [weak failed] in failed?.handleRequestFailure() }
-        failed.resolve(cached: makeFix(ageSeconds: 120)) { _, isFresh in freshness.append(isFresh) }
+        failed.resolve(cached: makeFix(ageSeconds: 120), purpose: .movement) { _, isFresh in freshness.append(isFresh) }
         #expect(freshness == [true, true, false]) // fell back to the fix that prompted the request
 
         // A fix landing after that failure must not retroactively make the answer fresh.
@@ -73,7 +73,7 @@ struct MovementFixResolverTests {
         let resolver = makeResolver(onRequest: { requestCount += 1 })
         var received: [LocationData?] = []
 
-        resolver.resolve(cached: makeFix(latitude: 31.5, ageSeconds: 5)) { location, _ in received.append(location) }
+        resolver.resolve(cached: makeFix(latitude: 31.5, ageSeconds: 5), purpose: .movement) { location, _ in received.append(location) }
 
         #expect(received.map(\.?.latitude) == [31.5])
         #expect(requestCount == 0)
@@ -85,7 +85,7 @@ struct MovementFixResolverTests {
         let resolver = makeResolver(onRequest: { requestCount += 1 })
         var received: [LocationData?] = []
 
-        resolver.resolve(cached: makeFix(latitude: 31.1, ageSeconds: 120)) { location, _ in received.append(location) }
+        resolver.resolve(cached: makeFix(latitude: 31.1, ageSeconds: 120), purpose: .movement) { location, _ in received.append(location) }
         #expect(received.isEmpty)
         #expect(requestCount == 1)
 
@@ -99,7 +99,7 @@ struct MovementFixResolverTests {
         let resolver = makeResolver(onRequest: { requestCount += 1 })
         var received: [LocationData?] = []
 
-        resolver.resolve(cached: nil) { location, _ in received.append(location) }
+        resolver.resolve(cached: nil, purpose: .movement) { location, _ in received.append(location) }
         #expect(requestCount == 1)
 
         resolver.handleRequestFailure()
@@ -112,7 +112,7 @@ struct MovementFixResolverTests {
         let resolver = makeResolver()
         var received: [LocationData?] = []
 
-        resolver.resolve(cached: makeFix(latitude: 31.2, ageSeconds: 120)) { location, _ in received.append(location) }
+        resolver.resolve(cached: makeFix(latitude: 31.2, ageSeconds: 120), purpose: .movement) { location, _ in received.append(location) }
         resolver.handleRequestFailure()
 
         #expect(received.map(\.?.latitude) == [31.2])
@@ -125,8 +125,8 @@ struct MovementFixResolverTests {
         var first: [LocationData?] = []
         var second: [LocationData?] = []
 
-        resolver.resolve(cached: makeFix(ageSeconds: 120)) { location, _ in first.append(location) }
-        resolver.resolve(cached: makeFix(ageSeconds: 90)) { location, _ in second.append(location) }
+        resolver.resolve(cached: makeFix(ageSeconds: 120), purpose: .movement) { location, _ in first.append(location) }
+        resolver.resolve(cached: makeFix(ageSeconds: 90), purpose: .movement) { location, _ in second.append(location) }
         #expect(requestCount == 1)
 
         resolver.handleResolvedFix(makeFix(latitude: 32.0, ageSeconds: 0))
@@ -139,7 +139,7 @@ struct MovementFixResolverTests {
         let resolver = makeResolver(requestTimeout: 0.05)
         var received: [LocationData?] = []
 
-        resolver.resolve(cached: makeFix(latitude: 31.3, ageSeconds: 120)) { location, _ in received.append(location) }
+        resolver.resolve(cached: makeFix(latitude: 31.3, ageSeconds: 120), purpose: .movement) { location, _ in received.append(location) }
 
         for _ in 0 ..< 200 {
             if !received.isEmpty { break }
@@ -159,8 +159,8 @@ struct MovementFixResolverTests {
         var first: [LocationData?] = []
         var second: [LocationData?] = []
 
-        resolver.resolve(cached: makeFix(latitude: 31.6, ageSeconds: 120)) { location, _ in first.append(location) }
-        resolver.resolve(cached: makeFix(latitude: 31.7, ageSeconds: 90)) { location, _ in second.append(location) }
+        resolver.resolve(cached: makeFix(latitude: 31.6, ageSeconds: 120), purpose: .movement) { location, _ in first.append(location) }
+        resolver.resolve(cached: makeFix(latitude: 31.7, ageSeconds: 90), purpose: .movement) { location, _ in second.append(location) }
         resolver.handleRequestFailure()
 
         #expect(first.map(\.?.latitude) == [31.7])
@@ -172,7 +172,7 @@ struct MovementFixResolverTests {
         let resolver = makeResolver()
         var received: [LocationData?] = []
 
-        resolver.resolve(cached: nil) { location, _ in received.append(location) }
+        resolver.resolve(cached: nil, purpose: .movement) { location, _ in received.append(location) }
         resolver.locationManager(CLLocationManager(), didUpdateLocations: [
             makeFix(latitude: 200.0, longitude: 200.0, ageSeconds: 0)
         ])
@@ -200,10 +200,10 @@ struct MovementFixResolverTests {
         let resolver = makeResolver(onRequest: { requestCount += 1 })
         var received: [LocationData?] = []
 
-        resolver.resolve(cached: makeFix(ageSeconds: 120)) { location, _ in received.append(location) }
+        resolver.resolve(cached: makeFix(ageSeconds: 120), purpose: .movement) { location, _ in received.append(location) }
         resolver.handleResolvedFix(makeFix(latitude: 32.1, ageSeconds: 0))
 
-        resolver.resolve(cached: makeFix(ageSeconds: 120)) { location, _ in received.append(location) }
+        resolver.resolve(cached: makeFix(ageSeconds: 120), purpose: .movement) { location, _ in received.append(location) }
         #expect(requestCount == 2)
 
         resolver.handleResolvedFix(makeFix(latitude: 32.2, ageSeconds: 0))
@@ -215,7 +215,7 @@ struct MovementFixResolverTests {
         let resolver = makeResolver()
         var received: [LocationData?] = []
 
-        resolver.resolve(cached: nil) { location, _ in received.append(location) }
+        resolver.resolve(cached: nil, purpose: .movement) { location, _ in received.append(location) }
         // Core Location echoing a cached (stale) location must not complete the pass...
         resolver.locationManager(CLLocationManager(), didUpdateLocations: [
             makeFix(latitude: 31.9, ageSeconds: 120)
@@ -235,7 +235,7 @@ struct MovementFixResolverTests {
         let resolver = makeResolver()
         var received: [LocationData?] = []
 
-        resolver.resolve(cached: nil) { location, _ in received.append(location) }
+        resolver.resolve(cached: nil, purpose: .movement) { location, _ in received.append(location) }
         resolver.locationManager(CLLocationManager(), didUpdateLocations: [
             makeFix(latitude: 31.9, ageSeconds: 0, accuracy: -1)
         ])
@@ -254,7 +254,7 @@ struct MovementFixResolverTests {
         let resolver = makeResolver(backgroundTaskRunner: runner)
         var received: [LocationData?] = []
 
-        resolver.resolve(cached: makeFix(ageSeconds: 120)) { location, _ in received.append(location) }
+        resolver.resolve(cached: makeFix(ageSeconds: 120), purpose: .movement) { location, _ in received.append(location) }
         for _ in 0 ..< 200 {
             if runner.started.wrappedValue == 1 { break }
             try? await Task.sleep(nanoseconds: 5000000)


### PR DESCRIPTION
Part of [MBL-2415](https://linear.app/customerio/issue/MBL-2415).

The ticket is blocked on field calibration, and two of the four constants could not be calibrated from a drive because the inputs were never logged. This adds them ahead of a weekend field run.

## What it does

- `spd` on `movement.fix.resolved`. Speed rode only on `os.callback.received`, which samples the moments the OS chose to wake us — a different population from the fixes a movement pass actually uses, which is what the wake margin is sized against. Omitted rather than reported as `-1` when the fix carries no speed; CoreLocation's `-1` is not stationary.
- `contradiction.evaluated` — every event arriving while a re-add record is held, with `dly` (event date minus the add) and `win` (whether the current bound covered it). The gate recorded only refusals, so an event just outside `contradictionGateReplayWindow` and one that was never a replay both logged nothing. The constant's own comment cites 0.003–3.3 s measured in reproductions; this is what confirms or moves it from real traffic.

No behaviour change — both are diagnostics, gated by `CIOGeofenceDiagnostics`.

The other two constants need nothing: `movement.fix.resolved` already logs `age` on both sides of the 30 s threshold, so the live-fix bound is measurable as-is.

## Tests

564/564 `LocationGeofenceTests`, lint clean.

**Evidence:** dropping the negative-speed guard makes `movementFixResolved_givenNoSpeedOnTheFix_expectTheKeyOmitted` fail with `spd=-1.0` — a fabricated value that would skew any average taken over the sample.

**Not covered:** `contradiction.evaluated`'s placement. The contract table pins the record's shape and vocabulary, but `CLMonitorGeofenceMonitor` cannot be instantiated in a unit test, so nothing asserts the gate emits it before the window check rather than after. That is the one thing worth a careful read.

## Related

Touches `GeofenceLogTailTests.swift` in the same place as #1265 — both hoist `declaredVocabulary` out of the test to stay under the function-length cap, with identical text. Whoever merges second may see a trivial overlap there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
