### PR TITLE
fix(geofence): refuse re-delivered CLMonitor events by their date

### DIFF
--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+BaselineHeal.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+BaselineHeal.swift
@@ -62,10 +62,13 @@ extension CLMonitorGeofenceMonitor {
                 // arrived from the OS on this path. This is also the only site that can return
                 // `.suppressedNewerBaseline` — the OS path passes no evidence timestamp — so
                 // without this the token exists but can never print.
+                // Stamped with the fix's time, not the drain time: OS events are judged against this
+                // stamp by their own date, so both writers must record evidence time.
                 let outcome = await self.storage.recordMonitorEvent(
                     transition,
                     forIdentifier: identifier,
-                    onlyIfBaselinePredates: fix.timestamp
+                    onlyIfBaselinePredates: fix.timestamp,
+                    now: fix.timestamp
                 )
                 guard case .deliver = outcome else {
                     if let reason = outcome.diagnosticReason {

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+BaselineHeal.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor+BaselineHeal.swift
@@ -59,9 +59,8 @@ extension CLMonitorGeofenceMonitor {
                 ) else { continue }
                 // A heal that decides a crossing is real and is then refused by the baseline used
                 // to vanish. Reported as `baseline.refused`, not `os.callback.dropped`: nothing
-                // arrived from the OS on this path. This is also the only site that can return
-                // `.suppressedNewerBaseline` — the OS path passes no evidence timestamp — so
-                // without this the token exists but can never print.
+                // arrived from the OS on this path. Both writers pass their evidence time as the
+                // bound; the OS path passes the event's date, this one the fix's.
                 // Stamped with the fix's time, not the drain time: OS events are judged against this
                 // stamp by their own date, so both writers must record evidence time.
                 let outcome = await self.storage.recordMonitorEvent(

--- a/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
+++ b/Sources/LocationGeofence/Monitor/CLMonitorGeofenceMonitor.swift
@@ -301,7 +301,8 @@ final class CLMonitorGeofenceMonitor: NSObject, GeofenceRegionMonitoring, @preco
            await isEventContradictedByFreshFix(identifier: identifier, transition: transition, eventDate: event.date) {
             return
         }
-        let outcome = await storage.recordMonitorEvent(transition, forIdentifier: identifier)
+        // Dated by the OS, not by receipt: a re-delivered copy landing after its own movement pass re-seeded this baseline reads as stale, not new.
+        let outcome = await storage.recordMonitorEvent(transition, forIdentifier: identifier, onlyIfBaselinePredates: event.date, now: event.date)
         guard case .deliver = outcome else {
             logDiscardedCallback(identifier: identifier, transition: transition, outcome: outcome)
             return

--- a/Tests/LocationGeofence/Geofence/GeofenceBootstrapTests.swift
+++ b/Tests/LocationGeofence/Geofence/GeofenceBootstrapTests.swift
@@ -6,6 +6,9 @@ import Foundation
 import SharedTests
 import Testing
 
+// Nested for serialization only; the body keeps top-level indentation so the file's history stays readable.
+// swiftformat:disable indent
+extension SharedDIGraphSuites {
 @Suite("GeofenceBootstrap", .serialized)
 @MainActor
 struct GeofenceBootstrapTests {
@@ -435,11 +438,11 @@ struct GeofenceBootstrapTests {
         #expect(coordinator.applyCachedRegistrationCallsCount == 1)
 
         // Simulate iOS reporting a permission change. The handler spawns a Task to re-run
-        // wireMonitor; the sleep gives that Task time to schedule and complete.
+        // wireMonitor; wait for that re-run by its outcome. Waiting a fixed 100 ms let the re-run
+        // land after this test's `di.reset()`, inside the next test's overrides, under load.
         monitor.onAuthorizationChanged?()
-        try? await Task.sleep(nanoseconds: 100000000)
 
-        #expect(coordinator.applyCachedRegistrationCallsCount == 2)
+        #expect(await settle { coordinator.applyCachedRegistrationCallsCount == 2 })
     }
 
     @Test
@@ -457,11 +460,10 @@ struct GeofenceBootstrapTests {
 
         // The CLMonitor path calls this once it has reconciled the mirror against the OS's live set.
         // It must re-run wireMonitor so the adopt/re-register decision is re-made against live truth;
-        // the sleep gives the spawned Task time to complete.
+        // waited for by outcome so the re-run cannot outlive this test.
         monitor.onReconciled?()
-        try? await Task.sleep(nanoseconds: 100000000)
 
-        #expect(coordinator.applyCachedRegistrationCallsCount == 2)
+        #expect(await settle { coordinator.applyCachedRegistrationCallsCount == 2 })
     }
 
     @Test
@@ -495,3 +497,6 @@ private final class StubProvider: BackgroundDeliveryCdpApiKeyProvider {
 
     var cdpApiKey: String? { value }
 }
+}
+
+// swiftformat:enable indent

--- a/Tests/LocationGeofence/Geofence/SharedDIGraphSuites.swift
+++ b/Tests/LocationGeofence/Geofence/SharedDIGraphSuites.swift
@@ -1,0 +1,10 @@
+import Testing
+
+/// Parent for every suite that reads or overrides `DIGraphShared.shared`.
+///
+/// `GeofenceBootstrap.wireMonitor` resolves that graph when its chained task *runs*, not when it is
+/// called, and `GeofenceModule.initialize()` fires one without awaiting it. Two such suites running
+/// in parallel therefore wire one suite's mocks from the other suite's task. `.serialized` on this
+/// parent applies to every nested suite, so they take turns.
+@Suite(.serialized)
+enum SharedDIGraphSuites {}

--- a/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
+++ b/Tests/LocationGeofence/Geofence/Storage/GeofenceStorageTests.swift
@@ -935,4 +935,54 @@ struct GeofenceStorageTests {
         let tokens = cases.compactMap(\.diagnosticReason)
         #expect(Set(tokens).count == tokens.count, "duplicate tokens: \(tokens)")
     }
+
+    // MARK: - Re-delivered OS events
+
+    /// CoreLocation re-delivers the same crossing; every copy carries the original event `date`.
+    private static let trigger = GeofenceConstants.movementTriggerIdentifier
+    private static let eventDate = Date(timeIntervalSince1970: 1000060.107)
+    private static let reseedAt = Date(timeIntervalSince1970: 1000060.238)
+
+    private func registerTrigger(_ storage: GeofenceStorage, longitude: Double, at now: Date) async {
+        await storage.recordMonitorRegistration(
+            identifier: Self.trigger, transitionTypes: [.enter, .exit], initialState: .enter,
+            center: LocationData(latitude: 10, longitude: longitude), radius: 1000, now: now
+        )
+    }
+
+    @Test
+    func recordMonitorEvent_givenCopyBeforeReseed_expectNoStateChange() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        await registerTrigger(storage, longitude: 20, at: Date(timeIntervalSince1970: 1000000))
+
+        #expect(await storage.recordMonitorEvent(.exit, forIdentifier: Self.trigger, onlyIfBaselinePredates: Self.eventDate, now: Self.eventDate) == .deliver)
+        #expect(await storage.recordMonitorEvent(.exit, forIdentifier: Self.trigger, onlyIfBaselinePredates: Self.eventDate, now: Self.eventDate) == .suppressedNoChange)
+    }
+
+    @Test
+    func recordMonitorEvent_givenCopyAfterReseed_expectRefusedAsStale() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        await registerTrigger(storage, longitude: 20, at: Date(timeIntervalSince1970: 1000000))
+
+        #expect(await storage.recordMonitorEvent(.exit, forIdentifier: Self.trigger, onlyIfBaselinePredates: Self.eventDate, now: Self.eventDate) == .deliver)
+        await registerTrigger(storage, longitude: 20.01, at: Self.reseedAt)
+        #expect(await storage.recordMonitorEvent(.exit, forIdentifier: Self.trigger, onlyIfBaselinePredates: Self.eventDate, now: Self.eventDate) == .suppressedNewerBaseline)
+    }
+
+    @Test
+    func recordMonitorEvent_givenLaterEventAfterReseed_expectDelivered() async {
+        let dir = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let storage = makeStorage(directory: dir)
+        await registerTrigger(storage, longitude: 20, at: Date(timeIntervalSince1970: 1000000))
+
+        #expect(await storage.recordMonitorEvent(.exit, forIdentifier: Self.trigger, onlyIfBaselinePredates: Self.eventDate, now: Self.eventDate) == .deliver)
+        await registerTrigger(storage, longitude: 20.01, at: Self.reseedAt)
+        let later = Self.reseedAt.addingTimeInterval(300)
+        #expect(await storage.recordMonitorEvent(.exit, forIdentifier: Self.trigger, onlyIfBaselinePredates: later, now: later) == .deliver)
+    }
 }

--- a/Tests/LocationGeofence/Geofence/Stub/Settle.swift
+++ b/Tests/LocationGeofence/Geofence/Stub/Settle.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Waits for detached work by its outcome, not by a fixed sleep: polls every 10 ms up to `timeout`.
+@discardableResult
+func settle(timeout: TimeInterval = 2, until condition: @escaping () -> Bool) async -> Bool {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+        if condition() { return true }
+        try? await Task.sleep(nanoseconds: 10000000)
+    }
+    return condition()
+}
+
+/// For assertions of absence: a bounded window for a stray call to land.
+func settleQuietly(_ seconds: TimeInterval = 0.3) async {
+    await Task.yield()
+    try? await Task.sleep(nanoseconds: UInt64(seconds * 1000000000))
+}

--- a/Tests/LocationGeofence/GeofenceModuleSetupTests.swift
+++ b/Tests/LocationGeofence/GeofenceModuleSetupTests.swift
@@ -23,6 +23,8 @@ struct GeofenceModuleSetupTests {
         defer { f.cleanup() }
 
         let (resetSignal, resetContinuation) = AsyncStream<Void>.makeStream()
+        let resetContinuationWatchdog = bounded(resetContinuation)
+        defer { resetContinuationWatchdog.cancel() }
         f.spyCoordinator.resetClosure = {
             resetContinuation.yield()
             return .success(())
@@ -48,6 +50,8 @@ struct GeofenceModuleSetupTests {
         defer { f.cleanup() }
 
         let (refreshSignal, refreshContinuation) = AsyncStream<Void>.makeStream()
+        let refreshContinuationWatchdog = bounded(refreshContinuation)
+        defer { refreshContinuationWatchdog.cancel() }
         f.spyCoordinator.refreshClosure = { _, _ in
             refreshContinuation.yield()
             return .success(())
@@ -89,6 +93,8 @@ struct GeofenceModuleSetupTests {
         defer { f.cleanup() }
 
         let (refreshSignal, refreshContinuation) = AsyncStream<(Double, Double)>.makeStream()
+        let refreshContinuationWatchdog = bounded(refreshContinuation)
+        defer { refreshContinuationWatchdog.cancel() }
         f.spyCoordinator.refreshClosure = { lat, lon in
             refreshContinuation.yield((lat, lon))
             return .success(())
@@ -116,6 +122,8 @@ struct GeofenceModuleSetupTests {
         await f.di.geofenceStorage.recordRegistration(center: LocationData(latitude: 10, longitude: 20), businessIds: ["g1"])
 
         let (refreshSignal, refreshContinuation) = AsyncStream<(Double, Double)>.makeStream()
+        let refreshContinuationWatchdog = bounded(refreshContinuation)
+        defer { refreshContinuationWatchdog.cancel() }
         f.spyCoordinator.refreshClosure = { lat, lon in
             refreshContinuation.yield((lat, lon))
             return .success(())
@@ -152,6 +160,8 @@ struct GeofenceModuleSetupTests {
         defer { f.cleanup() }
 
         let (signal, continuation) = AsyncStream<Void>.makeStream()
+        let continuationWatchdog = bounded(continuation)
+        defer { continuationWatchdog.cancel() }
         f.stub.onRequestSilently = { continuation.yield() }
 
         f.wire()
@@ -171,9 +181,13 @@ struct GeofenceModuleSetupTests {
         defer { f.cleanup() }
 
         let (readSignal, readContinuation) = AsyncStream<Void>.makeStream()
+        let readContinuationWatchdog = bounded(readContinuation)
+        defer { readContinuationWatchdog.cancel() }
         f.stub.onGetLastKnown = { readContinuation.yield() }
 
         let (refreshSignal, refreshContinuation) = AsyncStream<(Double, Double)>.makeStream()
+        let refreshContinuationWatchdog = bounded(refreshContinuation)
+        defer { refreshContinuationWatchdog.cancel() }
         f.spyCoordinator.refreshClosure = { lat, lon in
             refreshContinuation.yield((lat, lon))
             return .success(())
@@ -207,13 +221,11 @@ struct GeofenceModuleSetupTests {
         // The anchor read is the last await before the no-anchor branch runs, so awaiting it as a
         // barrier guarantees the launch arm + acquire-gate decision has executed before we assert.
         let (readSignal, readContinuation) = AsyncStream<Void>.makeStream()
+        let readContinuationWatchdog = bounded(readContinuation)
+        defer { readContinuationWatchdog.cancel() }
         f.stub.onGetLastKnown = { readContinuation.yield() }
 
-        let (refreshSignal, refreshContinuation) = AsyncStream<(Double, Double)>.makeStream()
-        f.spyCoordinator.refreshClosure = { lat, lon in
-            refreshContinuation.yield((lat, lon))
-            return .success(())
-        }
+        f.spyCoordinator.refreshClosure = { _, _ in .success(()) }
 
         f.wire()
 
@@ -224,13 +236,18 @@ struct GeofenceModuleSetupTests {
         #expect(f.stub.requestSilentlyCount.wrappedValue == 0)
 
         // But launch still armed the first-run refresh, so a host-driven fix drives the sync.
+        // The arm is written after the read above returns and, in manual mode, has no observable
+        // of its own; a fix delivered before it is a no-op. So deliver until one is consumed.
         let locAcquired = try #require(f.bus.observers[LocationAcquiredEvent.key], "LocationAcquiredEvent observer must be registered")
-        locAcquired(LocationAcquiredEvent(location: LocationData(latitude: 9, longitude: 10)))
-
-        var refreshIter = refreshSignal.makeAsyncIterator()
-        let received = await refreshIter.next()
-        #expect(received?.0 == 9)
-        #expect(received?.1 == 10)
+        let refreshed = await settle {
+            if f.spyCoordinator.refreshCallsCount == 0 {
+                locAcquired(LocationAcquiredEvent(location: LocationData(latitude: 9, longitude: 10)))
+            }
+            return f.spyCoordinator.refreshCallsCount >= 1
+        }
+        #expect(refreshed, "the armed first-run refresh never consumed the host's fix")
+        #expect(f.spyCoordinator.refreshReceivedArguments?.latitude == 9)
+        #expect(f.spyCoordinator.refreshReceivedArguments?.longitude == 10)
         #expect(f.stub.requestSilentlyCount.wrappedValue == 0)
     }
 
@@ -243,6 +260,8 @@ struct GeofenceModuleSetupTests {
         defer { f.cleanup() }
 
         let (refreshSignal, refreshContinuation) = AsyncStream<(Double, Double)>.makeStream()
+        let refreshContinuationWatchdog = bounded(refreshContinuation)
+        defer { refreshContinuationWatchdog.cancel() }
         f.spyCoordinator.refreshClosure = { lat, lon in
             refreshContinuation.yield((lat, lon))
             return .success(())
@@ -274,6 +293,8 @@ struct GeofenceModuleSetupTests {
         defer { f.cleanup() }
 
         let (refreshSignal, refreshContinuation) = AsyncStream<Void>.makeStream()
+        let refreshContinuationWatchdog = bounded(refreshContinuation)
+        defer { refreshContinuationWatchdog.cancel() }
         f.spyCoordinator.refreshClosure = { _, _ in
             refreshContinuation.yield()
             return .success(())
@@ -388,4 +409,13 @@ private final class CapturingEventBusHandler: EventBusHandler, @unchecked Sendab
     func loadEventsFromStorage() async {}
     func removeFromStorage<E: EventRepresentable>(_ event: E) async {}
     func removeAllObservers() {}
+}
+
+/// Bounds a signal the test awaits: if the SDK never sends it, the stream finishes and the await
+/// returns `nil`, so the test fails instead of hanging the whole run.
+private func bounded<T>(_ continuation: AsyncStream<T>.Continuation, seconds: TimeInterval = 5) -> Task<Void, Never> {
+    Task {
+        try? await Task.sleep(nanoseconds: UInt64(seconds * 1000000000))
+        continuation.finish()
+    }
 }

--- a/Tests/LocationGeofence/GeofenceModuleTests.swift
+++ b/Tests/LocationGeofence/GeofenceModuleTests.swift
@@ -2,26 +2,29 @@
 import Foundation
 import Testing
 
-@Suite("GeofenceModule")
-struct GeofenceModuleTests {
-    @Test
-    func moduleName_expectGeofence() {
-        #expect(GeofenceModule().moduleName == "Geofence")
-    }
+extension SharedDIGraphSuites {
+    @Suite("GeofenceModule")
+    struct GeofenceModuleTests {
+        @Test
+        func moduleName_expectGeofence() {
+            #expect(GeofenceModule().moduleName == "Geofence")
+        }
 
-    @Test
-    func initialize_givenDefaultConfig_expectNoCrash() {
-        // Scaffold module performs no setup yet; this guards the no-op contract.
-        GeofenceModule().initialize()
-    }
+        @Test
+        func initialize_givenDefaultConfig_expectNoCrash() {
+            // Runs the real bootstrap against `DIGraphShared.shared` on a detached task, which is why
+            // this suite is nested under `SharedDIGraphSuites`.
+            GeofenceModule().initialize()
+        }
 
-    @Test
-    func config_defaultLocationMode_isAutomatic() {
-        #expect(GeofenceModuleConfig().locationMode == .automatic)
-    }
+        @Test
+        func config_defaultLocationMode_isAutomatic() {
+            #expect(GeofenceModuleConfig().locationMode == .automatic)
+        }
 
-    @Test
-    func config_givenExplicitLocationMode_isStored() {
-        #expect(GeofenceModuleConfig(locationMode: .manual).locationMode == .manual)
+        @Test
+        func config_givenExplicitLocationMode_isStored() {
+            #expect(GeofenceModuleConfig(locationMode: .manual).locationMode == .manual)
+        }
     }
 }


### PR DESCRIPTION
On device, CoreLocation delivers the same crossing event two to three times, identical down to the event date. The wrapper's only defence was the stored per-region baseline, and for the movement trigger the first copy's own movement pass re-seeds that baseline, so a copy landing after the re-seed read as a new exit and started a second movement pass and sync. Recorded drives won that race by 4–9 ms every time; customerio-ios#1268 (now closed) was the proof-of-bug PR that failed on main.

The fix is two arguments on the storage call the wrapper already makes: the OS event date as the evidence bound the baseline heal already uses, and as the baseline's own stamp so the comparison stays in one clock. The heal stamps its write the same way. Three storage tests pin the outcomes before and after the re-seed.

Two further commits fix pre-existing test defects in the same area. Two bootstrap tests slept for a detached re-run, and `GeofenceModule.initialize()` fires the bootstrap against the shared DI graph without awaiting it, so parallel suites wired each other's mocks; they now wait on the outcome, and every suite touching the shared graph is serialized under one parent. The module-setup suite used the trigger's cache read as a barrier for an arm that is written after the read returns, and awaited without a bound, so a fix delivered in that gap hung the whole run; every awaited stream now finishes after five seconds and that test re-delivers the fix until one is consumed.

Part of MBL-2309
Contributes to MBL-2421

🤖 Generated with [Claude Code](https://claude.com/claude-code)
